### PR TITLE
chore: add Glama listing metadata

### DIFF
--- a/Dockerfile.glama
+++ b/Dockerfile.glama
@@ -1,0 +1,28 @@
+# Glama sandbox image: start the MCP stdio server by default so Glama can run
+# protocol introspection (tools/list, resources/list, prompts/list).
+FROM python:3.13-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    MEMO_NONINTERACTIVE=1 \
+    MEMO_AUTO_UPDATE=0 \
+    MEMO_MCP_PROFILE=core \
+    MEMO_EMBEDDER_BACKEND=st \
+    MEMO_ST_EMBEDDER_MODEL=Qwen/Qwen3-Embedding-0.6B \
+    MEMO_EMBEDDER_DIMS=1024 \
+    MEMO_DATA_DIR=/data \
+    MEMO_STATE_DIR=/data/state \
+    HF_HOME=/opt/hf-cache
+
+RUN pip install --index-url https://download.pytorch.org/whl/cpu torch \
+    && pip install "mlx-memo[cpu]"
+
+RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('Qwen/Qwen3-Embedding-0.6B')"
+
+RUN useradd -m memo && mkdir -p /data/state /opt/hf-cache \
+    && chown -R memo:memo /data /opt/hf-cache
+
+USER memo
+VOLUME /data
+
+CMD ["memo-mcp"]

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "jagoff"
+  ],
+  "name": "memo",
+  "description": "Local-first long-term memory for coding agents. Hybrid vector + BM25 retrieval, markdown files as source of truth, time-machine queries, contradiction detection, and nightly synthesis.",
+  "type": "mcp_server",
+  "status": "production",
+  "framework": "FastMCP",
+  "transport": [
+    "stdio",
+    "http"
+  ],
+  "keywords": [
+    "memory",
+    "mcp",
+    "coding-agents",
+    "local-first",
+    "rag",
+    "mlx",
+    "sqlite-vec",
+    "bm25"
+  ]
+}


### PR DESCRIPTION
Adds Glama-specific listing metadata and a Dockerfile that starts the MCP stdio server by default for Glama introspection checks.\n\nVerification:\n- jq . glama.json\n- git diff --check\n- isolated MCP smoke: initialize OK, protocol 2024-11-05, tools/list returned 31 tools