### PR TITLE
feat: two-tier sync + identity + outcome loop + gerencial dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ uv run --no-sync memo config validate
 
 ## Architecture
 
-**`Memory` facade** (`src/memo/memory/facade.py`) multiply-inherits six operation mixins — `_WriteOpsMixin`, `_SearchOpsMixin`, `_AskOpsMixin`, `_RerankOpsMixin`, `_RepoOpsMixin`, `_MaintainOpsMixin` — each in their own `src/memo/memory/<op>_ops.py` file. Module-level constants, prompts, and pure helpers are in `src/memo/memory/record.py`. Never import from a mixin directly; always go through `Memory`.
+**`Memory` facade** (`src/memo/memory/facade.py`) multiply-inherits ten operation mixins — `_WriteOpsMixin`, `_UpdateOpsMixin`, `_DeleteOpsMixin`, `_SearchOpsMixin`, `_AskOpsMixin`, `_RerankOpsMixin`, `_RepoOpsMixin`, `_MaintainOpsMixin`, `_ConsolidateOpsMixin`, `_ReplayOpsMixin` — each in their own `src/memo/memory/<op>_ops.py` file. Module-level constants, prompts, and pure helpers are in `src/memo/memory/record.py`. Never import from a mixin directly; always go through `Memory`.
 
 **MCP server** (`src/memo/server.py`) registers tools via `build_server()`. Each domain is a `server_<domain>.py` module that exports `register(server, memory)` — called once in `build_server()`. Adding a new MCP tool = create `src/memo/server_<domain>.py` + add one `register` call in `server.py`. The `_MaintainOpsMixin` method is directly callable from tests via `mock_memory.<method>()`.
 
@@ -36,13 +36,36 @@ uv run --no-sync memo config validate
 
 **CLI** is in `src/memo/cli.py` (entry-point wiring only) + `src/memo/cli_<domain>.py` files. Each domain file exports a Click command or group imported and registered in `cli.py`.
 
-**Flags** (`src/memo/flags.py`) is the single registry for all `MEMO_*` env vars. Use `flag_bool/int/float/str(name)` — never `os.environ.get("MEMO_...")` inline. `memo config validate` parses every set flag.
+**Flags** (`src/memo/flags.py`) is the single registry for all `MEMO_*` env vars — it aggregates `FlagSpec`s defined in the per-domain `flags_<group>.py` modules (`flags_recall/search/behavior/ingest/misc.py`, base types in `flags_base.py`). Add a new flag in the matching `flags_<group>.py`. Use `flag_bool/int/float/str(name)` — never `os.environ.get("MEMO_...")` inline. `memo config validate` parses every set flag.
 
 **Cache** (`src/memo/embedder.py`): query embeddings use shared LRU cache from `consciousness_contracts.cache` when `MEMO_QUERY_CACHE_SIZE > 0`. This eliminates duplication with Synapse's embed cache and ensures consistent cache behavior across the trinity.
 
 **URI helpers** (`src/memo/memory/maintain_ops.py`): backend-native replay uses shared URI parsing/validation from `consciousness_contracts.uri` when available. Fallback to manual parsing for CI/clean installs.
 
-**Sync coordination** (`src/memo/sync.py`): vault sync uses the shared `SyncCoordinator` from `consciousness_contracts` to coordinate with Memflow's git sync and avoid git collisions. State persisted to `.memflow/state/sync_coordinator.json` (via consciousness-contracts default path).
+**Sync — two explicit tiers** (`src/memo/sync_git.py`, `src/memo/identity.py`):
+- **LOCAL (intra-machine):** all sessions on a Mac share one `data_dir`/`memvec.db`
+  (WAL, thread-local conns), so a save/capture is visible to sibling sessions on
+  their next recall **with no git**. `sync_tier(cfg)` → `"local"` when no git
+  remote is configured.
+- **REMOTE (inter-machine):** the git `memo-sync` remote is the only cross-machine
+  channel. `sync_tier(cfg)` → `"remote"`. ONE owner per machine: `sync_once()`
+  takes an `flock` on `state_dir/.sync.lock` (concurrent same-machine sessions
+  skip — their writes ride the lock holder's push) and does
+  **pull-rebase-before-push** so an advanced remote rebases instead of rejecting.
+  Triggers: per-prompt `memo sync auto` (debounced via `MEMO_SYNC_PUSH_DEBOUNCE_S`
+  / `MEMO_SYNC_PULL_INTERVAL_S`, async hook) + `memo sync once` on Stop. A failed
+  push stamps `state_dir/sync_pending` and retries next trigger.
+- **Identity** (`identity.py`): stable `machine_id` (= persisted `cfg.device_id`,
+  also `history.device_id`) + `hostname` (cross-tool match key) + `session_id` +
+  `terminal`. Commits are attributed `[<hostname>·<session>]`. memflow can
+  reference a terminal later; memo only exposes the identity.
+- **Durable capture:** `memo capture-tick` (per-prompt async, self-throttled by
+  `MEMO_CAPTURE_INTERVAL_S`) captures NEW turns since a per-session watermark so a
+  long session's insight reaches `.md` before Stop, not only at Stop.
+- `memo sync status` / `memo doctor` surface the silent no-op (not a clone) and
+  stranded commits. The legacy audit-log replay (`sync.py` `SyncManager`) is the
+  `--remote <path>` fallback; the `SyncCoordinator`/consciousness_contracts hook is
+  not wired (the machine `flock` is the coordinator).
 
 **Memory types** (`src/memo/tiers.py`): durable tier = `decision`, `fact`, `bug`, `feedback`, `preference`, `note`, `manual`, `synthesis`; reference tier = `reference` (bulk-ingested vault chunks, excluded from auto-recall). `synthesis` memories are auto-generated by `memo synthesize` / `MEMO_SYNTHESIS_ENABLED=1 memo maintain` — cross-cluster inferred insights with `synthesis_sources` provenance in their `extra` frontmatter bag.
 
@@ -98,7 +121,7 @@ keep the recall hook under its 5s budget.
 ## BM25 / Spanish search
 
 FTS5's tokenizer wraps each `\w+` token in its own phrase quotes, so a
-multi-token query becomes an AND-of-tokens (not a phrase match). `store/queries.py`
+multi-token query becomes an AND-of-tokens (not a phrase match). `store/bm25_queries.py`
 tokenizes, AND-joins, and falls back to OR only on zero recall. Diacritics are
 folded (`unicode61 remove_diacritics 2`) so "decision" matches "decisión".
 
@@ -188,11 +211,20 @@ Contract for any layer above memo (synapse, memflow, agents):
    session inherits them.
 3. **Respect freshness** — memo's contradiction/freshness state is authoritative
    for durable knowledge; don't reintroduce a fact memo has superseded.
-4. **Identify yourself** — pass `source="<layer>"` (e.g. `synapse`, `memflow`) on
-   the read tools (`memory_search` / `memory_ask` / `memory_chat_ask` /
-   `memory_unified_briefing`). Every consult lands in the shared ring buffer
-   (`recall.log`) tagged with that consumer, so `memo usefulness` proves who
-   actually reads memo — a layer that never appears is flagged as a silent gap.
+4. **Identify yourself** — every read path is attributable, so `memo usefulness`
+   proves who actually reads memo (a layer that never appears is a silent gap):
+   - **MCP tools** — pass `source="<layer>"` on `memory_search` / `memory_ask` /
+     `memory_chat_ask` / `memory_unified_briefing`. If omitted, `log_consult`
+     falls back to `MEMO_SOURCE` then to the MCP client's handshake
+     `clientInfo.name` — so agent clients (devin/opencode/windsurf) attribute
+     automatically without per-call args.
+   - **CLI** (synapse/memflow shell out) — `memo search/ask/chat-ask/recall`
+     take `--source` or read `MEMO_SOURCE` env; a consult logs only when one is
+     set (an interactive `memo search` stays out of the stats). `memo recall`
+     emits `{"results":[...]}` for the memflow bridge.
+   - **Warm socket** — the recall daemon's `{"op":"search","client":"<layer>"}`
+     gives sub-second structured recall (no cold CLI) and attributes the client;
+     this is how memflow reads memo without blowing its latency budget.
 
 memo deliberately keeps cognition OFF its MCP surface
 (`test_brain_like_mcp_tools_are_not_registered`): no `suggest`/`agent`/

--- a/docs/superpowers/specs/2026-06-17-memo-two-tier-sync-and-identity-design.md
+++ b/docs/superpowers/specs/2026-06-17-memo-two-tier-sync-and-identity-design.md
@@ -1,0 +1,95 @@
+# Design: memo two-tier sync (local vs git) + identity + durable capture
+
+**Date:** 2026-06-17
+**Goal:** maximize how much durable knowledge is available to every session — across
+multiple Macs AND multiple concurrent sessions on the same Mac — in the least time,
+without losing info in long sessions.
+
+## Problem (verified in code)
+
+Two distinct bottlenecks, conflated today:
+
+1. **Capture** — durable insight is extracted from the live session into `.md` only on
+   `Stop` (`memo capture-stop`) and on context-overflow snapshots. A long session without
+   a Stop leaves insight only in the live transcript (not in memo). `memory_save` writes
+   `.md` immediately (disk-durable), so explicit saves are safe; ambient insight is the risk.
+2. **Propagation** — captured `.md` reaches other sessions/machines via git (`memo-sync`
+   repo → GitHub), push on Stop, pull on SessionStart.
+
+Gaps found:
+- `device_id` exists+persisted (`state_dir/.device_id`, random uuid) but is NOT wired into
+  the git-sync path and is NOT aligned with memflow's machine identity (trinity disagrees).
+- `SyncCoordinator` mentioned in CLAUDE.md is NOT actually wired in `sync*.py`.
+- No machine-level lock/leader → concurrent same-machine sessions racing `sync push`.
+- `sync_push` does NOT pull-rebase before push → concurrent-machine push rejected → stranded.
+- git push/pull fires per-session unconditionally — same-machine sessions do redundant git
+  even though they already share the local sqlite store.
+
+## Two explicit models
+
+- **LOCAL (intra-machine):** all sessions on a Mac share one `data_dir` + `memvec.db`
+  (WAL, thread-local conns). Capture → visible to sibling sessions on their next recall.
+  NO git. Zero-config, always on.
+- **REMOTE (inter-machine):** the git `memo-sync` remote is the ONLY cross-machine channel,
+  owned by ONE coordinator per machine.
+
+## Sections
+
+### 1. Identity layer — `src/memo/identity.py` (new)
+One unit answering "who am I?", stable + shared:
+- `machine_id`: reuse `consciousness_contracts.identity` (trinity agrees) → fallback to
+  `cfg.device_id` (already persisted) + `hostname` for a human label. Shape `{id, hostname, label}`.
+- `session_id`: the client-supplied id already flowing into recall.log, now first-class.
+- `terminal`: TTY (`os.ttyname`) when available — so memflow can address "terminal X" in
+  future (memo only EXPOSES it; addressing is memflow's job — YAGNI here).
+- Used for: `history.device_id = machine_id` (fix "unknown"), git commit attribution
+  (`sync: <machine> · <session>`), optional provenance stamp in memoria `extra`, and the
+  coordinator's owner identity.
+
+### 2. LOCAL tier explicit
+- Document + test the invariant: intra-machine visibility is via the shared index, never git.
+- `sync_tier(cfg)` helper → `"local"` (always) vs `"remote"` (git remote configured). Collapses
+  the today-implicit, scattered decision into one place.
+- A session never needs to push for a sibling on the same Mac to see its writes.
+
+### 3. Machine-level git coordinator — single owner
+All triggers (per-prompt hook, maint-daemon tick, Stop) call ONE `sync_once(cfg, store, mem)`
+guarded by a machine file lock:
+- **Lock** (`flock` on `state_dir/.sync.lock`): lock holder does git; others skip (their changes
+  are already in the shared store → the leader carries them). Kills same-machine races.
+- **Debounce** (`.sync_auto_ts`, already built): coalesce rapid saves into one push.
+- **pull-rebase-before-push**: `sync_once` = `fetch → rebase --autostash → reindex → push`.
+  Remote-advanced no longer rejects. Real `.md` conflict → abort + `pending` marker (manual).
+- **Commit attributed** to identity.
+- Triggers become thin: hook + Stop just call `sync_once()` async; maint-daemon adds a periodic
+  pull tick calling the same `sync_once()`. No new daemon (reuse existing — option C).
+
+### 4. Durable capture cadence (in scope)
+- Periodic incremental ambient capture: debounced trigger (every `MEMO_CAPTURE_INTERVAL_S` or
+  N turns, async) runs capture over NEW turns since a watermark (last-captured turn) → bounded,
+  no reprocessing. Writes `.md` → picked up by local index + coordinator.
+- Reuses `capture-stop` logic; the watermark makes it incremental.
+
+### 5. Recovery
+- After pull → reindex → in local index. Session uses it via recall hook (every prompt, fresh
+  read), El Briefing (SessionStart), `memory_search/ask`. Mid-session pull → long session
+  converges without restart.
+- Fix: invalidate the query-cache (LRU keyed by query text) when reindex brings changes, else a
+  repeated query could serve stale results.
+- Crash: `.md` already on disk → next SessionStart pull + briefing recovers.
+
+### 6. Errors + testing
+- Errors: lock held → skip (not error); push reject → rebase; real `.md` conflict → `pending` +
+  manual; offline/auth → `pending` + retry; non-clone → local tier only (no error); reindex fail
+  → log + retry next tick.
+- Tests (2 clones + embed stub, no MLX): identity stable + contracts-aligned; `sync_tier`
+  local/remote; `sync_once` pull-rebase-before-push with advanced remote; lock contention
+  (2 procs → 1 does git); incremental capture respects watermark; cache invalidated after pull.
+
+## Reuses existing (uncommitted) work
+`sync status`, `sync auto` (evolves into the lock-guarded `sync_once`), `_pending_marker` +
+stranded-commit retry, `memo doctor` sync line, dashboard sync chip, `MEMO_SYNC_*` flags.
+
+## Out of scope (YAGNI)
+- memflow addressing "terminal X" to assign tasks (memo only EXPOSES identity).
+- Real-time cross-machine push (sub-second); debounce/interval is intentional.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -84,6 +84,20 @@
             "command": "MEMO_NONINTERACTIVE=1 memo session checkpoint",
             "timeout": 5,
             "async": true
+          },
+          {
+            "type": "command",
+            "command": "MEMO_NONINTERACTIVE=1 memo sync auto",
+            "timeout": 90000,
+            "async": true,
+            "comment": "Durable in-session GitHub sync: self-throttled (MEMO_SYNC_PUSH_DEBOUNCE_S / MEMO_SYNC_PULL_INTERVAL_S) so a crashed/long session doesn't strand hours of memorias until Stop, and a long session converges on another Mac's pushes without a restart. Cheap no-op (timestamp check, no git) when not due; soft no-ops on non-git installs. Async so it never touches the recall 5s budget. Disable with MEMO_SYNC_AUTO=0."
+          },
+          {
+            "type": "command",
+            "command": "MEMO_NONINTERACTIVE=1 memo capture-tick",
+            "timeout": 30,
+            "async": true,
+            "comment": "Durable incremental capture: self-throttled (MEMO_CAPTURE_INTERVAL_S, default 600s per session) so a long/crashed session's insight reaches .md mid-session instead of only at Stop. Mines NEW turns since a per-session watermark, reusing capture-stop's extract/dedup/save (bounded, no reprocessing). Cheap no-op (timestamp check, no transcript parse, no MLX) when not due. Async + soft-fail so it never touches the recall 5s budget. Disable with MEMO_CAPTURE_DISABLE=1."
           }
         ]
       }
@@ -112,11 +126,11 @@
           },
           {
             "type": "command",
-            "command": "MEMO_NONINTERACTIVE=1 memo sync push --quiet",
-            "timeout": 60000,
+            "command": "MEMO_NONINTERACTIVE=1 memo sync once --quiet",
+            "timeout": 90000,
             "async": true,
             "statusMessage": "memo: pushing memories cross-Mac…",
-            "comment": "Cross-Mac git push of memorias + signal (F5). Listed last so this session's capture-stop write is more likely already on disk. --quiet soft-fails (exit 0) on non-git installs. A just-captured memoria that loses the race syncs on the next Stop."
+            "comment": "Final flush via the single lock-guarded machine coordinator (pull-rebase-before-push). Listed last so this session's capture-stop write is on disk first. Lock-guarded so it never races the per-prompt `sync auto` or a sibling session. --quiet soft no-ops on local-tier (no remote) installs."
           }
         ]
       }

--- a/src/memo/capture.py
+++ b/src/memo/capture.py
@@ -237,6 +237,40 @@ def _read_last_exchange(transcript_path: Path) -> tuple[str, str] | None:
     return _read_recent_exchanges(transcript_path, n=1)
 
 
+def _parse_exchanges(transcript_path: Path) -> list[tuple[str, str]]:
+    """All (user, assistant) exchanges in chronological order.
+
+    Groups the flat (role, text) stream into ordered turns: consecutive
+    user messages are joined, then the following assistant run is joined,
+    forming one exchange. Only complete exchanges (a user turn followed by
+    an assistant response) are kept.
+
+    Where `_read_recent_exchanges` walks *backward* for the Stop hook's
+    last-N view, this walks *forward* so incremental capture can slice the
+    NEW turns since a per-session watermark (`exchanges[watermark:]`).
+    """
+    parsed = _parse_transcript(transcript_path)
+    exchanges: list[tuple[str, str]] = []
+    i = 0
+    n = len(parsed)
+    while i < n:
+        while i < n and parsed[i][0] != "user":
+            i += 1
+        if i >= n:
+            break
+        u_chunks: list[str] = []
+        while i < n and parsed[i][0] == "user":
+            u_chunks.append(parsed[i][1])
+            i += 1
+        a_chunks: list[str] = []
+        while i < n and parsed[i][0] == "assistant":
+            a_chunks.append(parsed[i][1])
+            i += 1
+        if a_chunks:  # complete exchange only (has an assistant response)
+            exchanges.append(("\n\n".join(u_chunks), "\n\n".join(a_chunks)))
+    return exchanges
+
+
 def _extract_text(content: Any) -> str:
     """Pull the plain text out of a Claude Code message content. Skips
     tool_use blocks, tool_result blocks, image blocks. Concatenates all
@@ -399,6 +433,71 @@ def is_near_duplicate(
     return top_score is not None and top_score >= threshold
 
 
+def _extract_and_save(
+    mem: Any,
+    cfg: Any,
+    user_text: str,
+    assistant_text: str,
+    *,
+    debug: bool = False,
+) -> dict[str, Any]:
+    """Extract insights from one (user, assistant) blob, dedup, save.
+
+    Shared by the Stop-hook (`run_capture`) and the incremental
+    (`run_capture_incremental`) paths so both apply the same quality
+    gate, near-duplicate check, and save metadata. Returns counts; every
+    per-candidate failure is absorbed (logged only in debug)."""
+    insights = extract_insights(
+        mem._ensure_chat(),
+        cfg.helper_model,
+        user_text,
+        assistant_text,
+    )
+    if debug:
+        print(f"# memo capture: {len(insights)} candidate(s)", file=sys.stderr)
+
+    saved: list[str] = []
+    skipped_dup = 0
+    skipped_quality = 0
+    for cand in insights:
+        # Quality gate: skip low-specificity memories before hitting the
+        # embedder or disk. Threshold controlled by MEMO_CAPTURE_MIN_WORDS.
+        body_for_quality = f"{cand['title']}\n\n{cand['body']}"
+        if not _passes_quality(body_for_quality):
+            skipped_quality += 1
+            if debug:
+                print(
+                    f"# memo capture: skip quality '{cand['title']}'",
+                    file=sys.stderr,
+                )
+            continue
+        if is_near_duplicate(mem, cand):
+            skipped_dup += 1
+            if debug:
+                print(f"# memo capture: skip dup '{cand['title']}'", file=sys.stderr)
+            continue
+        try:
+            rec = mem.save(
+                content=cand["body"],
+                title=cand["title"],
+                type_=cand["type"],
+                tags=cand["tags"],
+            )
+            saved.append(rec.id)
+            if debug:
+                print(f"# memo capture: saved [{rec.id[:8]}] {rec.title}", file=sys.stderr)
+        except Exception as exc:
+            if debug:
+                print(f"# memo capture: save failed: {exc}", file=sys.stderr)
+
+    return {
+        "candidates": len(insights),
+        "saved": saved,
+        "skipped_dup": skipped_dup,
+        "skipped_quality": skipped_quality,
+    }
+
+
 def run_capture(
     transcript_path: Path,
     *,
@@ -460,57 +559,133 @@ def run_capture(
 
     # Lazy heavy imports: only paid past pre-filter.
     mem = Memory(cfg)
-    insights = extract_insights(
-        mem._ensure_chat(),
-        cfg.helper_model,
-        user_text,
-        assistant_text,
-    )
-    if debug:
-        print(f"# memo capture: {len(insights)} candidate(s)", file=sys.stderr)
-
-    saved: list[str] = []
-    skipped_dup = 0
-    skipped_quality = 0
-    for cand in insights:
-        # Quality gate: skip low-specificity memories before hitting the
-        # embedder or disk. Threshold controlled by MEMO_CAPTURE_MIN_WORDS.
-        body_for_quality = f"{cand['title']}\n\n{cand['body']}"
-        if not _passes_quality(body_for_quality):
-            skipped_quality += 1
-            if debug:
-                print(
-                    f"# memo capture: skip quality '{cand['title']}'",
-                    file=sys.stderr,
-                )
-            continue
-        if is_near_duplicate(mem, cand):
-            skipped_dup += 1
-            if debug:
-                print(f"# memo capture: skip dup '{cand['title']}'", file=sys.stderr)
-            continue
-        try:
-            rec = mem.save(
-                content=cand["body"],
-                title=cand["title"],
-                type_=cand["type"],
-                tags=cand["tags"],
-            )
-            saved.append(rec.id)
-            if debug:
-                print(f"# memo capture: saved [{rec.id[:8]}] {rec.title}", file=sys.stderr)
-        except Exception as exc:
-            if debug:
-                print(f"# memo capture: save failed: {exc}", file=sys.stderr)
+    result = _extract_and_save(mem, cfg, user_text, assistant_text, debug=debug)
 
     state["last_hash"] = h
-    if saved:
+    if result["saved"]:
         state["last_save_ts"] = time.time()
     _save_state(cfg.state_dir, state)
-    return {
-        "status": "ok",
-        "candidates": len(insights),
-        "saved": saved,
-        "skipped_dup": skipped_dup,
-        "skipped_quality": skipped_quality,
-    }
+    return {"status": "ok", **result}
+
+
+# ── Incremental capture (mid-session) ───────────────────────────────────────
+#
+# The Stop hook only fires once, at session end. A long-running session can
+# accumulate hours of durable insight that never reaches `.md` (and thus the
+# local index + git sync) until Stop — and is lost entirely on a crash.
+#
+# Incremental capture closes that gap: a periodic, self-throttled pass mines
+# only the NEW turns since a per-session watermark, reusing the exact
+# extract → quality → dedup → save pipeline above. The watermark
+# (`state_dir/.capture_watermark/<session_id>.json`) records how many
+# (user, assistant) exchanges have been processed, so each pass is bounded to
+# the turns added since the last pass and old turns are never reprocessed.
+
+
+def _watermark_file(state_dir: Path, session_id: str) -> Path:
+    # session_id is a Claude Code UUID — filename-safe, matching how
+    # session.py keys its per-session JSON files.
+    return state_dir / ".capture_watermark" / f"{session_id}.json"
+
+
+def _load_watermark(state_dir: Path, session_id: str) -> dict[str, Any]:
+    """Per-session watermark, or {} on missing/corrupt (so a clobbered or
+    hand-edited file degrades to a fresh full pass, never a crash)."""
+    f = _watermark_file(state_dir, session_id)
+    if not f.is_file():
+        return {}
+    try:
+        data = json.loads(f.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_watermark(state_dir: Path, session_id: str, watermark: dict[str, Any]) -> None:
+    f = _watermark_file(state_dir, session_id)
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(json.dumps(watermark), encoding="utf-8")
+
+
+def incremental_tick_due(state_dir: Path, session_id: str, interval_s: int) -> bool:
+    """True if at least `interval_s` seconds elapsed since this session's last
+    incremental pass (the watermark `updated` stamp).
+
+    Cheap by design — a small JSON read, no transcript parse and no Memory /
+    MLX — so the per-prompt hook can call it on every prompt and bail when not
+    due. `interval_s <= 0` disables the throttle (always due)."""
+    if interval_s <= 0:
+        return True
+    import time
+
+    wm = _load_watermark(state_dir, session_id)
+    try:
+        last = float(wm.get("updated", 0) or 0)
+    except (TypeError, ValueError):
+        last = 0.0
+    return (time.time() - last) >= interval_s
+
+
+def run_capture_incremental(
+    transcript_path: Path,
+    session_id: str,
+    *,
+    debug: bool = False,
+) -> dict[str, Any]:
+    """Mine only NEW turns since this session's watermark, then advance it.
+
+    Reuses the Stop-hook extract/dedup/save pipeline (`_extract_and_save`);
+    the watermark is what makes it incremental. Bounded to the exchanges added
+    since the previous pass; old turns are never reprocessed. Self-throttling
+    is the caller's job (`incremental_tick_due`) — this always processes what
+    is new. Soft-fail: returns a status dict, never raises.
+
+    Statuses: ``no_pair`` (empty/unreadable transcript), ``no_new`` (watermark
+    already current), ``no_trigger`` (new turns but no insight keyword), ``ok``.
+    """
+    import time
+
+    from memo.config import Config
+    from memo.memory import Memory
+
+    cfg = Config.from_env()
+    exchanges = _parse_exchanges(transcript_path)
+    if not exchanges:
+        return {"status": "no_pair"}
+
+    total = len(exchanges)
+    wm = _load_watermark(cfg.state_dir, session_id)
+    try:
+        start = int(wm.get("exchange_count", 0) or 0)
+    except (TypeError, ValueError):
+        start = 0
+    # A corrupt / stale watermark must never skip the tail or go negative:
+    # clamp out-of-range values to a full re-pass rather than silently
+    # dropping turns.
+    if start < 0 or start > total:
+        start = 0
+
+    def _stamp() -> None:
+        _save_watermark(
+            cfg.state_dir,
+            session_id,
+            {"session_id": session_id, "exchange_count": total, "updated": time.time()},
+        )
+
+    new = exchanges[start:]
+    if not new:
+        _stamp()  # refresh `updated` so the throttle clock advances
+        return {"status": "no_new", "exchange_count": total}
+
+    combined_user = "\n\n---\n\n".join(u for u, _ in new)
+    combined_assistant = "\n\n---\n\n".join(a for _, a in new)
+
+    if not _passes_prefilter(combined_assistant):
+        # Advance past these triggerless turns so we don't re-scan them.
+        _stamp()
+        return {"status": "no_trigger", "exchange_count": total}
+
+    mem = Memory(cfg)
+    result = _extract_and_save(mem, cfg, combined_user, combined_assistant, debug=debug)
+    _stamp()
+    return {"status": "ok", "processed_turns": len(new), "exchange_count": total, **result}

--- a/src/memo/cli.py
+++ b/src/memo/cli.py
@@ -32,7 +32,7 @@ from memo.cli_as_of import as_of_group
 from memo.cli_backend_native import backend_native_group
 from memo.cli_backup import backup_group
 from memo.cli_briefing import briefing
-from memo.cli_capture import capture_stop, resume
+from memo.cli_capture import capture_stop, capture_tick, resume
 from memo.cli_chat import chat_group
 from memo.cli_collaborative import collaborative_group
 from memo.cli_common import console
@@ -77,6 +77,8 @@ from memo.cli_memory import (
     update,
 )
 from memo.cli_multimodal import multimodal_group
+from memo.cli_outcome import gaps as gaps_cmd
+from memo.cli_outcome import outcome as outcome_cmd
 from memo.cli_profile import profile_group
 from memo.cli_query import query_group
 from memo.cli_recall_daemon import recall_daemon_group
@@ -97,7 +99,7 @@ from memo.cli_runtime import (
     uninstall_watcher_cmd,
     watch,
 )
-from memo.cli_search import ask, chat_ask, embed_cmd, rerank_cmd, search
+from memo.cli_search import ask, chat_ask, embed_cmd, recall, rerank_cmd, search
 from memo.cli_session import continuity_cmd, session_group
 from memo.cli_share import share_group
 from memo.cli_stats import stats
@@ -115,7 +117,23 @@ from memo.cli_viz import mapa_cmd
 from memo.setup import run_picker, write_config_file
 
 
-@click.group()
+class SurfaceGroup(click.Group):
+    """Root Click group that filters commands by the configured surface profile."""
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        from memo.surface import cli_command_visible
+
+        return [name for name in super().list_commands(ctx) if cli_command_visible(name)]
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        from memo.surface import cli_command_visible
+
+        if not cli_command_visible(cmd_name):
+            return None
+        return super().get_command(ctx, cmd_name)
+
+
+@click.group(cls=SurfaceGroup)
 @click.version_option(package_name="mlx-memo")
 @click.pass_context
 def cli(ctx: click.Context) -> None:
@@ -136,6 +154,8 @@ cli.add_command(synthesize_cmd)
 cli.add_command(retier_cmd)
 cli.add_command(usefulness_cmd)
 cli.add_command(roi_cmd)
+cli.add_command(gaps_cmd)
+cli.add_command(outcome_cmd)
 cli.add_command(mandate_cmd)
 cli.add_command(mapa_cmd)
 cli.add_command(tui)
@@ -144,6 +164,7 @@ cli.add_command(logs)
 cli.add_command(mine_history)
 cli.add_command(ingest)
 cli.add_command(capture_stop)
+cli.add_command(capture_tick)
 cli.add_command(reflect)
 cli.add_command(resume)
 cli.add_command(diff_cmd)
@@ -168,6 +189,7 @@ cli.add_command(install_shell_wrapper)
 cli.add_command(config_group)
 cli.add_command(save)
 cli.add_command(search)
+cli.add_command(recall)
 cli.add_command(ask)
 cli.add_command(embed_cmd)
 cli.add_command(chat_ask)
@@ -237,6 +259,7 @@ _FIRST_RUN_GATE_SKIP_COMMANDS = {
     "recall-hook",
     "recall-daemon",
     "capture-stop",
+    "capture-tick",
     "session",
     "ingest",
     "historia",
@@ -258,9 +281,11 @@ def _first_run_gate(ctx: click.Context) -> None:
     """
     import sys as _sys
 
+    from memo.flags import flag_bool
+
     if ctx.invoked_subcommand in (None, *_FIRST_RUN_GATE_SKIP_COMMANDS):
         return
-    if os.environ.get("MEMO_NONINTERACTIVE") == "1":
+    if flag_bool("MEMO_NONINTERACTIVE"):
         return
     # Both stdin and stdout must be a TTY for the picker to make sense.
     if not (_sys.stdin.isatty() and _sys.stdout.isatty()):

--- a/src/memo/cli_capture.py
+++ b/src/memo/cli_capture.py
@@ -93,6 +93,102 @@ def capture_stop() -> None:
     _sys.exit(0)
 
 
+@click.command(name="capture-tick")
+@click.option(
+    "--session-id",
+    default=None,
+    help="Override session_id (default: read from the hook stdin payload).",
+)
+@click.option(
+    "--transcript-path",
+    default=None,
+    help="Override transcript path (default: read from the hook stdin payload).",
+)
+def capture_tick(session_id: str | None, transcript_path: str | None) -> None:
+    """UserPromptSubmit hook — incremental mid-session ambient capture.
+
+    The Stop hook (`memo capture-stop`) only fires at session end, so a long
+    or crashed session's durable insight never reaches `.md` (and thus the
+    local index + git sync) until Stop. This mines the NEW turns since a
+    per-session watermark into memorias — reusing capture-stop's
+    extract/dedup/save pipeline — so durable knowledge lands on disk
+    mid-session, not only at the end.
+
+    Hook input (stdin, JSON): Claude Code passes
+    `{"session_id", "transcript_path", ...}` on UserPromptSubmit. Falls back
+    to the flags for manual runs.
+
+    Hook output (stdout): `{}` — always. Capture is silent.
+
+    Self-throttled per session via ``MEMO_CAPTURE_INTERVAL_S`` (default 600s),
+    measured off the watermark's ``updated`` stamp — so firing on every prompt
+    is a cheap no-op when not due (a small JSON read, no transcript parse and
+    no MLX). Bounded: each due pass processes only the turns added since the
+    previous pass; the watermark guarantees old turns are never reprocessed.
+
+    Intended hook wiring (UserPromptSubmit, async, soft-fail):
+
+        MEMO_NONINTERACTIVE=1 memo capture-tick
+
+    Env vars:
+      MEMO_CAPTURE_DISABLE     — "1" → no-op (shared with capture-stop).
+      MEMO_CAPTURE_INTERVAL_S  — min seconds between ticks per session
+                                 (default 600; 0 = every prompt, no throttle).
+      MEMO_CAPTURE_DEBUG       — "1" → print progress to stderr.
+
+    Failure modes are absorbed: the hook never blocks or breaks the session.
+    """
+    import json as _json
+    import sys as _sys
+
+    from memo.flags import flag_bool, flag_int
+
+    if flag_bool("MEMO_CAPTURE_DISABLE"):
+        print("{}")
+        _sys.exit(0)
+
+    debug = flag_bool("MEMO_CAPTURE_DEBUG")
+
+    payload: dict = {}
+    # Stdin is a TTY when run interactively → don't block on a read.
+    if not _sys.stdin.isatty():
+        try:
+            raw = _sys.stdin.read()
+            if raw.strip():
+                payload = _json.loads(raw)
+        except _json.JSONDecodeError:
+            payload = {}
+
+    sid = session_id or payload.get("session_id")
+    transcript = transcript_path or payload.get("transcript_path")
+    if not sid or not transcript:
+        # Without both we can't key the watermark or read the turns — no-op.
+        print("{}")
+        _sys.exit(0)
+
+    try:
+        from memo.capture import incremental_tick_due, run_capture_incremental
+
+        cfg = Config.from_env()
+        interval_s = flag_int("MEMO_CAPTURE_INTERVAL_S")
+        if interval_s is None:
+            interval_s = 600
+
+        if not incremental_tick_due(cfg.state_dir, sid, interval_s):
+            if debug:
+                print("# memo capture-tick: throttled (not due)", file=_sys.stderr)
+        else:
+            out = run_capture_incremental(Path(transcript), sid, debug=debug)
+            if debug:
+                print(f"# memo capture-tick: {out}", file=_sys.stderr)
+    except Exception as exc:
+        if debug:
+            print(f"# memo capture-tick failed: {exc}", file=_sys.stderr)
+
+    print("{}")
+    _sys.exit(0)
+
+
 # ── Session reflection (v0.5.0) ─────────────────────────────────────────────
 #
 # `memo reflect` — read a full session transcript, extract durable insights

--- a/src/memo/cli_common.py
+++ b/src/memo/cli_common.py
@@ -28,6 +28,49 @@ def get_memory(cfg: Config) -> Any:
     return Memory(cfg)
 
 
+def log_cli_consult(
+    cfg: Config,
+    *,
+    verb: str,
+    query: str,
+    hits: list[dict[str, Any]] | None,
+    t0_ms: int,
+    source: str | None = None,
+) -> None:
+    """Attribute a CLI read (search / ask / chat-ask / recall) to a consumer.
+
+    Mirrors the MCP server's ``log_consult`` for the subprocess path: trinity
+    layers (synapse, memflow, …) shell out to the ``memo`` CLI, so without this
+    their consults never reach the recall ring buffer and they show up as
+    "silent" in ``memo usefulness`` even though they DO read memo.
+
+    Logs ONLY when a source is provided — via ``--source`` or the ``MEMO_SOURCE``
+    env var. A bare interactive ``memo search`` by the developer carries no
+    source and is intentionally NOT counted, so the usefulness stats stay clean.
+    """
+    from memo.flags import flag_str
+
+    src = (source or flag_str("MEMO_SOURCE") or "").strip().lower()
+    if not src:
+        return
+    try:
+        import time
+
+        from memo.dashboard import append_recall_log
+
+        append_recall_log(
+            cfg.state_dir,
+            prompt=query or "",
+            hits=hits or [],
+            via=f"cli:{verb}",
+            source=src,
+            latency_ms=int(time.time() * 1000) - t0_ms,
+        )
+    except Exception:
+        # Telemetry must never break a read command.
+        pass
+
+
 def _short(text: str, n: int = 120) -> str:
     """Collapse whitespace and truncate `text` to `n` chars with an ellipsis."""
     text = (text or "").strip().replace("\n", " ")

--- a/src/memo/cli_doctor.py
+++ b/src/memo/cli_doctor.py
@@ -135,6 +135,31 @@ def doctor(do_gc: bool, fix: bool, check_db: bool, strict_runtime: bool, as_json
             "[dim](`memo recall-daemon start` to enable warm recall)[/dim]"
         )
 
+    # GitHub sync health — surfaces the silent no-op (data_dir not a git clone)
+    # and stranded commits (committed locally but never pushed).
+    from memo.sync_git import sync_status as _sync_status
+
+    sync = _sync_status(cfg)
+    if not sync.get("is_git_clone"):
+        console.print(
+            "[dim]•[/dim] github sync: OFF "
+            "[dim](data_dir not a git clone — `memo sync bootstrap <url>` to enable)[/dim]"
+        )
+    elif sync.get("pending"):
+        console.print(
+            f"[red]✗[/red] github sync: STRANDED — local commit(s) not pushed "
+            f"(ahead {sync['ahead']}); offline/auth? next `memo sync push` retries"
+        )
+    elif sync.get("ahead") or sync.get("dirty_files"):
+        console.print(
+            f"[yellow]![/yellow] github sync: {sync['ahead']} unpushed, "
+            f"{sync['dirty_files']} uncommitted (auto-syncs in-session / on Stop)"
+        )
+    else:
+        console.print(
+            f"[green]✓[/green] github sync: up to date ({sync.get('remote') or 'no remote'})"
+        )
+
     if check_db:
         for db in _db_health_report(cfg):
             marker = "[green]✓[/green]" if db["ok"] else "[red]✗[/red]"

--- a/src/memo/cli_ingest.py
+++ b/src/memo/cli_ingest.py
@@ -130,7 +130,6 @@ def ingest(
     pattern per line, `#` comments allowed) — the durable way to drop a
     folder like `04-Archive/` without editing the launchd ingest command.
     """
-    import os as _os_min
     from pathlib import Path
 
     import frontmatter
@@ -280,9 +279,11 @@ def ingest(
             if row["path"] not in valid_paths and store.delete(row["id"]):
                 pruned += 1
 
-    min_chars = int(_os_min.environ.get("MEMO_INGEST_MIN_CHARS", "200"))
-    strict_mode = _os_min.environ.get("MEMO_INGEST_STRICT") == "1"
-    debug_mode = _os_min.environ.get("MEMO_INGEST_DEBUG") == "1"
+    from memo.flags import flag_bool, flag_int
+
+    min_chars = flag_int("MEMO_INGEST_MIN_CHARS") or 200
+    strict_mode = flag_bool("MEMO_INGEST_STRICT")
+    debug_mode = flag_bool("MEMO_INGEST_DEBUG")
 
     from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeRemainingColumn
 

--- a/src/memo/cli_maintain.py
+++ b/src/memo/cli_maintain.py
@@ -34,7 +34,7 @@ import click
 from memo.cli_common import console
 from memo.cli_common import get_memory as _get_memory
 from memo.config import Config
-from memo.flags import flag_bool
+from memo.flags import flag_bool, flag_int
 
 _log = logging.getLogger(__name__)
 
@@ -189,6 +189,8 @@ def maintain_cmd(
         "archived_stale": [],
         "synthesized": [],  # emergent cross-memory insights generated
         "synthesis_count": 0,  # new clusters synthesized by proactive pass
+        "outcome_reconciled": 0,  # memorias whose roi_score was re-derived from outcomes
+        "dead_archived": [],  # surfaced-never-grounded memorias soft-forgotten
         "errors": [],
     }
 
@@ -313,6 +315,32 @@ def maintain_cmd(
             _log.warning("maintain: proactive synthesis failed (non-fatal): %s", exc)
             receipt["errors"].append(f"maint_synthesize: {type(exc).__name__}: {exc}")
 
+    # 6. Outcome loop (opt-in: MEMO_OUTCOME_RANKING_ENABLED=1) ----------------
+    # Self-tuning recall: re-derive roi_score from real grounding outcomes (was
+    # the surfaced memoria USED in the answer?) so ranking promotes what helps,
+    # and reversibly archive dead weight (surfaced often, never grounded). Pure
+    # derivation over the recall/grounding logs + one roi write.
+    if flag_bool("MEMO_OUTCOME_RANKING_ENABLED"):
+        try:
+            from memo.outcome import compute_utilities, dead_weight, reconcile_roi
+
+            min_surfaced = flag_int("MEMO_OUTCOME_DEAD_MIN_SURFACED") or 0
+            dead = dead_weight(mem, min_surfaced=min_surfaced)
+            if dry_run:
+                receipt["outcome_reconciled"] = len(
+                    compute_utilities(cfg.state_dir)["by_prefix"]
+                )
+                receipt["dead_archived"] = [d["id"] for d in dead]
+            else:
+                receipt["outcome_reconciled"] = reconcile_roi(mem).get("updated", 0)
+                for d in dead:
+                    if mem.forget(
+                        d["id"], reason=f"outcome: surfaced {d['surfaced']}x sin grounding"
+                    ) is not None:
+                        receipt["dead_archived"].append(d["id"])
+        except Exception as exc:
+            receipt["errors"].append(f"outcome: {type(exc).__name__}: {exc}")
+
     # Persist receipt + timestamp (the daily guard reads the timestamp). Even
     # a dry-run stamps so a preview doesn't immediately re-trigger; the guard
     # cares only about "ran recently".
@@ -349,6 +377,11 @@ def maintain_cmd(
         )
     if receipt.get("synthesis_count"):
         console.print(f"  synthesis: {receipt['synthesis_count']} new clusters synthesized")
+    if receipt.get("outcome_reconciled") or receipt.get("dead_archived"):
+        console.print(
+            f"  outcome loop: roi_score re-derived for {receipt['outcome_reconciled']} "
+            f"memorias, {len(receipt['dead_archived'])} dead-weight archived"
+        )
     if receipt["errors"]:
         for e in receipt["errors"]:
             console.print(f"  [yellow]warn:[/yellow] {e}")

--- a/src/memo/cli_outcome.py
+++ b/src/memo/cli_outcome.py
@@ -1,0 +1,111 @@
+"""`memo gaps` + `memo outcome` — The Outcome Loop CLI surface.
+
+``memo gaps``     — knowledge-seeking prompts memo could NOT answer (what to
+                    capture next). Pure read over recall.log + grounding.log.
+``memo outcome``  — reconcile memory_health.roi_score from real grounding
+                    outcomes (promote memorias that ground answers, demote ones
+                    that surface but never help). The single write in the loop.
+"""
+
+from __future__ import annotations
+
+import json as _json
+
+import click
+
+from .config import Config
+
+
+@click.command(name="gaps")
+@click.option("--limit", default=2000, show_default=True, help="Recall-log rows to scan.")
+@click.option("--min-count", default=1, show_default=True, help="Minimum cluster size to report.")
+@click.option("--top", default=20, show_default=True, help="Max gap clusters to show.")
+@click.option("--json", "as_json", is_flag=True, help="Machine-readable output.")
+def gaps(*, limit: int, min_count: int, top: int, as_json: bool) -> None:
+    """What memo could NOT answer — knowledge gaps to fill."""
+    from .outcome import detect_gaps
+
+    cfg = Config.from_env()
+    found = detect_gaps(cfg.state_dir, limit=limit, min_count=min_count)
+
+    if as_json:
+        click.echo(_json.dumps(found[:top], ensure_ascii=False, indent=2))
+        return
+    if not found:
+        click.echo("Sin vacíos detectados — memo respondió todo lo que se le preguntó. ✅")
+        return
+    click.echo(f"memo gaps — {len(found)} tema(s) que memo no pudo responder\n")
+    click.echo(f"  {'veces':>5}  {'motivo':<30} pregunta")
+    click.echo("  " + "-" * 78)
+    for g in found[:top]:
+        reason = ", ".join(g["reasons"])[:30]
+        prompt = (g["prompt"] or "")[:60]
+        click.echo(f"  {g['count']:>5}  {reason:<30} {prompt}")
+    click.echo("\nCapturá estos temas con `memo save` para que dejen de ser vacíos.")
+
+
+@click.command(name="outcome")
+@click.option("--apply", "do_apply", is_flag=True, help="Write the reconciled roi_score (default: dry-run).")
+@click.option(
+    "--archive-dead",
+    is_flag=True,
+    help="Also reversibly forget dead-weight memorias (surfaced ≥ "
+    "MEMO_OUTCOME_DEAD_MIN_SURFACED times, never grounded). Reverse with `memo unforget`.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Machine-readable output.")
+def outcome(*, do_apply: bool, archive_dead: bool, as_json: bool) -> None:
+    """Reconcile roi_score from real grounding outcomes (the learning step)."""
+    from .flags import flag_bool, flag_int
+    from .memory import Memory
+    from .outcome import compute_utilities, dead_weight, reconcile_roi
+
+    cfg = Config.from_env()
+    min_surfaced = flag_int("MEMO_OUTCOME_DEAD_MIN_SURFACED") or 8
+
+    if not do_apply:
+        u = compute_utilities(cfg.state_dir)
+        scored = len(u["by_prefix"])
+        helpful = sum(1 for v in u["by_prefix"].values() if v["grounded"] > 0)
+        mem = Memory(cfg)
+        dead = dead_weight(mem, min_surfaced=min_surfaced)
+        if as_json:
+            click.echo(_json.dumps({"dry_run": True, "dead_weight": dead, **u}, ensure_ascii=False, indent=2))
+            return
+        click.echo(
+            f"outcome (dry-run) — {scored} memorias con historial; "
+            f"{helpful} aterrizaron ≥1 respuesta; baseline grounded={u['prior_mean']}."
+        )
+        if dead:
+            click.echo(
+                f"  peso muerto: {len(dead)} memoria(s) surfaceadas >={min_surfaced}x sin "
+                f"aterrizar nunca (candidatas a archivar con --apply --archive-dead)."
+            )
+        click.echo("Corré con --apply para escribir roi_score desde estos outcomes.")
+        if not flag_bool("MEMO_OUTCOME_RANKING_ENABLED"):
+            click.echo(
+                "Nota: MEMO_OUTCOME_RANKING_ENABLED está OFF — el ranking sigue usando "
+                "el roi por acceso. Activalo para que estos outcomes manden."
+            )
+        return
+
+    mem = Memory(cfg)
+    res = reconcile_roi(mem)
+    archived: list[str] = []
+    if archive_dead:
+        for d in dead_weight(mem, min_surfaced=min_surfaced):
+            if mem.forget(d["id"], reason=f"outcome: surfaced {d['surfaced']}x sin grounding") is not None:
+                archived.append(d["id"])
+    if as_json:
+        click.echo(_json.dumps({**res, "archived": archived}, ensure_ascii=False, indent=2))
+        return
+    click.echo(
+        f"outcome aplicado — roi_score actualizado para {res['updated']} memoria(s) "
+        f"(baseline grounded={res['prior_mean']}, rango [{res['floor']},{res['cap']}])."
+    )
+    if archive_dead:
+        click.echo(f"  peso muerto archivado (reversible con `memo unforget`): {len(archived)}")
+    if not flag_bool("MEMO_OUTCOME_RANKING_ENABLED"):
+        click.echo(
+            "Nota: MEMO_OUTCOME_RANKING_ENABLED está OFF — escribí roi_score pero el "
+            "boost-por-acceso lo va a re-pisar. Activá el flag para que mande el outcome."
+        )

--- a/src/memo/cli_roi.py
+++ b/src/memo/cli_roi.py
@@ -32,6 +32,10 @@ def _secs(env: str, default: int) -> int:
     return flag_int(env) or default
 
 
+# Rough chars→tokens ratio for English/Spanish prose (OpenAI/Anthropic ~4).
+_CHARS_PER_TOKEN = 4
+
+
 def _fmt_duration(seconds: float) -> str:
     seconds = int(seconds)
     if seconds < 90:
@@ -39,6 +43,15 @@ def _fmt_duration(seconds: float) -> str:
     if seconds < 5400:
         return f"{seconds / 60:.0f}m"
     return f"{seconds / 3600:.1f}h"
+
+
+def _fmt_tokens(tokens: float) -> str:
+    tokens = int(tokens)
+    if tokens < 1000:
+        return f"{tokens}"
+    if tokens < 1_000_000:
+        return f"{tokens / 1000:.1f}k"
+    return f"{tokens / 1_000_000:.2f}M"
 
 
 def compute_roi(state_dir, *, limit: int = 500, window_turns: int = 4) -> dict:
@@ -67,6 +80,21 @@ def compute_roi(state_dir, *, limit: int = 500, window_turns: int = 4) -> dict:
     secs_reask = _secs("MEMO_ROI_SECS_PER_REASK", 120)
     time_saved_s = grounded_total * secs_grounded + reask_avoided * secs_reask
 
+    # Tokens saved: same ledger as time, different unit. A grounded recall hands
+    # the model a fact it would otherwise re-derive; an avoided re-ask spares a
+    # whole answer-regeneration round-trip. Per-unit estimates are flag-tunable;
+    # the measured avg answer size is reported alongside so the number is
+    # transparent, not magic.
+    tok_grounded = _secs("MEMO_ROI_TOKENS_PER_GROUNDED", 350)
+    tok_reask = _secs("MEMO_ROI_TOKENS_PER_REASK", 900)
+    tokens_saved = grounded_total * tok_grounded + reask_avoided * tok_reask
+    answer_lens = [
+        int(g["answer_len"]) for g in read_grounding_log(state_dir) if g.get("answer_len")
+    ]
+    avg_answer_tokens = (
+        round(sum(answer_lens) / len(answer_lens) / _CHARS_PER_TOKEN) if answer_lens else None
+    )
+
     return {
         "grounded_rate": health.get("grounded_rate"),
         "grounded": grounded_total,
@@ -77,6 +105,11 @@ def compute_roi(state_dir, *, limit: int = 500, window_turns: int = 4) -> dict:
         "time_saved_human": _fmt_duration(time_saved_s),
         "secs_per_grounded": secs_grounded,
         "secs_per_reask": secs_reask,
+        "tokens_saved": tokens_saved,
+        "tokens_saved_human": _fmt_tokens(tokens_saved),
+        "tokens_per_grounded": tok_grounded,
+        "tokens_per_reask": tok_reask,
+        "avg_answer_tokens": avg_answer_tokens,
         "by_consumer": breakdown["consumers"],
         "silent": breakdown["silent"],
         "actions_by_client": actions,
@@ -119,6 +152,12 @@ def roi(*, limit: int = 500, window_turns: int = 4, as_json: bool = False) -> No
     click.echo(
         f"  estimated time    ~{data['time_saved_human']} saved "
         f"(est: {data['secs_per_grounded']}s/grounded + {data['secs_per_reask']}s/re-ask avoided)"
+    )
+    avg_tok = data.get("avg_answer_tokens")
+    avg_note = f", medido ~{avg_tok} tok/respuesta" if avg_tok else ""
+    click.echo(
+        f"  estimated tokens  ~{data['tokens_saved_human']} saved "
+        f"(est: {data['tokens_per_grounded']}/grounded + {data['tokens_per_reask']}/re-ask{avg_note})"
     )
 
     # Per-client value table.

--- a/src/memo/cli_search.py
+++ b/src/memo/cli_search.py
@@ -13,9 +13,26 @@ import click
 from rich.panel import Panel
 from rich.table import Table
 
-from memo.cli_common import console
+from memo.cli_common import console, log_cli_consult
 from memo.cli_common import get_memory as _get_memory
 from memo.config import Config
+
+
+def _sources_as_hits(out: dict) -> list[dict]:
+    """Map an ask/chat-ask answer envelope's ``sources`` to recall-log hit dicts
+    so the consult records which memorias backed the answer."""
+    hits: list[dict] = []
+    for s in out.get("sources") or []:
+        if not isinstance(s, dict):
+            continue
+        hits.append(
+            {
+                "id": s.get("id") or s.get("id_short") or "",
+                "score": s.get("score"),
+                "title": s.get("title") or "",
+            }
+        )
+    return hits
 
 
 @click.command()
@@ -39,6 +56,12 @@ from memo.config import Config
     "--mode hybrid.",
 )
 @click.option("--json", "as_json", is_flag=True)
+@click.option(
+    "--source",
+    default=None,
+    help="Identify the calling layer (synapse / memflow / …) so the consult is "
+    "attributed in `memo usefulness`. Falls back to the MEMO_SOURCE env var.",
+)
 def search(
     query: str,
     limit: int,
@@ -46,9 +69,11 @@ def search(
     mode: str,
     use_rerank: bool | None,
     as_json: bool,
+    source: str | None,
 ) -> None:
     """Top-k search — hybrid (semantic + keyword) by default."""
     import os
+    import time
 
     # Apply --rerank / --no-rerank override before Config.from_env() reads it.
     if use_rerank is True:
@@ -56,11 +81,15 @@ def search(
     elif use_rerank is False:
         os.environ["MEMO_RERANKER_ENABLED"] = "0"
 
-    mem = _get_memory(Config.from_env())
+    cfg = Config.from_env()
+    mem = _get_memory(cfg)
     disable_reranker = use_rerank is False
+    t0 = int(time.time() * 1000)
     hits = mem.search(query, limit=limit, type_=type_, mode=mode, disable_reranker=disable_reranker)
+    hit_dicts = [h.to_dict() for h in hits]
+    log_cli_consult(cfg, verb="search", query=query, hits=hit_dicts, t0_ms=t0, source=source)
     if as_json:
-        click.echo(json.dumps([h.to_dict() for h in hits], ensure_ascii=False, indent=2))
+        click.echo(json.dumps(hit_dicts, ensure_ascii=False, indent=2))
         return
     if not hits:
         console.print("[dim]no results[/dim]")
@@ -87,13 +116,25 @@ def search(
 )
 @click.option("--type", "type_", default=None, help="Restrict the retrieval to one record type.")
 @click.option("--json", "as_json", is_flag=True)
-def ask(question: str, k: int, type_: str | None, as_json: bool) -> None:
+@click.option(
+    "--source",
+    default=None,
+    help="Identify the calling layer so the consult is attributed in "
+    "`memo usefulness` (falls back to MEMO_SOURCE).",
+)
+def ask(question: str, k: int, type_: str | None, as_json: bool, source: str | None) -> None:
     """RAG over the memory archive — synthesises a prose answer with
     inline `[id]` citations using MLXChat 7B over the top-K hybrid hits.
     """
+    import time
 
-    mem = _get_memory(Config.from_env())
+    cfg = Config.from_env()
+    mem = _get_memory(cfg)
+    t0 = int(time.time() * 1000)
     out = mem.ask(question, k=k, type_=type_)
+    log_cli_consult(
+        cfg, verb="ask", query=question, hits=_sources_as_hits(out), t0_ms=t0, source=source
+    )
     if as_json:
         click.echo(json.dumps(out, ensure_ascii=False, indent=2))
         return
@@ -193,6 +234,12 @@ def embed_cmd(text: str | None, batch_json) -> None:
         "immediately. Forces JSON output and disables the panel."
     ),
 )
+@click.option(
+    "--source",
+    default=None,
+    help="Identify the calling layer so the consult is attributed in "
+    "`memo usefulness` (falls back to MEMO_SOURCE).",
+)
 def chat_ask(
     question: str,
     k: int,
@@ -201,6 +248,7 @@ def chat_ask(
     context_json,
     as_json: bool,
     as_stream: bool,
+    source: str | None,
 ) -> None:
     """Chat-shaped RAG over memo."""
 
@@ -222,11 +270,16 @@ def chat_ask(
         except Exception:
             context = {}
 
-    mem = _get_memory(Config.from_env())
+    import time
+
+    cfg = Config.from_env()
+    mem = _get_memory(cfg)
+    t0 = int(time.time() * 1000)
 
     if as_stream:
         import sys
 
+        stream_hits: list[dict] = []
         for event in mem.chat_ask_stream(
             question,
             k=k,
@@ -234,8 +287,13 @@ def chat_ask(
             history=history,
             context=context,
         ):
+            if isinstance(event, dict) and event.get("sources") and not stream_hits:
+                stream_hits = _sources_as_hits(event)
             sys.stdout.write(json.dumps(event, ensure_ascii=False) + "\n")
             sys.stdout.flush()
+        log_cli_consult(
+            cfg, verb="chat_ask", query=question, hits=stream_hits, t0_ms=t0, source=source
+        )
         return
 
     envelope = mem.chat_ask(
@@ -244,6 +302,14 @@ def chat_ask(
         type_=type_,
         history=history,
         context=context,
+    )
+    log_cli_consult(
+        cfg,
+        verb="chat_ask",
+        query=question,
+        hits=_sources_as_hits(envelope),
+        t0_ms=t0,
+        source=source,
     )
     if as_json:
         click.echo(json.dumps(envelope, ensure_ascii=False, indent=2))
@@ -262,6 +328,52 @@ def chat_ask(
                 f"  [dim][{s.get('id_short', '?')}][/dim] {(s.get('title', '') or '')[:60]}  "
                 f"[dim](score {s.get('score', 0):.3f})[/dim]"
             )
+
+
+@click.command(name="recall")
+@click.argument("query")
+@click.option("--limit", default=5, type=int, show_default=True)
+@click.option("--type", "type_", default=None, help="Filter by record type.")
+@click.option("--json", "as_json", is_flag=True, help='Emit {"results": [...]} for callers.')
+@click.option(
+    "--source",
+    default=None,
+    help="Identify the calling layer so the consult is attributed in "
+    "`memo usefulness` (falls back to MEMO_SOURCE).",
+)
+def recall(query: str, limit: int, type_: str | None, as_json: bool, source: str | None) -> None:
+    """Hybrid recall for programmatic callers (synapse / memflow bridge).
+
+    Same retrieval as ``memo search`` but emits ``{"results": [...]}`` — the
+    shape the memflow memo-bridge parses — and attributes the consult so the
+    layer stops showing as silent in ``memo usefulness``.
+    """
+    import time
+
+    cfg = Config.from_env()
+    mem = _get_memory(cfg)
+    t0 = int(time.time() * 1000)
+    hits = mem.search(query, limit=limit, type_=type_, mode="hybrid")
+    results = []
+    for h in hits:
+        d = h.to_dict()
+        d["kind"] = d.get("type")  # memflow reads `kind`; memo stores `type`
+        results.append(d)
+    log_cli_consult(cfg, verb="recall", query=query, hits=results, t0_ms=t0, source=source)
+    if as_json:
+        click.echo(json.dumps({"results": results}, ensure_ascii=False))
+        return
+    if not results:
+        console.print("[dim]no results[/dim]")
+        return
+    for d in results:
+        score = d.get("score")
+        console.print(
+            f"  [dim][{(d.get('id') or '')[:8]}][/dim] {(d.get('title') or '')[:60]}  "
+            f"[dim](score {score:.3f})[/dim]"
+            if isinstance(score, (int, float))
+            else f"  [dim][{(d.get('id') or '')[:8]}][/dim] {(d.get('title') or '')[:60]}"
+        )
 
 
 @click.command(name="rerank")

--- a/src/memo/cli_sync.py
+++ b/src/memo/cli_sync.py
@@ -234,6 +234,151 @@ def sync_bootstrap(url: str, dest: str | None, as_json: bool) -> None:
     console.print("[bold green]Ready.[/bold green] memo now reads the git-synced corpus.")
 
 
+@sync_group.command(name="status")
+@click.option("--check-remote", is_flag=True, help="Probe the remote (network) for reachability.")
+@click.option("--json", "as_json", is_flag=True, help="Output raw JSON")
+def sync_status(check_remote: bool, as_json: bool) -> None:
+    """Is the GitHub sync healthy? Shows clone / ahead-behind / dirty / stranded.
+
+    Kills the silent no-op: if the memorias dir isn't a git clone, the
+    SessionStart/Stop hooks soft-fail and nothing syncs — this says so plainly.
+    """
+    from memo.sync_git import sync_status as _status
+
+    cfg = Config.from_env()
+    st = _status(cfg, check_remote=check_remote)
+
+    if as_json:
+        click.echo(json.dumps(st, indent=2))
+        return
+    if not st.get("is_git_clone"):
+        console.print("[bold red]NOT syncing[/bold red] — data_dir is not a git clone.")
+        console.print(f"  [dim]{st.get('reason', '')}[/dim]")
+        console.print("  Fix: [cyan]memo sync bootstrap <url>[/cyan]")
+        return
+    ahead, behind, dirty = st["ahead"], st["behind"], st["dirty_files"]
+    if st["pending"]:
+        verdict, color = "STRANDED — push failed, will retry", "red"
+    elif ahead or dirty:
+        verdict, color = f"behind remote by {ahead} commit(s) unpushed", "yellow"
+    elif behind:
+        verdict, color = f"{behind} remote commit(s) to pull", "yellow"
+    else:
+        verdict, color = "up to date with GitHub", "green"
+    console.print(f"[bold {color}]{verdict}[/bold {color}]")
+    console.print(f"  repo:   {st['root']}  ({st['branch']})")
+    console.print(f"  remote: {st['remote'] or '—'}")
+    console.print(f"  ahead {ahead} · behind {behind} · dirty {dirty} · last {st['last_commit'] or '—'}")
+    if check_remote:
+        console.print(f"  remote reachable: {st['remote_reachable']}")
+
+
+@sync_group.command(name="once")
+@click.option("--quiet", is_flag=True, help="Soft-fail (exit 0) if not a git clone — for hooks")
+@click.option("--json", "as_json", is_flag=True, help="Output raw JSON")
+def sync_once_cmd(quiet: bool, as_json: bool) -> None:
+    """One lock-guarded machine sync (pull-rebase-before-push). Stop-hook flush.
+
+    Unlike `sync auto` (debounced), this always attempts the git step — used at
+    session end to flush this session's captures. The machine lock still ensures
+    only one process does git at a time.
+    """
+    from memo.sync_git import sync_once, sync_tier
+
+    cfg = Config.from_env()
+    if sync_tier(cfg) != "remote":
+        if not quiet:
+            console.print("[dim]sync once skipped: local tier (no remote / not a clone)[/dim]")
+        if as_json:
+            click.echo(json.dumps({"tier": "local", "skipped": "no remote"}))
+        return
+    mem = _get_memory(cfg)
+    out = sync_once(cfg, mem.store, mem)
+    if as_json:
+        click.echo(json.dumps(out))
+        return
+    bits = []
+    if out.get("pulled"):
+        bits.append("pulled")
+    if out.get("pushed"):
+        bits.append("pushed")
+    if out.get("skipped"):
+        bits.append(f"skipped({out['skipped']})")
+    console.print(f"[green]sync once[/green] → {', '.join(bits) or 'nothing to do'}")
+
+
+@sync_group.command(name="auto")
+@click.option("--json", "as_json", is_flag=True, help="Output raw JSON")
+def sync_auto(as_json: bool) -> None:
+    """Debounced, self-throttled sync — safe to fire every prompt (async hook).
+
+    Makes durable knowledge propagate WITHIN a session instead of only at Stop:
+    pulls if ``MEMO_SYNC_PULL_INTERVAL_S`` elapsed, pushes if there's something
+    to share (dirty/ahead/stranded) and ``MEMO_SYNC_PUSH_DEBOUNCE_S`` elapsed.
+    Cheap no-op (timestamp check, no git) when neither is due; soft-fails when
+    the data_dir isn't a git clone. Disable with ``MEMO_SYNC_AUTO=0``.
+    """
+    import time
+
+    from memo.flags import flag_bool, flag_int
+
+    cfg = Config.from_env()
+    did: dict = {"pulled": False, "pushed": False, "skipped": None}
+
+    if not flag_bool("MEMO_SYNC_AUTO"):  # registry default True; MEMO_SYNC_AUTO=0 opts out
+        did["skipped"] = "disabled"
+        if as_json:
+            click.echo(json.dumps(did))
+        return
+
+    ts_file = cfg.state_dir / ".sync_auto_ts"
+    try:
+        ts = json.loads(ts_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        ts = {}
+    now = time.time()
+    push_debounce = flag_int("MEMO_SYNC_PUSH_DEBOUNCE_S") or 120
+    pull_interval = flag_int("MEMO_SYNC_PULL_INTERVAL_S") or 300
+    pull_due = now - float(ts.get("last_pull", 0)) >= pull_interval
+    push_due = now - float(ts.get("last_push", 0)) >= push_debounce
+    if not pull_due and not push_due:
+        did["skipped"] = "not due"
+        if as_json:
+            click.echo(json.dumps(did))
+        return
+
+    from memo.sync_git import sync_tier
+
+    if sync_tier(cfg) != "remote":
+        did["skipped"] = "local tier (no remote / not a clone)"
+        if as_json:
+            click.echo(json.dumps(did))
+        return
+
+    # Route through the single, lock-guarded machine coordinator: it owns the
+    # pull-rebase-before-push ordering and the same-machine lock, so concurrent
+    # sessions don't race and an advanced remote rebases cleanly.
+    from memo.sync_git import sync_once
+
+    mem = _get_memory(cfg)
+    out = sync_once(cfg, mem.store, mem, do_pull=pull_due, do_push=push_due)
+    did["pulled"] = bool(out.get("pulled"))
+    did["pushed"] = bool(out.get("pushed"))
+    if out.get("skipped"):
+        did["skipped"] = out["skipped"]
+    if pull_due:
+        ts["last_pull"] = now
+    if push_due:
+        ts["last_push"] = now
+
+    import contextlib
+
+    with contextlib.suppress(OSError):
+        ts_file.write_text(json.dumps(ts), encoding="utf-8")
+    if as_json:
+        click.echo(json.dumps(did))
+
+
 @sync_group.command(name="both")
 @click.option("--remote", required=True, help="Path to remote memo state dir")
 def sync_both(remote: str) -> None:

--- a/src/memo/contextual_retrieval.py
+++ b/src/memo/contextual_retrieval.py
@@ -27,8 +27,9 @@ SUMMARY_MARKER = "[contexto:"
 
 
 def contextual_retrieval_enabled() -> bool:
-    raw = os.environ.get("MEMO_CONTEXTUAL_RETRIEVAL", "").strip().lower()
-    return raw in {"1", "true", "yes", "on"}
+    from memo.flags import flag_bool
+
+    return flag_bool("MEMO_CONTEXTUAL_RETRIEVAL")
 
 
 def context_cache_path(state_dir: Path) -> Path:

--- a/src/memo/dashboard_metrics.py
+++ b/src/memo/dashboard_metrics.py
@@ -23,6 +23,12 @@ SPECIFIC_MARGIN = 0.06
 # only when it is both read enough (volume) and actually helping (grounded).
 VERDICT_MIN_CONSULTS = 20
 VERDICT_MIN_GROUNDED = 0.10
+# Layers we EXPECT to read memo (flagged as "silent" if absent). "windsurf" was
+# retired — that IDE is now Devin Desktop (Cognition), which reads
+# ~/.codeium/windsurf/mcp_config.json with MEMO_SOURCE=devin-desktop, so it is
+# labelled "devin-desktop" when it consults. It is NOT in this expected set: it's
+# a GUI app that can't be driven headless, so flagging it silent is just noise —
+# it appears as a reader if/when Cascade actually queries memo.
 EXPECTED_CONSUMERS = (
     "claude-code",
     "synapse",
@@ -30,7 +36,6 @@ EXPECTED_CONSUMERS = (
     "codex",
     "devin",
     "opencode",
-    "windsurf",
 )
 
 

--- a/src/memo/embedder.py
+++ b/src/memo/embedder.py
@@ -197,8 +197,8 @@ class MLXEmbedder:  # duck-type implements EmbedderBase (see memo.embed_base)
         # cache when available. The embedder is a foundation module that must not
         # import memo.flags (see the architecture-boundary test), so flags-aware
         # callers (Memory facade, recall daemon) pass the registry default via
-        # `cache_size`. When that is None we fall back to the raw env read — which
-        # defaults to 0/off — so a bare `MLXEmbedder()` stays opt-in.
+        # `cache_size`. When that is None we keep the legacy bare-embedder env
+        # fallback for tests and standalone use.
         if cache_size is None:
             cache_size = int(os.environ.get("MEMO_QUERY_CACHE_SIZE", "0") or 0)
         # Either the shared consciousness-contracts cache or the local _SimpleLRU

--- a/src/memo/embedder_client.py
+++ b/src/memo/embedder_client.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import threading
 from collections.abc import Sequence
 from pathlib import Path
@@ -68,18 +67,18 @@ def _resolve_state_dir(state_dir: Path | None) -> Path:
 
 
 def _timeout() -> float:
-    raw = os.environ.get("MEMO_EMBEDDER_CLIENT_TIMEOUT")
-    if not raw:
-        return _DEFAULT_TIMEOUT_S
-    try:
-        value = float(raw)
-    except ValueError:
+    from memo.flags import flag_float
+
+    value = flag_float("MEMO_EMBEDDER_CLIENT_TIMEOUT")
+    if value is None:
         return _DEFAULT_TIMEOUT_S
     return value if value > 0 else _DEFAULT_TIMEOUT_S
 
 
 def _require_daemon() -> bool:
-    return os.environ.get("MEMO_EMBEDDER_CLIENT_REQUIRE_DAEMON") == "1"
+    from memo.flags import flag_bool
+
+    return flag_bool("MEMO_EMBEDDER_CLIENT_REQUIRE_DAEMON")
 
 
 def _try_socket(state_dir: Path, payload: dict[str, Any]) -> dict[str, Any] | None:

--- a/src/memo/flags_ingest.py
+++ b/src/memo/flags_ingest.py
@@ -62,7 +62,7 @@ SPECS: tuple[FlagSpec, ...] = (
     ),
     _spec("MEMO_REPO_FLUSH_BATCH", "int", None, "repo", "Rows per DB flush during repo index."),
     _spec(
-        "MEMO_REPO_GIT_TIMEOUT_S", "int", None, "repo", "Timeout (s) for git operations on clone."
+        "MEMO_REPO_GIT_TIMEOUT_S", "float", None, "repo", "Timeout (s) for git operations on clone."
     ),
     # embedder daemon / client
     _spec(

--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -55,6 +55,20 @@ SPECS: tuple[FlagSpec, ...] = (
         "Expose only the 26 core inline tools (skip domain modules). "
         "Reduces tool count from ~116 to 26 for local/constrained LLMs.",
     ),
+    _spec(
+        "MEMO_MCP_PROFILE",
+        "str",
+        "default",
+        "mcp",
+        "MCP surface profile: default/full expose advanced tools; core/slim expose only stable core tools.",
+    ),
+    _spec(
+        "MEMO_CLI_PROFILE",
+        "str",
+        "default",
+        "cli",
+        "CLI surface profile: default/full expose every command; core/slim hide advanced and experimental commands.",
+    ),
     # synapse / memflow integration
     _spec(
         "MEMO_RESPECT_SYNAPSE_FREEZE",
@@ -274,6 +288,127 @@ SPECS: tuple[FlagSpec, ...] = (
         120,
         "roi",
         "Estimated seconds cost per re-ask.",
+        min_val=0,
+    ),
+    _spec(
+        "MEMO_SOURCE",
+        "str",
+        "",
+        "roi",
+        "Identity of the calling layer (synapse / memflow / devin / devin-desktop "
+        "/ opencode …) used to attribute memo consults in `memo usefulness` when a "
+        "read does not pass an explicit source. Set it in that tool's CLI/MCP "
+        "environment; a bare developer consult leaves it empty and is not counted.",
+    ),
+    # The Outcome Loop — recall self-tunes from real grounding outcomes.
+    _spec(
+        "MEMO_OUTCOME_RANKING_ENABLED",
+        "bool",
+        False,
+        "roi",
+        "Drive memory_health.roi_score from real grounding OUTCOMES (was the "
+        "surfaced memoria actually used in the answer?) instead of mere access "
+        "frequency. When on, `memo maintain` / `memo outcome` reconcile roi_score "
+        "from recall.log+grounding.log, and the blind per-access roi boost is "
+        "skipped so the outcome signal stays authoritative. Default off = legacy "
+        "access-driven behaviour.",
+    ),
+    _spec(
+        "MEMO_OUTCOME_PRIOR_N",
+        "float",
+        3.0,
+        "roi",
+        "Bayesian prior strength for per-memoria utility = (grounded + "
+        "prior_mean*prior_n) / (surfaced + prior_n). Higher = more surfacings "
+        "needed before a memoria's utility moves off the global baseline.",
+        min_val=0.0,
+    ),
+    _spec(
+        "MEMO_OUTCOME_ROI_FLOOR",
+        "float",
+        0.6,
+        "roi",
+        "Lowest roi_score the outcome loop assigns (utility 0 → floor). Demotes "
+        "but never zeroes a memoria that surfaces a lot yet never grounds.",
+        min_val=0.0,
+    ),
+    _spec(
+        "MEMO_OUTCOME_ROI_CAP",
+        "float",
+        1.5,
+        "roi",
+        "Highest roi_score the outcome loop assigns (utility 1 → cap).",
+        min_val=1.0,
+    ),
+    _spec(
+        "MEMO_OUTCOME_DEAD_MIN_SURFACED",
+        "int",
+        8,
+        "roi",
+        "Dead-weight archival: a memoria must have been surfaced at least this "
+        "many times (and never grounded) before `memo maintain` proposes "
+        "archiving it as recall noise. 0 disables dead-weight archival.",
+        min_val=0,
+    ),
+    _spec(
+        "MEMO_ROI_TOKENS_PER_GROUNDED",
+        "int",
+        350,
+        "roi",
+        "Estimated model tokens saved per grounded answer — the tokens the model "
+        "would have spent re-deriving the fact memo surfaced instead of being "
+        "given it directly.",
+        min_val=0,
+    ),
+    _spec(
+        "MEMO_ROI_TOKENS_PER_REASK",
+        "int",
+        900,
+        "roi",
+        "Estimated model tokens saved per re-ask avoided — a full answer "
+        "regeneration round-trip the user did NOT have to repeat.",
+        min_val=0,
+    ),
+    # Git sync (memo-sync repo ↔ GitHub)
+    _spec(
+        "MEMO_SYNC_AUTO",
+        "bool",
+        True,
+        "sync",
+        "Enable the debounced in-session auto-sync (`memo sync auto`, wired as an "
+        "async per-prompt hook). Default on; set 0 to fall back to push-on-Stop / "
+        "pull-on-SessionStart only.",
+    ),
+    _spec(
+        "MEMO_SYNC_PUSH_DEBOUNCE_S",
+        "int",
+        120,
+        "sync",
+        "Minimum seconds between auto-pushes (coalesces rapid saves into one "
+        "commit+push so git isn't thrashed every prompt).",
+        min_val=0,
+    ),
+    _spec(
+        "MEMO_SYNC_PULL_INTERVAL_S",
+        "int",
+        300,
+        "sync",
+        "Minimum seconds between background auto-pulls — lets a long-running "
+        "session converge on another Mac's pushes without a restart.",
+        min_val=0,
+    ),
+    # Durable incremental capture (memo capture-tick)
+    _spec(
+        "MEMO_CAPTURE_INTERVAL_S",
+        "int",
+        600,
+        "capture",
+        "Minimum seconds between incremental in-session captures (`memo "
+        "capture-tick`, wired as an async per-prompt hook). Mines NEW turns "
+        "since a per-session watermark into durable memorias so a long/crashed "
+        "session's insight reaches .md mid-session instead of only at Stop. "
+        "Self-throttled per session off the capture watermark; a cheap no-op "
+        "when not due. 0 disables the throttle (capture every prompt).",
         min_val=0,
     ),
     # WhatsApp ingest

--- a/src/memo/identity.py
+++ b/src/memo/identity.py
@@ -1,0 +1,85 @@
+"""Stable identity for memo: which MACHINE, which SESSION/terminal.
+
+The sync layer needs a stable per-machine id to attribute git commits, decide
+same-machine vs cross-machine, and own the machine-level git coordinator lock.
+The session/terminal id makes each open agent session addressable — so memflow
+can reference "terminal X" for a task in future. memo only EXPOSES this; the
+addressing/coordination is memflow's job (YAGNI here).
+
+Machine identity is decoupled from the trinity by design: ``hostname`` is the
+shared match key every tool computes identically; memo's persisted
+``cfg.device_id`` (``state_dir/.device_id``) adds uniqueness. No hard dependency
+on ``consciousness_contracts`` — its ``IdentityClaim`` is an assertion record,
+not a machine-id provider.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Identity:
+    """Who this memo process is. Immutable snapshot resolved at use time."""
+
+    machine_id: str  # stable, unique per machine (persisted device_id)
+    hostname: str  # cross-tool match key (every trinity tool computes it the same)
+    session_id: str | None  # the open agent session, if the client supplied one
+    terminal: str | None  # controlling TTY, when attached — for future addressing
+
+    @property
+    def label(self) -> str:
+        """Human/commit-friendly label, e.g. ``Fer-Mac-Black·a1b2c3d4``."""
+        s = self.hostname
+        if self.session_id:
+            s = f"{s}·{self.session_id[:8]}"
+        return s
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "machine_id": self.machine_id,
+            "hostname": self.hostname,
+            "session_id": self.session_id,
+            "terminal": self.terminal,
+            "label": self.label,
+        }
+
+
+def _hostname() -> str:
+    try:
+        return socket.gethostname().strip() or "unknown-host"
+    except OSError:
+        return "unknown-host"
+
+
+def _session_id() -> str | None:
+    # Clients pass their session id via env (memo's own var wins). Best-effort:
+    # the machine id is what sync correctness depends on; session is provenance.
+    for k in ("MEMO_SESSION_ID", "CLAUDE_SESSION_ID", "CLAUDE_CODE_SESSION_ID"):
+        v = os.environ.get(k)
+        if v and v.strip():
+            return v.strip()
+    return None
+
+
+def _terminal() -> str | None:
+    for fd in (0, 1, 2):
+        try:
+            return os.ttyname(fd)
+        except OSError:
+            continue
+    return None
+
+
+def current(cfg: Any) -> Identity:
+    """Resolve this process's identity. ``cfg.device_id`` is the persisted stable
+    machine id; ``hostname`` is the cross-tool match key."""
+    return Identity(
+        machine_id=str(getattr(cfg, "device_id", "") or "unknown"),
+        hostname=_hostname(),
+        session_id=_session_id(),
+        terminal=_terminal(),
+    )

--- a/src/memo/llm.py
+++ b/src/memo/llm.py
@@ -30,7 +30,6 @@ monkeypatch `MLXChat.chat` directly to skip the load.
 from __future__ import annotations
 
 import logging
-import os
 import threading
 import time
 from collections import OrderedDict
@@ -52,12 +51,9 @@ def _prompt_cache_enabled() -> bool:
     keep it off unless `MEMO_PROMPT_CACHE` is set — the daemon turns it on.
     Output is byte-identical either way (greedy/temp=0).
     """
-    return os.environ.get("MEMO_PROMPT_CACHE", "").strip().lower() in (
-        "1",
-        "true",
-        "yes",
-        "on",
-    )
+    from memo.flags import flag_bool
+
+    return flag_bool("MEMO_PROMPT_CACHE")
 
 
 def _apply_chat_template(tok: Any, **kw: Any) -> Any:

--- a/src/memo/memory/capabilities.py
+++ b/src/memo/memory/capabilities.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+CapabilityFactory = Callable[[Any], Any]
+
+
+def _contextual(memory: Any) -> Any:
+    from memo.contextual import ContextStore, ContextualRecall
+
+    return ContextualRecall(memory, ContextStore(memory.cfg.state_dir))
+
+
+def _crossref(memory: Any) -> Any:
+    from memo.crossref import CrossReferenceIndex
+
+    return CrossReferenceIndex(memory.cfg.crossref_db)
+
+
+def _link_suggester(memory: Any) -> Any:
+    from memo.crossref import LinkSuggester
+
+    return LinkSuggester(memory, memory.crossref)
+
+
+def _lifecycle(memory: Any) -> Any:
+    from memo.lifecycle import LifecycleManager
+
+    return LifecycleManager(memory)
+
+
+def _proactive(memory: Any) -> Any:
+    from memo.proactive import ProactiveSuggester
+
+    return ProactiveSuggester(memory, memory._ensure_chat())
+
+
+def _versioning(memory: Any) -> Any:
+    from memo.versioning import VersionManager
+
+    return VersionManager(memory)
+
+
+def _query_composer(memory: Any) -> Any:
+    from memo.saved_queries import QueryComposer, QueryStore
+
+    return QueryComposer(memory, QueryStore(memory.cfg.state_dir))
+
+
+def _federation(memory: Any) -> Any:
+    from memo.federation import FederationConfig, FederationSearcher
+
+    return FederationSearcher(FederationConfig(memory.cfg.state_dir / "federation.json"))
+
+
+def _backup(memory: Any) -> Any:
+    from memo.sync import BackupManager
+
+    return BackupManager(
+        memory_dir=memory.cfg.memory_dir,
+        db_dir=memory.cfg.state_dir,
+        backup_dir=memory.cfg.state_dir / "backups",
+    )
+
+
+def _sync(memory: Any) -> Any:
+    from memo.sync import SyncManager
+
+    return SyncManager(memory)
+
+
+def _encryption(memory: Any) -> Any:
+    from memo.encryption import EncryptionManager, Encryptor, KeyManager
+
+    key_manager = KeyManager(memory.cfg.state_dir)
+    encryptor = Encryptor(key_manager)
+    return EncryptionManager(key_manager, encryptor)
+
+
+def _sharing(memory: Any) -> Any:
+    from memo.sharing import ShareManager, ShareStore
+
+    return ShareManager(ShareStore(memory.cfg.state_dir))
+
+
+def _analytics(memory: Any) -> Any:
+    from memo.analytics import AnalyticsEngine
+
+    return AnalyticsEngine(memory)
+
+
+def _dashboard(memory: Any) -> Any:
+    from memo.analytics import Dashboard
+
+    return Dashboard(memory.analytics)
+
+
+def _import_export(memory: Any) -> Any:
+    from memo.import_export import ImportExportManager
+
+    return ImportExportManager(memory)
+
+
+def _multimodal(memory: Any) -> Any:
+    from memo.multimodal import (
+        CrossModalSearch,
+        MultiModalManager,
+        MultiModalStore,
+        UniversalEmbedder,
+    )
+
+    store = MultiModalStore(memory.cfg.state_dir)
+    embedder = UniversalEmbedder()
+    search = CrossModalSearch(store, embedder)
+    return MultiModalManager(store, embedder, search)
+
+
+def _collaborative(memory: Any) -> Any:
+    from memo.collaborative import CollaborativeFilter, CollaborativeGraph, CollaborativeManager
+
+    graph = CollaborativeGraph(memory.cfg.state_dir)
+    filter_ = CollaborativeFilter(graph)
+    return CollaborativeManager(graph, filter_)
+
+
+OPTIONAL_CAPABILITIES: dict[str, CapabilityFactory] = {
+    "analytics": _analytics,
+    "backup": _backup,
+    "collaborative": _collaborative,
+    "contextual": _contextual,
+    "crossref": _crossref,
+    "dashboard": _dashboard,
+    "encryption": _encryption,
+    "federation": _federation,
+    "import_export": _import_export,
+    "lifecycle": _lifecycle,
+    "link_suggester": _link_suggester,
+    "multimodal": _multimodal,
+    "proactive": _proactive,
+    "query_composer": _query_composer,
+    "sharing": _sharing,
+    "sync": _sync,
+    "versioning": _versioning,
+}

--- a/src/memo/memory/facade.py
+++ b/src/memo/memory/facade.py
@@ -11,26 +11,18 @@ public + private member of the original god-class.
 from __future__ import annotations
 
 import contextlib
-import os
 import threading
 from typing import Any
 
-from memo.analytics import AnalyticsEngine, Dashboard
-from memo.collaborative import CollaborativeFilter, CollaborativeGraph, CollaborativeManager
 from memo.config import Config
 from memo.consolidation import AdvancedConsolidator
-from memo.contextual import ContextStore, ContextualRecall
 from memo.contextual_retrieval import get_or_generate_context, prepend_context
 from memo.contradict import ContradictionScanner, ContradictionStore
-from memo.crossref import CrossReferenceIndex, LinkSuggester
 from memo.embedder import MLXEmbedder
-from memo.encryption import EncryptionManager, Encryptor, KeyManager
-from memo.federation import FederationConfig, FederationSearcher
 from memo.graph import GraphStore
-from memo.import_export import ImportExportManager
-from memo.lifecycle import LifecycleManager
 from memo.llm import MLXChat
 from memo.memory.ask_ops import _AskOpsMixin
+from memo.memory.capabilities import OPTIONAL_CAPABILITIES
 from memo.memory.consolidate_ops import _ConsolidateOpsMixin
 from memo.memory.delete_ops import _DeleteOpsMixin
 from memo.memory.maintain_ops import _MaintainOpsMixin
@@ -41,15 +33,8 @@ from memo.memory.rerank_ops import _RerankOpsMixin
 from memo.memory.search_ops import _SearchOpsMixin
 from memo.memory.update_ops import _UpdateOpsMixin
 from memo.memory.write_ops import _WriteOpsMixin
-from memo.multimodal import CrossModalSearch, MultiModalManager, MultiModalStore, UniversalEmbedder
-from memo.navigation import GraphNavigator
-from memo.proactive import ProactiveSuggester
-from memo.saved_queries import QueryComposer, QueryStore
-from memo.sharing import ShareManager, ShareStore
 from memo.store import VecStore
-from memo.sync import BackupManager, SyncManager
 from memo.temporal import TemporalAnalyzer
-from memo.versioning import VersionManager
 
 
 class Memory(
@@ -94,12 +79,9 @@ class Memory(
         # the warm memo-mcp chat daemon so its resident footprint is just the
         # synthesis model — the recall daemon already holds the embedder warm.
         # Falls back in-process automatically if the socket is down.
-        if os.environ.get("MEMO_EMBEDDER_VIA_DAEMON", "").strip().lower() in (
-            "1",
-            "true",
-            "yes",
-            "on",
-        ):
+        from memo.flags import flag_bool
+
+        if flag_bool("MEMO_EMBEDDER_VIA_DAEMON"):
             from memo.embedder_client import SocketEmbedder
 
             self.embedder: Any = SocketEmbedder(
@@ -143,6 +125,7 @@ class Memory(
         # `cache`, memoized here. Construction triggers no cold-start and the
         # backend is built lazily on first use (see CacheManager.ensure_backend).
         self._cache: Any | None = None
+        self._capabilities: dict[str, Any] = {}
         # Reranker is lazy — first hybrid `search()` triggers the load
         # if `cfg.reranker_enabled`. Cold load of Qwen3-Reranker-0.6B
         # is ~1-2s; users who disable it (CI, vec-only mode) pay zero.
@@ -156,11 +139,6 @@ class Memory(
         self._maybe_warn_legacy_paths()
         # Temporal analyzer for contradiction detection and timeline analysis
         self._temporal: TemporalAnalyzer | None = None
-        # Memoized ContextualRecall (its ContextStore reads disk on init).
-        self._contextual: ContextualRecall | None = None
-        # Encryption manager carries unlock state in memory, so it must be
-        # stable across accesses within a long-lived MCP process.
-        self._encryption: EncryptionManager | None = None
         # Serialises unique-path allocation + .md creation in save() so two
         # concurrent same-title saves can't race the path probe (see write_ops).
         self._save_path_lock = threading.Lock()
@@ -238,35 +216,35 @@ class Memory(
         return ContradictionScanner(self, self.contradict_store, self.temporal)
 
     @property
-    def navigator(self) -> GraphNavigator:
+    def navigator(self) -> Any:
         """Lazy accessor for GraphNavigator."""
+        from memo.navigation import GraphNavigator
+
         return GraphNavigator(self.graph)
 
     @property
-    def contextual(self) -> ContextualRecall:
+    def contextual(self) -> Any:
         """Lazy, memoized accessor for ContextualRecall.
 
         Memoized because ContextStore() reads JSON state from disk on init —
         re-creating it on every access (e.g. twice per recall) is wasted I/O.
         """
-        if self._contextual is None:
-            self._contextual = ContextualRecall(self, ContextStore(self.cfg.state_dir))
-        return self._contextual
+        return self.capability("contextual")
 
     @property
-    def crossref(self) -> CrossReferenceIndex:
+    def crossref(self) -> Any:
         """Lazy accessor for CrossReferenceIndex."""
-        return CrossReferenceIndex(self.cfg.crossref_db)
+        return self.capability("crossref")
 
     @property
-    def link_suggester(self) -> LinkSuggester:
+    def link_suggester(self) -> Any:
         """Lazy accessor for LinkSuggester."""
-        return LinkSuggester(self, self.crossref)
+        return self.capability("link_suggester")
 
     @property
-    def lifecycle(self) -> LifecycleManager:
+    def lifecycle(self) -> Any:
         """Lazy accessor for LifecycleManager."""
-        return LifecycleManager(self)
+        return self.capability("lifecycle")
 
     @property
     def cache(self):
@@ -283,82 +261,77 @@ class Memory(
         return self._cache
 
     @property
-    def proactive(self) -> ProactiveSuggester:
+    def proactive(self) -> Any:
         """Lazy accessor for ProactiveSuggester."""
-        return ProactiveSuggester(self, self._ensure_chat())
+        return self.capability("proactive")
 
     @property
-    def versioning(self) -> VersionManager:
+    def versioning(self) -> Any:
         """Lazy accessor for VersionManager."""
-        return VersionManager(self)
+        return self.capability("versioning")
 
     @property
-    def query_composer(self) -> QueryComposer:
+    def query_composer(self) -> Any:
         """Lazy accessor for QueryComposer."""
-        return QueryComposer(self, QueryStore(self.cfg.state_dir))
+        return self.capability("query_composer")
 
     @property
-    def federation(self) -> FederationSearcher:
+    def federation(self) -> Any:
         """Lazy accessor for FederationSearcher."""
-        return FederationSearcher(FederationConfig(self.cfg.state_dir / "federation.json"))
+        return self.capability("federation")
 
     @property
-    def backup(self) -> BackupManager:
+    def backup(self) -> Any:
         """Lazy accessor for BackupManager."""
-        return BackupManager(
-            memory_dir=self.cfg.memory_dir,
-            db_dir=self.cfg.state_dir,
-            backup_dir=self.cfg.state_dir / "backups",
-        )
+        return self.capability("backup")
 
     @property
-    def sync(self) -> SyncManager:
+    def sync(self) -> Any:
         """Lazy accessor for SyncManager."""
-        return SyncManager(self)
+        return self.capability("sync")
 
     @property
-    def encryption(self) -> EncryptionManager:
+    def encryption(self) -> Any:
         """Lazy accessor for EncryptionManager."""
-        if self._encryption is None:
-            key_manager = KeyManager(self.cfg.state_dir)
-            encryptor = Encryptor(key_manager)
-            self._encryption = EncryptionManager(key_manager, encryptor)
-        return self._encryption
+        return self.capability("encryption")
 
     @property
-    def sharing(self) -> ShareManager:
+    def sharing(self) -> Any:
         """Lazy accessor for ShareManager."""
-        return ShareManager(ShareStore(self.cfg.state_dir))
+        return self.capability("sharing")
 
     @property
-    def analytics(self) -> AnalyticsEngine:
+    def analytics(self) -> Any:
         """Lazy accessor for AnalyticsEngine."""
-        return AnalyticsEngine(self)
+        return self.capability("analytics")
 
     @property
-    def dashboard(self) -> Dashboard:
+    def dashboard(self) -> Any:
         """Lazy accessor for Dashboard."""
-        return Dashboard(self.analytics)
+        return self.capability("dashboard")
 
     @property
-    def import_export(self) -> ImportExportManager:
+    def import_export(self) -> Any:
         """Lazy accessor for ImportExportManager."""
-        return ImportExportManager(self)
+        return self.capability("import_export")
 
     @property
-    def multimodal(self) -> MultiModalManager:
+    def multimodal(self) -> Any:
         """Lazy accessor for MultiModalManager."""
-        store = MultiModalStore(self.cfg.state_dir)
-        embedder = UniversalEmbedder()
-        search = CrossModalSearch(store, embedder)
-        return MultiModalManager(store, embedder, search)
+        return self.capability("multimodal")
 
     @property
-    def collaborative(self) -> CollaborativeManager:
+    def collaborative(self) -> Any:
         """Lazy accessor for CollaborativeManager."""
-        graph = CollaborativeGraph(self.cfg.state_dir)
-        filter = CollaborativeFilter(graph)
-        return CollaborativeManager(graph, filter)
+        return self.capability("collaborative")
+
+    def capability(self, name: str) -> Any:
+        """Build and memoize an optional subsystem by registry name."""
+        if name not in OPTIONAL_CAPABILITIES:
+            raise KeyError(f"unknown Memory capability: {name}")
+        if name not in self._capabilities:
+            self._capabilities[name] = OPTIONAL_CAPABILITIES[name](self)
+        return self._capabilities[name]
 
     def _maybe_warn_legacy_paths(self) -> None:
         """Stderr warning when stored `meta.path` rows don't resolve.
@@ -375,12 +348,13 @@ class Memory(
                 return
             missing = sum(1 for r in sample if not self._resolve_existing(r["path"]).is_file())
             if missing == len(sample):
-                import os as _os
                 import sys
+
+                from memo.flags import flag_bool
 
                 # Suppressible — TUI sets MEMO_SUPPRESS_LEGACY_WARN=1 because
                 # the message is moot while in alt-screen mode.
-                if _os.environ.get("MEMO_SUPPRESS_LEGACY_WARN") == "1":
+                if flag_bool("MEMO_SUPPRESS_LEGACY_WARN"):
                     return
                 print(
                     f"[memo] heads-up: tu índice apunta a paths antiguos "

--- a/src/memo/memory/maintain_ops.py
+++ b/src/memo/memory/maintain_ops.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import builtins
 import json
-import os
 from typing import Any
 
 import frontmatter
@@ -65,7 +64,9 @@ class _MaintainOpsMixin(_MemoryBase):
         # per-save kwarg) we stay permissive — synapse outages mustn't block
         # memo's standalone writes. A missing binary is handled above and is
         # always permissive regardless of this flag.
-        fail_closed = os.environ.get("MEMO_RESPECT_SYNAPSE_FREEZE") == "1"
+        from memo.flags import flag_bool
+
+        fail_closed = flag_bool("MEMO_RESPECT_SYNAPSE_FREEZE")
         try:
             conflicts = synapse_client.list_conflicts(
                 query,

--- a/src/memo/memory/search_ops.py
+++ b/src/memo/memory/search_ops.py
@@ -9,12 +9,11 @@ from __future__ import annotations
 
 import builtins
 import math
-import os
 import sqlite3
 from dataclasses import replace
 from typing import Any
 
-from memo.flags import flag_bool, flag_float, flag_int
+from memo.flags import active_flags, flag_bool, flag_float, flag_int
 from memo.lifecycle import IS_FORGOTTEN_KEY
 from memo.memory._base import _MemoryBase
 from memo.memory.record import (
@@ -47,6 +46,7 @@ class _SearchOpsMixin(_MemoryBase):
         include_forgotten: bool = False,
         read_through: bool = False,
         entity_boost: bool | None = None,
+        _trace: list[dict[str, Any]] | None = None,
     ) -> list[MemoryRecord]:
         """Top-k search. Three modes:
 
@@ -80,7 +80,13 @@ class _SearchOpsMixin(_MemoryBase):
                 (see `memo.tiers`) so bulk vault material stays searchable on
                 demand but never drowns durable knowledge in the prompt.
         """
+        def _add_trace(stage: str, **data: Any) -> None:
+            if _trace is not None:
+                _trace.append({"stage": stage, **data})
+
         if not query or not query.strip():
+            _add_trace("candidate_generation", mode=mode, output_count=0)
+            _add_trace("final", output_count=0)
             return []
         limit = limit or self.cfg.search_default_limit
 
@@ -88,6 +94,7 @@ class _SearchOpsMixin(_MemoryBase):
             rows = self.store.search_bm25(
                 query, limit=limit, type_=type_, exclude_types=exclude_types
             )
+            _add_trace("candidate_generation", mode=mode, bm25_count=len(rows), output_count=len(rows))
         elif mode == "exact":
             # Precise keyword lookup: strict AND (no OR loosening) with an
             # elevated tag/title field boost so a term in curated metadata
@@ -99,10 +106,12 @@ class _SearchOpsMixin(_MemoryBase):
                 exclude_types=exclude_types,
                 field_boost="exact",
             )
+            _add_trace("candidate_generation", mode=mode, bm25_count=len(rows), output_count=len(rows))
         elif mode == "fuzzy":
             rows = self.store.search_fuzzy(
                 query, limit=limit, type_=type_, exclude_types=exclude_types
             )
+            _add_trace("candidate_generation", mode=mode, fuzzy_count=len(rows), output_count=len(rows))
         elif mode == "vec":
             # Asymmetric retrieval: queries are embedded WITH the
             # instruction prefix; documents are embedded RAW (in
@@ -110,6 +119,7 @@ class _SearchOpsMixin(_MemoryBase):
             # in `embedder.py` for the why.
             emb = self.embedder.embed_query(query)
             rows = self.store.search(emb, limit=limit, type_=type_, exclude_types=exclude_types)
+            _add_trace("candidate_generation", mode=mode, vec_count=len(rows), output_count=len(rows))
         else:
             # hybrid — fetch a wider candidate set from each side and
             # fuse with reciprocal rank fusion (RRF). When the reranker
@@ -183,8 +193,9 @@ class _SearchOpsMixin(_MemoryBase):
             w_bm25 = w_bm25 if w_bm25 is not None else 0.5
             # Warn when the user has explicitly set both but their sum deviates
             # from 1.0 by more than the 0.05 tolerance.
-            _vec_set = os.environ.get("MEMO_SEARCH_VEC_WEIGHT") not in (None, "")
-            _bm25_set = os.environ.get("MEMO_SEARCH_BM25_WEIGHT") not in (None, "")
+            _active = active_flags()
+            _vec_set = "MEMO_SEARCH_VEC_WEIGHT" in _active
+            _bm25_set = "MEMO_SEARCH_BM25_WEIGHT" in _active
             if _vec_set and _bm25_set:
                 _weight_sum = w_vec + w_bm25
                 if abs(_weight_sum - 1.0) > 0.05:
@@ -200,6 +211,16 @@ class _SearchOpsMixin(_MemoryBase):
             rows = _rrf_fuse(
                 vec_hits, bm_hits, graph_hits,
                 limit=input_k, k=rrf_k, weights=rrf_weights,
+            )
+            _add_trace(
+                "candidate_generation",
+                mode="hybrid",
+                vec_count=len(vec_hits),
+                bm25_count=len(bm_hits),
+                graph_count=len(graph_hits),
+                output_count=len(rows),
+                rrf_k=rrf_k,
+                input_k=input_k,
             )
         out: list[MemoryRecord] = []
         for r in rows:
@@ -218,12 +239,15 @@ class _SearchOpsMixin(_MemoryBase):
                     score=r.get("score"),
                 ),
             )
+        _add_trace("materialize", input_count=len(rows), output_count=len(out), load_bodies=load_bodies)
         # Drop soft-forgotten memorias (forget_after TTL elapsed, see
         # lifecycle.py) before feedback/rerank so they never reach the
         # consumer — recall, ask, chat all route through here. Reversible
         # via `unforget`; pass include_forgotten=True to surface them.
         if out and not include_forgotten:
+            before = len(out)
             out = [r for r in out if not (r.extra or {}).get(IS_FORGOTTEN_KEY)]
+            _add_trace("forget_filter", input_count=before, output_count=len(out))
         # Source-level feedback (👍 / 👎) — applied AFTER RRF/vec retrieval
         # but BEFORE cross-encoder rerank so the reranker doesn't waste
         # cycles on hits the user already vetoed. Embeds the query once
@@ -237,9 +261,11 @@ class _SearchOpsMixin(_MemoryBase):
         # is itself vector-based, so applying it only when a query vector already
         # exists is consistent.
         fb_emb = locals().get("emb")
-        if out and fb_emb is not None and os.environ.get("MEMO_FEEDBACK_DISABLED") != "1":
+        if out and fb_emb is not None and not flag_bool("MEMO_FEEDBACK_DISABLED"):
             try:
+                before = len(out)
                 out = self._apply_source_feedback(out, fb_emb)
+                _add_trace("feedback", input_count=before, output_count=len(out))
             except Exception as exc:
                 _log.warning("source_feedback failed: %s", exc, exc_info=True)
         elif out and fb_emb is None:
@@ -259,15 +285,19 @@ class _SearchOpsMixin(_MemoryBase):
         )
         _health_applied = False
         if _reranker_will_run and not flag_bool("MEMO_HEALTH_SCORES_DISABLED"):
+            before = len(out)
             out = self._apply_health_scores(out)
             _health_applied = True
+            _add_trace("health_pre_rerank", input_count=before, output_count=len(out))
         # Cross-encoder rerank on hybrid mode only. Skipped for vec/bm25
         # since those callers explicitly opted out of fusion entirely;
         # adding rerank to single-mode searches would surprise users
         # benchmarking the raw bi-encoder or BM25 surfaces.
         # Also skipped when disable_reranker=True (e.g., chat synthesis).
         if _reranker_will_run:
+            before = len(out)
             out = self._rerank(query, out, top_n=limit)
+            _add_trace("rerank", input_count=before, output_count=len(out))
         # Recency decay: blend a freshness bonus into the score so older
         # memories don't crowd out recent ones. MEMO_SEARCH_DECAY_HALFLIFE
         # (days) sets the halflife explicitly; if unset, the consumer paths
@@ -278,14 +308,24 @@ class _SearchOpsMixin(_MemoryBase):
         if halflife_days <= 0 and recency:
             halflife_days = _RECALL_DECAY_HALFLIFE_DEFAULT
         if halflife_days > 0 and out:
+            before = len(out)
             alpha = min(max(flag_float("MEMO_SEARCH_DECAY_ALPHA") or 0.15, 0.0), 1.0)
             out = _apply_decay(out, halflife_days=halflife_days, alpha=alpha)
+            _add_trace(
+                "recency_decay",
+                input_count=before,
+                output_count=len(out),
+                halflife_days=halflife_days,
+                alpha=alpha,
+            )
         # Cache-tier read-through: on a local miss/under-fill, pull from the
         # backing store and materialize locally. OPT-IN per call — only the
         # consumer paths (ask/chat) pass read_through=True. The recall hook
         # never does: a backend subprocess (≤5s) would blow its 5s budget.
         if read_through and self.cache.policy.read_through and len(out) < limit:
+            before = len(out)
             out = self._cache_read_through(query, out, limit)
+            _add_trace("cache_read_through", input_count=before, output_count=len(out))
         # Entity-aware score boost: if query mentions known entities (persons,
         # technologies, projects), boost chunks whose extra["entities"] overlaps.
         # Gated by MEMO_ENTITY_RETRIEVAL_ENABLED. Best-effort: any failure is
@@ -296,7 +336,9 @@ class _SearchOpsMixin(_MemoryBase):
             entity_boost if entity_boost is not None else flag_bool("MEMO_ENTITY_RETRIEVAL_ENABLED")
         )
         if out and _entity_on:
+            before = len(out)
             out = self._apply_entity_boost(query, out)
+            _add_trace("entity_boost", input_count=before, output_count=len(out))
 
         # Contradiction penalty: penalise the older side of open contradiction
         # pairs among the retrieved results so stale/superseded memories don't
@@ -305,19 +347,34 @@ class _SearchOpsMixin(_MemoryBase):
         # least once). Only the recall/ask/chat consumer paths benefit; the eval
         # harness and recall-hook budget make this opt-in.
         if out and flag_bool("MEMO_CONTRADICT_PENALTY_ENABLED"):
+            before = len(out)
             out = self._apply_contradict_penalty(out)
+            _add_trace("contradiction_penalty", input_count=before, output_count=len(out))
         if out and flag_bool("MEMO_GRAPH_EXPANSION_ENABLED"):
+            before = len(out)
             out = self._apply_graph_expansion(
                 out,
                 load_bodies=load_bodies,
                 exclude_types=exclude_types,
             )
+            _add_trace("graph_expansion", input_count=before, output_count=len(out))
         if out and flag_bool("MEMO_RETRIEVAL_BOOST"):
+            before = len(out)
             out = self._apply_retrieval_boost(query, out)
+            _add_trace("retrieval_boost", input_count=before, output_count=len(out))
         if out and not flag_bool("MEMO_HEALTH_SCORES_DISABLED") and not _health_applied:
+            before = len(out)
             out = self._apply_health_scores(out)
+            _add_trace("health", input_count=before, output_count=len(out))
         self._record_access([r.id for r in out])
+        _add_trace("final", output_count=len(out), limit=limit)
         return out
+
+    def search_with_trace(self, query: str, **kwargs: Any) -> dict[str, Any]:
+        """Run `search()` and return the same hits plus structured pipeline trace."""
+        trace: list[dict[str, Any]] = []
+        hits = self.search(query, _trace=trace, **kwargs)
+        return {"hits": hits, "trace": trace}
 
     def _fetch_graph_candidates(
         self,
@@ -625,7 +682,14 @@ class _SearchOpsMixin(_MemoryBase):
             return
         try:
             self.store.touch(ids)
-            if not flag_bool("MEMO_HEALTH_SCORES_DISABLED"):
+            # roi_score boost on access is the LEGACY signal (rewards mere
+            # surfacing). When the outcome loop owns roi_score
+            # (MEMO_OUTCOME_RANKING_ENABLED), skip it so `reconcile_roi` —
+            # driven by real grounding outcomes — stays authoritative instead of
+            # being washed out by every-surfacing increments.
+            if not flag_bool("MEMO_HEALTH_SCORES_DISABLED") and not flag_bool(
+                "MEMO_OUTCOME_RANKING_ENABLED"
+            ):
                 self.store.boost_roi_batch(ids)
         except sqlite3.Error as exc:  # never let access tracking break a read
             _log.debug("access tracking skipped: %s", exc)

--- a/src/memo/memory/write_ops.py
+++ b/src/memo/memory/write_ops.py
@@ -20,6 +20,7 @@ from typing import Any
 import frontmatter
 
 from memo._trace import current_trace
+from memo.flags import flag_bool
 from memo.memory._base import _MemoryBase
 from memo.memory.record import (
     _DERIVE_SYSTEM_PROMPT,
@@ -74,7 +75,7 @@ _TYPE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
 
 def _infer_type_from_content(content: str) -> str | None:
     """Zero-cost regex-based type inference. Returns a type string or None."""
-    if os.environ.get("MEMO_CAPTURE_PATTERN_TYPES", "1") == "0":
+    if not flag_bool("MEMO_CAPTURE_PATTERN_TYPES"):
         return None
     snippet = content[:600]
     for type_name, pattern in _TYPE_PATTERNS:
@@ -204,7 +205,7 @@ class _WriteOpsMixin(_MemoryBase):
         # save carries provenance (otherwise we have no agent context
         # to reason about), and (c) synapse is on PATH.
         if respect_synapse_freeze is None:
-            respect_synapse_freeze = os.environ.get("MEMO_RESPECT_SYNAPSE_FREEZE") == "1"
+            respect_synapse_freeze = flag_bool("MEMO_RESPECT_SYNAPSE_FREEZE")
         if respect_synapse_freeze and extra and extra.get("synapse_trace_id"):
             self._enforce_synapse_freeze(
                 title=title,
@@ -264,7 +265,7 @@ class _WriteOpsMixin(_MemoryBase):
         # MEMO_PROJECT_TAG) so per-repo recall can boost the right
         # memorias. Skipped when the caller already passed any
         # `project:` tag — explicit always wins.
-        if auto_project and os.environ.get("MEMO_AUTO_PROJECT_TAG", "1") == "1":
+        if auto_project and flag_bool("MEMO_AUTO_PROJECT_TAG"):
             try:
                 from memo.project import current_project_tag, has_project_tag
 
@@ -291,7 +292,7 @@ class _WriteOpsMixin(_MemoryBase):
         # Near-duplicate check: quick vec search before committing. Best-effort
         # — never blocks the save. Gated on MEMO_SAVE_DEDUP_CHECK (default on).
         # Skipped on an empty corpus (no embed cost, no duplicates possible).
-        from memo.flags import flag_bool, flag_float
+        from memo.flags import flag_float
 
         if flag_bool("MEMO_SAVE_DEDUP_CHECK") and not defer_embed:
             try:

--- a/src/memo/ocr.py
+++ b/src/memo/ocr.py
@@ -15,7 +15,6 @@ import contextlib
 import hashlib
 import json
 import logging
-import os
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -44,8 +43,10 @@ def ocr_min_confidence(default: float = _DEFAULT_OCR_MIN_CONFIDENCE) -> float:
     """Per-line OCR confidence floor. Lines below this are dropped before the
     text is indexed, so mojibake doesn't pollute retrieval. Override with
     ``MEMO_OCR_MIN_CONFIDENCE`` (0 disables)."""
-    raw = os.environ.get("MEMO_OCR_MIN_CONFIDENCE", "").strip()
-    if not raw:
+    from memo.flags import active_flags
+
+    raw = active_flags().get("MEMO_OCR_MIN_CONFIDENCE")
+    if raw is None:
         return default
     try:
         return max(0.0, min(1.0, float(raw)))
@@ -73,8 +74,10 @@ _DEFAULT_OCR_LOW_CONF_THRESHOLD = 0.6
 def ocr_low_conf_threshold(default: float = _DEFAULT_OCR_LOW_CONF_THRESHOLD) -> float:
     """Mean-confidence threshold below which an OCR'd image is treated as
     low-quality. Override with ``MEMO_OCR_LOW_CONF_THRESHOLD`` (0 disables)."""
-    raw = os.environ.get("MEMO_OCR_LOW_CONF_THRESHOLD", "").strip()
-    if not raw:
+    from memo.flags import active_flags
+
+    raw = active_flags().get("MEMO_OCR_LOW_CONF_THRESHOLD")
+    if raw is None:
         return default
     try:
         return max(0.0, min(1.0, float(raw)))
@@ -272,5 +275,8 @@ def extract_text_cached_with_confidence(
 
 
 def ocr_enabled_via_env(default: bool = False) -> bool:
-    raw = os.environ.get("MEMO_OCR_ENABLED", "1" if default else "0").strip().lower()
-    return raw in {"1", "true", "on", "yes"}
+    from memo.flags import active_flags, flag_bool
+
+    if "MEMO_OCR_ENABLED" not in active_flags():
+        return default
+    return flag_bool("MEMO_OCR_ENABLED")

--- a/src/memo/outcome.py
+++ b/src/memo/outcome.py
@@ -1,0 +1,250 @@
+"""The Outcome Loop — memo learns from whether its recalls actually got USED.
+
+Closes the recall → use → outcome loop. The grounding detector already records,
+per turn, whether a surfaced memoria was actually used in the answer
+(``grounding.log``). Today that signal dies in the dashboard while ranking's
+``memory_health.roi_score`` is driven by mere ACCESS (every surfacing boosts it
+— so noise that keeps showing up ranks higher). This module turns the outcome
+signal into:
+
+  - a per-memoria UTILITY score (Bayesian-smoothed grounded/surfaced) reconciled
+    into ``roi_score`` so ranking promotes memorias that ground answers and
+    demotes ones that surface but never help (:func:`reconcile_roi`);
+  - a KNOWLEDGE-GAP report — prompts where recall bailed / returned nothing /
+    was never grounded: what memo could not answer, i.e. what to capture next
+    (:func:`detect_gaps`);
+  - DEAD-WEIGHT detection — memorias surfaced often yet never grounded, for
+    reversible archival by ``memo maintain`` (:func:`dead_weight`).
+
+Pure reads over recall.log + grounding.log, plus a single roi write on reconcile.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_PRIOR_N = 3.0
+_DEFAULT_ROI_FLOOR = 0.6
+_DEFAULT_ROI_CAP = 1.5
+
+
+def compute_utilities(
+    state_dir: Path,
+    *,
+    prior_n: float = _DEFAULT_PRIOR_N,
+    recall_limit: int = 2000,
+    grounding_limit: int = 4000,
+) -> dict[str, Any]:
+    """Per-memoria utility from real outcomes, keyed by 8-char id prefix.
+
+    ``surfaced`` = distinct (session, turn) the memoria was shown in;
+    ``grounded`` = of those, how many the answer actually used (intersection,
+    so utility never exceeds 1). ``utility`` is Bayesian-smoothed toward the
+    global grounded rate so a memoria seen once isn't judged on one data point::
+
+        utility = (grounded + prior_mean * prior_n) / (surfaced + prior_n)
+    """
+    from memo.dashboard import GROUNDED_SCORE, read_grounding_log, read_recall_log
+
+    surfaced: dict[str, set[tuple[str, int]]] = defaultdict(set)
+    for r in read_recall_log(state_dir, limit=recall_limit):
+        sid, turn = r.get("session_id"), r.get("turn")
+        if not (sid and isinstance(turn, int)):
+            continue
+        for h in r.get("hits") or []:
+            pid = (h.get("id") or "")[:8]
+            if pid:
+                surfaced[pid].add((sid, turn))
+
+    grounded: dict[str, set[tuple[str, int]]] = defaultdict(set)
+    for g in read_grounding_log(state_dir, limit=grounding_limit):
+        sid, turn = g.get("session_id"), g.get("turn")
+        pid = (g.get("recall_id") or "")[:8]
+        score = g.get("used_score")
+        if not (sid and isinstance(turn, int) and pid):
+            continue
+        if isinstance(score, (int, float)) and float(score) >= GROUNDED_SCORE:
+            grounded[pid].add((sid, turn))
+
+    total_surf = sum(len(v) for v in surfaced.values())
+    total_grnd = sum(len(grounded.get(p, set()) & s) for p, s in surfaced.items())
+    prior_mean = (total_grnd / total_surf) if total_surf else 0.5
+
+    by_prefix: dict[str, dict[str, Any]] = {}
+    for pid, sset in surfaced.items():
+        s = len(sset)
+        g_count = len(grounded.get(pid, set()) & sset)
+        utility = (g_count + prior_mean * prior_n) / (s + prior_n)
+        by_prefix[pid] = {"surfaced": s, "grounded": g_count, "utility": round(utility, 4)}
+    return {
+        "prior_mean": round(prior_mean, 4),
+        "surfaced_total": total_surf,
+        "grounded_total": total_grnd,
+        "by_prefix": by_prefix,
+    }
+
+
+def _prefix_to_id(memory: Any) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for fid in memory.store.all_ids():
+        out.setdefault(fid[:8], fid)
+    return out
+
+
+def reconcile_roi(
+    memory: Any,
+    *,
+    prior_n: float | None = None,
+    floor: float | None = None,
+    cap: float | None = None,
+) -> dict[str, Any]:
+    """Recompute ``roi_score`` from grounding outcomes and write it.
+
+    ``roi_score = floor + utility * (cap - floor)`` — utility 0 (surfaced, never
+    grounded) → floor; utility 1 → cap; no-data memorias stay near neutral via
+    the Bayesian prior. Authoritative absolute write (overwrites access drift).
+    """
+    from memo.flags import flag_float
+
+    prior_n = prior_n if prior_n is not None else (flag_float("MEMO_OUTCOME_PRIOR_N") or _DEFAULT_PRIOR_N)
+    floor = floor if floor is not None else (flag_float("MEMO_OUTCOME_ROI_FLOOR") or _DEFAULT_ROI_FLOOR)
+    cap = cap if cap is not None else (flag_float("MEMO_OUTCOME_ROI_CAP") or _DEFAULT_ROI_CAP)
+    span = max(0.0, cap - floor)
+
+    u = compute_utilities(memory.cfg.state_dir, prior_n=prior_n)
+    by_prefix = u["by_prefix"]
+    if not by_prefix:
+        return {"updated": 0, "scored": 0, "prior_mean": u["prior_mean"]}
+
+    p2id = _prefix_to_id(memory)
+    pairs: list[tuple[str, float]] = []
+    for pid, st in by_prefix.items():
+        fid = p2id.get(pid)
+        if not fid:
+            continue
+        pairs.append((fid, floor + st["utility"] * span))
+    written = memory.store.set_roi_batch(pairs, floor=floor, cap=cap)
+    return {
+        "updated": written,
+        "scored": len(pairs),
+        "prior_mean": u["prior_mean"],
+        "floor": floor,
+        "cap": cap,
+    }
+
+
+def dead_weight(
+    memory: Any,
+    *,
+    min_surfaced: int,
+    prior_n: float | None = None,
+) -> list[dict[str, Any]]:
+    """Memorias surfaced ``>= min_surfaced`` times yet NEVER grounded — recall
+    noise that crowds out useful hits. Candidates for reversible archival.
+    ``min_surfaced <= 0`` disables (returns [])."""
+    from memo.flags import flag_float
+
+    if min_surfaced <= 0:
+        return []
+    prior_n = prior_n if prior_n is not None else (flag_float("MEMO_OUTCOME_PRIOR_N") or _DEFAULT_PRIOR_N)
+    u = compute_utilities(memory.cfg.state_dir, prior_n=prior_n)
+    p2id = _prefix_to_id(memory)
+    out: list[dict[str, Any]] = []
+    for pid, st in u["by_prefix"].items():
+        if st["surfaced"] >= min_surfaced and st["grounded"] == 0:
+            fid = p2id.get(pid)
+            if fid:
+                out.append({"id": fid, "surfaced": st["surfaced"], "utility": st["utility"]})
+    out.sort(key=lambda d: d["surfaced"], reverse=True)
+    return out
+
+
+_NOISE_MARKERS = (
+    "<task-notification", "<tool-use-id", "task-id>", "tool-use-id>",
+    "system-reminder", "<system", "hook additional context",
+)
+
+
+def _is_injected_noise(prompt: str) -> bool:
+    """Drop prompts that are clearly injected machine context (hook blobs, tool
+    notifications, system reminders) rather than real user questions — they are
+    not knowledge gaps, just telemetry that landed in recall.log."""
+    p = prompt.lstrip()
+    if p.startswith("<"):
+        return True
+    low = p.lower()
+    return any(m in low for m in _NOISE_MARKERS)
+
+
+def detect_gaps(
+    state_dir: Path,
+    *,
+    limit: int = 2000,
+    sim_threshold: float = 0.6,
+    min_count: int = 1,
+) -> list[dict[str, Any]]:
+    """Knowledge gaps — knowledge-seeking prompts memo could NOT answer.
+
+    A gap is a knowledge prompt whose recall (a) bailed for no-match (NOT for a
+    slash command / short prompt — those aren't gaps), (b) returned zero hits,
+    or (c) surfaced something but the turn was never grounded (nothing used).
+    Similar prompts are clustered by token Jaccard so a repeated question
+    surfaces once with a count. Sorted by frequency, then recency.
+    """
+    from memo.dashboard import GROUNDED_SCORE, read_grounding_log, read_recall_log
+    from memo.dashboard_metrics import _is_knowledge_prompt, _jaccard, _reask_tokens
+
+    grounded_turns: set[tuple[str, int]] = set()
+    for g in read_grounding_log(state_dir):
+        sid, turn = g.get("session_id"), g.get("turn")
+        score = g.get("used_score")
+        if sid and isinstance(turn, int) and isinstance(score, (int, float)) and float(score) >= GROUNDED_SCORE:
+            grounded_turns.add((sid, turn))
+
+    raw: list[dict[str, Any]] = []
+    for r in read_recall_log(state_dir, limit=limit):
+        prompt = (r.get("prompt") or "").strip()
+        if not prompt or not _is_knowledge_prompt(prompt) or _is_injected_noise(prompt):
+            continue
+        via = r.get("via")
+        hits = r.get("hits") or []
+        sid, turn = r.get("session_id"), r.get("turn")
+        if via == "bail":
+            reason_raw = r.get("reason") or ""
+            if "min_sim" not in reason_raw and "no hits" not in reason_raw:
+                continue  # slash command / short prompt → not a knowledge gap
+            reason = "sin coincidencias"
+        elif not hits:
+            reason = "0 resultados"
+        elif sid and isinstance(turn, int) and (sid, turn) not in grounded_turns:
+            reason = "encontró algo pero no se usó"
+        else:
+            continue
+        raw.append({"prompt": prompt, "reason": reason, "ts": r.get("ts")})
+
+    clusters: list[dict[str, Any]] = []
+    for g in raw:
+        tok = _reask_tokens(g["prompt"])
+        for c in clusters:
+            if _jaccard(tok, c["tokens"]) >= sim_threshold:
+                c["count"] += 1
+                c["reasons"].add(g["reason"])
+                if (g["ts"] or "") > (c["last_seen"] or ""):
+                    c["last_seen"] = g["ts"]
+                    c["prompt"] = g["prompt"]
+                break
+        else:
+            clusters.append({
+                "tokens": tok, "prompt": g["prompt"], "count": 1,
+                "reasons": {g["reason"]}, "last_seen": g["ts"],
+            })
+
+    out = [
+        {"prompt": c["prompt"], "count": c["count"],
+         "reasons": sorted(c["reasons"]), "last_seen": c["last_seen"]}
+        for c in clusters if c["count"] >= min_count
+    ]
+    out.sort(key=lambda c: (c["count"], c["last_seen"] or ""), reverse=True)
+    return out

--- a/src/memo/project.py
+++ b/src/memo/project.py
@@ -46,7 +46,9 @@ def current_project_tag(cwd: str | os.PathLike[str] | None = None) -> str | None
         2. Git toplevel under `cwd` (defaults to `os.getcwd()`).
         3. None.
     """
-    pinned = os.environ.get("MEMO_PROJECT_TAG", "").strip()
+    from memo.flags import flag_str
+
+    pinned = flag_str("MEMO_PROJECT_TAG").strip()
     if pinned:
         slug = pinned.split(":", 1)[1] if pinned.startswith(_PROJECT_PREFIX) else pinned
         slug = slugify_project(slug)

--- a/src/memo/recall_logic.py
+++ b/src/memo/recall_logic.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
-import os
 import sys
 import time
 from collections.abc import Callable
@@ -60,7 +59,9 @@ def _session_context(mem: Any, exclude_types: set[str] | None, *, max_titles: in
         titles = [t for t in titles if t][:max_titles]
         return " ; ".join(titles)
     except Exception as exc:
-        if os.environ.get("MEMO_RECALL_DEBUG") == "1":
+        from memo.flags import flag_bool
+
+        if flag_bool("MEMO_RECALL_DEBUG"):
             print(f"# recall-daemon: session_context failed: {exc}", file=sys.stderr)
         return ""
 

--- a/src/memo/recall_socket.py
+++ b/src/memo/recall_socket.py
@@ -41,7 +41,9 @@ class _RecallHandler(socketserver.StreamRequestHandler):
             return True
         except (BrokenPipeError, ConnectionResetError, OSError) as exc:
             if debug:
-                print(f"# recall-daemon: client disconnected before response: {exc}", file=sys.stderr)
+                print(
+                    f"# recall-daemon: client disconnected before response: {exc}", file=sys.stderr
+                )
             return False
 
     def _embed_query(self, req: dict[str, Any]) -> str:
@@ -49,14 +51,73 @@ class _RecallHandler(socketserver.StreamRequestHandler):
         if not text.strip():
             return json.dumps({"error": "embed_query: empty text"})
         vec = self.server._mem.embedder.embed_query(text)
-        return json.dumps({"vector": vec, "dim": len(vec), "dims": len(vec), "model": self.server._cfg.embedder_model}, ensure_ascii=False)
+        return json.dumps(
+            {
+                "vector": vec,
+                "dim": len(vec),
+                "dims": len(vec),
+                "model": self.server._cfg.embedder_model,
+            },
+            ensure_ascii=False,
+        )
+
+    def _search(self, req: dict[str, Any]) -> str:
+        """Warm structured search for programmatic readers (memflow bridge).
+
+        Same hybrid retrieval as ``memo search`` but served from the hot daemon
+        (~0.7s vs ~9s cold CLI) and emitting ``{"results": [...]}``. Attributes
+        the consult to ``client`` so the layer counts in ``memo usefulness``.
+        """
+        prompt = str(req.get("prompt") or req.get("query") or "").strip()
+        if not prompt:
+            return json.dumps({"error": "search: empty prompt", "results": []})
+        from memo.flags import flag_int
+
+        limit = req.get("limit")
+        limit = int(limit) if isinstance(limit, (int, float)) else 5
+        type_ = req.get("type") or None
+        client = req.get("client") or None
+        t0 = time.time()
+        timeout_s = max(0.1, (flag_int("MEMO_RECALL_LOCK_TIMEOUT_MS") or 2500) / 1000.0)
+        if not self.server._priority_lock.acquire(priority=1, timeout=timeout_s):
+            return json.dumps({"error": "search: timeout acquiring lock", "results": []})
+        try:
+            # No cross-encoder rerank: it adds ~6s and a fallback bridge wants a
+            # fast hybrid shortlist, not a precision re-sort. Caller score-filters.
+            hits = self.server._mem.search(
+                prompt, limit=limit, type_=type_, mode="hybrid", disable_reranker=True
+            )
+        finally:
+            self.server._priority_lock.release()
+        results = []
+        for h in hits[:limit]:
+            d = h.to_dict()
+            d["kind"] = d.get("type")
+            results.append(d)
+        try:
+            from memo.dashboard import append_recall_log
+
+            append_recall_log(
+                self.server._cfg.state_dir,
+                prompt=prompt,
+                hits=results,
+                via="daemon",
+                client=client,
+                source=(req.get("source") or None),
+                latency_ms=int((time.time() - t0) * 1000),
+            )
+        except Exception:
+            pass
+        return json.dumps({"results": results}, ensure_ascii=False)
 
     def _embed_batch(self, req: dict[str, Any]) -> str:
         texts = req.get("texts")
         if not isinstance(texts, list):
             return json.dumps({"error": "embed_batch: `texts` must be a list"})
         if not texts:
-            return json.dumps({"vectors": [], "dim": 0, "dims": 0, "model": self.server._cfg.embedder_model})
+            return json.dumps(
+                {"vectors": [], "dim": 0, "dims": 0, "model": self.server._cfg.embedder_model}
+            )
         if not all(isinstance(t, str) for t in texts):
             return json.dumps({"error": "embed_batch: every element of `texts` must be a string"})
         from memo.flags import flag_int
@@ -72,12 +133,23 @@ class _RecallHandler(socketserver.StreamRequestHandler):
             else:
                 return json.dumps({"error": "embed_batch: timeout acquiring lock"})
         dim = len(vectors[0]) if vectors else 0
-        return json.dumps({"vectors": vectors, "dim": dim, "dims": dim, "model": self.server._cfg.embedder_model}, ensure_ascii=False)
+        return json.dumps(
+            {"vectors": vectors, "dim": dim, "dims": dim, "model": self.server._cfg.embedder_model},
+            ensure_ascii=False,
+        )
 
     def _ping(self) -> str:
         stats = getattr(self.server, "_stats", None)
         snap = stats.snapshot() if stats is not None else {}
-        return json.dumps({"ok": True, "model": self.server._cfg.embedder_model, "dims": self.server._cfg.embedder_dims, "started_at": snap.get("started_at"), "uptime_s": snap.get("uptime_s")})
+        return json.dumps(
+            {
+                "ok": True,
+                "model": self.server._cfg.embedder_model,
+                "dims": self.server._cfg.embedder_dims,
+                "started_at": snap.get("started_at"),
+                "uptime_s": snap.get("uptime_s"),
+            }
+        )
 
     def _stats(self) -> str:
         stats = getattr(self.server, "_stats", None)
@@ -87,7 +159,9 @@ class _RecallHandler(socketserver.StreamRequestHandler):
 
     def handle(self) -> None:
         t0 = time.time()
-        debug = os.environ.get("MEMO_RECALL_DEBUG") == "1"
+        from memo.flags import flag_bool
+
+        debug = flag_bool("MEMO_RECALL_DEBUG")
         op = "parse"
         error = False
         try:
@@ -131,11 +205,25 @@ class _RecallHandler(socketserver.StreamRequestHandler):
                     timeout_s = max(0.1, (flag_int("MEMO_RECALL_LOCK_TIMEOUT_MS") or 2500) / 1000.0)
                     if not self.server._priority_lock.acquire(priority=priority, timeout=timeout_s):
                         if debug:
-                            print(f"# recall-daemon: lock busy >{timeout_s:.1f}s, bailing empty", file=sys.stderr)
+                            print(
+                                f"# recall-daemon: lock busy >{timeout_s:.1f}s, bailing empty",
+                                file=sys.stderr,
+                            )
                         self._write_response("{}", debug=debug)
                         return
                     try:
-                        result, log_fn = _recall_logic(prompt, cwd, self.server._mem, self.server._cfg, debug, t0=t0, session_id=_sid, turn=_turn, client=_client, micro_embedder=self.server._micro_embedder)
+                        result, log_fn = _recall_logic(
+                            prompt,
+                            cwd,
+                            self.server._mem,
+                            self.server._cfg,
+                            debug,
+                            t0=t0,
+                            session_id=_sid,
+                            turn=_turn,
+                            client=_client,
+                            micro_embedder=self.server._micro_embedder,
+                        )
                     finally:
                         self.server._priority_lock.release()
                 elif op == "embed_query":
@@ -146,6 +234,8 @@ class _RecallHandler(socketserver.StreamRequestHandler):
                             self.server._priority_lock.release()
                     else:
                         result = json.dumps({"error": "embed_query: timeout acquiring lock"})
+                elif op == "search":
+                    result = self._search(req)
                 elif op == "embed_batch":
                     result = self._embed_batch(req)
                 elif op == "ping":
@@ -157,7 +247,10 @@ class _RecallHandler(socketserver.StreamRequestHandler):
                     result = json.dumps({"error": f"unknown op: {op!r}"})
             except Exception as exc:
                 error = True
-                print(f"# recall-daemon: handler error (op={op}): {type(exc).__name__}: {exc}", file=sys.stderr)
+                print(
+                    f"# recall-daemon: handler error (op={op}): {type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                )
                 result = json.dumps({"error": f"{type(exc).__name__}: {exc}"})
 
             delivered = self._write_response(result, debug=debug)
@@ -212,6 +305,7 @@ class _RecallServer(socketserver.ThreadingUnixStreamServer):
         if flag_bool("MEMO_RECALL_PRIORITY_ENABLED"):
             self._priority_lock = PriorityLock()
         else:
+
             class FakePriorityLock:
                 def __init__(self, lock: threading.Lock):
                     self._lock = lock
@@ -234,7 +328,9 @@ class _RecallServer(socketserver.ThreadingUnixStreamServer):
             except Exception as exc:
                 print(f"# recall-daemon: failed to init micro-embedder: {exc}", file=sys.stderr)
 
-        self._stats = _DaemonStats(started_at=time.time(), model=cfg.embedder_model, dims=cfg.embedder_dims)
+        self._stats = _DaemonStats(
+            started_at=time.time(), model=cfg.embedder_model, dims=cfg.embedder_dims
+        )
         super().__init__(sock_path, _RecallHandler)
 
     def server_close(self) -> None:
@@ -283,16 +379,22 @@ def run_server(state_dir: Path | None = None) -> None:
     signal.signal(signal.SIGTERM, _sigterm)
     signal.signal(signal.SIGINT, _sigterm)
 
-    debug = os.environ.get("MEMO_RECALL_DEBUG") == "1"
+    from memo.flags import flag_bool, flag_float
+
+    debug = flag_bool("MEMO_RECALL_DEBUG")
     if debug:
         print(f"# recall-daemon: listening on {sock_path}", file=sys.stderr)
 
-    try:
-        interval = float(os.environ.get("MEMO_EMBEDDER_STATS_INTERVAL_S") or _STATS_DEFAULT_PERSIST_INTERVAL_S)
-    except ValueError:
-        interval = _STATS_DEFAULT_PERSIST_INTERVAL_S
+    interval = flag_float("MEMO_EMBEDDER_STATS_INTERVAL_S") or _STATS_DEFAULT_PERSIST_INTERVAL_S
     if interval > 0:
-        persister = threading.Thread(target=_stats_persister, args=(state_dir, server._stats, interval), daemon=True, name="recall-daemon-stats-persister")
+        persister = threading.Thread(
+            target=_stats_persister,
+            args=(state_dir, server._stats, interval),
+            daemon=True,
+            name="recall-daemon-stats-persister",
+        )
         persister.start()
 
-    _serve_until_shutdown(server, shutdown_event, name="recall-daemon-serve", on_shutdown=lambda: _cleanup(state_dir))
+    _serve_until_shutdown(
+        server, shutdown_event, name="recall-daemon-serve", on_shutdown=lambda: _cleanup(state_dir)
+    )

--- a/src/memo/recall_stats.py
+++ b/src/memo/recall_stats.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import sys
 import threading
 import time
@@ -91,5 +90,7 @@ def _stats_persister(state_dir: Path, stats: _DaemonStats, interval_s: float) ->
             tmp.write_text(json.dumps(snap, indent=2))
             tmp.replace(target)
         except (OSError, ValueError, TypeError) as exc:
-            if os.environ.get("MEMO_RECALL_DEBUG") == "1":
+            from memo.flags import flag_bool
+
+            if flag_bool("MEMO_RECALL_DEBUG"):
                 print(f"# recall-daemon: stats persist failed: {exc}", file=sys.stderr)

--- a/src/memo/repo_index.py
+++ b/src/memo/repo_index.py
@@ -9,7 +9,6 @@ one note-shaped Markdown file per record.
 from __future__ import annotations
 
 import hashlib
-import os
 import shutil
 from pathlib import Path
 from typing import Any
@@ -192,7 +191,9 @@ class RepoCorpus:
 
         max_bytes = max_file_bytes
         if max_bytes is None:
-            max_bytes = int(os.environ.get("MEMO_REPO_MAX_FILE_BYTES", DEFAULT_MAX_FILE_BYTES))
+            from memo.flags import flag_int
+
+            max_bytes = flag_int("MEMO_REPO_MAX_FILE_BYTES") or DEFAULT_MAX_FILE_BYTES
         include_globs = list(include or [])
         exclude_globs = [*DEFAULT_EXCLUDE_GLOBS, *(exclude or [])]
 

--- a/src/memo/repo_index_helpers.py
+++ b/src/memo/repo_index_helpers.py
@@ -6,10 +6,8 @@ intended for direct use outside the repo-indexing subsystem.
 
 from __future__ import annotations
 
-import contextlib
 import fnmatch
 import hashlib
-import os
 import re
 import subprocess
 from collections.abc import Callable
@@ -135,12 +133,10 @@ def _git_timeout(default: float) -> float:
     indefinitely, blocking the indexer thread (and any caller awaiting it).
     Configurable via MEMO_REPO_GIT_TIMEOUT_S (seconds, 0 disables).
     """
-    raw = os.environ.get("MEMO_REPO_GIT_TIMEOUT_S")
-    if not raw:
-        return default
-    try:
-        v = float(raw)
-    except ValueError:
+    from memo.flags import flag_float
+
+    v = flag_float("MEMO_REPO_GIT_TIMEOUT_S")
+    if v is None:
         return default
     return v if v > 0 else 0.0
 
@@ -216,11 +212,10 @@ def _repo_embed_input(chunk: dict[str, Any]) -> RepoEmbedInput:
 
 
 def _repo_embed_batch_size() -> int:
-    raw = os.environ.get("MEMO_REPO_EMBED_BATCH")
-    if raw:
-        with contextlib.suppress(ValueError):
-            return max(MIN_EMBED_BATCH, int(raw))
-    return DEFAULT_EMBED_BATCH
+    from memo.flags import flag_int
+
+    value = flag_int("MEMO_REPO_EMBED_BATCH")
+    return DEFAULT_EMBED_BATCH if value is None else max(MIN_EMBED_BATCH, value)
 
 
 def _repo_flush_batch_size() -> int:
@@ -229,11 +224,10 @@ def _repo_flush_batch_size() -> int:
     Lower values trade write overhead for finer-grained resume
     granularity if the run is interrupted.
     """
-    raw = os.environ.get("MEMO_REPO_FLUSH_BATCH")
-    if raw:
-        with contextlib.suppress(ValueError):
-            return max(MIN_FLUSH_BATCH, int(raw))
-    return DEFAULT_FLUSH_BATCH
+    from memo.flags import flag_int
+
+    value = flag_int("MEMO_REPO_FLUSH_BATCH")
+    return DEFAULT_FLUSH_BATCH if value is None else max(MIN_FLUSH_BATCH, value)
 
 
 def _embed_cache_model(embedder: MLXEmbedder, cfg: Config) -> str:

--- a/src/memo/runtime/daemon.py
+++ b/src/memo/runtime/daemon.py
@@ -179,11 +179,12 @@ def prewarm(download_all: bool) -> None:
     Failures are silent when run as a hook — a hook crash must never block
     Claude Code's prompt submission.
     """
-    import os
     import sys as _sys
     import time as _time
 
-    if os.environ.get("MEMO_RECALL_DISABLE") == "1":
+    from memo.flags import flag_bool
+
+    if flag_bool("MEMO_RECALL_DISABLE"):
         _sys.exit(0)
     try:
         from memo.embedder import MLXEmbedder
@@ -221,6 +222,6 @@ def prewarm(download_all: bool) -> None:
             except Exception as dl_exc:
                 click.echo(f"[memo] chat model download failed: {dl_exc}", err=True)
     except Exception as exc:
-        if os.environ.get("MEMO_RECALL_DEBUG") == "1":
+        if flag_bool("MEMO_RECALL_DEBUG"):
             print(f"# memo prewarm failed: {exc}", file=_sys.stderr)
     _sys.exit(0)

--- a/src/memo/server.py
+++ b/src/memo/server.py
@@ -139,8 +139,9 @@ def build_server(memory: Memory | None = None) -> FastMCP:
     # feature is part of memo's stable core contract; see experimental_index.md.
     # Skip when MEMO_MCP_SLIM=1 — reduces ~116 tools to ~26 core inline tools
     # for local/constrained LLMs where tool-definition tokens are expensive.
-    from memo.flags import flag_bool as _flag_bool
-    if not _flag_bool("MEMO_MCP_SLIM"):
+    from memo.surface import mcp_include_advanced_tools
+
+    if mcp_include_advanced_tools():
         _srv_repo.register(server, memory)
         _srv_entities.register(server, memory)
         _srv_temporal.register(server, memory)

--- a/src/memo/server_common.py
+++ b/src/memo/server_common.py
@@ -14,6 +14,23 @@ def now_ms() -> int:
     return int(time.time() * 1000)
 
 
+def _mcp_client_name() -> str | None:
+    """Best-effort name of the connected MCP client, from the initialize
+    handshake's ``clientInfo.name`` (e.g. ``devin`` / ``opencode`` / ``windsurf``).
+    Lets every MCP consult self-attribute even when the caller passed no
+    ``source=`` and set no ``MEMO_SOURCE`` — so agent-class consumers stop
+    showing up as the anonymous ``mcp:unknown``. Fully guarded: returns None off
+    a request or on any FastMCP/MCP API drift."""
+    try:
+        from fastmcp.server.dependencies import get_context
+
+        ctx = get_context()
+        name = ctx.session.client_params.clientInfo.name  # type: ignore[union-attr]
+        return (name or "").strip().lower() or None
+    except Exception:
+        return None
+
+
 def log_consult(
     memory: Memory,
     *,
@@ -23,16 +40,26 @@ def log_consult(
     t0_ms: int,
     source: str = "",
 ) -> None:
-    """Record an MCP consult into the shared recall ring buffer."""
+    """Record an MCP consult into the shared recall ring buffer.
+
+    ``source`` identifies the calling layer. Attribution precedence:
+    explicit ``source=`` → ``MEMO_SOURCE`` env (mirrors the CLI's
+    ``log_cli_consult``) → the MCP client's declared ``clientInfo.name``. The
+    last tier means agent-class clients (devin / opencode / windsurf …) are
+    attributed automatically from the handshake instead of showing up as the
+    anonymous ``mcp:unknown`` consumer — no per-call args or env needed.
+    """
     try:
         from memo.dashboard import append_recall_log
+        from memo.flags import flag_str
 
+        src = (source or flag_str("MEMO_SOURCE") or "").strip().lower() or _mcp_client_name()
         append_recall_log(
             memory.cfg.state_dir,
             prompt=query or "",
             hits=hits or [],
             via=f"mcp:{tool}",
-            source=(source or "").strip().lower() or None,
+            source=src,
             latency_ms=now_ms() - t0_ms,
         )
     except Exception as exc:

--- a/src/memo/server_core_search.py
+++ b/src/memo/server_core_search.py
@@ -73,6 +73,28 @@ def register(server: Any, memory: Memory) -> None:
         return out
 
     @server.tool()
+    def memory_search_trace(
+        query: str,
+        limit: int = 10,
+        type: str | None = None,
+        body_chars: int = 280,
+        mode: str = "hybrid",
+        source: str = "",
+    ) -> dict[str, Any]:
+        t0 = now_ms()
+        envelope = memory.search_with_trace(query, limit=limit, type_=type, mode=mode)
+        hits: list[dict[str, Any]] = []
+        for r in envelope["hits"]:
+            d = r.to_dict()
+            body = d.get("body") or ""
+            if body_chars >= 0 and len(body) > body_chars:
+                d["body"] = body[:body_chars].rstrip() + "…"
+                d["body_truncated"] = True
+            hits.append(d)
+        log_consult(memory, tool="search_trace", query=query, hits=hits, t0_ms=t0, source=source)
+        return {"hits": hits, "trace": envelope["trace"]}
+
+    @server.tool()
     def memory_rerank(
         query: str,
         hits: list[dict[str, Any]],

--- a/src/memo/store/signal_queries.py
+++ b/src/memo/store/signal_queries.py
@@ -223,6 +223,39 @@ class _SignalQueriesMixin(_StoreBase):
                 [(i, floor, c, c) for i, c in pairs],
             )
 
+    def all_ids(self) -> list[str]:
+        """Return every memoria id in ``meta``. Used by the outcome loop to map
+        the 8-char id prefixes stored in recall.log / grounding.log back to full
+        ids (roi_score is keyed by the full id)."""
+        return [r["id"] for r in self._conn.execute("SELECT id FROM meta").fetchall()]
+
+    def set_roi_batch(
+        self,
+        pairs: list[tuple[str, float]],
+        *,
+        floor: float = 0.5,
+        cap: float = 1.5,
+    ) -> int:
+        """Set an ABSOLUTE roi_score for each (id, roi) pair, clamped to
+        ``[floor, cap]``. Authoritative write used by the outcome loop
+        (`memo.outcome`) to overwrite the access-driven roi drift with a value
+        derived from real grounding outcomes (was the surfaced memoria actually
+        USED in the answer?). Confidence is left at its existing value (new rows
+        default 1.0). Returns the number of (id, roi) pairs written."""
+        if not pairs:
+            return 0
+        clamped = [(i, max(floor, min(cap, float(r)))) for i, r in pairs]
+        with self._tx() as cx:
+            cx.executemany(
+                "INSERT INTO memory_health(id, confidence, roi_score, updated_at) "
+                "VALUES(?, 1.0, ?, datetime('now')) "
+                "ON CONFLICT(id) DO UPDATE SET "
+                "roi_score = excluded.roi_score, "
+                "updated_at = datetime('now')",
+                [(i, r) for i, r in clamped],
+            )
+        return len(clamped)
+
     def decay_roi(
         self,
         factor: float = 0.98,

--- a/src/memo/surface.py
+++ b/src/memo/surface.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from memo.flags import flag_bool, flag_str
+
+CORE_CLI_COMMANDS: frozenset[str] = frozenset(
+    {
+        "ask",
+        "as-of",
+        "briefing",
+        "capture-stop",
+        "config",
+        "delete",
+        "diff",
+        "doctor",
+        "get",
+        "historia",
+        "history",
+        "init",
+        "install-mcp",
+        "install-slash",
+        "install-watcher",
+        "list",
+        "mcp-command",
+        "migrate",
+        "migrate-vault",
+        "prewarm",
+        "provenance",
+        "recall-daemon",
+        "recall-hook",
+        "reindex",
+        "restore",
+        "save",
+        "search",
+        "self-update",
+        "stats",
+        "uninstall-watcher",
+        "update",
+        "watch",
+    },
+)
+
+_CORE_PROFILES = {"core", "slim"}
+
+
+def _profile(name: str, *, default: str = "default") -> str:
+    value = flag_str(name).strip().lower()
+    return value or default
+
+
+def cli_command_visible(command_name: str) -> bool:
+    """Return whether a root CLI command is visible in the selected profile."""
+    profile = _profile("MEMO_CLI_PROFILE")
+    if profile in _CORE_PROFILES:
+        return command_name in CORE_CLI_COMMANDS
+    return True
+
+
+def mcp_include_advanced_tools() -> bool:
+    """Return whether MCP should expose advanced/experimental tool modules."""
+    profile = _profile("MEMO_MCP_PROFILE")
+    if profile in _CORE_PROFILES:
+        return False
+    return not flag_bool("MEMO_MCP_SLIM")

--- a/src/memo/synapse_client.py
+++ b/src/memo/synapse_client.py
@@ -66,19 +66,19 @@ def _executable() -> str | None:
     Override with `MEMO_SYNAPSE_EXECUTABLE=/path/to/synapse` (useful in
     tests and for non-PATH installs).
     """
-    override = os.environ.get("MEMO_SYNAPSE_EXECUTABLE")
+    from memo.flags import flag_str
+
+    override = flag_str("MEMO_SYNAPSE_EXECUTABLE")
     if override:
         return override if os.path.exists(override) else None
     return shutil.which("synapse")
 
 
 def _timeout() -> float:
-    raw = os.environ.get("MEMO_SYNAPSE_CLIENT_TIMEOUT")
-    if not raw:
-        return _DEFAULT_TIMEOUT_S
-    try:
-        value = float(raw)
-    except ValueError:
+    from memo.flags import flag_float
+
+    value = flag_float("MEMO_SYNAPSE_CLIENT_TIMEOUT")
+    if value is None:
         return _DEFAULT_TIMEOUT_S
     return value if value > 0 else _DEFAULT_TIMEOUT_S
 

--- a/src/memo/sync_git.py
+++ b/src/memo/sync_git.py
@@ -191,6 +191,13 @@ def sync_once(
             return {"tier": "remote", "skipped": "locked"}
 
         result: dict = {"tier": "remote", "pulled": False, "pushed": False}
+        # Commit local work (incl. deletions) BEFORE the pull. An uncommitted
+        # delete/edit would be lost to `rebase --autostash` when the remote still
+        # has the file; committing first makes it a real commit the rebase merges.
+        try:
+            _commit_local(cfg, store)
+        except SyncGitError as exc:
+            result["commit_error"] = str(exc)
         if do_pull:
             try:
                 pull_out = sync_pull(cfg, store, mem, remote=remote)
@@ -264,12 +271,19 @@ def sync_status(cfg: Config, *, remote: str = "origin", check_remote: bool = Fal
     }
 
 
-def sync_push(cfg: Config, store: VecStore, *, remote: str = "origin") -> dict:
-    """Export signal, commit any changes, and push. Returns a summary dict."""
+def _commit_local(cfg: Config, store: VecStore) -> tuple[Path, str, int]:
+    """Export signal, stage everything (incl. deletions), and commit if dirty.
+
+    Returns ``(root, branch, n_committed)``. Idempotent — a no-op commit when the
+    tree is already clean. Pulled out of ``sync_push`` so the coordinator can
+    commit local work BEFORE the pull/rebase: an uncommitted deletion/edit would
+    otherwise be lost to ``rebase --autostash`` when the remote still has the
+    file (the delete-during-sync bug). Committing first turns local work into a
+    real commit the rebase merges correctly.
+    """
     root = git_root_for(cfg)
     branch = _current_branch(root)
     export_signal(store, signal_dir_for(cfg))
-
     _git(root, "add", "-A")
     staged = _git(root, "diff", "--cached", "--name-only").stdout.strip()
     n_files = len(staged.splitlines()) if staged else 0
@@ -278,6 +292,12 @@ def sync_push(cfg: Config, store: VecStore, *, remote: str = "origin") -> dict:
 
         who = _identity(cfg).label
         _git(root, "commit", "-m", f"sync: memo signal + memorias ({n_files} files) [{who}]")
+    return root, branch, n_files
+
+
+def sync_push(cfg: Config, store: VecStore, *, remote: str = "origin") -> dict:
+    """Commit any local changes and push. Returns a summary dict."""
+    root, branch, n_files = _commit_local(cfg, store)
 
     # Stranded-commit retry: a prior push may have failed AFTER committing
     # (offline/auth), leaving local commits unpushed. Detect that and push even
@@ -287,7 +307,7 @@ def sync_push(cfg: Config, store: VecStore, *, remote: str = "origin") -> dict:
         root, "rev-list", "--count", f"{remote}/{branch}..HEAD", check=False
     ).stdout.strip()
     has_unpushed = unpushed.isdigit() and int(unpushed) > 0
-    if not staged and not has_unpushed and not _pending_marker(cfg).is_file():
+    if n_files == 0 and not has_unpushed and not _pending_marker(cfg).is_file():
         return {"pushed": False, "reason": "nothing to commit", "branch": branch}
 
     # push; set upstream on first push
@@ -366,7 +386,20 @@ def sync_pull(cfg: Config, store: VecStore, mem: Memory, *, remote: str = "origi
     # 3) load any new/changed memorias the pull brought in
     reindexed = mem.reindex()
 
+    # 3b) prune index rows whose `.md` the pull DELETED. reindex() only adds/
+    # updates from existing files — without this, a memoria deleted on another
+    # Mac stays findable here (orphan row) until a full rebuild. gc(fix=True)
+    # drops rows whose `.md` is gone, so a deletion propagates cross-machine.
+    pruned: list[str] = []
+    try:
+        pruned = mem.gc(fix=True).get("orphan_store", [])
+    except Exception as exc:  # never let GC break the pull
+        from memo.errors import MemoError
+
+        if not isinstance(exc, MemoError):
+            raise
+
     # 4) re-export the merged signal so the next push carries the union
     export_signal(store, signal_dir_for(cfg))
 
-    return {"pulled": True, "branch": branch, "reindexed": reindexed}
+    return {"pulled": True, "branch": branch, "reindexed": reindexed, "pruned": len(pruned)}

--- a/src/memo/sync_git.py
+++ b/src/memo/sync_git.py
@@ -21,6 +21,7 @@ the rebase aborts and reports rather than guessing.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import subprocess
 from pathlib import Path
@@ -129,6 +130,140 @@ def bootstrap_clone(url: str, dest: Path, *, config_path: Path | None = None) ->
     return summary
 
 
+def sync_tier(cfg: Config) -> str:
+    """Which sync model applies. ``"local"`` = intra-machine only (sessions share
+    ``data_dir``/``memvec.db``; visibility is via the shared index, no git).
+    ``"remote"`` = a git remote is configured, so cross-machine sync is in play.
+
+    Makes the today-implicit local-vs-cloud decision explicit and single-sourced.
+    """
+    try:
+        root = git_root_for(cfg)
+    except SyncGitError:
+        return "local"
+    has_remote = bool(_git(root, "remote", check=False).stdout.strip())
+    return "remote" if has_remote else "local"
+
+
+def _lock_path(cfg: Config) -> Path:
+    return cfg.state_dir / ".sync.lock"
+
+
+def sync_once(
+    cfg: Config,
+    store: VecStore,
+    mem: Memory,
+    *,
+    remote: str = "origin",
+    do_pull: bool = True,
+    do_push: bool = True,
+) -> dict:
+    """The single, machine-level git step — pull-rebase-before-push, lock-guarded.
+
+    ONE owner per machine: whoever grabs the ``.sync.lock`` flock does the git;
+    concurrent same-machine sessions skip (``locked``) because their writes are
+    already in the shared store — the lock holder's push carries them. The
+    pull-before-push ordering means a remote that advanced (another Mac) rebases
+    cleanly instead of rejecting the push.
+
+    No-op (``tier='local'``) when no remote is configured. Never raises for the
+    expected cases (not a clone, lock held, offline) — returns a status dict so
+    triggers (hooks/daemon) stay quiet; only a genuine `.md` rebase conflict
+    surfaces as a ``pending`` marker.
+    """
+    import fcntl
+
+    if sync_tier(cfg) != "remote":
+        return {"tier": "local", "skipped": "no remote"}
+
+    lock_file = _lock_path(cfg)
+    try:
+        lock_file.parent.mkdir(parents=True, exist_ok=True)
+        fh = lock_file.open("w")
+    except OSError as exc:
+        return {"tier": "remote", "skipped": f"lock open failed: {exc}"}
+    try:
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            # Another process on this machine owns the git step right now. Our
+            # writes are already in the shared store; the holder will carry them.
+            return {"tier": "remote", "skipped": "locked"}
+
+        result: dict = {"tier": "remote", "pulled": False, "pushed": False}
+        if do_pull:
+            try:
+                pull_out = sync_pull(cfg, store, mem, remote=remote)
+                result["pulled"] = bool(pull_out.get("pulled"))
+            except SyncGitError as exc:
+                result["pull_error"] = str(exc)
+        if do_push:
+            try:
+                push_out = sync_push(cfg, store, remote=remote)
+                result["pushed"] = bool(push_out.get("pushed"))
+            except SyncGitError as exc:
+                result["push_error"] = str(exc)
+        return result
+    finally:
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        finally:
+            fh.close()
+
+
+def _pending_marker(cfg: Config) -> Path:
+    """Sentinel file written when a push fails (offline / auth / remote down) so
+    `sync status` / `doctor` can surface stranded local commits and the next
+    trigger knows to retry. Lives in the state dir (not the synced repo)."""
+    return cfg.state_dir / "sync_pending"
+
+
+def sync_status(cfg: Config, *, remote: str = "origin", check_remote: bool = False) -> dict:
+    """Read-only health of the git-sync repo — never raises, never mutates.
+
+    Surfaces the silent no-op (data_dir not a git clone) and stranded commits
+    (committed locally but not pushed: offline/auth). ``ahead``/``behind`` are
+    relative to the LAST fetch unless ``check_remote`` (then a network
+    ``ls-remote`` probe runs — slower, used by `doctor`, not the hot path).
+    """
+    try:
+        root = git_root_for(cfg)
+    except SyncGitError as exc:
+        return {"is_git_clone": False, "reason": str(exc)}
+
+    branch = _current_branch(root)
+    porcelain = _git(root, "status", "--porcelain", check=False).stdout.strip()
+    dirty = len(porcelain.split("\n")) if porcelain else 0
+    remote_url = _git(root, "remote", "get-url", remote, check=False).stdout.strip()
+    ahead = behind = 0
+    counts = _git(
+        root, "rev-list", "--left-right", "--count", f"{remote}/{branch}...HEAD", check=False
+    )
+    if counts.returncode == 0 and counts.stdout.strip():
+        parts = counts.stdout.split()
+        if len(parts) == 2:
+            behind, ahead = int(parts[0]), int(parts[1])
+    last = _git(root, "log", "-1", "--format=%cI", check=False).stdout.strip()
+
+    remote_reachable: bool | None = None
+    if check_remote and remote_url:
+        probe = _git(root, "ls-remote", "--exit-code", remote, "HEAD", check=False)
+        remote_reachable = probe.returncode == 0
+
+    return {
+        "is_git_clone": True,
+        "root": str(root),
+        "branch": branch,
+        "remote": remote_url,
+        "dirty_files": dirty,
+        "ahead": ahead,
+        "behind": behind,
+        "last_commit": last,
+        "pending": _pending_marker(cfg).is_file(),
+        "remote_reachable": remote_reachable,
+    }
+
+
 def sync_push(cfg: Config, store: VecStore, *, remote: str = "origin") -> dict:
     """Export signal, commit any changes, and push. Returns a summary dict."""
     root = git_root_for(cfg)
@@ -137,18 +272,38 @@ def sync_push(cfg: Config, store: VecStore, *, remote: str = "origin") -> dict:
 
     _git(root, "add", "-A")
     staged = _git(root, "diff", "--cached", "--name-only").stdout.strip()
-    if not staged:
-        return {"pushed": False, "reason": "nothing to commit", "branch": branch}
+    n_files = len(staged.splitlines()) if staged else 0
+    if staged:
+        from memo.identity import current as _identity
 
-    n_files = len(staged.splitlines())
-    _git(root, "commit", "-m", f"sync: memo signal + memorias ({n_files} files)")
+        who = _identity(cfg).label
+        _git(root, "commit", "-m", f"sync: memo signal + memorias ({n_files} files) [{who}]")
+
+    # Stranded-commit retry: a prior push may have failed AFTER committing
+    # (offline/auth), leaving local commits unpushed. Detect that and push even
+    # when there's nothing new to commit this round — otherwise the early return
+    # would strand the work until the next save.
+    unpushed = _git(
+        root, "rev-list", "--count", f"{remote}/{branch}..HEAD", check=False
+    ).stdout.strip()
+    has_unpushed = unpushed.isdigit() and int(unpushed) > 0
+    if not staged and not has_unpushed and not _pending_marker(cfg).is_file():
+        return {"pushed": False, "reason": "nothing to commit", "branch": branch}
 
     # push; set upstream on first push
     push = _git(root, "push", remote, branch, check=False)
     if push.returncode != 0:
         push = _git(root, "push", "-u", remote, branch, check=False)
         if push.returncode != 0:
-            raise SyncGitError(f"git push failed: {push.stderr.strip()}")
+            # Commit landed locally but didn't reach the remote (offline / auth /
+            # remote down). Stamp a pending marker so `sync status` / `doctor`
+            # flag the stranded commit and the next trigger retries — the work is
+            # NOT lost, just not yet shared.
+            with contextlib.suppress(OSError):
+                _pending_marker(cfg).write_text(branch, encoding="utf-8")
+            raise SyncGitError(f"git push failed (commit kept locally, will retry): {push.stderr.strip()}")
+    # Pushed — clear any prior pending marker.
+    _pending_marker(cfg).unlink(missing_ok=True)
     return {"pushed": True, "committed_files": n_files, "branch": branch}
 
 

--- a/src/memo/text_quality.py
+++ b/src/memo/text_quality.py
@@ -21,7 +21,6 @@ garbage the OCR/PDF layer already cleaned. Validate any change against
 
 from __future__ import annotations
 
-import os
 import unicodedata
 
 __all__ = [
@@ -38,22 +37,19 @@ _REPLACEMENT_CHARS = "�￼"
 def text_quality_enabled() -> bool:
     """Whether ingest stamps a text-quality confidence on records. Default on;
     ``MEMO_TEXT_QUALITY=0`` disables."""
-    return os.environ.get("MEMO_TEXT_QUALITY", "1").strip().lower() not in {
-        "0", "false", "off", "no",
-    }
+    from memo.flags import flag_bool
+
+    return flag_bool("MEMO_TEXT_QUALITY")
 
 
 def _threshold() -> float:
     """Garbage ratio at/above which a record is down-weighted. Default 0.02
     (2% replacement/control chars — far above any clean text, which is ~0).
     ``MEMO_TEXT_QUALITY_THRESHOLD`` overrides; 0 disables."""
-    raw = os.environ.get("MEMO_TEXT_QUALITY_THRESHOLD", "").strip()
-    if not raw:
-        return 0.02
-    try:
-        return max(0.0, min(1.0, float(raw)))
-    except ValueError:
-        return 0.02
+    from memo.flags import flag_float
+
+    value = flag_float("MEMO_TEXT_QUALITY_THRESHOLD")
+    return 0.02 if value is None else max(0.0, min(1.0, value))
 
 
 def garbage_ratio(text: str) -> float:

--- a/src/memo/whatsapp_ingest.py
+++ b/src/memo/whatsapp_ingest.py
@@ -250,8 +250,9 @@ def resolve_notes_dir(mem: Any) -> Path:
     Si la estructura no contiene `<SYSTEM_DIR>`, usar el env var.
     """
     from memo.config import SYSTEM_DIR
+    from memo.flags import flag_str
 
-    env = os.environ.get("MEMO_WHATSAPP_NOTES_DIR")
+    env = flag_str("MEMO_WHATSAPP_NOTES_DIR")
     if env:
         return Path(env).expanduser()
     data_dir = Path(mem.cfg.data_dir)

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -147,3 +147,103 @@ def test_lazy_property_caches_after_access(mock_memory) -> None:
     first = mock_memory.temporal
     assert mock_memory._temporal is first
     assert mock_memory.temporal is first
+
+
+def test_optional_memory_capabilities_live_in_registry(mock_memory) -> None:
+    """Experimental/advanced Memory subsystems are declared in one registry."""
+    from memo.memory.capabilities import OPTIONAL_CAPABILITIES
+
+    expected = {
+        "analytics",
+        "backup",
+        "collaborative",
+        "dashboard",
+        "federation",
+        "import_export",
+        "lifecycle",
+        "multimodal",
+        "proactive",
+        "query_composer",
+        "sharing",
+        "sync",
+        "versioning",
+    }
+
+    assert expected.issubset(OPTIONAL_CAPABILITIES)
+    assert mock_memory.capability("analytics") is mock_memory.analytics
+    assert mock_memory.capability("lifecycle") is mock_memory.lifecycle
+
+
+def test_behavior_flags_are_not_read_directly_from_environ() -> None:
+    """Behavioral MEMO_* reads go through memo.flags, not ad-hoc env parsing."""
+    allowed_modules = {
+        SRC / "config.py",
+        SRC / "flags.py",
+        SRC / "flags_base.py",
+        SRC / "flags_behavior.py",
+        SRC / "flags_ingest.py",
+        SRC / "flags_misc.py",
+        SRC / "flags_recall.py",
+        SRC / "flags_search.py",
+    }
+    config_owned = {
+        "MEMO_CONFIG_FILE",
+        "MEMO_DATA_DIR",
+        "MEMO_EMBEDDER_DIMS",
+        "MEMO_EMBEDDER_MODEL",
+        "MEMO_HELPER_MODEL",
+        "MEMO_LLM_MODEL",
+        "MEMO_MAX_CONTENT_CHARS",
+        "MEMO_MEMORY_SUBDIR",
+        "MEMO_MODEL_PROFILE",
+        "MEMO_RERANKER_ENABLED",
+        "MEMO_RERANKER_MODEL",
+        "MEMO_RERANKER_REVISION",
+        "MEMO_RERANK_FUSION_ALPHA",
+        "MEMO_RERANK_INPUT_K",
+        "MEMO_SEARCH_DEFAULT_LIMIT",
+        "MEMO_SINGLE_DB",
+        "MEMO_STATE_DIR",
+        "MEMO_VAULT_PATH",
+    }
+    pure_leaf_owned = {
+        SRC / "embedder.py": {"MEMO_QUERY_CACHE_SIZE"},
+        SRC / "mlx_gpu.py": {"MEMO_GPU_LOCK_PATH", "MEMO_GPU_XPROC_LOCK"},
+        SRC / "store" / "schema.py": {"MEMO_SKIP_MODEL_VERSION_CHECK"},
+    }
+    violations: list[str] = []
+
+    for path in sorted(SRC.rglob("*.py")):
+        if path in allowed_modules:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            is_env_get = (
+                isinstance(func, ast.Attribute)
+                and func.attr == "get"
+                and isinstance(func.value, ast.Attribute)
+                and func.value.attr == "environ"
+                and isinstance(func.value.value, ast.Name)
+                and func.value.value.id in {"os", "_os", "_os_min"}
+            )
+            is_getenv = (
+                isinstance(func, ast.Attribute)
+                and func.attr == "getenv"
+                and isinstance(func.value, ast.Name)
+                and func.value.id in {"os", "_os", "_os_min"}
+            )
+            if (
+                (is_env_get or is_getenv)
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+                and node.args[0].value.startswith("MEMO_")
+                and node.args[0].value not in config_owned
+                and node.args[0].value not in pure_leaf_owned.get(path, set())
+            ):
+                violations.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}: {node.args[0].value}")
+
+    assert violations == []

--- a/tests/test_capture_incremental.py
+++ b/tests/test_capture_incremental.py
@@ -1,0 +1,350 @@
+"""Incremental mid-session capture — watermark + throttle tests.
+
+Stubs the helper LLM (`extract_insights`) and the embedder so tests run on
+any platform (no MLX). Focus: the watermark advances and bounds reprocessing,
+a re-run with no new turns is a no-op, and a corrupt/missing/out-of-range
+watermark degrades to a safe full pass — the parts most likely to break under
+refactor or to silently drop a long session's insight.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memo.capture import incremental_tick_due, run_capture_incremental
+from memo.cli import cli
+
+
+def _write_transcript(p: Path, lines: list[dict]) -> None:
+    p.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+
+
+def _assistant(marker: str) -> str:
+    """≥200 chars + trigger keywords so the combined turn passes the prefilter."""
+    return (
+        f"{marker} decidí cambiar la configuración porque encontramos un bug en el "
+        "reranker que se manifestaba con bodies largos; el fix fue truncar el texto "
+        "antes de rankear y la latencia bajó tres veces en el camino caliente del hook."
+    )
+
+
+def _exchange(user: str, marker: str) -> list[dict]:
+    return [
+        {"type": "user", "message": {"content": user}},
+        {"type": "assistant", "message": {"content": _assistant(marker)}},
+    ]
+
+
+def _setup_env(tmp_path: Path, monkeypatch) -> Path:
+    """Isolated data/state/vault + a deterministic 4-dim embedder stub.
+
+    Mirrors the env-pinning conventions in tests/conftest.py: nothing reads
+    the developer's real vault or the live recall daemon.
+    """
+    data = tmp_path / "data"
+    vault = tmp_path / "vault"
+    state = tmp_path / "state"
+    data.mkdir()
+    (vault / "Obsidian" / "AI" / "memory").mkdir(parents=True)
+    state.mkdir()
+    monkeypatch.setenv("MEMO_DATA_DIR", str(data))
+    monkeypatch.setenv("MEMO_VAULT_PATH", str(vault))
+    monkeypatch.setenv("MEMO_STATE_DIR", str(state))
+    monkeypatch.setenv("MEMO_EMBEDDER_DIMS", "4")
+    monkeypatch.setenv("MEMO_AUTO_PROJECT_TAG", "0")
+    monkeypatch.setattr(
+        "memo.embedder.MLXEmbedder.embed",
+        lambda self, inputs: [[1.0, 0.0, 0.0, 0.0] for _ in inputs],
+    )
+    monkeypatch.setattr(
+        "memo.embedder.MLXEmbedder.embed_query",
+        lambda self, query: [1.0, 0.0, 0.0, 0.0],
+    )
+    return state
+
+
+def _watermark(state_dir: Path, session_id: str) -> dict:
+    f = state_dir / ".capture_watermark" / f"{session_id}.json"
+    return json.loads(f.read_text(encoding="utf-8"))
+
+
+# ── watermark advances + bounds reprocessing ────────────────────────────────
+
+
+def test_watermark_advances_and_bounds_reprocessing(tmp_path: Path, monkeypatch):
+    state = _setup_env(tmp_path, monkeypatch)
+    calls: list[tuple[str, str]] = []
+
+    def _record(chat, model, user_text, assistant_text):
+        calls.append((user_text, assistant_text))
+        return []  # no saves — this test asserts on the watermark + slicing
+
+    monkeypatch.setattr("memo.capture.extract_insights", _record)
+
+    transcript = tmp_path / "t.jsonl"
+    sid = "sess-A"
+    _write_transcript(
+        transcript,
+        _exchange("primera pregunta", "ALPHAMARK") + _exchange("segunda", "BETAMARK"),
+    )
+
+    out1 = run_capture_incremental(transcript, sid)
+    assert out1["status"] == "ok"
+    assert out1["exchange_count"] == 2
+    assert _watermark(state, sid)["exchange_count"] == 2
+    # First pass sees both new exchanges.
+    assert len(calls) == 1
+    assert "ALPHAMARK" in calls[0][1] and "BETAMARK" in calls[0][1]
+
+    # A third exchange arrives — only IT should be reprocessed.
+    _write_transcript(
+        transcript,
+        _exchange("primera pregunta", "ALPHAMARK")
+        + _exchange("segunda", "BETAMARK")
+        + _exchange("tercera", "GAMMAMARK"),
+    )
+    out2 = run_capture_incremental(transcript, sid)
+    assert out2["status"] == "ok"
+    assert out2["processed_turns"] == 1
+    assert _watermark(state, sid)["exchange_count"] == 3
+    assert len(calls) == 2
+    # Bounded: the second pass saw GAMMA only, never the already-captured turns.
+    assert "GAMMAMARK" in calls[1][1]
+    assert "ALPHAMARK" not in calls[1][1]
+    assert "BETAMARK" not in calls[1][1]
+
+
+def test_second_immediate_pass_captures_nothing_new(tmp_path: Path, monkeypatch):
+    state = _setup_env(tmp_path, monkeypatch)
+    calls: list[tuple[str, str]] = []
+
+    def _record(chat, model, user_text, assistant_text):
+        calls.append((user_text, assistant_text))
+        return []
+
+    monkeypatch.setattr("memo.capture.extract_insights", _record)
+
+    transcript = tmp_path / "t.jsonl"
+    sid = "sess-B"
+    _write_transcript(transcript, _exchange("pregunta", "ALPHAMARK"))
+
+    first = run_capture_incremental(transcript, sid)
+    assert first["status"] == "ok"
+    assert len(calls) == 1
+
+    # No transcript change → nothing new → no extraction, watermark steady.
+    second = run_capture_incremental(transcript, sid)
+    assert second["status"] == "no_new"
+    assert second["exchange_count"] == 1
+    assert len(calls) == 1  # extractor was NOT called again
+    assert _watermark(state, sid)["exchange_count"] == 1
+
+
+def test_incremental_saves_new_insight(tmp_path: Path, monkeypatch):
+    """End-to-end: a survived insight is saved and the watermark advances."""
+    _setup_env(tmp_path, monkeypatch)
+
+    def _one_insight(chat, model, user_text, assistant_text):
+        return [
+            {
+                "title": "Reranker threshold 0.4 fix",
+                "type": "decision",
+                "body": (
+                    "Cambiar el threshold del reranker a 0.4 resolvió el bug de hits "
+                    "relevantes filtrados en queries difusas, porque los scores "
+                    "fusionados necesitan un piso más permisivo que el coseno puro."
+                ),
+                "tags": ["reranker", "bug"],
+            }
+        ]
+
+    monkeypatch.setattr("memo.capture.extract_insights", _one_insight)
+
+    transcript = tmp_path / "t.jsonl"
+    sid = "sess-save"
+    _write_transcript(transcript, _exchange("qué arreglamos", "ALPHAMARK"))
+
+    out = run_capture_incremental(transcript, sid)
+    assert out["status"] == "ok"
+    assert len(out["saved"]) == 1
+
+
+# ── corrupt / missing / out-of-range watermark ──────────────────────────────
+
+
+def test_missing_watermark_starts_from_zero(tmp_path: Path, monkeypatch):
+    state = _setup_env(tmp_path, monkeypatch)
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "memo.capture.extract_insights",
+        lambda *a: calls.append((a[2], a[3])) or [],
+    )
+
+    transcript = tmp_path / "t.jsonl"
+    sid = "sess-missing"
+    _write_transcript(transcript, _exchange("pregunta", "ALPHAMARK"))
+
+    assert not (state / ".capture_watermark" / f"{sid}.json").exists()
+    out = run_capture_incremental(transcript, sid)
+    assert out["status"] == "ok"
+    assert len(calls) == 1  # processed from scratch
+    assert _watermark(state, sid)["exchange_count"] == 1
+
+
+def test_corrupt_watermark_handled(tmp_path: Path, monkeypatch):
+    state = _setup_env(tmp_path, monkeypatch)
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "memo.capture.extract_insights",
+        lambda *a: calls.append((a[2], a[3])) or [],
+    )
+
+    sid = "sess-corrupt"
+    wm_file = state / ".capture_watermark" / f"{sid}.json"
+    wm_file.parent.mkdir(parents=True, exist_ok=True)
+    wm_file.write_text("}{ not json at all", encoding="utf-8")
+
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(transcript, _exchange("pregunta", "ALPHAMARK"))
+
+    out = run_capture_incremental(transcript, sid)  # must not raise
+    assert out["status"] == "ok"
+    assert len(calls) == 1  # corrupt → treated as fresh, full pass
+    assert _watermark(state, sid)["exchange_count"] == 1
+
+
+@pytest.mark.parametrize("bad_count", [999, -5])
+def test_out_of_range_watermark_clamped(tmp_path: Path, monkeypatch, bad_count: int):
+    state = _setup_env(tmp_path, monkeypatch)
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "memo.capture.extract_insights",
+        lambda *a: calls.append((a[2], a[3])) or [],
+    )
+
+    sid = "sess-oob"
+    wm_file = state / ".capture_watermark" / f"{sid}.json"
+    wm_file.parent.mkdir(parents=True, exist_ok=True)
+    wm_file.write_text(json.dumps({"exchange_count": bad_count}), encoding="utf-8")
+
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(transcript, _exchange("pregunta", "ALPHAMARK"))
+
+    out = run_capture_incremental(transcript, sid)
+    assert out["status"] == "ok"
+    assert len(calls) == 1  # clamped to 0 → reprocesses the whole transcript
+    assert _watermark(state, sid)["exchange_count"] == 1
+
+
+def test_empty_transcript_is_no_pair(tmp_path: Path, monkeypatch):
+    _setup_env(tmp_path, monkeypatch)
+    transcript = tmp_path / "missing.jsonl"  # never created
+    out = run_capture_incremental(transcript, "sess-empty")
+    assert out["status"] == "no_pair"
+
+
+# ── throttle (incremental_tick_due) ─────────────────────────────────────────
+
+
+def test_tick_due_respects_interval(tmp_path: Path, monkeypatch):
+    import time
+
+    state = _setup_env(tmp_path, monkeypatch)
+    sid = "sess-throttle"
+    wm_file = state / ".capture_watermark" / f"{sid}.json"
+    wm_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # No watermark yet → always due.
+    assert incremental_tick_due(state, sid, 600) is True
+
+    # Just stamped → not due within the interval.
+    wm_file.write_text(json.dumps({"updated": time.time()}), encoding="utf-8")
+    assert incremental_tick_due(state, sid, 600) is False
+
+    # Stamped long ago → due again.
+    wm_file.write_text(json.dumps({"updated": time.time() - 700}), encoding="utf-8")
+    assert incremental_tick_due(state, sid, 600) is True
+
+    # interval_s <= 0 disables the throttle (every prompt).
+    wm_file.write_text(json.dumps({"updated": time.time()}), encoding="utf-8")
+    assert incremental_tick_due(state, sid, 0) is True
+
+
+# ── CLI: memo capture-tick ──────────────────────────────────────────────────
+
+
+def _cli_env(state: Path, tmp_path: Path, interval: str) -> dict:
+    return {
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_DATA_DIR": str(tmp_path / "data"),
+        "MEMO_STATE_DIR": str(state),
+        "MEMO_VAULT_PATH": str(tmp_path / "vault"),
+        "MEMO_EMBEDDER_DIMS": "4",
+        "MEMO_AUTO_PROJECT_TAG": "0",
+        "MEMO_EMBEDDER_VIA_DAEMON": "0",
+        "MEMO_CAPTURE_INTERVAL_S": interval,
+    }
+
+
+def test_capture_tick_cli_silent_and_advances(tmp_path: Path, monkeypatch):
+    state = _setup_env(tmp_path, monkeypatch)
+    monkeypatch.setattr("memo.capture.extract_insights", lambda *a, **k: [])
+
+    transcript = tmp_path / "t.jsonl"
+    sid = "sess-cli"
+    _write_transcript(transcript, _exchange("pregunta", "ALPHAMARK"))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["capture-tick"],
+        input=json.dumps({"session_id": sid, "transcript_path": str(transcript)}),
+        env=_cli_env(state, tmp_path, interval="0"),  # disable throttle
+    )
+    assert result.exit_code == 0
+    assert result.output.strip() == "{}"  # always silent
+    assert _watermark(state, sid)["exchange_count"] == 1
+
+
+def test_capture_tick_cli_throttled_second_call(tmp_path: Path, monkeypatch):
+    state = _setup_env(tmp_path, monkeypatch)
+    calls: list[int] = []
+    monkeypatch.setattr(
+        "memo.capture.extract_insights",
+        lambda *a, **k: calls.append(1) or [],
+    )
+
+    transcript = tmp_path / "t.jsonl"
+    sid = "sess-cli-throttle"
+    _write_transcript(transcript, _exchange("pregunta", "ALPHAMARK"))
+
+    runner = CliRunner()
+    env = _cli_env(state, tmp_path, interval="600")  # real throttle
+    payload = json.dumps({"session_id": sid, "transcript_path": str(transcript)})
+
+    first = runner.invoke(cli, ["capture-tick"], input=payload, env=env)
+    assert first.exit_code == 0
+    assert len(calls) == 1
+
+    # Second call within the interval → throttled, no extraction.
+    second = runner.invoke(cli, ["capture-tick"], input=payload, env=env)
+    assert second.exit_code == 0
+    assert second.output.strip() == "{}"
+    assert len(calls) == 1  # extractor NOT called again
+
+
+def test_capture_tick_cli_no_session_is_noop(tmp_path: Path, monkeypatch):
+    state = _setup_env(tmp_path, monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["capture-tick"],
+        input=json.dumps({"transcript_path": "/nope.jsonl"}),  # no session_id
+        env=_cli_env(state, tmp_path, interval="0"),
+    )
+    assert result.exit_code == 0
+    assert result.output.strip() == "{}"

--- a/tests/test_cli_consult_attribution.py
+++ b/tests/test_cli_consult_attribution.py
@@ -1,0 +1,89 @@
+"""CLI consult attribution — trinity layers (synapse / memflow) shell out to the
+`memo` CLI, so without source-tagging they show up as "silent" in
+`memo usefulness` even though they read memo. `log_cli_consult` records the
+consult ONLY when a source is given (so the developer's own interactive
+`memo search` stays out of the stats)."""
+
+from __future__ import annotations
+
+import json
+
+from memo.cli_common import log_cli_consult
+from memo.config import Config
+from memo.dashboard import read_recall_log
+
+
+def _hits() -> list[dict]:
+    return [{"id": "abc12345", "score": 1.2, "title": "a decision"}]
+
+
+def test_logs_when_source_explicit(tmp_cfg: Config):
+    log_cli_consult(tmp_cfg, verb="search", query="q", hits=_hits(), t0_ms=0, source="synapse")
+    rows = read_recall_log(tmp_cfg.state_dir, limit=10)
+    assert len(rows) == 1
+    assert rows[0]["source"] == "synapse"
+    assert rows[0]["via"] == "cli:search"
+    assert len(rows[0]["hits"]) == 1
+
+
+def test_logs_from_env(tmp_cfg: Config, monkeypatch):
+    monkeypatch.setenv("MEMO_SOURCE", "memflow")
+    log_cli_consult(tmp_cfg, verb="recall", query="q", hits=_hits(), t0_ms=0, source=None)
+    rows = read_recall_log(tmp_cfg.state_dir, limit=10)
+    assert len(rows) == 1
+    assert rows[0]["source"] == "memflow"
+    assert rows[0]["via"] == "cli:recall"
+
+
+def test_silent_without_source(tmp_cfg: Config, monkeypatch):
+    monkeypatch.delenv("MEMO_SOURCE", raising=False)
+    log_cli_consult(tmp_cfg, verb="search", query="q", hits=_hits(), t0_ms=0, source=None)
+    assert read_recall_log(tmp_cfg.state_dir, limit=10) == []
+
+
+def test_explicit_source_overrides_env(tmp_cfg: Config, monkeypatch):
+    monkeypatch.setenv("MEMO_SOURCE", "env-layer")
+    log_cli_consult(tmp_cfg, verb="ask", query="q", hits=_hits(), t0_ms=0, source="synapse")
+    rows = read_recall_log(tmp_cfg.state_dir, limit=10)
+    assert rows[0]["source"] == "synapse"
+
+
+def test_mcp_consult_attributes_to_client_name(tmp_cfg: Config, monkeypatch):
+    """An MCP consult with no explicit source / MEMO_SOURCE falls back to the
+    client's handshake name — so devin/opencode/windsurf aren't 'mcp:unknown'."""
+    import types as _t
+
+    from memo import server_common
+
+    monkeypatch.delenv("MEMO_SOURCE", raising=False)
+    monkeypatch.setattr(server_common, "_mcp_client_name", lambda: "devin")
+    mem = _t.SimpleNamespace(cfg=tmp_cfg)
+    server_common.log_consult(mem, tool="search", query="q", hits=_hits(), t0_ms=0)
+    rows = read_recall_log(tmp_cfg.state_dir, limit=10)
+    assert rows[0]["source"] == "devin"
+    assert rows[0]["via"] == "mcp:search"
+
+
+def test_mcp_explicit_source_beats_client_name(tmp_cfg: Config, monkeypatch):
+    import types as _t
+
+    from memo import server_common
+
+    monkeypatch.delenv("MEMO_SOURCE", raising=False)
+    monkeypatch.setattr(server_common, "_mcp_client_name", lambda: "devin")
+    mem = _t.SimpleNamespace(cfg=tmp_cfg)
+    server_common.log_consult(mem, tool="ask", query="q", hits=_hits(), t0_ms=0, source="synapse")
+    assert read_recall_log(tmp_cfg.state_dir, limit=10)[0]["source"] == "synapse"
+
+
+def test_attributed_consult_lands_in_usefulness(tmp_cfg: Config):
+    """A source-tagged CLI consult must surface as a reader, not 'unknown'."""
+    log_cli_consult(tmp_cfg, verb="recall", query="q", hits=_hits(), t0_ms=0, source="memflow")
+    from memo.dashboard import consult_breakdown
+
+    cb = consult_breakdown(tmp_cfg.state_dir, limit=50)
+    names = [c["consumer"] for c in cb["consumers"]]
+    assert "memflow" in names
+    assert "memflow" not in cb["silent"]
+    # serializable end-to-end (dashboard payload)
+    json.dumps(cb, default=str)

--- a/tests/test_dashboard_build.py
+++ b/tests/test_dashboard_build.py
@@ -29,6 +29,24 @@ def test_poll_mode_keeps_cheap_metrics(tmp_cfg: Config):
     assert "silent" in data["usefulness"]
 
 
+def test_poll_mode_includes_gerencial_block(tmp_cfg: Config):
+    """The management rollup (funnel + value KPIs + trend) must be on the cheap
+    poll path — it is the centerpiece of the dashboard, not a full-build extra."""
+    data = build.collect_data(tmp_cfg, include_projection=False)
+    g = data["gerencial"]
+    assert [s["key"] for s in g["funnel"]] == ["preguntas", "activado", "encontro"]
+    for key in ("coverage_rate", "hit_rate", "used_rate", "time_saved_human", "trend"):
+        assert key in g, f"missing gerencial.{key}"
+    assert len(g["trend"]) == 14
+    assert all({"date", "consultas", "activado"} <= d.keys() for d in g["trend"])
+    # detailed token-savings: daily series + composition, KPI consistent with panel
+    td = g["token_detail"]
+    assert len(td["daily"]) == 14
+    assert all({"date", "grounded", "tokens"} <= d.keys() for d in td["daily"])
+    assert td["total"] == td["grounded_tokens"] + td["reask_tokens"]
+    assert g["tokens_saved"] == td["total"]
+
+
 def test_full_mode_includes_projection(tmp_cfg: Config):
     data = build.collect_data(tmp_cfg, include_projection=True)
     assert isinstance(data["projection"], dict)

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,54 @@
+"""Identity layer — stable machine id + session/terminal provenance.
+
+`current(cfg)` resolves a frozen `Identity` snapshot: `machine_id` from the
+persisted `cfg.device_id`, `hostname` from the socket, `session_id` from env.
+No MLX, no network — pure resolution against an isolated `Config` (the `tmp_cfg`
+fixture, per tests/conftest.py isolation rules).
+"""
+
+from __future__ import annotations
+
+from memo.config import Config
+from memo.identity import Identity, current
+
+# Every var `_session_id()` consults — cleared so the dev machine's own
+# CLAUDE_SESSION_ID can't leak into the deterministic assertions below.
+_SESSION_ENV_VARS = ("MEMO_SESSION_ID", "CLAUDE_SESSION_ID", "CLAUDE_CODE_SESSION_ID")
+
+
+def _clear_session_env(monkeypatch) -> None:
+    for k in _SESSION_ENV_VARS:
+        monkeypatch.delenv(k, raising=False)
+
+
+def test_machine_id_is_device_id_and_stable(tmp_cfg: Config):
+    ident = current(tmp_cfg)
+    assert isinstance(ident, Identity)
+    assert ident.machine_id == tmp_cfg.device_id
+    # device_id is persisted (state_dir/.device_id) → identical on a second call
+    assert current(tmp_cfg).machine_id == ident.machine_id
+
+
+def test_hostname_nonempty_and_label_includes_it(tmp_cfg: Config, monkeypatch):
+    _clear_session_env(monkeypatch)
+    ident = current(tmp_cfg)
+    assert ident.hostname  # non-empty
+    assert ident.hostname in ident.label
+    # with no session id supplied, the label is exactly the hostname
+    assert ident.session_id is None
+    assert ident.label == ident.hostname
+
+
+def test_session_id_from_env_in_label(tmp_cfg: Config, monkeypatch):
+    _clear_session_env(monkeypatch)
+    monkeypatch.setenv("MEMO_SESSION_ID", "abcdef0123456789")
+    ident = current(tmp_cfg)
+    assert ident.session_id == "abcdef0123456789"
+    # label carries only the 8-char prefix (commit-attribution friendly)
+    assert ident.label == f"{ident.hostname}·abcdef01"
+    assert "abcdef01" in ident.label
+
+
+def test_as_dict_has_expected_keys(tmp_cfg: Config):
+    d = current(tmp_cfg).as_dict()
+    assert set(d) == {"machine_id", "hostname", "session_id", "terminal", "label"}

--- a/tests/test_mandate.py
+++ b/tests/test_mandate.py
@@ -8,8 +8,12 @@ from memo.cli_mandate import _MARKER, MANDATE_TEXT, _write_mandate
 
 
 def test_expected_consumers_covers_non_hook_clients() -> None:
-    for c in ("claude-code", "synapse", "memflow", "codex", "devin", "opencode", "windsurf"):
+    for c in ("claude-code", "synapse", "memflow", "codex", "devin", "opencode"):
         assert c in dashboard.EXPECTED_CONSUMERS
+    # "windsurf" retired (now Devin Desktop); devin-desktop is a GUI app that
+    # can't be driven headless, so it's not flagged as a silent gap.
+    assert "windsurf" not in dashboard.EXPECTED_CONSUMERS
+    assert "devin-desktop" not in dashboard.EXPECTED_CONSUMERS
 
 
 def test_write_mandate_creates_and_is_idempotent(tmp_path: Path) -> None:

--- a/tests/test_memory_search.py
+++ b/tests/test_memory_search.py
@@ -125,3 +125,17 @@ def test_apply_decay_lets_fresher_memory_win_a_tie():
     assert [r.id for r in out] == ["fresh", "old"]
     assert out[0].score is not None and out[1].score is not None
     assert out[0].score > out[1].score
+
+
+def test_search_with_trace_reports_retrieval_stages(mem_with_stub: Memory) -> None:
+    mem_with_stub.save(content="alpha body", title="Alpha")
+    mem_with_stub.save(content="beta body", title="Beta")
+
+    envelope = mem_with_stub.search_with_trace("alpha", limit=2, mode="hybrid")
+
+    assert envelope["hits"]
+    stages = [item["stage"] for item in envelope["trace"]]
+    assert stages[0] == "candidate_generation"
+    assert "materialize" in stages
+    assert stages[-1] == "final"
+    assert envelope["trace"][-1]["output_count"] == len(envelope["hits"])

--- a/tests/test_outcome.py
+++ b/tests/test_outcome.py
@@ -1,0 +1,117 @@
+"""The Outcome Loop — utility from grounding, roi reconcile, gaps, dead weight."""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from memo import dashboard, outcome
+
+
+def _recall(tmp: Path, sid: str, turn: int, prompt: str, mem_id: str, *, via: str = "subprocess",
+            reason: str | None = None, hit: bool = True) -> None:
+    hits = [{"id": mem_id, "score": 0.8, "title": "t"}] if hit else []
+    dashboard.append_recall_log(
+        tmp, prompt=prompt, via=via, session_id=sid, turn=turn, client="claude-code",
+        hits=hits, reason=reason,
+    )
+
+
+def _grounded(tmp: Path, sid: str, turn: int, mem_id: str, score: float = 0.9) -> None:
+    dashboard.append_grounding_log(
+        tmp, session_id=sid, turn=turn, recall_id=mem_id, used_score=score, method="lexical",
+    )
+
+
+# ---------------- utility ----------------
+
+def test_compute_utilities_rewards_grounded_over_surfaced(tmp_path: Path) -> None:
+    # mem00001: surfaced 2 turns, grounded both → high utility
+    _recall(tmp_path, "s", 1, "decision about deploy yaml pipeline", "mem00001")
+    _grounded(tmp_path, "s", 1, "mem00001")
+    _recall(tmp_path, "s", 2, "deploy pipeline config again", "mem00001")
+    _grounded(tmp_path, "s", 2, "mem00001")
+    # mem00002: surfaced 3 turns, never grounded → low utility
+    for t in (1, 2, 3):
+        _recall(tmp_path, "s", t, f"prompt {t}", "mem00002")
+
+    u = outcome.compute_utilities(tmp_path, prior_n=3.0)
+    by = u["by_prefix"]
+    assert by["mem00001"]["surfaced"] == 2 and by["mem00001"]["grounded"] == 2
+    assert by["mem00002"]["surfaced"] == 3 and by["mem00002"]["grounded"] == 0
+    assert by["mem00001"]["utility"] > by["mem00002"]["utility"]
+
+
+# ---------------- roi reconcile ----------------
+
+class _FakeStore:
+    def __init__(self, ids: list[str]) -> None:
+        self._ids = ids
+        self.roi: dict[str, float] = {}
+
+    def all_ids(self) -> list[str]:
+        return list(self._ids)
+
+    def set_roi_batch(self, pairs, *, floor: float, cap: float) -> int:
+        self.roi = {i: max(floor, min(cap, r)) for i, r in pairs}
+        return len(pairs)
+
+
+def test_reconcile_roi_promotes_grounded_demotes_dead(tmp_path: Path) -> None:
+    _recall(tmp_path, "s", 1, "deploy yaml pipeline decision", "mem00001")
+    _grounded(tmp_path, "s", 1, "mem00001")
+    for t in (1, 2, 3, 4):
+        _recall(tmp_path, "s", t, f"noise prompt number {t}", "mem00002")  # never grounded
+
+    store = _FakeStore(["mem00001", "mem00002"])
+    mem = SimpleNamespace(cfg=SimpleNamespace(state_dir=tmp_path), store=store)
+    res = outcome.reconcile_roi(mem, floor=0.6, cap=1.5)
+    assert res["updated"] == 2
+    assert store.roi["mem00001"] > store.roi["mem00002"]
+    assert store.roi["mem00002"] >= 0.6  # demoted but floored, never zeroed
+
+
+# ---------------- dead weight ----------------
+
+def test_dead_weight_flags_surfaced_never_grounded(tmp_path: Path) -> None:
+    for t in range(1, 6):  # surfaced 5×, never grounded
+        _recall(tmp_path, "s", t, f"never used prompt {t}", "mem0dead")
+    _recall(tmp_path, "s", 1, "useful one", "mem0live")
+    _grounded(tmp_path, "s", 1, "mem0live")
+
+    mem = SimpleNamespace(cfg=SimpleNamespace(state_dir=tmp_path), store=_FakeStore(["mem0dead", "mem0live"]))
+    dead = outcome.dead_weight(mem, min_surfaced=4)
+    ids = {d["id"] for d in dead}
+    assert "mem0dead" in ids
+    assert "mem0live" not in ids
+    # min_surfaced=0 disables
+    assert outcome.dead_weight(mem, min_surfaced=0) == []
+
+
+# ---------------- gaps ----------------
+
+def test_detect_gaps_clusters_and_excludes_slash_and_answered(tmp_path: Path) -> None:
+    # gap: knowledge prompt, no-match bail
+    _recall(tmp_path, "s", 1, "como configuro el sync loop de memflow exactamente",
+            "x", via="bail", reason="no hits above min_sim", hit=False)
+    # near-dup of the above → same cluster
+    _recall(tmp_path, "s", 2, "como configuro exactamente el sync loop de memflow",
+            "x", via="bail", reason="no hits above min_sim", hit=False)
+    # NOT a gap: slash command bail
+    _recall(tmp_path, "s", 3, "/status", "x", via="bail", reason="slash command", hit=False)
+    # NOT a gap: answered + grounded
+    _recall(tmp_path, "s", 4, "que decidimos sobre el embedder de memo", "mem00001")
+    _grounded(tmp_path, "s", 4, "mem00001")
+
+    gaps = outcome.detect_gaps(tmp_path, sim_threshold=0.5)
+    assert len(gaps) == 1, gaps  # the two memflow prompts cluster into one
+    assert gaps[0]["count"] == 2
+    assert "sync loop" in gaps[0]["prompt"]
+
+
+def test_detect_gaps_drops_injected_system_noise(tmp_path: Path) -> None:
+    # injected hook/tool blobs land in recall.log but are not user questions
+    _recall(tmp_path, "s", 1, "<task-notification>\n<task-id>abc</task-id> something long here that exceeds sixty chars easily",
+            "x", via="bail", reason="no hits above min_sim", hit=False)
+    _recall(tmp_path, "s", 2, "system-reminder: the following context may be relevant to your task here",
+            "x", via="bail", reason="no hits above min_sim", hit=False)
+    assert outcome.detect_gaps(tmp_path) == []

--- a/tests/test_roi_reask.py
+++ b/tests/test_roi_reask.py
@@ -99,7 +99,24 @@ def test_compute_roi_time_saved_and_table(tmp_path: Path, monkeypatch) -> None:
     assert data["actions_by_client"]["claude-code"]["actions"] == 1
 
 
+def test_compute_roi_tokens_saved(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("MEMO_ROI_TOKENS_PER_GROUNDED", "350")
+    monkeypatch.setenv("MEMO_ROI_TOKENS_PER_REASK", "900")
+    _recall(tmp_path, "s", 1, "configure the deploy pipeline yaml settings now", "mem00001")
+    # answer_len anchors the measured avg-answer-tokens transparency number.
+    _grounded(tmp_path, "s", 1, "mem00001", answer_len=800)
+    data = compute_roi(tmp_path)
+    # 1 grounded + 1 reask_avoided → 1*350 + 1*900 = 1250 tokens.
+    assert data["grounded"] == 1
+    assert data["reask"]["reask_avoided"] == 1
+    assert data["tokens_saved"] == 1250
+    assert data["tokens_saved_human"] == "1.2k"
+    assert data["avg_answer_tokens"] == 200  # 800 chars / 4
+
+
 def test_compute_roi_empty(tmp_path: Path) -> None:
     data = compute_roi(tmp_path)
     assert data["by_consumer"] == []
     assert data["time_saved_seconds"] == 0
+    assert data["tokens_saved"] == 0
+    assert data["avg_answer_tokens"] is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -77,6 +77,18 @@ def test_search_full_body_when_chars_huge(mem: Memory):
     assert "body_truncated" not in out[0]
 
 
+def test_search_trace_returns_hits_and_pipeline(mem: Memory):
+    mem.save(content="alpha body", title="Alpha")
+    server = build_server(memory=mem)
+    search_trace = _tool(server, "memory_search_trace")
+
+    out = search_trace(query="alpha", limit=3)
+
+    assert out["hits"]
+    assert out["trace"][0]["stage"] == "candidate_generation"
+    assert out["trace"][-1]["stage"] == "final"
+
+
 def test_get_returns_ambiguous_shape(mem: Memory, monkeypatch):
     fixed = iter([
         uuid.UUID("aaaaaaaa1111000000000000000000ff"),

--- a/tests/test_surface_profiles.py
+++ b/tests/test_surface_profiles.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+
+from click.testing import CliRunner
+
+from memo.cli import cli
+from memo.config import Config
+from memo.memory import Memory
+from memo.server import build_server
+
+
+def _isolated_env(tmp_path, **extra: str) -> dict[str, str]:
+    data = tmp_path / "data"
+    state = tmp_path / "state"
+    vault = tmp_path / "vault"
+    data.mkdir()
+    state.mkdir()
+    vault.mkdir()
+    return {
+        "MEMO_DATA_DIR": str(data),
+        "MEMO_STATE_DIR": str(state),
+        "MEMO_VAULT_PATH": str(vault),
+        "MEMO_CONFIG_FILE": str(tmp_path / "memo-config.toml"),
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_EMBEDDER_VIA_DAEMON": "0",
+        **extra,
+    }
+
+
+def test_cli_core_profile_hides_experimental_commands(tmp_path) -> None:
+    runner = CliRunner()
+    env = _isolated_env(tmp_path, MEMO_CLI_PROFILE="core")
+
+    result = runner.invoke(cli, ["--help"], env=env)
+
+    assert result.exit_code == 0
+    assert "save" in result.output
+    assert "search" in result.output
+    assert "briefing" in result.output
+    assert "graph" not in result.output
+    assert "collaborative" not in result.output
+    assert "multimodal" not in result.output
+
+
+def test_cli_core_profile_rejects_hidden_command(tmp_path) -> None:
+    runner = CliRunner()
+    env = _isolated_env(tmp_path, MEMO_CLI_PROFILE="core")
+
+    result = runner.invoke(cli, ["graph", "--help"], env=env)
+
+    assert result.exit_code != 0
+    assert "No such command" in result.output
+
+
+def test_mcp_core_profile_hides_advanced_tools(tmp_path, monkeypatch) -> None:
+    cfg = Config(
+        data_dir=tmp_path / "data",
+        state_dir=tmp_path / "state",
+        vault_path=tmp_path / "vault",
+        embedder_dims=4,
+    )
+    monkeypatch.setattr(
+        "memo.embedder.MLXEmbedder.embed",
+        lambda self, inputs: [[1.0, 0.0, 0.0, 0.0] for _ in inputs],
+    )
+    monkeypatch.setenv("MEMO_MCP_PROFILE", "core")
+    mem = Memory(cfg)
+    try:
+        server = build_server(memory=mem)
+
+        assert asyncio.run(server.get_tool("memory_save")) is not None
+        assert asyncio.run(server.get_tool("memory_search")) is not None
+        assert asyncio.run(server.get_tool("memory_graph_path")) is None
+        assert asyncio.run(server.get_tool("memory_collaborative_connections")) is None
+    finally:
+        mem.close()

--- a/tests/test_sync_git.py
+++ b/tests/test_sync_git.py
@@ -194,6 +194,71 @@ def test_sync_push_retries_stranded_commit(remote: Path, tmp_path: Path, monkeyp
         mem.close()
 
 
+def test_sync_once_commits_local_deletion_before_pull(remote: Path, tmp_path: Path, monkeypatch):
+    """Regression: an uncommitted local .md deletion must survive sync_once
+    (commit-before-pull), not be resurrected by rebase --autostash from origin."""
+    clone = _make_clone(remote, tmp_path / "A")
+    mem = _mem_for(clone, tmp_path / "stateA", monkeypatch)
+    try:
+        rec = mem.save(content="to be deleted cross-mac", title="DeleteMe")
+        sync_once(mem.cfg, mem.store, mem)  # push it to origin
+        md = next((clone / "memorias").glob("*.md"))
+        # simulate `memo delete`'s file removal WITHOUT committing
+        md.unlink()
+        assert not md.exists()
+        out = sync_once(mem.cfg, mem.store, mem)
+        assert out["tier"] == "remote"
+        # deletion stuck locally (not resurrected) and reached origin
+        assert not md.exists(), "deletion was resurrected by the pull/rebase"
+        _git(clone, "fetch", "origin", "main")
+        tree = subprocess.run(
+            ["git", "-C", str(clone), "ls-tree", "-r", "origin/main", "--name-only"],
+            capture_output=True, text=True,
+        ).stdout
+        assert md.name not in tree, "deleted memoria still on origin"
+        _ = rec
+    finally:
+        mem.close()
+
+
+def test_sync_pull_prunes_remote_deletion(remote: Path, tmp_path: Path, monkeypatch):
+    """Receiver side: a memoria deleted on Mac A must DISAPPEAR from Mac B's
+    index after pull — reindex only adds, so sync_pull's gc(fix=True) must drop
+    the orphan row whose .md the pull removed."""
+    # A: save + push a memoria
+    clone_a = _make_clone(remote, tmp_path / "A")
+    mem_a = _mem_for(clone_a, tmp_path / "stateA", monkeypatch)
+    rec_id = None
+    try:
+        rec_id = mem_a.save(content="cross-mac delete target", title="DelTarget").id
+        sync_once(mem_a.cfg, mem_a.store, mem_a)
+    finally:
+        mem_a.close()
+    # B: pull → has it
+    clone_b = _make_clone(remote, tmp_path / "B")
+    mem_b = _mem_for(clone_b, tmp_path / "stateB", monkeypatch)
+    try:
+        sync_pull(mem_b.cfg, mem_b.store, mem_b)
+        assert mem_b.get(rec_id) is not None
+    finally:
+        mem_b.close()
+    # A: delete it + push the deletion
+    mem_a2 = _mem_for(clone_a, tmp_path / "stateA", monkeypatch)
+    try:
+        mem_a2.delete(rec_id)
+        sync_once(mem_a2.cfg, mem_a2.store, mem_a2)
+    finally:
+        mem_a2.close()
+    # B: pull again → it must be GONE from B's index (pruned), not an orphan
+    mem_b2 = _mem_for(clone_b, tmp_path / "stateB", monkeypatch)
+    try:
+        out = sync_pull(mem_b2.cfg, mem_b2.store, mem_b2)
+        assert out["pruned"] >= 1
+        assert mem_b2.get(rec_id) is None, "deleted memoria still in receiver's index"
+    finally:
+        mem_b2.close()
+
+
 def test_cli_pull_quiet_softfails_on_non_git(tmp_path: Path):
     """The SessionStart hook calls `memo sync pull --quiet`; a non-git install
     must exit 0 (not break the session)."""

--- a/tests/test_sync_git.py
+++ b/tests/test_sync_git.py
@@ -18,8 +18,11 @@ from memo.sync_git import (
     SyncGitError,
     clone_bootstrap,
     git_root_for,
+    sync_once,
     sync_pull,
     sync_push,
+    sync_status,
+    sync_tier,
 )
 
 
@@ -149,6 +152,48 @@ def test_clone_refuses_nonempty_dest(remote: Path, tmp_path: Path):
         clone_bootstrap(str(remote), dest)
 
 
+def test_sync_status_reports_clone_state(remote: Path, tmp_path: Path, monkeypatch):
+    clone = _make_clone(remote, tmp_path / "A")
+    mem = _mem_for(clone, tmp_path / "stateA", monkeypatch)
+    try:
+        st = sync_status(mem.cfg)
+        assert st["is_git_clone"] is True
+        assert st["branch"] == "main"
+        assert st["ahead"] == 0 and st["pending"] is False
+        # a save leaves the working tree dirty until the next push
+        mem.save(content="status body here", title="StatusX")
+        assert sync_status(mem.cfg)["dirty_files"] > 0
+    finally:
+        mem.close()
+
+
+def test_sync_status_not_a_clone(tmp_path: Path):
+    cfg = Config(data_dir=tmp_path / "memorias", state_dir=tmp_path / "state", embedder_dims=4)
+    (tmp_path / "memorias").mkdir()
+    st = sync_status(cfg)
+    assert st["is_git_clone"] is False
+
+
+def test_sync_push_retries_stranded_commit(remote: Path, tmp_path: Path, monkeypatch):
+    """A commit that landed locally but never pushed (offline/auth) must be
+    pushed by the next sync_push even when there's nothing new to commit."""
+    clone = _make_clone(remote, tmp_path / "A")
+    mem = _mem_for(clone, tmp_path / "stateA", monkeypatch)
+    try:
+        sync_push(mem.cfg, mem.store)  # initial push
+        # simulate a stranded local commit (committed, not pushed)
+        (clone / "memorias" / "stray.md").write_text("---\nid: y\n---\nstray\n")
+        _git(clone, "add", "-A")
+        _git(clone, "commit", "-m", "stranded")
+        assert sync_status(mem.cfg)["ahead"] == 1
+        # nothing NEW to commit, but ahead>0 → push must still fire
+        out = sync_push(mem.cfg, mem.store)
+        assert out["pushed"] is True
+        assert sync_status(mem.cfg)["ahead"] == 0
+    finally:
+        mem.close()
+
+
 def test_cli_pull_quiet_softfails_on_non_git(tmp_path: Path):
     """The SessionStart hook calls `memo sync pull --quiet`; a non-git install
     must exit 0 (not break the session)."""
@@ -173,6 +218,41 @@ def test_cli_pull_quiet_softfails_on_non_git(tmp_path: Path):
     # without --quiet it surfaces the error (non-zero)
     r2 = CliRunner().invoke(cli, ["sync", "pull"], env=env)
     assert r2.exit_code != 0
+
+
+def test_sync_auto_throttle_and_disable(remote: Path, tmp_path: Path):
+    """sync auto: cheap no-op when not due (no Memory/MLX built), and a hard
+    skip when MEMO_SYNC_AUTO=0."""
+    import json
+    import time
+
+    from click.testing import CliRunner
+
+    from memo.cli import cli
+
+    clone = _make_clone(remote, tmp_path / "A")
+    state = tmp_path / "stateA"
+    state.mkdir()
+    env = {
+        "MEMO_CONFIG_FILE": str(tmp_path / "memo-config.toml"),
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_DATA_DIR": str(clone / "memorias"),
+        "MEMO_STATE_DIR": str(state),
+        "MEMO_EMBEDDER_DIMS": "4",
+        "MEMO_EMBEDDER_MODEL": "stub",
+    }
+    # pre-stamp recent timestamps → neither pull nor push due → returns before
+    # building Memory (so no MLX needed).
+    (state / ".sync_auto_ts").write_text(
+        json.dumps({"last_pull": time.time(), "last_push": time.time()})
+    )
+    r = CliRunner().invoke(cli, ["sync", "auto", "--json"], env=env)
+    assert r.exit_code == 0, r.output
+    assert '"skipped": "not due"' in r.output
+
+    r2 = CliRunner().invoke(cli, ["sync", "auto", "--json"], env={**env, "MEMO_SYNC_AUTO": "0"})
+    assert r2.exit_code == 0
+    assert '"skipped": "disabled"' in r2.output
 
 
 def test_pull_aborts_on_memoria_conflict(remote: Path, tmp_path: Path, monkeypatch):
@@ -200,3 +280,102 @@ def test_pull_aborts_on_memoria_conflict(remote: Path, tmp_path: Path, monkeypat
         assert not (clone_b / ".git" / "rebase-merge").exists()
     finally:
         mem_b.close()
+
+
+def test_sync_tier_remote_clone_vs_local_plain_dir(remote: Path, tmp_path: Path, monkeypatch):
+    """`sync_tier` is "remote" only when a git remote is configured; a plain
+    (non-git) data dir is "local" and never raises."""
+    clone = _make_clone(remote, tmp_path / "A")
+    mem = _mem_for(clone, tmp_path / "stateA", monkeypatch)
+    try:
+        assert sync_tier(mem.cfg) == "remote"
+    finally:
+        mem.close()
+
+    plain = Config(
+        data_dir=tmp_path / "plain",
+        state_dir=tmp_path / "state_plain",
+        embedder_dims=4,
+    )
+    (tmp_path / "plain").mkdir()
+    assert sync_tier(plain) == "local"
+
+
+def test_sync_once_pull_rebase_before_push(remote: Path, tmp_path: Path, monkeypatch):
+    """Mac A has a divergent local commit while the remote advanced (Mac B
+    pushed). `sync_once` on A must pull-rebase A's commit onto B's tip and then
+    push without rejection — A ends with ahead==0 and B's memoria indexed."""
+    clone_a = _make_clone(remote, tmp_path / "A")
+    clone_b = _make_clone(remote, tmp_path / "B")
+
+    # --- Mac B advances the remote with a new memoria ---
+    mem_b = _mem_for(clone_b, tmp_path / "stateB", monkeypatch)
+    try:
+        rec_b_id = mem_b.save(content="from mac B", title="FromB").id
+        assert sync_push(mem_b.cfg, mem_b.store)["pushed"] is True
+    finally:
+        mem_b.close()
+
+    # --- Mac A makes a divergent local commit (committed, not pushed) ---
+    mem_a = _mem_for(clone_a, tmp_path / "stateA", monkeypatch)
+    try:
+        rec_a_id = mem_a.save(content="from mac A", title="FromA").id
+        _git(clone_a, "add", "-A")
+        _git(clone_a, "commit", "-m", "A local memoria")
+        # A is ahead of its last-known remote and unaware of B's commit
+        assert sync_status(mem_a.cfg)["ahead"] == 1
+
+        res = sync_once(mem_a.cfg, mem_a.store, mem_a)
+        assert res["tier"] == "remote"
+        assert res["pulled"] is True
+        assert res["pushed"] is True
+
+        # rebased onto B's tip + pushed cleanly → nothing stranded
+        assert sync_status(mem_a.cfg)["ahead"] == 0
+        # B's memoria arrived via the pull-reindex; A's own survived the rebase
+        assert mem_a.get(rec_b_id) is not None
+        assert mem_a.get(rec_a_id) is not None
+    finally:
+        mem_a.close()
+
+
+def test_sync_once_skips_when_lock_held(remote: Path, tmp_path: Path, monkeypatch):
+    """A held machine lock makes `sync_once` skip without doing git mutation —
+    the concurrent sibling's writes are already in the shared store, so the lock
+    holder carries them."""
+    import fcntl
+
+    clone = _make_clone(remote, tmp_path / "A")
+    mem = _mem_for(clone, tmp_path / "stateA", monkeypatch)
+    try:
+        lock_path = mem.cfg.state_dir / ".sync.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        fh = lock_path.open("w")
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            res = sync_once(mem.cfg, mem.store, mem)
+            # exact shape proves the pull/push branch never ran
+            assert res == {"tier": "remote", "skipped": "locked"}
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+            fh.close()
+    finally:
+        mem.close()
+
+
+def test_sync_push_commit_carries_identity_label(remote: Path, tmp_path: Path, monkeypatch):
+    """A commit produced by the sync path is attributed to the identity label —
+    the message ends with `[<label>]`."""
+    clone = _make_clone(remote, tmp_path / "A")
+    mem = _mem_for(clone, tmp_path / "stateA", monkeypatch)
+    try:
+        assert sync_push(mem.cfg, mem.store)["pushed"] is True
+        subject = subprocess.run(
+            ["git", "-C", str(clone), "log", "-1", "--format=%s"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        assert "[" in subject and "]" in subject
+    finally:
+        mem.close()

--- a/tests/test_usefulness.py
+++ b/tests/test_usefulness.py
@@ -64,6 +64,34 @@ def test_log_consult_records_via_and_lowercased_source(tmp_path: Path) -> None:
     assert dashboard.consumer_label(rows[0]) == "synapse"
 
 
+def test_log_consult_falls_back_to_memo_source_env(tmp_path: Path, monkeypatch) -> None:
+    """A client that can't pass per-call source= (devin / opencode / windsurf)
+    is still attributed when MEMO_SOURCE is set in the server env."""
+    monkeypatch.setenv("MEMO_SOURCE", "Devin")
+    fake = SimpleNamespace(cfg=SimpleNamespace(state_dir=tmp_path))
+    _log_consult(
+        fake,  # type: ignore[arg-type]
+        tool="search",
+        query="q",
+        hits=[{"id": "y" * 8, "score": 0.9, "title": "t"}],
+        t0_ms=0,
+    )
+    rows = dashboard.read_recall_log(tmp_path, limit=5)
+    assert rows and rows[0]["source"] == "devin"
+    assert dashboard.consumer_label(rows[0]) == "devin"
+
+
+def test_log_consult_explicit_source_overrides_env(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("MEMO_SOURCE", "devin")
+    fake = SimpleNamespace(cfg=SimpleNamespace(state_dir=tmp_path))
+    _log_consult(
+        fake,  # type: ignore[arg-type]
+        tool="ask", query="q", hits=[], t0_ms=0, source="synapse",
+    )
+    rows = dashboard.read_recall_log(tmp_path, limit=5)
+    assert rows and rows[0]["source"] == "synapse"
+
+
 def test_log_consult_never_raises_on_bad_memory(tmp_path: Path) -> None:
     # A memory object without cfg must not break the caller — telemetry is
     # best-effort and swallows its own errors.

--- a/web/build.py
+++ b/web/build.py
@@ -479,6 +479,197 @@ def _usefulness(cfg: Config) -> dict[str, Any]:
     }
 
 
+def _consult_trend(state_dir: Path, *, days: int = 14, limit: int = 1000) -> list[dict[str, Any]]:
+    """Consults per calendar day (last ``days``), split activated vs total.
+
+    Pure read over recall.log — shows whether memo is being asked MORE over time
+    (adoption) or going quiet. ``activado`` = the hook actually searched (fired);
+    the rest were skipped (slash commands / short prompts / no match)."""
+    by_day: dict[str, dict[str, int]] = defaultdict(lambda: {"consultas": 0, "activado": 0})
+    for r in read_recall_log(state_dir, limit=limit):
+        day = (r.get("ts") or "")[:10]
+        if not day:
+            continue
+        by_day[day]["consultas"] += 1
+        if r.get("via") in ("daemon", "subprocess"):
+            by_day[day]["activado"] += 1
+    today = datetime.now(UTC).date()
+    out: list[dict[str, Any]] = []
+    for i in range(days - 1, -1, -1):
+        d = (today - timedelta(days=i)).isoformat()
+        b = by_day.get(d, {"consultas": 0, "activado": 0})
+        out.append({"date": d, "consultas": b["consultas"], "activado": b["activado"]})
+    return out
+
+
+def _fmt_tokens_compact(tokens: float) -> str:
+    tokens = int(tokens)
+    if tokens < 1000:
+        return str(tokens)
+    if tokens < 1_000_000:
+        return f"{tokens / 1000:.1f}k"
+    return f"{tokens / 1_000_000:.2f}M"
+
+
+def _token_savings(state_dir: Path, *, days: int = 14) -> dict[str, Any]:
+    """Detailed token-savings breakdown for the dashboard graph.
+
+    Two honest drivers, each a clearly-labeled estimate:
+      - "hechos reutilizados" — a surfaced memoria the answer actually used
+        (grounding.log, used_score ≥ GROUNDED_SCORE, deduped by sid+turn+id) ×
+        ``MEMO_ROI_TOKENS_PER_GROUNDED``: tokens the model didn't spend
+        re-deriving the fact. This one is DATED, so it drives the daily series.
+      - "repreguntas evitadas" — grounded recalls the user did not have to ask
+        again × ``MEMO_ROI_TOKENS_PER_REASK``: a saved answer-regeneration
+        round-trip. A session-level metric (no clean per-day bucket), shown only
+        in the composition total, not the daily bars.
+    """
+    from memo.dashboard import GROUNDED_SCORE, read_grounding_log
+    from memo.flags import flag_int
+
+    tok_grounded = flag_int("MEMO_ROI_TOKENS_PER_GROUNDED") or 350
+    tok_reask = flag_int("MEMO_ROI_TOKENS_PER_REASK") or 900
+
+    seen: set[tuple[str, int, str]] = set()
+    by_day: dict[str, int] = defaultdict(int)
+    answer_lens: list[int] = []
+    for g in read_grounding_log(state_dir):
+        if g.get("answer_len"):
+            answer_lens.append(int(g["answer_len"]))
+        sid, turn, rid = g.get("session_id"), g.get("turn"), g.get("recall_id")
+        score = g.get("used_score")
+        day = (g.get("ts") or "")[:10]
+        if not (
+            sid and isinstance(turn, int) and rid and day
+            and isinstance(score, (int, float)) and float(score) >= GROUNDED_SCORE
+        ):
+            continue
+        key = (sid, turn, rid)
+        if key in seen:
+            continue
+        seen.add(key)
+        by_day[day] += 1
+
+    today = datetime.now(UTC).date()
+    daily: list[dict[str, Any]] = []
+    for i in range(days - 1, -1, -1):
+        d = (today - timedelta(days=i)).isoformat()
+        g = by_day.get(d, 0)
+        daily.append({"date": d, "grounded": g, "tokens": g * tok_grounded})
+
+    grounded_total = sum(by_day.values())
+    try:
+        reask = reask_stats(state_dir, limit=500)
+    except Exception:
+        reask = {}
+    reask_avoided = int(reask.get("reask_avoided") or 0)
+    grounded_tokens = grounded_total * tok_grounded
+    reask_tokens = reask_avoided * tok_reask
+    return {
+        "daily": daily,
+        "grounded": grounded_total,
+        "grounded_tokens": grounded_tokens,
+        "reask_avoided": reask_avoided,
+        "reask_tokens": reask_tokens,
+        "total": grounded_tokens + reask_tokens,
+        "tok_grounded": tok_grounded,
+        "tok_reask": tok_reask,
+        "avg_answer_tokens": (
+            round(sum(answer_lens) / len(answer_lens) / 4) if answer_lens else None
+        ),
+    }
+
+
+def _sync_health(cfg: Config) -> dict[str, Any]:
+    """GitHub sync health for the dashboard — is durable knowledge reaching the
+    shared repo so other sessions/Macs can read it? Cheap read; [] on error."""
+    try:
+        from memo.sync_git import sync_status
+
+        st = sync_status(cfg)
+        if not st.get("is_git_clone"):
+            return {"state": "off", "label": "Sin sync (data_dir no es repo git)"}
+        if st.get("pending"):
+            return {"state": "bad", "label": "Commits varados — push falló", **st}
+        if st.get("ahead") or st.get("dirty_files"):
+            return {"state": "warn",
+                    "label": f"{st['ahead']} sin pushear · {st['dirty_files']} sin commitear", **st}
+        return {"state": "ok", "label": "Al día con GitHub", **st}
+    except Exception:
+        return {"state": "off", "label": "Sync no disponible"}
+
+
+def _gaps(cfg: Config, *, top: int = 12) -> list[dict[str, Any]]:
+    """Knowledge gaps — what memo could NOT answer (The Outcome Loop). Cheap
+    read; degrades to [] if the outcome module/logs are unavailable."""
+    try:
+        from memo.outcome import detect_gaps
+
+        return detect_gaps(cfg.state_dir)[:top]
+    except Exception:
+        return []
+
+
+def _gerencial(cfg: Config) -> dict[str, Any]:
+    """Management-grade rollup: the consult funnel, the value numbers, the
+    per-tool reader breakdown, and the adoption trend — everything the gerencial
+    dashboard needs in plain numbers, no re-derivation in the browser."""
+    state_dir = cfg.state_dir
+    try:
+        health = recall_health(state_dir, limit=500)
+    except Exception:
+        health = {}
+    try:
+        from memo.cli_roi import compute_roi
+
+        roi = compute_roi(state_dir, limit=500)
+    except Exception:
+        roi = {}
+
+    fired = int(health.get("fired") or 0)
+    sampled = int(health.get("sampled") or 0)
+    hit_rate = float(health.get("hit_rate") or 0.0)
+    with_hits = round(hit_rate * fired) if fired else 0
+
+    # Funnel stages that share ONE honest denominator (sampled). "Used in the
+    # answer" is deliberately NOT a 4th bar — it is measured on a smaller scored
+    # subset, so it lives as its own KPI to avoid implying a false collapse.
+    funnel = [
+        {"key": "preguntas", "label": "Preguntas hechas", "value": sampled},
+        {"key": "activado", "label": "memo se activó", "value": fired},
+        {"key": "encontro", "label": "Encontró información útil", "value": with_hits},
+    ]
+
+    k_total = int(health.get("answers_knowledge_total") or 0)
+    used_rate = health.get("answer_rate_knowledge") if k_total else health.get("answer_rate")
+    used_total = k_total if k_total else int(health.get("answers_total") or 0)
+    used_grounded = (
+        int(health.get("answers_knowledge_grounded") or 0)
+        if k_total
+        else int(health.get("answers_grounded") or 0)
+    )
+
+    reask = roi.get("reask") if isinstance(roi.get("reask"), dict) else {}
+    # Detailed token-savings (full grounding.log, daily series + composition).
+    # The KPI reads from this too so the headline number == the panel total.
+    token_detail = _token_savings(state_dir)
+    return {
+        "funnel": funnel,
+        "coverage_rate": round(fired / sampled, 3) if sampled else None,
+        "hit_rate": health.get("hit_rate"),
+        "used_rate": used_rate,
+        "used_total": used_total,
+        "used_grounded": used_grounded,
+        "time_saved_human": roi.get("time_saved_human"),
+        "reask_avoided": reask.get("reask_avoided"),
+        "tokens_saved": token_detail["total"],
+        "tokens_saved_human": _fmt_tokens_compact(token_detail["total"]),
+        "avg_answer_tokens": token_detail["avg_answer_tokens"],
+        "token_detail": token_detail,
+        "trend": _consult_trend(state_dir),
+    }
+
+
 def collect_data(cfg: Config, *, include_projection: bool = True, limit: int = 1500) -> dict[str, Any]:
     """Gather every metric the dashboard renders, as a JSON-serializable dict.
 
@@ -574,6 +765,9 @@ def collect_data(cfg: Config, *, include_projection: bool = True, limit: int = 1
         "contradictions": contradictions or {},
         "verdict": verdict(cfg.state_dir, limit=500),
         "memflow_util": _fetch_memflow_utility(),
+        "gerencial": _gerencial(cfg),
+        "gaps": _gaps(cfg),
+        "sync": _sync_health(cfg),
     }
     return data
 
@@ -626,509 +820,465 @@ def _probe_mlx() -> None:
 # ── HTML / JS template ───────────────────────────────────────────────────
 
 _HTML_TEMPLATE = r"""<!doctype html>
-<html lang="en">
+<html lang="es">
 <head>
 <meta charset="utf-8" />
-<title>Memo · Health Dashboard</title>
+<title>memo · ¿funciona como memoria?</title>
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
 <style>
   :root {
-    --bg: #0b0f17;
-    --panel: #131a26;
-    --panel-soft: #1a2231;
+    --bg: #0a0e16;
+    --bg-soft: #0e1320;
+    --panel: #131a28;
+    --panel-soft: #1a2233;
     --border: #243049;
-    --fg: #e6edf7;
-    --fg-mute: #94a3b8;
-    --green: #34d399;
+    --fg: #eef3fb;
+    --fg-mute: #93a1b8;
+    --fg-dim: #5d6b85;
+    --green: #2ee6a6;
     --yellow: #fbbf24;
-    --red:    #f87171;
-    --blue:   #4f8ef7;
+    --red:    #fb7185;
+    --blue:   #5b9dff;
+    --shadow: 0 1px 2px rgba(0,0,0,.4), 0 8px 24px rgba(0,0,0,.25);
   }
   * { box-sizing: border-box; }
-  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg);
-               font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-                            "Helvetica Neue", Arial, sans-serif; }
-  header { padding: 18px 24px; border-bottom: 1px solid var(--border);
-           display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap; }
-  header h1 { margin: 0; font-size: 18px; font-weight: 600; letter-spacing: 0.5px; }
-  header .meta { color: var(--fg-mute); font-size: 12px; }
-  header .overall { margin-left: auto; display: flex; gap: 6px; align-items: center; }
-  .dot { width: 10px; height: 10px; border-radius: 50%;
-         box-shadow: 0 0 8px currentColor; display: inline-block; }
-  .dot.green  { background: var(--green); color: var(--green); }
+  html, body { margin: 0; padding: 0; background:
+      radial-gradient(1200px 600px at 80% -10%, #16203a 0%, var(--bg) 55%); color: var(--fg);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                 "Helvetica Neue", Arial, sans-serif; -webkit-font-smoothing: antialiased; }
+
+  header { padding: 22px 28px 18px; display: flex; align-items: baseline;
+           gap: 14px; flex-wrap: wrap; max-width: 1180px; margin: 0 auto; }
+  header h1 { margin: 0; font-size: 17px; font-weight: 700; letter-spacing: .3px; }
+  header h1 .sub { color: var(--fg-mute); font-weight: 400; }
+  header .meta { color: var(--fg-dim); font-size: 12px; }
+  .live-badge { margin-left: auto; font-size: 12px; color: var(--fg-mute);
+                display: inline-flex; align-items: center; gap: 6px;
+                background: var(--panel); border: 1px solid var(--border);
+                padding: 5px 11px; border-radius: 999px; }
+  .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+         box-shadow: 0 0 8px currentColor; }
+  .dot.green  { background: var(--green);  color: var(--green); }
   .dot.yellow { background: var(--yellow); color: var(--yellow); }
-  .dot.red    { background: var(--red); color: var(--red); }
-  .dot.blue   { background: var(--blue); color: var(--blue); }
+  .dot.red    { background: var(--red);    color: var(--red); }
+  .dot.blue   { background: var(--blue);   color: var(--blue); }
+  .dot.live { animation: pulse 2s ease-in-out infinite; }
+  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .35; } }
 
-  main { padding: 18px 24px; display: grid; gap: 18px; }
-  .pillars { display: grid; gap: 14px;
-             grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
-  .card { background: var(--panel); border: 1px solid var(--border);
-          border-radius: 10px; padding: 14px 16px; }
-  .card.green  { border-left: 4px solid var(--green); }
-  .card.yellow { border-left: 4px solid var(--yellow); }
-  .card.red    { border-left: 4px solid var(--red); }
-  .card.blue   { border-left: 4px solid var(--blue); }
-  .card .label { font-size: 12px; color: var(--fg-mute); text-transform: uppercase;
-                 letter-spacing: 0.5px; display: flex; align-items: center; gap: 8px; }
-  .card .summary { font-size: 20px; font-weight: 600; margin-top: 6px; }
-  .card details { margin-top: 10px; }
-  .card details summary { cursor: pointer; color: var(--fg-mute); font-size: 12px;
-                          list-style: none; }
-  .card details summary::-webkit-details-marker { display: none; }
-  .card details summary::before { content: "▸ "; }
-  .card details[open] summary::before { content: "▾ "; }
-  .card details pre { background: var(--panel-soft); border-radius: 6px;
-                      padding: 10px 12px; font-size: 12px; line-height: 1.5;
-                      white-space: pre-wrap; word-break: break-word;
-                      margin: 8px 0 0; color: var(--fg); }
-
-  .grid { display: grid; gap: 18px;
-          grid-template-columns: minmax(0, 2fr) minmax(0, 1fr); }
-  @media (max-width: 1000px) { .grid { grid-template-columns: 1fr; } }
+  main { padding: 4px 28px 48px; display: grid; gap: 18px;
+         max-width: 1180px; margin: 0 auto; }
   .panel { background: var(--panel); border: 1px solid var(--border);
-           border-radius: 10px; padding: 14px 16px; }
-  .panel h2 { margin: 0 0 10px; font-size: 13px; font-weight: 600;
-              color: var(--fg-mute); text-transform: uppercase;
-              letter-spacing: 0.5px; }
-  .row2 { display: grid; gap: 18px; grid-template-columns: 1fr 1fr; }
-  @media (max-width: 800px) { .row2 { grid-template-columns: 1fr; } }
+           border-radius: 16px; padding: 20px 22px; box-shadow: var(--shadow); }
+  .panel > h2 { margin: 0 0 4px; font-size: 12px; font-weight: 600;
+                color: var(--fg-mute); text-transform: uppercase; letter-spacing: .8px; }
+  .panel .hint { color: var(--fg-dim); font-size: 12.5px; margin: 0 0 16px; line-height: 1.5; }
 
-  .statcards { display: grid; gap: 12px;
-               grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
-  .statcard { background: var(--panel); border: 1px solid var(--border);
-              border-radius: 10px; padding: 14px 16px; }
-  .statcard .num { font-size: 1.9rem; font-weight: 800; line-height: 1.1;
-                   letter-spacing: -1px; }
-  .statcard .cap { color: var(--fg-mute); font-size: 0.74rem; margin-top: 4px;
-                   text-transform: uppercase; letter-spacing: 0.5px; }
-  .live-badge { font-size: 11px; color: var(--fg-mute); display: inline-flex;
-                align-items: center; gap: 5px; }
-  .live-badge .dot { width: 7px; height: 7px; }
+  /* ── verdict hero ── */
+  .verdict { position: relative; overflow: hidden; border-width: 1px;
+             display: flex; align-items: center; gap: 26px; padding: 30px 30px; }
+  .verdict .glyph { font-size: 56px; line-height: 1; filter: drop-shadow(0 2px 8px rgba(0,0,0,.4)); }
+  .verdict .vmain { flex: 1; min-width: 0; }
+  .verdict .vlabel { font-size: clamp(26px, 4vw, 40px); font-weight: 800;
+                     letter-spacing: -.5px; line-height: 1.05; }
+  .verdict .vexplain { color: var(--fg-mute); font-size: 15px; margin-top: 8px; line-height: 1.5; }
+  .verdict .vstat { text-align: right; }
+  .verdict .vstat b { display: block; font-size: 30px; font-weight: 800; letter-spacing: -1px; }
+  .verdict .vstat span { color: var(--fg-dim); font-size: 11.5px; text-transform: uppercase; letter-spacing: .6px; }
+  @media (max-width: 720px) { .verdict { flex-wrap: wrap; } .verdict .vstat { text-align: left; } }
 
-  table { width: 100%; border-collapse: collapse; font-size: 12px; }
-  th, td { text-align: left; padding: 6px 8px; border-bottom: 1px solid var(--border); }
-  th { color: var(--fg-mute); font-weight: 500; }
-  tr:last-child td { border-bottom: none; }
-  .pill { display: inline-block; padding: 1px 8px; border-radius: 999px;
-          font-size: 11px; background: var(--panel-soft); color: var(--fg-mute); }
-  .op-save   { color: var(--green); }
-  .op-update { color: var(--yellow); }
-  .op-delete { color: var(--red); }
+  /* ── funnel ── */
+  .funnel { display: grid; gap: 10px; }
+  .fstage { display: grid; grid-template-columns: 190px 1fr auto; align-items: center;
+            gap: 14px; }
+  .fstage .fname { font-size: 13.5px; color: var(--fg); }
+  .fstage .fname small { display: block; color: var(--fg-dim); font-size: 11px; margin-top: 1px; }
+  .fbar { height: 34px; background: var(--panel-soft); border-radius: 9px; overflow: hidden; }
+  .fbar > div { height: 100%; border-radius: 9px; transition: width .6s cubic-bezier(.16,1,.3,1);
+                display: flex; align-items: center; padding-left: 12px;
+                font-weight: 700; font-size: 13px; color: #06121f; }
+  .fstage .fval { font-weight: 800; font-size: 17px; min-width: 84px; text-align: right; }
+  .fstage .fval small { color: var(--fg-dim); font-weight: 600; font-size: 11.5px; }
+  @media (max-width: 620px) { .fstage { grid-template-columns: 1fr; gap: 4px; } .fstage .fval { text-align: left; } }
 
-  footer { padding: 12px 24px; color: var(--fg-mute); font-size: 11px;
-           text-align: center; border-top: 1px solid var(--border); }
-  code { background: var(--panel-soft); padding: 1px 5px; border-radius: 4px;
-         font-size: 11px; }
+  /* ── KPI cards ── */
+  .kpis { display: grid; gap: 14px; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+  .kpi { background: var(--panel); border: 1px solid var(--border); border-radius: 16px;
+         padding: 18px 20px; box-shadow: var(--shadow); position: relative; overflow: hidden; }
+  .kpi::before { content: ""; position: absolute; inset: 0 auto 0 0; width: 4px; background: var(--accent, var(--blue)); }
+  .kpi .knum { font-size: 2.5rem; font-weight: 800; line-height: 1; letter-spacing: -1.5px; }
+  .kpi .kcap { color: var(--fg); font-size: 13px; font-weight: 600; margin-top: 10px; }
+  .kpi .ksub { color: var(--fg-dim); font-size: 11.5px; margin-top: 3px; line-height: 1.4; }
+
+  /* ── readers (per-tool) ── */
+  .tools { display: grid; gap: 9px; }
+  .tool { display: grid; grid-template-columns: 150px 1fr 130px; align-items: center; gap: 14px; }
+  .tool .tname { font-size: 13.5px; font-weight: 600; display: flex; align-items: center; gap: 7px; }
+  .tbar { height: 26px; background: var(--panel-soft); border-radius: 7px; overflow: hidden; }
+  .tbar > div { height: 100%; border-radius: 7px; transition: width .6s cubic-bezier(.16,1,.3,1); }
+  .tool .tstate { font-size: 11.5px; font-weight: 600; text-align: right; }
+  .tool .tstate small { display:block; color: var(--fg-dim); font-weight: 500; }
+  @media (max-width: 620px) { .tool { grid-template-columns: 1fr auto; } .tool .tbar { display:none; } }
+  .badge-silent { margin-top: 16px; font-size: 12.5px; padding: 11px 14px; border-radius: 10px;
+                  background: rgba(251,113,133,.08); border: 1px solid rgba(251,113,133,.25); color: #ffb3c0; line-height: 1.5; }
+  .badge-silent.ok { background: rgba(46,230,166,.07); border-color: rgba(46,230,166,.22); color: #9af0d0; }
+
+  /* ── token savings detail ── */
+  .tok-top { display: grid; grid-template-columns: 220px 1fr; gap: 26px; align-items: center; }
+  @media (max-width: 620px) { .tok-top { grid-template-columns: 1fr; gap: 16px; } }
+  .tok-total .tnum { font-size: 3rem; font-weight: 800; letter-spacing: -1.5px; line-height: 1; color: var(--green); }
+  .tok-total .tcap { color: var(--fg); font-size: 13px; font-weight: 600; margin-top: 8px; }
+  .tok-total .tassump { color: var(--fg-dim); font-size: 11px; margin-top: 6px; line-height: 1.5; }
+  .tok-compbar { height: 30px; background: var(--panel-soft); border-radius: 9px; overflow: hidden; display: flex; }
+  .tok-compbar > div { height: 100%; transition: width .6s cubic-bezier(.16,1,.3,1); }
+  #tok-seg-grounded { background: var(--green); }
+  #tok-seg-reask { background: var(--blue); }
+  .tok-legend { display: flex; gap: 22px; margin-top: 12px; flex-wrap: wrap; font-size: 13px; color: var(--fg-mute); }
+  .tok-legend b { color: var(--fg); }
+  .tok-legend small { color: var(--fg-dim); }
+  .tok-legend .sw { display: inline-block; width: 11px; height: 11px; border-radius: 3px; margin-right: 6px; vertical-align: middle; }
+  .tok-subh { margin: 22px 0 6px; font-size: 12px; font-weight: 600; color: var(--fg-mute); }
+
+  /* ── knowledge gaps ── */
+  .gap-row { display: grid; grid-template-columns: 44px 1fr auto; align-items: center;
+             gap: 12px; padding: 9px 0; border-bottom: 1px solid var(--border); }
+  .gap-row:last-child { border-bottom: none; }
+  .gap-n { font-weight: 800; color: var(--yellow); font-size: 14px; text-align: right; }
+  .gap-q { font-size: 13.5px; color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .gap-why { font-size: 11.5px; color: var(--fg-dim); white-space: nowrap; }
+  @media (max-width: 620px) { .gap-row { grid-template-columns: 36px 1fr; } .gap-why { display: none; } }
+
+  footer { padding: 18px 28px 28px; color: var(--fg-dim); font-size: 11.5px;
+           text-align: center; max-width: 1180px; margin: 0 auto; }
+  code { background: var(--panel-soft); padding: 1px 6px; border-radius: 5px; font-size: 11px; }
 </style>
 </head>
 <body>
 <header>
-  <h1>memo · health</h1>
+  <h1>memo · <span class="sub">¿está funcionando como memoria?</span></h1>
   <span class="meta" id="meta-stamp"></span>
   <span class="live-badge" id="live-badge"></span>
-  <span class="overall" id="overall-lights"></span>
 </header>
 
 <main>
-  <section class="pillars" id="pillars"></section>
+  <!-- VEREDICTO -->
+  <section class="panel verdict" id="verdict-panel">
+    <div class="glyph" id="verdict-glyph">⏳</div>
+    <div class="vmain">
+      <div class="vlabel" id="verdict-label">—</div>
+      <div class="vexplain" id="verdict-explain">—</div>
+    </div>
+    <div class="vstat">
+      <b id="verdict-consults">—</b>
+      <span>consultas analizadas</span>
+    </div>
+  </section>
 
-  <div class="row2">
-    <div class="panel" id="verdict-panel" style="border-width:2px;">
-      <h2>¿Funciona memo?</h2>
-      <div id="verdict-label" style="font-size:1.8rem;font-weight:800;line-height:1.2;">—</div>
-      <div id="verdict-sub" style="color:var(--fg-mute);font-size:0.85rem;margin:0.3rem 0 0.8rem;">—</div>
-      <div style="font-size:0.82rem;line-height:1.8;">
-        <div><span style="color:var(--fg-mute);">lee:&nbsp;</span><span id="verdict-readers" style="color:var(--green);">—</span></div>
-        <div><span style="color:var(--fg-mute);">NO lee:&nbsp;</span><span id="verdict-silent" style="color:var(--red);font-weight:600;">—</span></div>
+  <!-- EMBUDO -->
+  <section class="panel">
+    <h2>De cada pregunta, ¿cuánto aporta memo?</h2>
+    <p class="hint">Por cada cosa que se le pregunta al asistente, memo decide si activarse, busca, y entrega información. Esto muestra cuántas llegan a cada paso.</p>
+    <div class="funnel" id="funnel"></div>
+  </section>
+
+  <!-- KPIs -->
+  <section class="kpis" id="kpis"></section>
+
+  <!-- AHORRO DE TOKENS (detalle) -->
+  <section class="panel">
+    <h2>Ahorro de tokens — detalle</h2>
+    <p class="hint">Tokens que el modelo NO tuvo que gastar porque la respuesta usó información que memo ya tenía, en vez de re-generarla o repreguntar. Estimación con supuestos explícitos.</p>
+    <div class="tok-top">
+      <div class="tok-total">
+        <div class="tnum" id="tok-total">—</div>
+        <div class="tcap">tokens ahorrados (acumulado)</div>
+        <div class="tassump" id="tok-assump">—</div>
       </div>
-    </div>
-    <div class="panel" id="memflow-panel">
-      <h2>memflow utility</h2>
-      <div id="memflow-estado" style="font-size:1.1rem;font-weight:700;margin-bottom:0.6rem;">—</div>
-      <table><tbody>
-        <tr><td style="color:var(--fg-mute);">reads 7d</td><td id="mf-reads" style="text-align:right;font-weight:600;">—</td></tr>
-        <tr><td style="color:var(--fg-mute);">memory_used</td><td id="mf-used" style="text-align:right;font-weight:600;">—</td></tr>
-        <tr><td style="color:var(--fg-mute);">re_explain</td><td id="mf-reexplain" style="text-align:right;font-weight:600;">—</td></tr>
-      </tbody></table>
-    </div>
-  </div>
-
-  <section class="statcards" id="statcards"></section>
-
-  <div class="panel" id="utility-panel" style="border-width:2px;">
-    <h2>Utilidad — respuestas CON memo vs SIN memo</h2>
-    <div style="display:flex;align-items:baseline;gap:1rem;flex-wrap:wrap;">
-      <div id="utility-pct" style="font-size:3.2rem;font-weight:800;line-height:1;letter-spacing:-1px;">—</div>
-      <div id="utility-sub" style="color:var(--fg-mute);font-size:0.9rem;">—</div>
-    </div>
-    <div style="background:var(--border);border-radius:6px;height:16px;overflow:hidden;display:flex;margin-top:0.7rem;">
-      <div id="utility-seg-con" style="height:100%;background:var(--green);width:0%;transition:width .4s;" title="respondió con memo"></div>
-      <div id="utility-seg-sin" style="height:100%;background:#f8717155;width:0%;transition:width .4s;" title="respondió sin memo"></div>
-    </div>
-    <div style="font-size:0.78rem;color:var(--fg-mute);margin-top:0.45rem;">
-      <span id="utility-leg-con" style="color:var(--green);font-weight:600;">—</span> con memo ·
-      <span id="utility-leg-sin" style="font-weight:600;">—</span> sin memo
-    </div>
-  </div>
-
-  <div class="panel">
-    <h2>Quién lee memo</h2>
-    <table id="readers-table">
-      <thead><tr><th>capa</th><th>consultas</th><th>hit%</th><th>grounded%</th><th>última</th></tr></thead>
-      <tbody></tbody>
-    </table>
-    <div id="readers-silent" style="margin-top:0.6rem;font-size:0.8rem;color:var(--fg-mute);"></div>
-  </div>
-
-  <div class="grid">
-    <div class="panel">
-      <h2>3-D memory map <span id="map-method" class="pill"></span></h2>
-      <div id="map3d" style="height: 520px;"></div>
-    </div>
-    <div class="panel">
-      <h2>Type distribution</h2>
-      <div id="types" style="height: 240px;"></div>
-      <h2 style="margin-top:14px">Saves · last 30 days</h2>
-      <div id="growth" style="height: 220px;"></div>
-    </div>
-  </div>
-
-  <div class="row2" style="grid-template-columns:1fr;">
-    <div class="panel">
-      <h2>Utilización de consultas</h2>
-      <div style="display:flex;align-items:center;gap:2.5rem;padding:1.2rem 0 0.6rem;">
-        <div id="util-pct" style="font-size:6rem;font-weight:800;line-height:1;color:var(--fg);min-width:8rem;letter-spacing:-2px;">—</div>
-        <div style="flex:1;">
-          <div id="util-sub" style="margin-bottom:1rem;color:var(--fg-mute);font-size:0.9rem;line-height:1.6;">—</div>
-          <div style="background:var(--border);border-radius:6px;height:18px;overflow:hidden;display:flex;">
-            <div id="util-seg-hits"  style="height:100%;background:var(--green);width:0%;transition:width 0.4s;" title="con hits"></div>
-            <div id="util-seg-miss"  style="height:100%;background:#f8717166;width:0%;transition:width 0.4s;" title="sin hits"></div>
-            <div id="util-seg-bail"  style="height:100%;background:#94a3b833;width:0%;transition:width 0.4s;" title="omitidas"></div>
-          </div>
-          <div style="display:flex;gap:1.2rem;margin-top:0.5rem;font-size:0.78rem;color:var(--fg-mute);">
-            <span><span style="display:inline-block;width:10px;height:10px;background:var(--green);border-radius:2px;margin-right:4px;vertical-align:middle;"></span><span id="util-leg-hits">—</span> con hits</span>
-            <span><span style="display:inline-block;width:10px;height:10px;background:#f8717166;border-radius:2px;margin-right:4px;vertical-align:middle;"></span><span id="util-leg-miss">—</span> sin hits</span>
-            <span><span style="display:inline-block;width:10px;height:10px;background:#94a3b833;border-radius:2px;margin-right:4px;vertical-align:middle;"></span><span id="util-leg-bail">—</span> omitidas</span>
-          </div>
+      <div class="tok-comp">
+        <div class="tok-compbar">
+          <div id="tok-seg-grounded" title="hechos reutilizados"></div>
+          <div id="tok-seg-reask" title="repreguntas evitadas"></div>
+        </div>
+        <div class="tok-legend">
+          <span><span class="sw" style="background:var(--green)"></span><b id="tok-leg-grounded">—</b> hechos reutilizados <small id="tok-leg-grounded-n"></small></span>
+          <span><span class="sw" style="background:var(--blue)"></span><b id="tok-leg-reask">—</b> repreguntas evitadas <small id="tok-leg-reask-n"></small></span>
         </div>
       </div>
     </div>
-  </div>
+    <h3 class="tok-subh">Por día — tokens ahorrados por hechos reutilizados (14 días)</h3>
+    <div id="token-trend" style="height: 220px;"></div>
+  </section>
 
-  <div class="row2">
-    <div class="panel">
-      <h2>Recent history</h2>
-      <table id="history-table">
-        <thead><tr><th>when</th><th>op</th><th>id</th><th>title</th><th>type</th></tr></thead>
-        <tbody></tbody>
-      </table>
-    </div>
-    <div class="panel">
-      <h2>Recent recalls</h2>
-      <table id="recall-table">
-        <thead><tr><th>when</th><th>prompt</th><th>hits</th><th>ms</th></tr></thead>
-        <tbody></tbody>
-      </table>
-    </div>
-  </div>
+  <!-- QUIÉN USA MEMO -->
+  <section class="panel">
+    <h2>¿Quién usa memo?</h2>
+    <p class="hint">memo es la memoria compartida de todas las herramientas (Claude Code, Codex, Devin…). Cada barra es cuántas veces esa herramienta consultó memo.</p>
+    <div class="tools" id="tools"></div>
+    <div class="badge-silent" id="silent-callout"></div>
+  </section>
+
+  <!-- VACÍOS DE CONOCIMIENTO -->
+  <section class="panel">
+    <h2>¿Qué le falta saber a memo?</h2>
+    <p class="hint">Preguntas de conocimiento que memo no pudo responder (no encontró nada, o lo que mostró no se usó). Capturar estos temas hace que memo deje de fallar ahí.</p>
+    <div id="gaps-body"></div>
+  </section>
+
+  <!-- TENDENCIA -->
+  <section class="panel">
+    <h2>Uso en el tiempo · últimos 14 días</h2>
+    <p class="hint">¿Se consulta memo cada vez más, o se está quedando en silencio?</p>
+    <div id="trend" style="height: 240px;"></div>
+  </section>
 </main>
 
 <footer>
-  Generated by <code>python web/build.py</code> ·
-  v<span id="memo-version"></span> ·
-  refresh by re-running the script.
+  memo <span id="memo-version"></span> · <span id="sys-status">—</span> ·
+  <span id="sync-status">—</span> ·
+  en vivo con <code>memo dashboard</code>
 </footer>
 
 <script id="payload" type="application/json">__DATA_JSON__</script>
 <script>
 (() => {
   const PAYLOAD = JSON.parse(document.getElementById("payload").textContent);
-
-  function escapeHTML(s) {
-    return String(s).replace(/[&<>"]/g, c => ({
-      "&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;"
-    })[c]);
-  }
-  const asPct = x => (x == null ? "—" : Math.round(x * 100) + "%");
+  const asPct = (x, d=0) => (x == null ? "—" : (x * 100).toFixed(d) + "%");
   const shortTs = v => (v ? String(v).slice(0, 16).replace("T", " ") : "—");
-  function dbRecords(DATA) {
-    const db = (DATA.doctor_raw && DATA.doctor_raw.db) || [];
-    const mv = db.find(d => d.label === "memvec");
-    return mv && typeof mv.records === "number" ? mv.records : null;
-  }
+  const ago = v => {
+    if (!v) return "nunca";
+    const ms = Date.now() - new Date(v).getTime();
+    if (isNaN(ms)) return "—";
+    const m = Math.floor(ms / 60000);
+    if (m < 1) return "recién"; if (m < 60) return "hace " + m + "m";
+    const h = Math.floor(m / 60); if (h < 24) return "hace " + h + "h";
+    return "hace " + Math.floor(h / 24) + "d";
+  };
 
-  // Single idempotent render — safe to call repeatedly with fresh data.
+  const VERDICT_COPY = {
+    ok:     { glyph: "✅", color: "var(--green)",
+              explain: "memo se consulta seguido y la información que entrega termina usándose en las respuestas. Está cumpliendo su rol de memoria primaria." },
+    weak:   { glyph: "⚠️", color: "var(--yellow)",
+              explain: "Las herramientas leen memo, pero lo que entrega casi no termina usándose en las respuestas. Funciona como búsqueda, todavía no como memoria de verdad." },
+    unused: { glyph: "❌", color: "var(--red)",
+              explain: "Casi no hay consultas registradas. Sin uso no se puede saber si memo ayuda — hay que conectar y ejercitar las herramientas." },
+  };
+
   function render(DATA) {
-    const PAL = DATA.type_palette || {};
-    document.getElementById("meta-stamp").textContent = "generated " + DATA.generated_at;
+    const G = DATA.gerencial || {};
+    const V = DATA.verdict || {};
+    const uf = DATA.usefulness || {};
+
+    document.getElementById("meta-stamp").textContent = "datos al " + shortTs(DATA.generated_at);
     document.getElementById("memo-version").textContent = DATA.memo_version || "?";
 
-    // -- pillars + overall lights ----------------------------------------
-    const order = ["red", "yellow", "green", "blue"];
-    const pillars = (DATA.pillars || []).slice()
-      .sort((a,b) => order.indexOf(a.status) - order.indexOf(b.status));
-    const pillarsEl = document.getElementById("pillars");
-    pillarsEl.innerHTML = "";
-    for (const p of pillars) {
-      const card = document.createElement("div");
-      card.className = "card " + p.status;
-      card.innerHTML = `
-        <div class="label"><span class="dot ${p.status}"></span>${p.label}</div>
-        <div class="summary">${p.summary}</div>
-        <details><summary>details</summary><pre></pre></details>
-      `;
-      card.querySelector("pre").textContent = (p.detail || []).join("\n");
-      pillarsEl.appendChild(card);
-    }
-    const lights = document.getElementById("overall-lights");
-    lights.innerHTML = "";
-    for (const p of pillars) {
-      const d = document.createElement("span");
-      d.className = "dot " + p.status;
-      d.title = p.label + " — " + p.summary;
-      lights.appendChild(d);
-    }
+    // ── VEREDICTO ──
+    const vc = VERDICT_COPY[V.status] || VERDICT_COPY.unused;
+    const vPanel = document.getElementById("verdict-panel");
+    vPanel.style.borderColor = vc.color;
+    vPanel.style.background = "linear-gradient(120deg, color-mix(in srgb, " + vc.color + " 9%, var(--panel)) 0%, var(--panel) 60%)";
+    document.getElementById("verdict-glyph").textContent = vc.glyph;
+    const vl = document.getElementById("verdict-label");
+    vl.textContent = (V.label || "❌ NO SE USA").replace(/^[^ ]+ /, "");
+    vl.style.color = vc.color;
+    document.getElementById("verdict-explain").textContent = vc.explain;
+    document.getElementById("verdict-consults").textContent = (V.consults ?? 0).toLocaleString("es");
 
-    // -- stat cards (simple at-a-glance metrics) -------------------------
-    const ru = DATA.recall_util || {};
-    const uf = DATA.usefulness || {};
-    const contra = DATA.contradictions || {};
-    const cards = [
-      { num: dbRecords(DATA) ?? "—", cap: "memorias" },
-      { num: asPct(ru.hit_rate), cap: "recall hit" },
-      { num: asPct(ru.grounded_rate), cap: "grounded" },
-      { num: asPct(ru.referenced_rate), cap: "referenced" },
-      { num: uf.reask_avoided ?? "—", cap: "repreguntas evitadas" },
-      { num: (uf.consumers || []).length, cap: "lectores activos" },
-      { num: contra.open ?? 0, cap: "contradicciones" },
-      { num: uf.sampled ?? "—", cap: "consultas (muestra)" },
+    // ── EMBUDO ──
+    const funnel = G.funnel || [];
+    const top = funnel.length ? (funnel[0].value || 0) : 0;
+    const fcolors = ["var(--blue)", "var(--green)", "var(--green)"];
+    const fnotes = ["lo que se le preguntó al asistente",
+                    "decidió que valía la pena buscar",
+                    "devolvió algo relevante"];
+    const fEl = document.getElementById("funnel");
+    fEl.innerHTML = "";
+    funnel.forEach((s, i) => {
+      const pct = top > 0 ? (s.value / top * 100) : 0;
+      const ofTop = (i > 0 && top > 0) ? `<small>${Math.round(pct)}% del total</small>` : "";
+      const row = document.createElement("div");
+      row.className = "fstage";
+      row.innerHTML =
+        `<div class="fname">${s.label}<small>${fnotes[i] || ""}</small></div>
+         <div class="fbar"><div style="width:${Math.max(pct, 3)}%;background:${fcolors[i] || 'var(--blue)'};"></div></div>
+         <div class="fval">${(s.value ?? 0).toLocaleString("es")} ${ofTop}</div>`;
+      fEl.appendChild(row);
+    });
+
+    // ── KPIs ──
+    const usedRate = G.used_rate;
+    const usedColor = usedRate == null ? "var(--fg-mute)"
+      : usedRate >= 0.6 ? "var(--green)" : usedRate >= 0.35 ? "var(--yellow)" : "var(--red)";
+    const covColor = (G.coverage_rate ?? 0) >= 0.7 ? "var(--green)" : "var(--yellow)";
+    const kpis = [
+      { num: asPct(G.coverage_rate), accent: covColor, cap: "Preguntas donde memo se activó",
+        sub: "del total de consultas" },
+      { num: asPct(G.hit_rate), accent: "var(--green)", cap: "Encontró info al buscar",
+        sub: "de las veces que se activó" },
+      { num: usedRate == null ? "sin datos" : asPct(usedRate), accent: usedColor,
+        cap: "Sus datos se usaron en la respuesta",
+        sub: G.used_total ? `${G.used_grounded}/${G.used_total} respuestas medidas` : "aún sin medir" },
+      { num: G.time_saved_human || "—", accent: "var(--blue)", cap: "Tiempo ahorrado estimado",
+        sub: (G.reask_avoided != null ? G.reask_avoided + " repreguntas evitadas" : "estimación conservadora") },
+      { num: G.tokens_saved_human || "—", accent: "var(--blue)", cap: "Tokens ahorrados al modelo",
+        sub: "info traída de memo, no re-generada" + (G.avg_answer_tokens ? " · ~" + G.avg_answer_tokens + " tok/resp" : "") },
     ];
-    const scEl = document.getElementById("statcards");
-    scEl.innerHTML = "";
-    for (const c of cards) {
+    const kEl = document.getElementById("kpis");
+    kEl.innerHTML = "";
+    for (const k of kpis) {
       const d = document.createElement("div");
-      d.className = "statcard";
-      d.innerHTML = `<div class="num">${c.num}</div><div class="cap">${c.cap}</div>`;
-      scEl.appendChild(d);
+      d.className = "kpi";
+      d.style.setProperty("--accent", k.accent);
+      d.innerHTML = `<div class="knum" style="color:${k.accent}">${k.num}</div>
+                     <div class="kcap">${k.cap}</div><div class="ksub">${k.sub}</div>`;
+      kEl.appendChild(d);
     }
 
-    // -- utility: answers WITH memo vs WITHOUT (per-answer, measured only) -
-    // Denominator = answers actually grounding-scored (Stop hook ran). Surfaced
-    // memorias on un-scored turns are "not measured", not "not used", so they
-    // are reported as coverage rather than counted as misses.
-    // Headline = utility among knowledge-seeking answers (the ones that COULD
-    // use memo); overall (incl. mechanical turns) shown as context.
-    const kTotal = ru.answers_knowledge_total || 0;
-    const kGrounded = ru.answers_knowledge_grounded || 0;
-    const answersTotal = ru.answers_total || 0;
-    const answersGrounded = ru.answers_grounded || 0;
-    const headRate = kTotal > 0 ? ru.answer_rate_knowledge : ru.answer_rate;
-    const headTotal = kTotal > 0 ? kTotal : answersTotal;
-    const headGrounded = kTotal > 0 ? kGrounded : answersGrounded;
-    const withoutMemo = Math.max(0, headTotal - headGrounded);
-    const utilColor = headRate == null ? "var(--fg-mute)"
-      : headRate >= 0.7 ? "var(--green)" : headRate >= 0.4 ? "var(--yellow)" : "var(--red)";
-    const utilPanel = document.getElementById("utility-panel");
-    if (utilPanel) utilPanel.style.borderColor = utilColor;
-    const utilPct = document.getElementById("utility-pct");
-    utilPct.textContent = headRate == null ? "sin datos" : asPct(headRate);
-    utilPct.style.color = utilColor;
-    const unmeasured = ru.unmeasured_surfaced || 0;
-    const overallTxt = ru.answer_rate == null ? "—" : asPct(ru.answer_rate);
-    document.getElementById("utility-sub").textContent = headRate == null
-      ? "todavía no hay respuestas medidas (Stop hook)"
-      : `en preguntas de conocimiento (${headTotal}) · global ${overallTxt} sobre ${answersTotal} · usó memo ≥0.8 / paráfrasis / acción`;
-    if (headTotal > 0) {
-      document.getElementById("utility-seg-con").style.width = (headGrounded / headTotal * 100).toFixed(1) + "%";
-      document.getElementById("utility-seg-sin").style.width = (withoutMemo / headTotal * 100).toFixed(1) + "%";
-    }
-    document.getElementById("utility-leg-con").textContent = headGrounded;
-    document.getElementById("utility-leg-sin").textContent = withoutMemo;
-
-    // -- who reads memo (per-consumer) -----------------------------------
-    const rdBody = document.querySelector("#readers-table tbody");
-    rdBody.innerHTML = "";
-    for (const c of (uf.consumers || [])) {
-      const tr = document.createElement("tr");
-      tr.innerHTML = `<td>${escapeHTML(c.consumer)}</td>
-                      <td>${c.consults}</td>
-                      <td>${asPct(c.hit_rate)}</td>
-                      <td>${asPct(c.grounded_rate)}</td>
-                      <td>${shortTs(c.last_seen)}</td>`;
-      rdBody.appendChild(tr);
-    }
-    const silentLayers = uf.silent || [];
-    document.getElementById("readers-silent").textContent = silentLayers.length
-      ? "NO leen memo: " + silentLayers.join(", ")
-      : "todas las capas esperadas leen memo ✅";
-
-    // -- 3-D scatter (only present on a full build / first load) ----------
-    if (DATA.projection) {
-      const proj = DATA.projection;
-      document.getElementById("map-method").textContent = proj.method;
-      const colors = proj.types.map(t => PAL[t] || "#94a3b8");
-      const hover = proj.ids.map((id, i) =>
-        `${proj.titles[i]}<br><b>${proj.types[i]}</b> · ${id}<br>${proj.tags[i] || ""}<br>${proj.created[i]}`
-      );
-      Plotly.react("map3d", [{
-        type: "scatter3d", mode: "markers",
-        x: proj.xs, y: proj.ys, z: proj.zs,
-        marker: { size: 4, color: colors, opacity: 0.85, line: { width: 0 } },
-        text: hover, hoverinfo: "text",
+    // ── AHORRO DE TOKENS (detalle) ──
+    const td = G.token_detail || {};
+    const fmtTok = n => n == null ? "—" : (n < 1000 ? String(n)
+      : n < 1e6 ? (n/1000).toFixed(1) + "k" : (n/1e6).toFixed(2) + "M");
+    const gTok = td.grounded_tokens || 0, rTok = td.reask_tokens || 0, tTot = td.total || 0;
+    document.getElementById("tok-total").textContent = fmtTok(tTot);
+    document.getElementById("tok-assump").textContent =
+      `${td.tok_grounded || 0} tok/hecho · ${td.tok_reask || 0} tok/repregunta`
+      + (td.avg_answer_tokens ? ` · ~${td.avg_answer_tokens} tok/respuesta medido` : "");
+    const segG = tTot > 0 ? (gTok / tTot * 100) : 0;
+    document.getElementById("tok-seg-grounded").style.width = segG.toFixed(1) + "%";
+    document.getElementById("tok-seg-reask").style.width = (100 - segG).toFixed(1) + "%";
+    document.getElementById("tok-leg-grounded").textContent = fmtTok(gTok);
+    document.getElementById("tok-leg-reask").textContent = fmtTok(rTok);
+    document.getElementById("tok-leg-grounded-n").textContent = `(${td.grounded || 0} hechos)`;
+    document.getElementById("tok-leg-reask-n").textContent = `(${td.reask_avoided || 0} evitadas)`;
+    const tdaily = td.daily || [];
+    if (tdaily.length) {
+      Plotly.react("token-trend", [{
+        type: "bar", x: tdaily.map(d => d.date.slice(5)), y: tdaily.map(d => d.tokens),
+        marker: { color: "#2ee6a6" },
+        hovertemplate: "%{x}<br>%{y} tokens (%{customdata} hechos)<extra></extra>",
+        customdata: tdaily.map(d => d.grounded),
       }], {
         paper_bgcolor: "transparent", plot_bgcolor: "transparent",
-        margin: { l: 0, r: 0, t: 0, b: 0 },
-        font: { color: "#e6edf7", size: 11 },
-        scene: {
-          xaxis: { showgrid: true, gridcolor: "#243049", zeroline: false, title: "" },
-          yaxis: { showgrid: true, gridcolor: "#243049", zeroline: false, title: "" },
-          zaxis: { showgrid: true, gridcolor: "#243049", zeroline: false, title: "" },
-          bgcolor: "transparent",
-        },
-      }, { displaylogo: false, responsive: true });
+        font: { color: "#93a1b8", size: 11 },
+        margin: { l: 44, r: 10, t: 8, b: 34 },
+        xaxis: { type: "category", color: "#5d6b85", tickangle: 0, automargin: true },
+        yaxis: { gridcolor: "#243049", color: "#5d6b85", rangemode: "tozero" },
+      }, { displaylogo: false, responsive: true, displayModeBar: false });
     }
 
-    // -- type donut (only when type_counts present) ----------------------
-    const tc = DATA.type_counts || {};
-    if (Object.keys(tc).length) {
-      Plotly.react("types", [{
-        type: "pie", hole: 0.55,
-        labels: Object.keys(tc),
-        values: Object.values(tc),
-        marker: { colors: Object.keys(tc).map(k => PAL[k] || "#94a3b8") },
-        textinfo: "label+percent", textfont: { color: "#0b0f17" },
-      }], {
-        paper_bgcolor: "transparent", plot_bgcolor: "transparent",
-        font: { color: "#e6edf7", size: 11 }, showlegend: false,
-        margin: { l: 0, r: 0, t: 0, b: 0 },
-      }, { displaylogo: false, responsive: true });
+    // ── QUIÉN USA MEMO ──
+    const consumers = (uf.consumers || []).slice().sort((a,b) => b.consults - a.consults);
+    const maxC = consumers.reduce((m,c) => Math.max(m, c.consults || 0), 1);
+    const tEl = document.getElementById("tools");
+    tEl.innerHTML = "";
+    for (const c of consumers) {
+      const helping = c.grounded_rate != null && c.grounded_rate >= 0.10;
+      let color, state, sub;
+      if (c.consults < 5) { color = "var(--yellow)"; state = "uso esporádico"; }
+      else if (helping)   { color = "var(--green)";  state = "uso activo"; }
+      else                { color = "var(--green)";  state = "uso activo"; }
+      sub = (c.grounded_rate != null ? "usa " + asPct(c.grounded_rate) : "hit " + asPct(c.hit_rate)) + " · " + ago(c.last_seen);
+      const pct = Math.max(c.consults / maxC * 100, 3);
+      const row = document.createElement("div");
+      row.className = "tool";
+      row.innerHTML =
+        `<div class="tname"><span class="dot" style="background:${color};color:${color}"></span>${c.consumer}</div>
+         <div class="tbar"><div style="width:${pct}%;background:${color}"></div></div>
+         <div class="tstate" style="color:${color}">${c.consults.toLocaleString("es")} consultas<small>${sub}</small></div>`;
+      tEl.appendChild(row);
     }
-
-    // -- growth bar ------------------------------------------------------
-    if (DATA.growth) {
-      Plotly.react("growth", [{
-        type: "bar",
-        x: DATA.growth.map(g => g.date),
-        y: DATA.growth.map(g => g.count),
-        marker: { color: "#4f8ef7" },
-      }], {
-        paper_bgcolor: "transparent", plot_bgcolor: "transparent",
-        font: { color: "#e6edf7", size: 11 },
-        margin: { l: 30, r: 10, t: 4, b: 30 },
-        xaxis: { tickangle: -45, automargin: true, color: "#94a3b8" },
-        yaxis: { gridcolor: "#243049", color: "#94a3b8" },
-      }, { displaylogo: false, responsive: true });
-    }
-
-    // -- recall utilization ----------------------------------------------
-    if (ru && ru.fired > 0) {
-      const hits   = Math.round((ru.hit_rate || 0) * ru.fired);
-      const misses = ru.fired - hits;
-      const total  = ru.fired + ru.bailed;
-      const p      = Math.round((ru.hit_rate || 0) * 100);
-      const color  = p >= 70 ? 'var(--green)' : p >= 40 ? 'var(--yellow)' : 'var(--red)';
-      document.getElementById('util-pct').style.color = color;
-      document.getElementById('util-pct').textContent = p + '%';
-      document.getElementById('util-seg-hits').style.width = (hits   / total * 100).toFixed(1) + '%';
-      document.getElementById('util-seg-miss').style.width = (misses / total * 100).toFixed(1) + '%';
-      document.getElementById('util-seg-bail').style.width = (ru.bailed / total * 100).toFixed(1) + '%';
-      document.getElementById('util-leg-hits').textContent = hits;
-      document.getElementById('util-leg-miss').textContent = misses;
-      document.getElementById('util-leg-bail').textContent = ru.bailed;
-      const strong = ru.strong_hit_rate != null ? Math.round(ru.strong_hit_rate * 100) + '% strong' : '';
-      const score  = ru.median_top_score != null ? 'score mediano ' + ru.median_top_score : '';
-      document.getElementById('util-sub').textContent = [strong, score, total + ' totales'].filter(Boolean).join(' · ');
+    const silent = uf.silent || [];
+    const sc = document.getElementById("silent-callout");
+    if (silent.length) {
+      sc.className = "badge-silent";
+      sc.innerHTML = "<b>No están usando memo:</b> " + silent.join(", ") +
+        " — estas herramientas están conectadas pero no consultan la memoria.";
     } else {
-      document.getElementById('util-pct').textContent = 'sin datos';
-      document.getElementById('util-sub').textContent = ru && ru.bailed > 0
-        ? ru.bailed + ' omitidas (prompts cortos / slash commands)'
-        : 'recall.log vacío';
+      sc.className = "badge-silent ok";
+      sc.textContent = "✅ Todas las herramientas esperadas están consultando memo.";
     }
 
-    // -- verdict (¿funciona memo?) ---------------------------------------
-    const V = DATA.verdict || {};
-    const vColors = { ok: 'var(--green)', weak: 'var(--yellow)', unused: 'var(--red)' };
-    const vColor = vColors[V.status] || 'var(--red)';
-    const vPanel = document.getElementById('verdict-panel');
-    if (vPanel) vPanel.style.borderColor = vColor;
-    document.getElementById('verdict-label').textContent = V.label || '❌ NO SE USA';
-    document.getElementById('verdict-label').style.color = vColor;
-    const gr = V.grounded_rate == null ? '—' : Math.round(V.grounded_rate * 100) + '%';
-    document.getElementById('verdict-sub').textContent = `grounded ${gr} · ${V.consults || 0} consultas`;
-    const per = V.per_consumer || [];
-    const readers = per.filter(x => x.reads).map(x => x.name + ' ✅');
-    const silent  = per.filter(x => !x.reads).map(x => x.name + ' ❌');
-    document.getElementById('verdict-readers').textContent = readers.length ? readers.join('  ') : '—';
-    document.getElementById('verdict-silent').textContent  = silent.length  ? silent.join('  ')  : 'ninguno';
-
-    // -- memflow utility -------------------------------------------------
-    const MF = DATA.memflow_util || {};
-    const cons = MF.consumption || {}, outc = MF.outcome || {};
-    const reads = cons.total_read_calls || 0;
-    const reexp = outc.re_explain || 0;
-    const used  = outc.memory_used_rate;
-    let mfEstado, mfColor;
-    if (!MF.consumption) { mfEstado = 'no disponible'; mfColor = 'var(--fg-mute)'; }
-    else if (reads < 5)  { mfEstado = '❌ casi no se lee'; mfColor = 'var(--red)'; }
-    else if (used == null) { mfEstado = '⚠️ sin outcomes aún'; mfColor = 'var(--yellow)'; }
-    else if (used >= 0.10 && reexp < 10) { mfEstado = '✅ útil'; mfColor = 'var(--green)'; }
-    else { mfEstado = '⚠️ poco útil'; mfColor = 'var(--yellow)'; }
-    const mfEl = document.getElementById('memflow-estado');
-    mfEl.textContent = mfEstado; mfEl.style.color = mfColor;
-    const mfp = document.getElementById('memflow-panel');
-    if (mfp) mfp.style.borderColor = mfColor;
-    document.getElementById('mf-reads').textContent = reads;
-    document.getElementById('mf-used').textContent = used == null ? '—' : Math.round(used * 100) + '%';
-    const reEl = document.getElementById('mf-reexplain');
-    reEl.textContent = reexp; reEl.style.color = reexp >= 10 ? 'var(--red)' : '';
-
-    // -- tables (idempotent) ---------------------------------------------
-    const histBody = document.querySelector("#history-table tbody");
-    histBody.innerHTML = "";
-    for (const h of (DATA.history || [])) {
-      const tr = document.createElement("tr");
-      tr.innerHTML = `<td>${h.ts}</td><td class="op-${h.op}">${h.op}</td>
-                      <td><code>${h.id}</code></td><td>${escapeHTML(h.title || "")}</td>
-                      <td><span class="pill">${h.type || ""}</span></td>`;
-      histBody.appendChild(tr);
+    // ── VACÍOS DE CONOCIMIENTO ──
+    const gaps = DATA.gaps || [];
+    const gapsBody = document.getElementById("gaps-body");
+    if (gapsBody) {
+      if (!gaps.length) {
+        gapsBody.innerHTML = `<div class="badge-silent ok">✅ Sin vacíos detectados — memo respondió lo que se le preguntó.</div>`;
+      } else {
+        const esc = s => String(s).replace(/[&<>"]/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;"}[c]));
+        gapsBody.innerHTML = `<div class="tools">` + gaps.map(g => {
+          const reason = (g.reasons || []).join(", ");
+          const n = g.count || 1;
+          return `<div class="gap-row">
+            <span class="gap-n">${n}&times;</span>
+            <span class="gap-q">${esc((g.prompt || "").slice(0, 90))}</span>
+            <span class="gap-why">${esc(reason)}</span>
+          </div>`;
+        }).join("") + `</div>`;
+      }
     }
-    const recBody = document.querySelector("#recall-table tbody");
-    recBody.innerHTML = "";
-    for (const r of (DATA.recall_log || [])) {
-      const tr = document.createElement("tr");
-      tr.innerHTML = `<td>${r.ts || ""}</td>
-                      <td>${escapeHTML((r.prompt || "").slice(0, 80))}</td>
-                      <td>${(r.hits || []).length}</td>
-                      <td>${r.latency_ms ?? ""}</td>`;
-      recBody.appendChild(tr);
+
+    // ── TENDENCIA ──
+    const tr = G.trend || [];
+    if (tr.length) {
+      const x = tr.map(d => d.date.slice(5));
+      Plotly.react("trend", [
+        { type: "bar", name: "consultadas", x, y: tr.map(d => d.activado),
+          marker: { color: "#2ee6a6" } },
+        { type: "bar", name: "omitidas", x,
+          y: tr.map(d => Math.max(0, (d.consultas||0) - (d.activado||0))),
+          marker: { color: "#3a4a68" } },
+      ], {
+        barmode: "stack",
+        paper_bgcolor: "transparent", plot_bgcolor: "transparent",
+        font: { color: "#93a1b8", size: 11 },
+        margin: { l: 34, r: 10, t: 8, b: 34 },
+        legend: { orientation: "h", y: 1.16, x: 0, font: { size: 11 } },
+        xaxis: { type: "category", color: "#5d6b85", tickangle: 0, automargin: true },
+        yaxis: { gridcolor: "#243049", color: "#5d6b85", rangemode: "tozero" },
+      }, { displaylogo: false, responsive: true, displayModeBar: false });
+    }
+
+    // ── system status (footer) ──
+    const pillars = DATA.pillars || [];
+    const bad = pillars.filter(p => p.status === "red");
+    const warn = pillars.filter(p => p.status === "yellow");
+    const ss = document.getElementById("sys-status");
+    if (bad.length)      { ss.textContent = "⚠ " + bad.length + " problema(s) de sistema"; ss.style.color = "var(--red)"; }
+    else if (warn.length){ ss.textContent = "sistema con avisos"; ss.style.color = "var(--yellow)"; }
+    else                 { ss.textContent = "sistema sano"; ss.style.color = "var(--green)"; }
+
+    // ── GitHub sync chip ──
+    const sync = DATA.sync || {};
+    const syncEl = document.getElementById("sync-status");
+    if (syncEl) {
+      const sc = { ok: "var(--green)", warn: "var(--yellow)", bad: "var(--red)", off: "var(--fg-dim)" };
+      syncEl.textContent = "GitHub: " + (sync.label || "—");
+      syncEl.style.color = sc[sync.state] || "var(--fg-dim)";
     }
   }
 
   render(PAYLOAD);
 
-  // -- live auto-refresh (only when served over http; file:// is static) -
+  // ── live auto-refresh (http only; file:// is a static snapshot) ──
   const badge = document.getElementById("live-badge");
-  const setBadge = (state, txt) => {
-    badge.innerHTML = `<span class="dot ${state}"></span>${txt}`;
-  };
+  const setBadge = (state, txt, live=false) =>
+    badge.innerHTML = `<span class="dot ${state}${live ? " live" : ""}"></span>${txt}`;
   if (location.protocol.startsWith("http")) {
     const intervalS = PAYLOAD.refresh_interval_s || 5;
-    setBadge("green", "en vivo · " + intervalS + "s");
+    setBadge("green", "en vivo", true);
     const poll = async () => {
       try {
         const r = await fetch("/api/data.json", { cache: "no-store" });
         if (!r.ok) throw new Error("HTTP " + r.status);
         render(await r.json());
-        setBadge("green", "actualizado " + new Date().toLocaleTimeString());
+        setBadge("green", "en vivo · " + new Date().toLocaleTimeString("es"), true);
       } catch (e) {
-        setBadge("yellow", "sin conexión · reintentando");
+        setBadge("yellow", "reconectando…");
       }
     };
     setInterval(poll, intervalS * 1000);
   } else {
-    setBadge("blue", "snapshot estático · usar `memo dashboard` para tiempo real");
+    setBadge("blue", "snapshot · usá `memo dashboard` para tiempo real");
   }
 })();
 </script>


### PR DESCRIPTION
## Summary
Multi-feature session, all green (1443 passed / 1 skip, ruff + mypy clean).

### Two-tier sync + identity (`sync_git.py`, `identity.py`)
- Explicit **LOCAL** (intra-machine: shared sqlite/WAL, no git) vs **REMOTE** (git `memo-sync`) models via `sync_tier(cfg)`.
- `sync_once()` = single machine coordinator: `flock` on `.sync.lock` (concurrent same-machine sessions skip; their writes ride the lock holder's push) + **pull-rebase-before-push**.
- Triggers: `memo sync auto` (debounced, per-prompt) + `memo sync once` (Stop flush). Failed push → `sync_pending` marker + retry.
- Identity layer: stable `machine_id` (=`device_id`) + hostname (cross-tool match key) + session + terminal; commits attributed `[hostname·session]`.

### Durable capture (`capture.py`, `cli_capture.py`)
- `memo capture-tick`: per-session watermark, captures only new turns mid-session so a long session's insight reaches `.md` before Stop (`MEMO_CAPTURE_INTERVAL_S`).

### The Outcome Loop (`outcome.py`, `cli_outcome.py`)
- `roi_score` driven by real grounding outcomes (not mere access): `reconcile_roi` + `memo gaps` + dead-weight archival. Gated `MEMO_OUTCOME_RANKING_ENABLED` (default off).

### Gerencial dashboard (`web/build.py`)
- Rebuilt around "is memo useful as primary memory?": verdict, consult funnel, per-tool readers, tokens-saved detail, knowledge-gaps + sync-health panels.

### Other
- Tokens-saved metric (`memo roi`); trinity consult attribution (MEMO_SOURCE env + MCP clientInfo fallback; windsurf→devin-desktop); CLAUDE.md sync section + design spec in `docs/superpowers/specs/`.
- Sweeps in pre-existing uncommitted working-tree changes present at session start (suite passes with them).

## Test plan
- [x] `uv run --no-sync pytest tests/` → 1443 passed, 1 skipped
- [x] `uv run --no-sync ruff check src/ tests/ web/build.py` clean
- [x] `uv run --no-sync mypy src/memo/` clean (229 files)
- [x] Live smoke: `memo sync status/once/auto`, `memo gaps`, `memo outcome`, dashboard panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)