### PR TITLE
feat(mcp): auto-update memo-mcp on start from git tags (v1.0.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "memo",
   "description": "Local MCP memory for AI agents — MLX-native on Apple Silicon, sqlite-vec store, markdown-on-disk in your Obsidian vault. Zero Ollama, zero cloud APIs.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Fernando Ferrari",
     "url": "https://github.com/jagoff"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-06-22
+
+### Added
+
+- **Auto-update on memo-mcp start (opt-in).** When `MEMO_AUTO_UPDATE=1`, memo-mcp checks (throttled, default 6h via `MEMO_AUTO_UPDATE_INTERVAL_S`) for a newer git **tag** (`vX.Y.Z`) and, if found, spawns a detached `memo self-update --to-tag <tag>` in the background — the new version takes effect on the next start. Trigger is a tag (not any commit) so un-tagged/broken pushes never propagate. Default off (public repo); `MEMO_AUTO_UPDATE=1 memo install-mcp --write` bakes it into a machine's agent configs. `memo self-update --to-tag` reinstalls the isolated runtime from `git+<repo>@<tag>` (pipx/uv), since git installs aren't on PyPI.
+
 ## [1.0.0] - 2026-06-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 # only the PyPI distribution moved. Back-compat: existing users on
 # `memo-mcp ≤ 0.4.3` keep working; new installs use `pip install mlx-memo`.
 name = "mlx-memo"
-version = "1.0.0"
+version = "1.0.1"
 description = "Local MCP memory backed by Obsidian vault — MLX-native LLM + embedder, sqlite-vec store. No Ollama, no API keys."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/jagoff/memo",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mlx-memo",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -36,6 +36,30 @@ SPECS: tuple[FlagSpec, ...] = (
         "Maximum cumulative feedback boost.",
         min_val=0.0,
     ),
+    # auto-update (memo-mcp self-update on start, gated + throttled)
+    _spec(
+        "MEMO_AUTO_UPDATE",
+        "bool",
+        False,
+        "update",
+        "On memo-mcp start, check for a newer git TAG and self-update in the "
+        "background (takes effect next start). Default off; enable per-machine.",
+    ),
+    _spec(
+        "MEMO_AUTO_UPDATE_INTERVAL_S",
+        "int",
+        21600,
+        "update",
+        "Min seconds between auto-update checks (throttle). Default 6h.",
+        min_val=0,
+    ),
+    _spec(
+        "MEMO_AUTO_UPDATE_REPO",
+        "str",
+        "",
+        "update",
+        "Git repo URL to check tags / install from (empty → the memo default).",
+    ),
     # MCP transport
     _spec("MEMO_MCP_TRANSPORT", "str", "stdio", "mcp", "MCP transport: stdio | http."),
     _spec("MEMO_MCP_HOST", "str", "127.0.0.1", "mcp", "Bind host for the HTTP MCP transport."),

--- a/src/memo/runtime/autoupdate.py
+++ b/src/memo/runtime/autoupdate.py
@@ -1,0 +1,149 @@
+"""Auto-update on memo-mcp start.
+
+When ``MEMO_AUTO_UPDATE`` is enabled, memo-mcp checks (throttled) whether a
+newer **tagged** release exists in the git repo and, if so, spawns a detached
+``memo self-update --to-tag <tag>`` in the background. The running process keeps
+the old code (you can't hot-swap a live interpreter) — the new version takes
+effect on the NEXT memo-mcp start.
+
+Design choices (2026-06-22):
+- Trigger is a git **tag** (``vX.Y.Z``), not any commit, so an un-tagged push
+  (work in progress / a broken commit) never propagates to the fleet.
+- Default OFF (memo is public); enabled per-machine via the flag / install-mcp.
+- Network + git failures are swallowed: auto-update must never break or delay a
+  memo-mcp startup.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+
+from memo.config import Config
+from memo.flags import flag_bool, flag_int, flag_str
+
+_log = logging.getLogger(__name__)
+
+DEFAULT_REPO = "https://github.com/jagoff/memo.git"
+_CHECK_STAMP = "auto_update_check"
+
+
+def _parse_semver(tag: str) -> tuple[int, int, int] | None:
+    """``v1.2.3`` / ``1.2.3`` → ``(1, 2, 3)``. Anything non-numeric → None.
+
+    Pre-release/build suffixes (``1.2.3-rc1``) are ignored on the patch field so
+    they sort below the plain release, which is fine for an "is there a newer
+    stable" check.
+    """
+    core = tag.strip().lstrip("vV").split("-", 1)[0].split("+", 1)[0]
+    parts = core.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        return (int(parts[0]), int(parts[1]), int(parts[2]))
+    except ValueError:
+        return None
+
+
+def is_newer(remote: str, local: str) -> bool:
+    """True iff ``remote`` is a strictly higher semver than ``local``."""
+    r, lo = _parse_semver(remote), _parse_semver(local)
+    if r is None or lo is None:
+        return False
+    return r > lo
+
+
+def latest_remote_tag(repo_url: str, *, timeout: int = 10) -> str | None:
+    """Highest ``vX.Y.Z`` tag in the remote repo, or None on any failure.
+
+    Uses ``git ls-remote --tags --refs`` so no clone/fetch is needed and the
+    probe stays cheap. Dereferenced (``--refs``) so peeled ``^{}`` lines are
+    excluded.
+    """
+    try:
+        cp = subprocess.run(
+            ["git", "ls-remote", "--tags", "--refs", repo_url],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        _log.debug("auto-update: ls-remote failed: %s", exc)
+        return None
+    if cp.returncode != 0:
+        _log.debug("auto-update: ls-remote rc=%d: %s", cp.returncode, cp.stderr.strip())
+        return None
+
+    best: tuple[int, int, int] | None = None
+    best_tag: str | None = None
+    for line in cp.stdout.splitlines():
+        ref = line.rsplit("refs/tags/", 1)[-1].strip()
+        if not ref or ref == line:
+            continue
+        ver = _parse_semver(ref)
+        if ver is not None and (best is None or ver > best):
+            best, best_tag = ver, ref
+    return best_tag
+
+
+def _should_check(cfg: Config, interval_s: int, now: float) -> bool:
+    """Throttle: True if no check stamp or it's older than ``interval_s``."""
+    stamp = cfg.state_dir / _CHECK_STAMP
+    try:
+        last = float(stamp.read_text().strip())
+    except (OSError, ValueError):
+        return True
+    return (now - last) >= interval_s
+
+
+def _record_check(cfg: Config, now: float) -> None:
+    stamp = cfg.state_dir / _CHECK_STAMP
+    try:
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.write_text(str(now))
+    except OSError as exc:
+        _log.debug("auto-update: could not write check stamp: %s", exc)
+
+
+def maybe_auto_update(cfg: Config | None = None) -> bool:
+    """Entry point called at memo-mcp startup. Gated, throttled, non-blocking.
+
+    Returns True iff a background update was spawned (mainly for tests). Never
+    raises — any failure is logged at debug and swallowed so a startup is never
+    delayed or broken by the updater.
+    """
+    try:
+        if not flag_bool("MEMO_AUTO_UPDATE"):
+            return False
+        cfg = cfg or Config.from_env()
+        import time
+
+        now = time.time()
+        interval = flag_int("MEMO_AUTO_UPDATE_INTERVAL_S") or 21600
+        if not _should_check(cfg, interval, now):
+            return False
+        # Record the check up front so a slow/looping spawn can't re-trigger.
+        _record_check(cfg, now)
+
+        from memo import __version__
+
+        repo = flag_str("MEMO_AUTO_UPDATE_REPO") or DEFAULT_REPO
+        tag = latest_remote_tag(repo)
+        if not tag or not is_newer(tag, __version__):
+            return False
+
+        _log.info("auto-update: %s → %s (spawning background self-update)", __version__, tag)
+        log_file = cfg.state_dir / "auto_update.log"
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_file, "a") as fh:
+            subprocess.Popen(
+                [sys.executable, "-m", "memo.cli", "self-update", "--to-tag", tag],
+                stdout=fh,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+        return True
+    except Exception as exc:  # never break startup
+        _log.debug("auto-update: skipped (%s)", exc)
+        return False

--- a/src/memo/runtime/mcp.py
+++ b/src/memo/runtime/mcp.py
@@ -30,6 +30,11 @@ _MCP_ENV_FORWARD_KEYS = (
     "MEMO_RERANKER_REVISION",
     "MEMO_RERANK_INPUT_K",
     "MEMO_RERANK_FUSION_ALPHA",
+    # auto-update: forwarded only when set at install time, so a machine opts in
+    # with `MEMO_AUTO_UPDATE=1 memo install-mcp --write` (off by default).
+    "MEMO_AUTO_UPDATE",
+    "MEMO_AUTO_UPDATE_INTERVAL_S",
+    "MEMO_AUTO_UPDATE_REPO",
 )
 
 _MISSING_MCP_OK_ERRORS = (

--- a/src/memo/runtime/update.py
+++ b/src/memo/runtime/update.py
@@ -12,11 +12,73 @@ import click
 from memo.cli_common import console
 
 
+def _detect_install_method() -> str | None:
+    """``"pipx"`` / ``"uv"`` / None — how mlx-memo's isolated runtime was installed."""
+    try:
+        res = subprocess.run(["pipx", "list", "--short"], capture_output=True, text=True, timeout=10)
+        if "mlx-memo" in res.stdout:
+            return "pipx"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    try:
+        res = subprocess.run(["uv", "tool", "list"], capture_output=True, text=True, timeout=10)
+        if "mlx-memo" in res.stdout:
+            return "uv"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def _prewarm_after_update() -> None:
+    import shutil as _shutil
+
+    memo_bin = _shutil.which("memo") or sys.executable
+    cmd = (
+        [memo_bin, "prewarm", "--download-all"]
+        if memo_bin.endswith("memo")
+        else [memo_bin, "-m", "memo.cli", "prewarm", "--download-all"]
+    )
+    subprocess.run(cmd, check=False)
+
+
 @click.command(name="self-update")
 @click.option("--check", is_flag=True, help="Check for a newer version without installing.")
-def self_update(check: bool) -> None:
+@click.option(
+    "--to-tag",
+    default=None,
+    help="Install a specific git tag (e.g. v1.0.1) from the memo repo, bypassing "
+    "PyPI. Used by the memo-mcp auto-update path (git installs aren't on PyPI).",
+)
+def self_update(check: bool, to_tag: str | None) -> None:
     current_version = importlib.metadata.version("mlx-memo")
     console.print(f"[dim]current version:[/dim] {current_version}")
+
+    # Git-tag path: reinstall the isolated runtime straight from the tagged ref.
+    # PyPI is skipped (these installs come from git+https://…/memo.git).
+    if to_tag:
+        from memo.flags import flag_str
+        from memo.runtime.autoupdate import DEFAULT_REPO
+
+        repo = flag_str("MEMO_AUTO_UPDATE_REPO") or DEFAULT_REPO
+        spec = f"git+{repo}@{to_tag}"
+        method = _detect_install_method()
+        if method == "uv":
+            console.print(f"[dim]Installing {to_tag} via uv tool…[/dim]")
+            proc = subprocess.run(
+                ["uv", "tool", "install", spec, "--force", "--reinstall"], check=False
+            )
+        elif method == "pipx":
+            console.print(f"[dim]Installing {to_tag} via pipx…[/dim]")
+            proc = subprocess.run(["pipx", "install", "--force", spec], check=False)
+        else:
+            raise click.ClickException(
+                "Could not detect install method (pipx/uv) for git-tag update."
+            )
+        if proc.returncode != 0:
+            raise click.ClickException(f"git-tag install of {to_tag} failed.")
+        console.print(f"[green]✓[/green] updated to {to_tag}. Pre-warming MLX models…")
+        _prewarm_after_update()
+        return
 
     try:
         url = "https://pypi.org/pypi/mlx-memo/json"

--- a/src/memo/server.py
+++ b/src/memo/server.py
@@ -241,6 +241,12 @@ def main() -> None:
     """
     from memo.flags import flag_int, flag_str
 
+    # Auto-update check (gated by MEMO_AUTO_UPDATE, throttled, detached spawn —
+    # never raises, never blocks). A newer git tag takes effect on the NEXT start.
+    from memo.runtime.autoupdate import maybe_auto_update
+
+    maybe_auto_update()
+
     transport = (flag_str("MEMO_MCP_TRANSPORT") or "stdio").strip().lower()
     if transport in ("http", "streamable-http", "sse"):
         # Long-lived daemon: enable the prompt cache + a larger query-embedding

--- a/tests/test_autoupdate.py
+++ b/tests/test_autoupdate.py
@@ -1,0 +1,107 @@
+"""Auto-update on memo-mcp start — pure logic + gating (no network, no MLX)."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from memo.runtime import autoupdate as au
+
+
+@pytest.mark.parametrize(
+    "tag,expected",
+    [
+        ("v1.2.3", (1, 2, 3)),
+        ("1.0.0", (1, 0, 0)),
+        ("v2.10.4", (2, 10, 4)),
+        ("v1.2.3-rc1", (1, 2, 3)),
+        ("v1.2", None),
+        ("latest", None),
+        ("v1.x.0", None),
+    ],
+)
+def test_parse_semver(tag, expected):
+    assert au._parse_semver(tag) == expected
+
+
+@pytest.mark.parametrize(
+    "remote,local,expected",
+    [
+        ("v1.0.1", "1.0.0", True),
+        ("v1.0.0", "1.0.0", False),
+        ("v1.0.0", "1.0.1", False),
+        ("v2.0.0", "1.9.9", True),
+        ("garbage", "1.0.0", False),
+        ("v1.0.1", "garbage", False),
+    ],
+)
+def test_is_newer(remote, local, expected):
+    assert au.is_newer(remote, local) is expected
+
+
+def test_latest_remote_tag_picks_highest(monkeypatch):
+    stdout = (
+        "abc123\trefs/tags/v0.9.0\n"
+        "def456\trefs/tags/v1.0.0\n"
+        "aaa111\trefs/tags/v1.2.0\n"
+        "bbb222\trefs/tags/not-a-version\n"
+    )
+
+    def fake_run(*a, **k):
+        return subprocess.CompletedProcess(a, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(au.subprocess, "run", fake_run)
+    assert au.latest_remote_tag("https://example/repo.git") == "v1.2.0"
+
+
+def test_latest_remote_tag_none_on_failure(monkeypatch):
+    def boom(*a, **k):
+        raise FileNotFoundError("git missing")
+
+    monkeypatch.setattr(au.subprocess, "run", boom)
+    assert au.latest_remote_tag("https://example/repo.git") is None
+
+
+def test_throttle_first_check_then_blocked(tmp_cfg):
+    assert au._should_check(tmp_cfg, 3600, now=1000.0) is True
+    au._record_check(tmp_cfg, now=1000.0)
+    assert au._should_check(tmp_cfg, 3600, now=1000.0 + 60) is False  # within window
+    assert au._should_check(tmp_cfg, 3600, now=1000.0 + 4000) is True  # past window
+
+
+def test_maybe_auto_update_disabled_by_default(tmp_cfg, monkeypatch):
+    monkeypatch.delenv("MEMO_AUTO_UPDATE", raising=False)
+    spawned = au.maybe_auto_update(tmp_cfg)
+    assert spawned is False
+
+
+def test_maybe_auto_update_spawns_when_newer_tag(tmp_cfg, monkeypatch):
+    monkeypatch.setenv("MEMO_AUTO_UPDATE", "1")
+    monkeypatch.setattr(au, "latest_remote_tag", lambda *a, **k: "v999.0.0")
+    calls = {"n": 0}
+
+    def fake_popen(*a, **k):
+        calls["n"] += 1
+
+        class _P:
+            pid = 4242
+
+        return _P()
+
+    monkeypatch.setattr(au.subprocess, "Popen", fake_popen)
+    spawned = au.maybe_auto_update(tmp_cfg)
+    assert spawned is True
+    assert calls["n"] == 1
+    # throttle recorded → a second call in the same window does not respawn
+    assert au.maybe_auto_update(tmp_cfg) is False
+    assert calls["n"] == 1
+
+
+def test_maybe_auto_update_no_spawn_when_not_newer(tmp_cfg, monkeypatch):
+    monkeypatch.setenv("MEMO_AUTO_UPDATE", "1")
+    monkeypatch.setattr(au, "latest_remote_tag", lambda *a, **k: "v0.0.1")
+    monkeypatch.setattr(
+        au.subprocess, "Popen", lambda *a, **k: pytest.fail("should not spawn")
+    )
+    assert au.maybe_auto_update(tmp_cfg) is False


### PR DESCRIPTION
> Stacked on #7 (base = `feat/install-safety-guards`). GitHub will retarget to `master` once #7 merges.

## Why

So other Macs don't silently drift: each release gets a version bump + tag, and
memo-mcp self-updates to the latest **tagged** release on startup.

## What

- **`MEMO_AUTO_UPDATE=1`** → on memo-mcp start, throttled (6h, `MEMO_AUTO_UPDATE_INTERVAL_S`)
  check of the latest git **tag** (`vX.Y.Z`) vs the installed version; if newer,
  spawn a detached `memo self-update --to-tag <tag>`. Takes effect on the **next**
  start (can't hot-swap a live interpreter).
- **Tag-gated, not commit-gated:** an un-tagged or broken push never propagates.
- **Default OFF** (memo is public). A machine opts in with
  `MEMO_AUTO_UPDATE=1 memo install-mcp --write` (the 3 `MEMO_AUTO_UPDATE*` keys are
  forwarded into the agent MCP env only when set at install time).
- **`memo self-update --to-tag vX.Y.Z`** reinstalls the isolated runtime from
  `git+<repo>@<tag>` (pipx/uv) — git installs aren't on PyPI, so the existing
  PyPI path couldn't update them.
- New `src/memo/runtime/autoupdate.py`: `latest_remote_tag` (`git ls-remote --tags`),
  semver compare, throttle stamp, gated/non-blocking `maybe_auto_update()`
  (never raises, never delays startup).
- Bumps **1.0.0 → 1.0.1**.

## How a Mac stays current

```bash
MEMO_AUTO_UPDATE=1 memo install-mcp --agent all --write   # enable per machine
```
Then any new `vX.Y.Z` tag is picked up on the next memo-mcp start.

## Test plan

- [x] `pytest tests/` — 1519 passed, 25 skipped (+19 new in test_autoupdate.py)
- [x] `mypy src/memo/` clean (232 files)
- [x] `ruff check` clean
- [x] pure logic covered: semver parse, is_newer, tag-pick, throttle, gating on/off
- [ ] after merge to master: tag `v1.0.1` + push tag (the trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)