### PR TITLE
feat(install,sync): from-zero install safety + data-loss guards

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "memo",
   "description": "Local MCP memory for AI agents — MLX-native on Apple Silicon, sqlite-vec store, markdown-on-disk in your Obsidian vault. Zero Ollama, zero cloud APIs.",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "author": {
     "name": "Fernando Ferrari",
     "url": "https://github.com/jagoff"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-06-22
+
 ### Added
 
 - **Auto-recall fires on more real prompts (less wasted coverage).** The
@@ -41,6 +43,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (history/graph/contradictions/crossref) into the single `memvec.db` file.
   `memo migrate --consolidate-db` merges existing `*.db` files (renames them
   `*.db.bak`, idempotent).
+- **Idle daemon and `memo_idle_capture` MCP tool.** Background auto-capture fires
+  every 10 s for agents without Claude Code hooks. Auto-starts from the
+  `unified_briefing`, `search`, and `ask` MCP side-effect paths.
+- **Two-tier cross-Mac git sync.** `memo sync bootstrap`, `memo sync auto`, and
+  `memo sync once` replicate the memory corpus across machines via a bare git
+  remote (`memo-sync`). Pull-rebase-before-push, `flock`-based single owner per
+  machine, debounced async hooks on every prompt. Cross-machine deletes propagate
+  via orphan-prune on pull.
+- **`memo install-mcp`** — one-command MCP registration into any agent (Claude
+  Code, Devin, Codex, opencode, Windsurf). Pins `MEMO_SOURCE` per-client for
+  per-consumer attribution telemetry.
+- **`memo stats` (formerly `memo tui`)** — production TUI with utility/verdict
+  panels and `--background` HTTP server with live auto-refresh at `localhost`.
+  Surfaces "¿funciona?" verdict, per-consumer grounded rate, and token-savings
+  estimate.
+- **`memo eval grounding`** — ground-truth calibration harness to measure whether
+  memo's context is actually used in model answers (paraphrase-aware,
+  knowledge-segmented).
+- **Hybrid search tuning.** Exact BM25 leg + confident-RRF skip; configurable
+  leg weights via `MEMO_SEARCH_VEC_WEIGHT` / `MEMO_SEARCH_BM25_WEIGHT`;
+  per-type recency decay half-lives (`MEMO_RECALL_DECAY_HALF_LIFE_*`).
+- **Sleep-time compute (dream pipeline improvements).** Signal gather, date
+  normalization, prune floor, and orientation passes added to the nightly dream
+  pipeline. Progress UI + LLM timeout/thinking hardened.
+- **`memo continuity`** — native "what was I working on" command providing
+  memflow-style cross-session state recall from within memo.
+- **`memo_health_report` MCP tool** — corpus health metrics exposed over MCP, with
+  34 covering tests.
+- **Token-savings ROI** surfaced in `memo doctor` output and the stats dashboard
+  (`MEMO_ROI_TOKENS_PER_*` flags).
+- **`memo_idle_capture`** MCP tool for agents without Claude Code hooks to trigger
+  background capture on demand.
+- Zero-config repo mode for MCP marketplace distribution (self-describing index
+  adopts embedder profile from DB metadata when env vars are unset).
 
 ### Changed
 
@@ -58,6 +94,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Fixed** a data-loss bug: `memo migrate-vault` previously deleted `memvec.db`,
   silently wiping feedback/access/health signal. It now preserves the DB and
   reindexes in place.
+- Recall token budget default raised to 600; session-dedup active in the
+  subprocess recall path. `MEMO_RECALL_FEEDBACK_HINT` default changed to off
+  (opt-in, saves ~20 tokens/recall).
+- `cli.py` monolith split into 11+ focused modules (`cli_capture`, `cli_memory`,
+  `cli_tui`, `cli_session`, `cli_runtime`, `cli_viz`, …). No command-line
+  behavior change.
+- Consolidation LLM timeout raised 60 s → 180 s; merge-proposal token budget
+  doubled to 2048; robust JSON-parsing with sampling retry on unparseable output.
+- MLX GPU work serialized across processes via a lock to prevent `SIGABRT` under
+  concurrent embedder calls.
+- Dashboard denominators corrected for trend and per-consumer grounded rate;
+  stale numbers and false-silent consumer warnings eliminated.
+
+### Fixed
+
+- `rebuild_feedback_vecs` crash on reindex; embedding correctly removed on delete
+  rollback.
+- Config self-describing index adopts embedder profile from DB metadata when env
+  unset, fixing "connection closed" in MCP clients lacking embedder env vars.
+- ~80 latent bugs repaired across 3 audit passes (data-loss error swallows,
+  error handling, thread safety, concurrency races).
+- CI smoke uses Homebrew `python@3.13` (setup-python lacks sqlite extension
+  loading; `--strict-runtime` was unsatisfiable in venv CI).
+- Sync: commit-before-pull + prune orphans on pull for correct cross-Mac delete
+  propagation.
+- `VecStore` per-thread connections fix HTTP-transport race under FastMCP worker
+  threadpool.
+- Idle-maintenance never ran (async hooks receive no stdin pipe) — fixed.
+- `inactivity-capture` self-cancelled every turn (keyed on wrong signal) — fixed.
+- **Data-loss guard: `reindex --rebuild` refuses an empty `data_dir`.** If the
+  markdown source vanished (deleted dir / half-broken clone) while the index is
+  still populated, a rebuild would truncate the derivable tables and replay
+  nothing — wiping the only surviving copy. It now raises `StorageError` with
+  recovery steps instead. Restore the `.md` first, or use `memo reindex` (no
+  `--rebuild`) to reconcile.
+- **Data-loss guard: `sync bootstrap` refuses a broken clone.** A `dest` that is
+  a git clone but has zero `.md` under `memorias/` is no longer "reused" (which
+  then fed `reindex --rebuild` → wipe); it raises with `git restore` / re-clone
+  guidance.
+- `install.sh` injects `consciousness-contracts` best-effort from a local
+  checkout (`MEMO_CONTRACTS_PATH`, default `~/repos/consciousness-contracts`) so
+  `install-mcp` + the shared embed cache work on a fresh Mac; absent → memo runs
+  with fallbacks. install.sh also hints `MEMO_SYNC_REMOTE` when no corpus is wired.
 
 ## [0.8.0] - 2026-05-21
 

--- a/install.sh
+++ b/install.sh
@@ -104,6 +104,25 @@ ensure_default_dirs() {
   mkdir -p "${MEMO_STATE_DIR:-$HOME/.local/share/memo}"
 }
 
+# consciousness-contracts is a sibling repo, not on PyPI — a `pipx install
+# git+...memo.git` cannot pull it. memo runs fine without it (shared embed cache
+# + URI parsing fall back), but `install-mcp` and the shared cache need it.
+# Inject best-effort from a local checkout; never fail the install if it's absent.
+inject_contracts() {
+  local cc="${MEMO_CONTRACTS_PATH:-$HOME/repos/consciousness-contracts}"
+  if [[ ! -f "$cc/pyproject.toml" ]]; then
+    say "consciousness-contracts not found at $cc — skipping (memo runs with fallbacks; set MEMO_CONTRACTS_PATH to enable)"
+    return 0
+  fi
+  say "injecting consciousness-contracts from $cc (enables install-mcp + shared cache)"
+  if run_pipx inject "$APP_NAME" -e "$cc" >/dev/null 2>&1; then
+    say "consciousness-contracts injected"
+  else
+    warn "consciousness-contracts inject failed (non-fatal; memo runs with fallbacks)."
+    warn "Re-run manually: pipx inject $APP_NAME -e $cc"
+  fi
+}
+
 resolve_memo_bin() {
   if command -v memo >/dev/null 2>&1; then
     command -v memo
@@ -169,6 +188,7 @@ main() {
   run_pipx install --force "$spec"
   run_pipx ensurepath >/dev/null 2>&1 || true
 
+  inject_contracts
   ensure_default_dirs
 
   local memo_bin
@@ -222,6 +242,9 @@ main() {
       warn "sync bootstrap failed — private repo needs git creds (SSH key/PAT) on this Mac."
       warn "Re-run after auth: memo sync bootstrap $MEMO_SYNC_REMOTE --dest $sync_dest"
     fi
+  else
+    say "no shared corpus wired (memo starts empty). To join an existing corpus on"
+    say "  a fresh Mac, re-run with: MEMO_SYNC_REMOTE=<git-url> ./install.sh"
   fi
 
   say "MCP registration command (manual fallback):"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 # only the PyPI distribution moved. Back-compat: existing users on
 # `memo-mcp ≤ 0.4.3` keep working; new installs use `pip install mlx-memo`.
 name = "mlx-memo"
-version = "0.8.0"
+version = "1.0.0"
 description = "Local MCP memory backed by Obsidian vault — MLX-native LLM + embedder, sqlite-vec store. No Ollama, no API keys."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/jagoff/memo",
     "source": "github"
   },
-  "version": "0.8.0",
+  "version": "1.0.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mlx-memo",
-      "version": "0.8.0",
+      "version": "1.0.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/memo/memory/maintain_ops.py
+++ b/src/memo/memory/maintain_ops.py
@@ -15,6 +15,7 @@ from typing import Any
 import frontmatter
 
 from memo.embedder import assert_valid_embedding
+from memo.errors import StorageError
 from memo.flags import flag_bool
 from memo.lifecycle import FORGET_AFTER_KEY, FORGET_REASON_KEY
 from memo.memory._base import _MemoryBase
@@ -220,6 +221,19 @@ class _MaintainOpsMixin(_MemoryBase):
         chunk_ingest = flag_bool("MEMO_CHUNK_INGEST")
 
         if rebuild:
+            # Safety: never truncate a populated index against an empty disk.
+            # If data_dir lost its .md (deleted dir, half-broken clone) a rebuild
+            # would clear the derivable tables and replay nothing — wiping the only
+            # surviving copy. Refuse so the markdown can be restored first.
+            if next(memory_root.rglob("*.md"), None) is None:
+                indexed = self.store.count()
+                if indexed > 0:
+                    raise StorageError(
+                        f"reindex --rebuild refused: data_dir {memory_root} has 0 .md "
+                        f"but the index holds {indexed} memorias — rebuilding would wipe "
+                        "them. Restore the .md first (`memo sync bootstrap <url>`, or "
+                        "`git -C <repo> restore .`), or run `memo reindex` (no --rebuild)."
+                    )
             # Wipe only the derivable tables; signal tables survive and re-join
             # on id. Every file then takes the `existing is None` add path.
             cleared = self.store.clear_memoria_index()

--- a/src/memo/sync_git.py
+++ b/src/memo/sync_git.py
@@ -110,9 +110,19 @@ def bootstrap_clone(url: str, dest: Path, *, config_path: Path | None = None) ->
     from memo.setup.config_io import load_config_file, write_config_file
 
     memorias = dest / "memorias"
-    if (dest / ".git").exists() and memorias.exists():
-        n_md = len(list(memorias.rglob("*.md")))
+    git_ok = (dest / ".git").exists()
+    n_md = len(list(memorias.rglob("*.md"))) if memorias.exists() else 0
+    if git_ok and n_md > 0:
         summary = {"cloned": str(dest), "memorias_dir": str(memorias), "memorias": n_md, "reused": True}
+    elif git_ok:
+        # A git clone with zero markdown is a BROKEN corpus, not a fresh one:
+        # reusing it then `reindex --rebuild` (the CLI's next step) would truncate
+        # the index against an empty disk and wipe it. Refuse with recovery steps.
+        raise SyncGitError(
+            f"{dest} is a git clone but has no .md under memorias/ — refusing to "
+            f"bootstrap (a rebuild would wipe the index). Restore tracked files with "
+            f"`git -C {dest} restore .`, or `rm -rf {dest}` then re-run bootstrap."
+        )
     else:
         summary = clone_bootstrap(url, dest)
         summary["reused"] = False

--- a/tests/test_memory_reindex.py
+++ b/tests/test_memory_reindex.py
@@ -55,6 +55,30 @@ def test_reindex_rebuild_preserves_signal(mem_with_stub: Memory):
     assert mem_with_stub.get(b.id) is not None
 
 
+def test_reindex_rebuild_refused_when_data_dir_empty(mem_with_stub: Memory):
+    """Rebuild against a data_dir with 0 .md must refuse, not wipe the index.
+    Markdown is the only source that can repopulate it — if it vanished (deleted
+    dir / half-broken clone), truncating the index destroys the last copy."""
+    import pytest
+
+    from memo.errors import StorageError
+
+    a = mem_with_stub.save(content="no me borres", title="A")
+    b = mem_with_stub.save(content="ni a mi", title="B")
+    for md in mem_with_stub.cfg.memory_dir.rglob("*.md"):
+        md.unlink()
+    assert next(mem_with_stub.cfg.memory_dir.rglob("*.md"), None) is None
+    assert mem_with_stub.store.count() == 2
+
+    with pytest.raises(StorageError, match="refused"):
+        mem_with_stub.reindex(rebuild=True)
+
+    # index untouched — both memorias still recoverable
+    assert mem_with_stub.store.count() == 2
+    assert mem_with_stub.get(a.id) is not None
+    assert mem_with_stub.get(b.id) is not None
+
+
 def test_reindex_rebuild_drops_orphans(mem_with_stub: Memory):
     a = mem_with_stub.save(content="vive", title="A")
     b = mem_with_stub.save(content="muere", title="B")

--- a/tests/test_sync_bootstrap.py
+++ b/tests/test_sync_bootstrap.py
@@ -102,6 +102,20 @@ def test_bootstrap_clone_rejects_nonempty_non_clone(tmp_path: Path):
         bootstrap_clone("file:///nonexistent", dest, config_path=tmp_path / "config.toml")
 
 
+def test_bootstrap_clone_refuses_broken_clone_empty_memorias(remote: Path, tmp_path: Path):
+    """A git clone whose memorias/ lost its .md must NOT be silently reused — the
+    caller's `reindex --rebuild` would truncate the index against an empty disk and
+    wipe it (the data-loss incident). Refuse with recovery guidance instead."""
+    dest = tmp_path / "memo-sync"
+    cfg_path = tmp_path / "config.toml"
+    bootstrap_clone(str(remote), dest, config_path=cfg_path)
+    # Simulate the incident: every .md gone but .git intact.
+    for md in (dest / "memorias").rglob("*.md"):
+        md.unlink()
+    with pytest.raises(SyncGitError, match=r"no \.md"):
+        bootstrap_clone(str(remote), dest, config_path=cfg_path)
+
+
 def _stub_embed(self, inputs):
     out = []
     for s in inputs:


### PR DESCRIPTION
## Why

A fresh-Mac `install.sh` should reproduce the full working setup, and the
`data_dir`-wipe incident (markdown source-of-truth deleted while the index
survived) must not be able to recur via automation.

## What

**Data-loss guards (memo code)**
- `reindex --rebuild` now **refuses** when `data_dir` has 0 `.md` and the index
  is populated — it would otherwise truncate `meta`/`vec`/`fts` and replay
  nothing, wiping the only surviving copy. Raises `StorageError` with recovery
  steps. Restore the `.md` first, or use `memo reindex` (no `--rebuild`).
- `sync bootstrap` now **refuses** a git clone with zero `.md` under `memorias/`
  (broken corpus) instead of "reusing" it → `reindex --rebuild` → wipe. Points
  to `git restore` / re-clone.

**install.sh (fresh-Mac)**
- Best-effort inject `consciousness-contracts` from `MEMO_CONTRACTS_PATH`
  (default `~/repos/consciousness-contracts`) so `install-mcp` + the shared embed
  cache work; absent → memo runs with fallbacks (graceful).
- Hint `MEMO_SYNC_REMOTE` when no shared corpus is wired.

**Release**
- Version bump to `1.0.0` (pyproject / plugin.json / server.json / CHANGELOG).

## Fresh-Mac command (env-driven, no private URL baked in)

```bash
MEMO_SYNC_REMOTE=git@github.com:jagoff/memo-sync.git \
MEMO_CONTRACTS_PATH=$HOME/repos/consciousness-contracts \
bash <(curl -fsSL https://raw.githubusercontent.com/jagoff/memo/master/install.sh)
```

## Test plan

- [x] `pytest tests/` — 1500 passed, 25 skipped
- [x] new: `test_reindex_rebuild_refused_when_data_dir_empty`
- [x] new: `test_bootstrap_clone_refuses_broken_clone_empty_memorias`
- [x] `mypy src/memo/` clean (231 files)
- [x] `ruff check` clean
- [x] `bash -n install.sh` clean
- [ ] tag `v1.0.0` after merge (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)