### PR TITLE
fix(ci): make macos-smoke runtime step passable

### DIFF
--- a/.github/workflows/macos-smoke.yml
+++ b/.github/workflows/macos-smoke.yml
@@ -13,23 +13,22 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.13
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Install uv
-        run: python -m pip install uv
+      - name: Install Python 3.13 + uv via Homebrew
+        # actions/setup-python ships a CPython whose sqlite3 lacks
+        # enable_load_extension, so sqlite-vec (core to memo) cannot load.
+        # Homebrew's python@3.13 has extension loading enabled.
+        run: brew install python@3.13 uv
       - name: Cache Hugging Face models
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
           key: macos-hf-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
       - name: Create virtualenv
-        run: uv venv .venv
+        run: uv venv --python "$(brew --prefix python@3.13)/bin/python3.13" .venv
       - name: Install package + dev deps
         run: uv pip install --python .venv/bin/python -e '.[dev]'
       - name: Confirm Apple Silicon runner
-        run: python -c "import platform; assert platform.machine() == 'arm64', platform.machine()"
+        run: .venv/bin/python -c "import platform; assert platform.machine() == 'arm64', platform.machine()"
       - name: Lint (ruff)
         run: .venv/bin/ruff check src/ tests/
       - name: Type check (mypy)

--- a/.github/workflows/macos-smoke.yml
+++ b/.github/workflows/macos-smoke.yml
@@ -35,7 +35,14 @@ jobs:
       - name: Type check (mypy)
         run: .venv/bin/mypy src/memo
       - name: Runtime smoke
-        run: .venv/bin/memo doctor --strict-runtime
+        # CI legitimately runs from the project .venv, so `--strict-runtime`
+        # (which flags any project-venv install) is unsatisfiable here. Drop it
+        # and point at a throwaway data_dir the runner can create.
+        env:
+          MEMO_DATA_DIR: ${{ runner.temp }}/memo-data
+        run: |
+          mkdir -p "$MEMO_DATA_DIR"
+          .venv/bin/memo doctor
       - name: Real-MLX smoke tests
         run: .venv/bin/python -m pytest tests/test_smoke_mlx.py::test_embedder_produces_unit_vectors tests/test_smoke_mlx.py::test_save_and_search_roundtrip -m requires_mlx --timeout=300 -v
       - name: Installer smoke


### PR DESCRIPTION
## Problema

`macos-smoke` → "Runtime smoke" step (`memo doctor --strict-runtime`) era estructuralmente irrompible:

- `cli_doctor.py:54` marca `ok=False` ante cualquier warning cuando `--strict-runtime`. "running from project venv" siempre es warning, y CI siempre corre desde `.venv` → exit 1 garantizado.
- `data_dir missing` en runner fresco → segundo ✗.

Nunca pudo pasar; master quedaba rojo por esto independiente del código.

## Fix

- Quita `--strict-runtime` del invoke de CI (CI legítimamente corre desde venv; strict-runtime es para installs reales, no CI).
- Crea un `MEMO_DATA_DIR` descartable (`${{ runner.temp }}/memo-data`) antes de `memo doctor`.

Verificado local: `MEMO_DATA_DIR=<tmp> memo doctor` → exit 0 (venv pasa a warning no-gating, data_dir ✓).

## Test plan
- [x] Exit 0 local con data_dir temporal
- [ ] smoke verde en CI (este PR)