### PR TITLE
docs: README how-it-works SVG diagrams + dream consolidate fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@
 
 `memo` gives any MCP-aware agent (Claude Code, Codex, Devin, OpenCode, Cursor, Cline, Continue, …) a long-term memory that **runs entirely on your Mac**. Each memory is a plain Markdown file; embeddings live in a single sqlite file; the LLM, embedder, and reranker run **in-process via [Apple MLX](https://github.com/ml-explore/mlx)** — no Ollama, no Qdrant, no cloud API, no keys. Your prompts and memories never leave the machine.
 
+<div align="center">
+
+<img src="docs/diagram-loop.svg" alt="Save a fact once and any later session recalls it automatically, all stored locally on your Mac." width="760" />
+
+</div>
+
 ## What makes memo different
 
 | Capability | memo | mem0 | letta | cognee |
@@ -254,7 +260,19 @@ Set via `MEMO_MCP_PROFILE=full` or in each client's MCP env config.
 
 **Hybrid search:** vec leg (MLX embedding) + BM25 leg (FTS5/Tantivy, diacritic-folding for Spanish) fused via Reciprocal Rank Fusion → optional MLX cross-encoder rerank.
 
+<div align="center">
+
+<img src="docs/diagram-recall.svg" alt="A prompt runs a vector search and a keyword search in parallel; results are fused, reranked, and the top memory is injected." width="820" />
+
+</div>
+
 **Markdown is the source of truth.** The `.md` files are canonical; sqlite is a rebuildable index. A hand-edit in Obsidian wins on the next `memo reindex`. `delete()` removes the index first, then the file — no silent data loss.
+
+<div align="center">
+
+<img src="docs/diagram-storage.svg" alt="Markdown files are canonical; the sqlite index is derived and can be rebuilt from them at any time." width="760" />
+
+</div>
 
 **Embedding models:**
 

--- a/docs/diagram-loop.svg
+++ b/docs/diagram-loop.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 330" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" role="img" aria-label="How memo works: you save a fact, it is stored locally on your Mac, and a later session recalls it automatically.">
+  <defs>
+    <marker id="a1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#475569"/>
+    </marker>
+    <marker id="a1b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#2563eb"/>
+    </marker>
+    <filter id="s1" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-opacity="0.07"/>
+    </filter>
+  </defs>
+  <style>
+    .t   { font-size: 23px; font-weight: 700; fill: #0f172a; }
+    .sub { font-size: 13px; fill: #64748b; }
+    .lab { font-size: 15px; font-weight: 600; fill: #0f172a; text-anchor: middle; }
+    .meta{ font-size: 11.5px; fill: #64748b; text-anchor: middle; }
+    .num { font-size: 13px; font-weight: 800; fill: #2563eb; text-anchor: middle; }
+  </style>
+
+  <rect x="0" y="0" width="900" height="330" fill="#ffffff"/>
+  <text x="40" y="46" class="t">Save once — recalled automatically, forever</text>
+  <text x="40" y="70" class="sub">No /remember calls. The agent saves a fact today and a future session gets it back on its own.</text>
+
+  <!-- loop-back arrow over the top -->
+  <path d="M760,150 C760,104 140,104 140,150" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#a1b)"/>
+  <rect x="288" y="106" width="324" height="20" fill="#ffffff"/>
+  <text x="450" y="121" class="meta" fill="#2563eb" font-weight="600">next session · any agent · any Mac — automatic</text>
+
+  <!-- 1 -->
+  <rect x="40" y="150" width="220" height="100" rx="12" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5" filter="url(#s1)"/>
+  <text x="150" y="180" class="num">1</text>
+  <text x="150" y="205" class="lab">You save a fact</text>
+  <text x="150" y="228" class="meta">"we use Postgres, not Mongo"</text>
+
+  <!-- 2 -->
+  <rect x="340" y="150" width="220" height="100" rx="12" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1.5" filter="url(#s1)"/>
+  <text x="450" y="180" class="num" fill="#16a34a">2</text>
+  <text x="450" y="205" class="lab">Stored on your Mac</text>
+  <text x="450" y="228" class="meta">Markdown + sqlite · no cloud</text>
+
+  <!-- 3 -->
+  <rect x="640" y="150" width="220" height="100" rx="12" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1.5" filter="url(#s1)"/>
+  <text x="750" y="180" class="num">3</text>
+  <text x="750" y="205" class="lab">Recalled for you</text>
+  <text x="750" y="228" class="meta">injected before it answers</text>
+
+  <line x1="260" y1="200" x2="336" y2="200" stroke="#475569" stroke-width="1.8" marker-end="url(#a1)"/>
+  <line x1="560" y1="200" x2="636" y2="200" stroke="#475569" stroke-width="1.8" marker-end="url(#a1)"/>
+
+  <text x="450" y="300" class="meta" font-size="12.5">100% local · runs in-process via Apple MLX · your prompts and memories never leave the machine</text>
+</svg>

--- a/docs/diagram-recall.svg
+++ b/docs/diagram-recall.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 360" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" role="img" aria-label="How recall works: a prompt runs two searches in parallel — vector for meaning and BM25 for keywords — which are fused, reranked, and the top memory injected.">
+  <defs>
+    <marker id="a2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#475569"/>
+    </marker>
+    <marker id="a2b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#2563eb"/>
+    </marker>
+    <filter id="s2" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-opacity="0.07"/>
+    </filter>
+  </defs>
+  <style>
+    .t   { font-size: 23px; font-weight: 700; fill: #0f172a; }
+    .sub { font-size: 13px; fill: #64748b; }
+    .lab { font-size: 14px; font-weight: 600; fill: #0f172a; text-anchor: middle; }
+    .meta{ font-size: 11px; fill: #64748b; text-anchor: middle; }
+  </style>
+
+  <rect x="0" y="0" width="960" height="360" fill="#ffffff"/>
+  <text x="40" y="46" class="t">How recall finds the right memory</text>
+  <text x="40" y="70" class="sub">Two searches run in parallel — one for meaning, one for keywords — then fuse and rerank.</text>
+
+  <!-- prompt -->
+  <rect x="30" y="158" width="150" height="84" rx="12" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5" filter="url(#s2)"/>
+  <text x="105" y="196" class="lab">Your prompt</text>
+  <text x="105" y="216" class="meta">a question</text>
+
+  <!-- vec leg -->
+  <rect x="220" y="96" width="200" height="78" rx="12" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1.5" filter="url(#s2)"/>
+  <text x="320" y="130" class="lab">Vector search</text>
+  <text x="320" y="151" class="meta">meaning · MLX embedding</text>
+
+  <!-- bm25 leg -->
+  <rect x="220" y="226" width="200" height="78" rx="12" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1.5" filter="url(#s2)"/>
+  <text x="320" y="260" class="lab">Keyword search</text>
+  <text x="320" y="281" class="meta">BM25 · FTS5</text>
+
+  <!-- fuse -->
+  <rect x="462" y="158" width="150" height="84" rx="12" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5" filter="url(#s2)"/>
+  <text x="537" y="192" class="lab">Fuse</text>
+  <text x="537" y="213" class="meta">rank-merge (RRF)</text>
+
+  <!-- rerank -->
+  <rect x="654" y="158" width="150" height="84" rx="12" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5" filter="url(#s2)"/>
+  <text x="729" y="192" class="lab">Rerank</text>
+  <text x="729" y="213" class="meta">cross-encoder · opt</text>
+
+  <!-- inject -->
+  <rect x="816" y="158" width="120" height="84" rx="12" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1.5" filter="url(#s2)"/>
+  <text x="876" y="192" class="lab" fill="#2563eb">Inject</text>
+  <text x="876" y="213" class="meta">top memory</text>
+
+  <!-- prompt -> two legs -->
+  <path d="M180,188 C202,180 200,140 218,135" fill="none" stroke="#475569" stroke-width="1.7" marker-end="url(#a2)"/>
+  <path d="M180,212 C202,220 200,260 218,265" fill="none" stroke="#475569" stroke-width="1.7" marker-end="url(#a2)"/>
+
+  <!-- legs -> fuse -->
+  <path d="M420,135 C442,140 440,180 460,186" fill="none" stroke="#475569" stroke-width="1.7" marker-end="url(#a2)"/>
+  <path d="M420,265 C442,260 440,220 460,214" fill="none" stroke="#475569" stroke-width="1.7" marker-end="url(#a2)"/>
+
+  <!-- fuse -> rerank -> inject -->
+  <line x1="612" y1="200" x2="650" y2="200" stroke="#475569" stroke-width="1.8" marker-end="url(#a2)"/>
+  <line x1="804" y1="200" x2="812" y2="200" stroke="#2563eb" stroke-width="1.8" marker-end="url(#a2b)"/>
+
+  <text x="480" y="334" class="meta" font-size="12.5">Warm recall daemon keeps the whole path under ~200 ms · output capped to a ~160-token budget</text>
+</svg>

--- a/docs/diagram-storage.svg
+++ b/docs/diagram-storage.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 300" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" role="img" aria-label="Storage model: Markdown files are the source of truth; the sqlite index is derived and can be rebuilt from them at any time.">
+  <defs>
+    <marker id="a3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#475569"/>
+    </marker>
+    <marker id="a3g" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#16a34a"/>
+    </marker>
+    <filter id="s3" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-opacity="0.07"/>
+    </filter>
+  </defs>
+  <style>
+    .t   { font-size: 23px; font-weight: 700; fill: #0f172a; }
+    .sub { font-size: 13px; fill: #64748b; }
+    .lab { font-size: 16px; font-weight: 700; fill: #0f172a; text-anchor: middle; }
+    .meta{ font-size: 12px; fill: #64748b; text-anchor: middle; }
+    .edge{ font-size: 12px; fill: #475569; text-anchor: middle; }
+  </style>
+
+  <rect x="0" y="0" width="900" height="300" fill="#ffffff"/>
+  <text x="40" y="46" class="t">Markdown is the source of truth</text>
+  <text x="40" y="70" class="sub">The .md files are canonical. sqlite is just a fast, rebuildable index derived from them.</text>
+
+  <!-- markdown (truth) -->
+  <rect x="60" y="120" width="300" height="120" rx="14" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1.6" filter="url(#s3)"/>
+  <text x="210" y="158" class="lab" fill="#16a34a">.md files</text>
+  <text x="210" y="184" class="meta">one plain file per memory</text>
+  <text x="210" y="204" class="meta">edit them in Obsidian — they win</text>
+  <text x="210" y="224" class="meta">canonical · human-readable</text>
+
+  <!-- sqlite (index) -->
+  <rect x="540" y="120" width="300" height="120" rx="14" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.6" filter="url(#s3)"/>
+  <text x="690" y="158" class="lab">sqlite-vec index</text>
+  <text x="690" y="184" class="meta">vec + BM25 · one file</text>
+  <text x="690" y="204" class="meta">derived · disposable</text>
+  <text x="690" y="224" class="meta">powers fast search</text>
+
+  <!-- truth -> index -->
+  <path d="M360,168 L536,168" fill="none" stroke="#475569" stroke-width="1.8" marker-end="url(#a3)"/>
+  <text x="448" y="156" class="edge">memo save · indexes it</text>
+
+  <!-- index rebuilt from truth -->
+  <path d="M536,206 L360,206" fill="none" stroke="#16a34a" stroke-width="1.8" stroke-dasharray="5 4" marker-end="url(#a3g)"/>
+  <text x="448" y="226" class="edge" fill="#16a34a">memo reindex · rebuilds it anytime</text>
+
+  <text x="450" y="278" class="meta" font-size="12.5">Lose the index? Rebuild it. Delete a memory? Index drops first, the .md last — no silent data loss.</text>
+</svg>

--- a/src/memo/dream_consolidate.py
+++ b/src/memo/dream_consolidate.py
@@ -173,7 +173,7 @@ def run_consolidate_episodes(
             if d.get("status") == "save":
                 try:
                     mem.save(
-                        f"{d['body']}\n\n[cross-session {d['provenance_hash']}]",
+                        content=f"{d['body']}\n\n[cross-session {d['provenance_hash']}]",
                         type="synthesis",
                         title=d["title"],
                         extra={

--- a/tests/test_dream_consolidate.py
+++ b/tests/test_dream_consolidate.py
@@ -67,3 +67,36 @@ def test_consolidate_skips_when_synthesize_returns_none():
         clusters, synthesize_fn=lambda cl: None, exists_fn=lambda h: False, dry_run=False
     )
     assert decisions[0]["status"] == "skipped"
+
+
+def test_run_consolidate_saves_with_keyword_content(monkeypatch):
+    """Orchestrator must call mem.save(content=...) — the real save is keyword-only.
+    A positional body would TypeError (the v2.3.11 bug this regression-guards)."""
+    saved: list[dict] = []
+
+    class _Store:
+        def count(self):
+            return 2
+
+        def recent(self, limit=50):
+            return [_ep("s1", "/r/memo", "a"), _ep("s2", "/r/memo", "b")]
+
+    class _Mem:
+        def search(self, q, limit=1, disable_reranker=True):
+            return []
+
+        def save(self, *, content, type, title, extra):  # keyword-only, like the real facade
+            saved.append({"content": content, "type": type, "title": title})
+
+    class _Cfg:
+        state_dir = "/tmp/unused"
+
+    monkeypatch.setattr("memo.resume._index.open_store", lambda cfg: _Store())
+    monkeypatch.setattr(dc, "_llm_synthesize", lambda mem, cl: {"title": "T", "body": "insight"})
+
+    res = dc.run_consolidate_episodes(_Cfg(), _Mem(), min_sessions=2, dry_run=False)
+    assert res["status"] == "done"
+    assert res["consolidated"][0]["status"] == "saved"
+    assert len(saved) == 1
+    assert saved[0]["type"] == "synthesis"
+    assert "insight" in saved[0]["content"]


### PR DESCRIPTION
Adds 3 simple SVG diagrams to the README (save→store→recall loop, hybrid recall pipeline, markdown-as-source-of-truth) plus a regression fix for dream consolidate save() being keyword-only.