### PR TITLE
fix(secrets): isolate encrypted credential storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,12 +346,13 @@ the normal text index.
 ### 🔐 Secret storage
 
 ```bash
+export MEMO_SECRET_STORAGE_ENABLED=1                     # explicit opt-in
 memo secret save --name openai-api-key --kind api_token   # value read from stdin
 memo secret get --name openai-api-key                       # decrypt one secret
 memo secret list                                            # names only, never values
 ```
 
-Keep credentials (API tokens, passwords, SSH keys, DB creds) in an **encrypted** local store — separate from your searchable memories, never indexed or embedded. Values are sealed with **AES-256-GCM** under a device-bound key (PBKDF2 over hostname + device id + a machine salt — same machine derives the same key, no passphrase to manage). Default-on (`MEMO_SECRET_STORAGE_ENABLED`); `memo secret list` shows names only. Optionally, `MEMO_CAPTURE_DETECT_SECRETS=1` auto-detects and quarantines secrets that show up in captured transcripts (opt-in) so they never land in a plain memory.
+Secret storage is **off by default** and requires `MEMO_SECRET_STORAGE_ENABLED=1`. Values are sealed with AES-256-GCM plus authenticated name/kind metadata under a random 256-bit master key at `$MEMO_STATE_DIR/secret-master.key`; memo enforces a private state directory (`0700`) and key/database permissions (`0600`). Credentials live only in the isolated `secret_store` table: no markdown marker is created, and they are never indexed, embedded, recalled, added to generated context, backed up as memory markdown, or committed by memo's git sync. `memo secret list` exposes metadata only. Treat `memo secret get` and `memo secret export` as explicit plaintext disclosure operations and redirect their output carefully.
 
 ### Daemons
 

--- a/docs/SPECS/2026-07-07-memo-secret-storage-design.md
+++ b/docs/SPECS/2026-07-07-memo-secret-storage-design.md
@@ -1,5 +1,13 @@
 # Memo Secret Storage System — Design Spec
 
+> Security amendment (2026-07-14): the implementation intentionally does not
+> create the metadata markdown proposed below. Storage is explicit opt-in,
+> ciphertext lives only in `secret_store`, and a random 256-bit local master key
+> replaces hostname/device-derived key material. Legacy markdown is excluded
+> from reindex, backup, recall context, and git sync, and is removed on delete.
+> The historical sections remain as design context; this amendment and the
+> current code are authoritative where they differ.
+
 **Date:** 2026-07-07  
 **Status:** Design (pending implementation)  
 **Scope:** Local-first encrypted credential storage (passwords, API keys, SSH keys, DB credentials)
@@ -121,7 +129,7 @@ SECRET_KINDS: frozenset[str] = frozenset({
 })
 ```
 
-#### Markdown Format (`secrets/2026/07/openai-api-key.md`)
+#### Historical Markdown Format (not created by current releases)
 
 ```markdown
 ---
@@ -138,7 +146,8 @@ confidence: 0.95
 [ENCRYPTED: AES-256-GCM]
 ```
 
-The encrypted blob is stored literally as `[ENCRYPTED: AES-256-GCM]` in markdown; the actual ciphertext + nonce live in `secret_store` table.
+Current releases create no markdown record. Old `[ENCRYPTED: AES-256-GCM]`
+markers contain metadata only and are treated as migration artifacts.
 
 #### SQLite Schema (`src/memo/store/schema.py`)
 
@@ -166,7 +175,7 @@ Migration adds this table in `src/memo/store/migrations.py`.
 
 ### 2.3 Encryption & Key Derivation
 
-#### Key Derivation (Device-Bound, No User Input)
+#### Historical Key Derivation (read-only migration compatibility)
 
 **File:** `src/memo/secret_store.py`
 
@@ -397,7 +406,7 @@ Warm socket daemon (like memo-recall-daemon):
 ## 9. Flags
 
 ```python
-flag_bool("MEMO_SECRET_STORAGE_ENABLED", default=True)
+flag_bool("MEMO_SECRET_STORAGE_ENABLED", default=False)
 flag_bool("MEMO_CAPTURE_DETECT_SECRETS", default=False)
 flag_bool("MEMO_DETECT_SECRETS_LLM", default=True)
 flag_int("MEMO_SECRET_DAEMON_CACHE_MAX", default=100)
@@ -409,7 +418,7 @@ flag_int("MEMO_SECRET_DAEMON_CACHE_TTL_SECONDS", default=3600)
 ## 10. Success Criteria
 
 1. ✅ Secrets encrypted at rest (AES-256-GCM)
-2. ✅ Device-bound key derivation
+2. ✅ Random local 256-bit master key with strict filesystem permissions
 3. ✅ Auto-detection (regex + LLM)
 4. ✅ User confirmation before save
 5. ✅ Daemon warm socket

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -33,3 +33,10 @@ is expected when the user explicitly requests:
 Local search, recall, save, history, briefing, and normal MCP startup do not send
 prompts or memories to a hosted memo service. A separately configured model,
 sync remote, HTTP integration, or external helper has its own privacy boundary.
+
+Encrypted credential storage is a separate, explicit opt-in
+(`MEMO_SECRET_STORAGE_ENABLED=1`). Secret values never become searchable memory
+or markdown and memo's git sync excludes legacy `secrets/` markers. The local
+master key and ciphertext database are permission-restricted, but a process
+running as your OS user can still request plaintext; protect access to your
+account and use `memo secret get/export` only when disclosure is intended.

--- a/src/memo/briefing.py
+++ b/src/memo/briefing.py
@@ -370,7 +370,10 @@ def memo_native_briefing_lines(
     # ── Open loops: recently updated memories ────────────────────────────
     try:
         cutoff = (datetime.now(tz=UTC) - timedelta(days=loops_days)).isoformat()
-        all_recent = mem.store.list_recent(limit=loops_n * 4, exclude_types={"reference"})
+        all_recent = mem.store.list_recent(
+            limit=loops_n * 4,
+            exclude_types={"reference", "secret"},
+        )
         open_loops = [r for r in all_recent if (r.get("updated") or "") >= cutoff][:loops_n]
         if open_loops:
             lines.append(f"### Open loops (last {loops_days} days)")
@@ -408,7 +411,10 @@ def memo_native_briefing_lines(
     if memory_of_day:
         try:
             today_str = datetime.now(tz=UTC).strftime("%Y-%m-%d")
-            all_ids_rows = mem.store.list_recent(limit=500, exclude_types={"reference"})
+            all_ids_rows = mem.store.list_recent(
+                limit=500,
+                exclude_types={"reference", "secret"},
+            )
             pick_id = ""
             if all_ids_rows:
                 sorted_rows = sorted(all_ids_rows, key=lambda r: r.get("updated") or "")

--- a/src/memo/cli_backup.py
+++ b/src/memo/cli_backup.py
@@ -43,6 +43,8 @@ def _portable_backup(out_path: str | None) -> None:
         if cfg.memory_dir.is_dir():
             for md in sorted(cfg.memory_dir.rglob("*.md")):
                 rel = md.relative_to(cfg.memory_dir)
+                if rel.parts[:1] == ("secrets",):
+                    continue
                 zf.write(md, arcname=f"memory/{rel}")
                 n_md += 1
         # 2) State DBs (vec + history). Stored at the root. Dedup by resolved

--- a/src/memo/cli_secret.py
+++ b/src/memo/cli_secret.py
@@ -26,12 +26,17 @@ def secret() -> None:
     ),
     help="Secret kind (auto-detected if not provided)",
 )
-@click.option("--value", required=False, help="Secret value (if not provided, read from stdin)")
 @click.option("--no-confirm", is_flag=True, help="Skip confirmation prompt")
-def save(name: str, kind: str | None, value: str | None, no_confirm: bool) -> None:
+def save(name: str, kind: str | None, no_confirm: bool) -> None:
     """Save a secret (encrypted)."""
-    if not value:
-        value = click.get_text_stream("stdin").read().strip()
+    stdin = click.get_text_stream("stdin")
+    if stdin.isatty():
+        value = click.prompt("Secret value", hide_input=True, show_default=False)
+    else:
+        value = stdin.read()
+        # Piping `printf 'value\n'` should not silently persist the line ending,
+        # while all other leading/trailing characters remain part of the secret.
+        value = value.removesuffix("\n").removesuffix("\r")
 
     if not value:
         raise click.ClickException("No value provided")

--- a/src/memo/context_pack.py
+++ b/src/memo/context_pack.py
@@ -46,7 +46,8 @@ def consult_hits_from_pack(pack: ContextPack) -> list[dict[str, Any]]:
     return hits
 
 
-def _is_sensitive(hit: Any) -> bool:
+def is_sensitive_memory(hit: Any) -> bool:
+    """Return whether a memory must never enter generated context."""
     tags = {str(tag) for tag in (getattr(hit, "tags", None) or [])}
     extra = getattr(hit, "extra", None)
     extra_dict = extra if isinstance(extra, dict) else {}
@@ -60,7 +61,7 @@ def _is_sensitive(hit: Any) -> bool:
 def build_context_row(hit: Any, *, snippet_chars: int) -> dict[str, Any] | None:
     """Build one prompt-ready memory row, omitting sensitive hits."""
 
-    if _is_sensitive(hit):
+    if is_sensitive_memory(hit):
         return None
     return _snippet(hit, snippet_chars, classify_quality(hit))
 

--- a/src/memo/context_surface.py
+++ b/src/memo/context_surface.py
@@ -105,7 +105,10 @@ def _static_profile(memory: Any, *, cwd: str | None) -> list[dict[str, Any]]:
 def _dynamic_rows(memory: Any, *, limit: int = 5, days: int = 7) -> list[dict[str, Any]]:
     try:
         cutoff = (datetime.now(tz=UTC) - timedelta(days=days)).isoformat()
-        rows = memory.store.list_recent(limit=limit * 3, exclude_types={"reference"})
+        rows = memory.store.list_recent(
+            limit=limit * 3,
+            exclude_types={"reference", "secret"},
+        )
     except Exception:
         return []
     out: list[dict[str, Any]] = []

--- a/src/memo/dream_profile.py
+++ b/src/memo/dream_profile.py
@@ -324,7 +324,10 @@ def run_profile_pass(
     try:
         from datetime import UTC, datetime
 
-        rows = mem.store.list_recent(limit=scan_limit, exclude_types={"reference"})
+        rows = mem.store.list_recent(
+            limit=scan_limit,
+            exclude_types={"reference", "secret"},
+        )
         rules = _gather_rules(mem, cfg, k=directive_k, min_used=directive_min_used)
         res["standing_rules"] = len(rules)
         now = datetime.now(tz=UTC).isoformat(timespec="seconds")

--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -1384,9 +1384,9 @@ SPECS: tuple[FlagSpec, ...] = (
     _spec(
         "MEMO_SECRET_STORAGE_ENABLED",
         "bool",
-        True,
+        False,
         "secret",
-        "Enable encrypted secret storage (passwords, tokens, SSH keys).",
+        "Explicitly opt in to encrypted local secret storage (passwords, tokens, SSH keys).",
     ),
     _spec(
         "MEMO_CAPTURE_DETECT_SECRETS",

--- a/src/memo/memory/ask_ops.py
+++ b/src/memo/memory/ask_ops.py
@@ -475,6 +475,13 @@ class _AskOpsMixin(_MemoryBase):
 
             hits = sorted(hits, key=_recency_sort_key, reverse=True)[:k]
 
+        # Defense in depth for legacy/corrupt index rows and test doubles that
+        # bypass Memory.search(): credentials never enter prompts or verbatim
+        # short-circuits, independent of the optional context-pack feature.
+        from memo.context_pack import is_sensitive_memory
+
+        hits = [hit for hit in hits if not is_sensitive_memory(hit)]
+
         snippet_lines: list[str] = []
         sources: list[dict[str, Any]] = []
         primary_memory_sources: dict[str, dict[str, Any]] = {}

--- a/src/memo/memory/consolidate_ops.py
+++ b/src/memo/memory/consolidate_ops.py
@@ -392,7 +392,7 @@ class _ConsolidateOpsMixin(_MemoryBase):
         if type_ is not None:
             items = self._pull_embeddings(type_filter=type_)
         else:
-            items = self._pull_embeddings(exclude_types={"reference"})
+            items = self._pull_embeddings(exclude_types={"reference", "secret"})
         if not items:
             return []
         clusters = self._greedy_cluster(items, threshold)

--- a/src/memo/memory/maintain_ops.py
+++ b/src/memo/memory/maintain_ops.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import builtins
 import json
 import time
+from pathlib import Path
 from typing import Any
 
 import frontmatter
@@ -38,6 +39,22 @@ from memo.prompt_overrides import resolve_prompt
 from memo.tiers import VerificationState
 from memo.util import sha256_full as _sha256_full
 from memo.util import sha256_short as _sha256_short
+
+
+def _purge_legacy_secret_index(
+    store: Any,
+    md_path: Path,
+    memory_root: Path,
+    md_id: str,
+    meta: dict[str, Any],
+) -> bool:
+    """Drop a legacy credential marker from the derived search index."""
+    rel = md_path.relative_to(memory_root)
+    if meta.get("type") != "secret" and rel.parts[:1] != ("secrets",):
+        return False
+    if store.get(md_id) is not None:
+        store.hard_delete(md_id)
+    return True
 
 
 class _MaintainOpsMixin(_MemoryBase):
@@ -256,7 +273,17 @@ class _MaintainOpsMixin(_MemoryBase):
                 continue
             meta: dict[str, Any] = post.metadata
             md_id = meta.get("id")
-            if not md_id or not isinstance(md_id, str):
+            if (
+                not md_id
+                or not isinstance(md_id, str)
+                or _purge_legacy_secret_index(
+                    self.store,
+                    md_path,
+                    self.cfg.memory_dir,
+                    md_id,
+                    meta,
+                )
+            ):
                 skipped += 1
                 continue
             body = post.content or ""

--- a/src/memo/memory/search_ops.py
+++ b/src/memo/memory/search_ops.py
@@ -28,7 +28,7 @@ from memo.memory.record import (
     record_from_row,
 )
 from memo.perf import timer
-from memo.tiers import REFERENCE_TYPES
+from memo.tiers import REFERENCE_TYPES, SENSITIVE_TYPES
 
 if TYPE_CHECKING:
     from memo.store.hype_store import HypeStore
@@ -145,6 +145,10 @@ class _SearchOpsMixin(_MemoryBase):
             _add_trace("candidate_generation", mode=mode, output_count=0)
             _add_trace("final", output_count=0)
             return []
+        # Credentials are managed only through the explicit secret API. Legacy
+        # `type: secret` rows must never be returned by any search mode, even if
+        # a caller asks for that type or forgets to pass an exclusion set.
+        exclude_types = set(exclude_types or ()) | set(SENSITIVE_TYPES)
         limit = limit or self.cfg.search_default_limit
         if date_to and len(date_to) == 10:
             date_to = date_to + "T23:59:59"  # bare date = whole day inclusive

--- a/src/memo/memory/secret_ops.py
+++ b/src/memo/memory/secret_ops.py
@@ -2,18 +2,58 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import os
 import secrets
+import sqlite3
+import stat
+from pathlib import Path
 from typing import Any
 
 import frontmatter
 
 from memo.errors import MemoError
+from memo.flags import flag_bool
 from memo.memory._base import _MemoryBase
-from memo.memory.record import MemoryRecord, _now_iso, _slugify
-from memo.secret_store import decrypt_secret, detect_secrets_heuristic, encrypt_secret
+from memo.memory.record import MemoryRecord, _now_iso
+from memo.secret_store import (
+    decrypt_secret,
+    detect_secrets_heuristic,
+    encrypt_secret,
+    secret_ciphertext_needs_rotation,
+)
 
 _log = logging.getLogger(__name__)
+
+
+def _require_secret_storage_enabled() -> None:
+    if not flag_bool("MEMO_SECRET_STORAGE_ENABLED"):
+        raise MemoError(
+            "Secret storage is disabled by default; explicitly set "
+            "MEMO_SECRET_STORAGE_ENABLED=1 to opt in"
+        )
+
+
+def _validate_secret_name(name: str) -> str:
+    clean = name.strip()
+    if clean != name or not clean or len(clean) > 128 or any(ord(char) < 32 for char in clean):
+        raise ValueError(
+            "Secret name must be 1-128 characters with no surrounding/control whitespace"
+        )
+    return clean
+
+
+def _validate_secret_value(value: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError("Secret value must be a non-empty string")
+    if len(value.encode()) > 1024 * 1024:
+        raise ValueError("Secret value exceeds the 1 MiB storage limit")
+    return value
+
+
+def _secret_aad(name: str, kind: str) -> bytes:
+    return f"memo-secret:{name}:{kind}".encode()
 
 
 class _SecretOpsMixin(_MemoryBase):
@@ -33,11 +73,14 @@ class _SecretOpsMixin(_MemoryBase):
 
         1. Auto-detect kind if not provided
         2. Encrypt with AES-256-GCM
-        3. Save markdown + index in sqlite
+        3. Save only to the isolated sqlite secret table
         4. Log access
         """
         from memo.tiers import SECRET_KINDS
 
+        _require_secret_storage_enabled()
+        name = _validate_secret_name(name)
+        value = _validate_secret_value(value)
         if kind and kind not in SECRET_KINDS:
             raise ValueError(f"Invalid kind: {kind}. Choices: {SECRET_KINDS}")
 
@@ -58,49 +101,43 @@ class _SecretOpsMixin(_MemoryBase):
                 raise MemoError("Secret save cancelled by user")
 
         # Encrypt
-        ciphertext, nonce = encrypt_secret(value)
+        ciphertext, nonce = encrypt_secret(
+            value,
+            state_dir=self.cfg.state_dir,
+            associated_data=_secret_aad(name, kind),
+        )
 
         # Create record
         now_iso = _now_iso()
         record_id = f"sec_{secrets.token_hex(8)}"
 
-        frontmatter_data = {
-            "id": record_id,
-            "type": "secret",
-            "kind": kind,
-            "name": name,
-            "created": now_iso,
-            "tags": tags or [],
-        }
-
         markdown_content = "[ENCRYPTED: AES-256-GCM]"
-        doc = frontmatter.Post(markdown_content, handler=None, **frontmatter_data)
-
-        # Write markdown
-        file_path = (
-            self.cfg.memory_dir / "secrets" / now_iso[:7].replace("-", "/") / f"{_slugify(name)}.md"
-        )
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-        file_path.write_text(frontmatter.dumps(doc), encoding="utf-8")
-        file_path.chmod(0o600)  # Restrict permissions
-
-        # Index in sqlite
-        self.store.secret_store_insert(
-            id=record_id,
-            name=name,
-            kind=kind,
-            encrypted_blob=ciphertext,
-            nonce=nonce,
-            created_at=now_iso,
-            detection_method="manual",
-        )
+        inserted = False
+        try:
+            self.store.secret_store_insert(
+                id=record_id,
+                name=name,
+                kind=kind,
+                encrypted_blob=ciphertext,
+                nonce=nonce,
+                created_at=now_iso,
+                detection_method="manual",
+            )
+            inserted = True
+            self._secure_secret_state_files()
+        except (OSError, sqlite3.Error):
+            # The database row is the only durable write. Roll it back if a
+            # post-insert security invariant (notably permissions) fails.
+            if inserted:
+                self.store.secret_store_delete(name)
+            raise
 
         # Log access
         self._log_secret_access(record_id, "save", name)
 
         return MemoryRecord(
             id=record_id,
-            path=str(file_path.relative_to(self.cfg.memory_dir)),
+            path=f"secret://{record_id}",
             type="secret",
             title=name,
             tags=tags or [],
@@ -112,6 +149,8 @@ class _SecretOpsMixin(_MemoryBase):
 
     def get_secret(self, name: str) -> str:
         """Retrieve and decrypt a secret by name."""
+        _require_secret_storage_enabled()
+        name = _validate_secret_name(name)
         secret_row = self.store.secret_store_get(name)
         if not secret_row:
             raise MemoError(f"Secret not found: {name}")
@@ -120,9 +159,22 @@ class _SecretOpsMixin(_MemoryBase):
         nonce = secret_row["nonce"]
 
         try:
-            plaintext = decrypt_secret(ciphertext, nonce)
+            plaintext = decrypt_secret(
+                ciphertext,
+                nonce,
+                state_dir=self.cfg.state_dir,
+                associated_data=_secret_aad(name, secret_row["kind"]),
+            )
         except Exception as exc:
             raise MemoError(f"Failed to decrypt secret '{name}': {exc}") from exc
+
+        if secret_ciphertext_needs_rotation(ciphertext):
+            rotated, rotated_nonce = encrypt_secret(
+                plaintext,
+                state_dir=self.cfg.state_dir,
+                associated_data=_secret_aad(name, secret_row["kind"]),
+            )
+            self.store.secret_store_update_encrypted(name, rotated, rotated_nonce)
 
         # Update access metadata
         self.store.secret_store_increment_access(name)
@@ -132,10 +184,17 @@ class _SecretOpsMixin(_MemoryBase):
 
     def list_secrets(self, kind: str | None = None) -> list[dict[str, Any]]:
         """List secret metadata (names and kinds, not values)."""
+        from memo.tiers import SECRET_KINDS
+
+        _require_secret_storage_enabled()
+        if kind is not None and kind not in SECRET_KINDS:
+            raise ValueError(f"Invalid kind: {kind}. Choices: {SECRET_KINDS}")
         return self.store.secret_store_list(kind=kind)
 
     def forget_secret(self, name: str) -> None:
         """Delete a secret."""
+        _require_secret_storage_enabled()
+        name = _validate_secret_name(name)
         secret_row = self.store.secret_store_get(name)
         if not secret_row:
             raise MemoError(f"Secret not found: {name}")
@@ -144,13 +203,69 @@ class _SecretOpsMixin(_MemoryBase):
         if not deleted:
             raise MemoError(f"Failed to delete secret: {name}")
 
+        failures: list[str] = []
+        for marker in self._legacy_secret_markers(secret_row["id"], name):
+            try:
+                marker.unlink()
+            except OSError as exc:
+                failures.append(f"{marker}: {exc}")
+        if failures:
+            raise MemoError(
+                "Secret value was deleted, but legacy metadata could not be removed: "
+                + "; ".join(failures)
+            )
+
         self._log_secret_access(secret_row["id"], "delete", name)
+
+    def _legacy_secret_markers(self, secret_id: str, name: str) -> list[Path]:
+        """Find old metadata-only files without following symlinks."""
+        root = self.cfg.memory_dir / "secrets"
+        if not root.is_dir() or root.is_symlink():
+            return []
+        matches: list[Path] = []
+        for path in root.rglob("*.md"):
+            if path.is_symlink() or not path.is_file():
+                continue
+            try:
+                if path.stat().st_size > 64 * 1024:
+                    continue
+                post = frontmatter.loads(path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, ValueError):
+                continue
+            if post.get("type") != "secret":
+                continue
+            if post.get("id") == secret_id or post.get("name") == name:
+                matches.append(path)
+        return matches
+
+    def _secure_secret_state_files(self) -> None:
+        """Ciphertext and SQLite journals must not be readable by other users."""
+        for path in self.cfg.state_dir.glob(f"{self.cfg.db_path.name}*"):
+            if path.is_file() and not path.is_symlink():
+                path.chmod(0o600)
 
     def _log_secret_access(self, secret_id: str, op: str, name: str) -> None:
         """Log secret access to grounding.log for audit trail."""
         try:
             grounding_log_path = self.cfg.state_dir / "grounding.log"
-            entry = f"{_now_iso()} | secret_id={secret_id[:8]} | op={op} | name={name}\n"
-            grounding_log_path.open("a", encoding="utf-8").write(entry)
+            name_hash = hashlib.sha256(name.encode("utf-8")).hexdigest()[:12]
+            entry = (
+                f"{_now_iso()} | secret_id={secret_id[:8]} | op={op} | name_sha256={name_hash}\n"
+            )
+            flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+            fd = os.open(grounding_log_path, flags, 0o600)
+            try:
+                info = os.fstat(fd)
+                if not stat.S_ISREG(info.st_mode):
+                    raise OSError("secret audit log is not a regular file")
+                os.fchmod(fd, 0o600)
+                payload = entry.encode()
+                while payload:
+                    written = os.write(fd, payload)
+                    if written <= 0:
+                        raise OSError("short write to secret audit log")
+                    payload = payload[written:]
+            finally:
+                os.close(fd)
         except Exception as exc:
             _log.debug("Failed to log secret access: %s", exc)

--- a/src/memo/recall_logic.py
+++ b/src/memo/recall_logic.py
@@ -1066,9 +1066,9 @@ def _recall_logic(
 
     search_k = top_k * 3 if (project_tag or contextual) else top_k
 
-    from memo.tiers import REFERENCE_TYPES
-
-    exclude_types = set(REFERENCE_TYPES) if flag_bool("MEMO_RECALL_EXCLUDE_REFERENCE") else None
+    # Credentials are never recallable, regardless of feature flags.
+    # Bulk reference exclusion remains an operator-controlled setting.
+    exclude_types = _recall_excluded_types()
     exclude_tags = uncertain_exclusion()
 
     use_fallback = False
@@ -1468,3 +1468,13 @@ def _recall_logic(
     except Exception as exc:
         _logger.debug("presence bump failed: %s", exc)
     return json.dumps(output, ensure_ascii=False), _log
+
+
+def _recall_excluded_types() -> set[str]:
+    """Sensitive credentials are unconditional; bulk reference is configurable."""
+    from memo.tiers import REFERENCE_TYPES
+
+    excluded = {"secret"}
+    if flag_bool("MEMO_RECALL_EXCLUDE_REFERENCE"):
+        excluded.update(REFERENCE_TYPES)
+    return excluded

--- a/src/memo/secret_store.py
+++ b/src/memo/secret_store.py
@@ -5,15 +5,117 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
 import secrets
 import socket
+import stat
 from pathlib import Path
 from typing import Any
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
+from memo.errors import MemoError
+
 _log = logging.getLogger(__name__)
+
+_MASTER_KEY_FILENAME = "secret-master.key"
+_MASTER_KEY_BYTES = 32
+_CIPHERTEXT_V2_PREFIX = b"memo-secret:v2\0"
+
+
+class SecretKeyError(MemoError):
+    """The local secret master key cannot be loaded safely."""
+
+
+def _resolve_state_dir(state_dir: Path | None) -> Path:
+    if state_dir is not None:
+        return Path(state_dir)
+    from memo.config import Config
+
+    return Config.from_env().state_dir
+
+
+def _secure_state_dir(state_dir: Path) -> None:
+    """Create the local key directory and keep it private to this user."""
+    if state_dir.is_symlink():
+        raise SecretKeyError(f"Secret state directory must not be a symlink: {state_dir}")
+    state_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        state_dir.chmod(0o700)
+    except OSError as exc:
+        raise SecretKeyError(f"Cannot secure secret state directory {state_dir}: {exc}") from exc
+
+
+def _read_master_key(path: Path) -> bytes:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        if path.is_symlink():
+            raise SecretKeyError(f"Secret master key must not be a symlink: {path}") from exc
+        raise SecretKeyError(f"Cannot open secret master key {path}: {exc}") from exc
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            raise SecretKeyError(f"Secret master key is not a regular file: {path}")
+        if stat.S_IMODE(info.st_mode) & 0o077:
+            raise SecretKeyError(
+                f"Secret master key permissions are too open at {path}; run chmod 600"
+            )
+        key = os.read(fd, _MASTER_KEY_BYTES + 1)
+    finally:
+        os.close(fd)
+    if len(key) != _MASTER_KEY_BYTES:
+        raise SecretKeyError(
+            f"Secret master key at {path} has invalid length; expected {_MASTER_KEY_BYTES} bytes"
+        )
+    return key
+
+
+def _write_all(fd: int, payload: bytes) -> None:
+    remaining = memoryview(payload)
+    while remaining:
+        written = os.write(fd, remaining)
+        if written <= 0:
+            raise OSError("short write while creating secret master key")
+        remaining = remaining[written:]
+
+
+def _load_or_create_master_key(state_dir: Path | None = None) -> bytes:
+    root = _resolve_state_dir(state_dir)
+    _secure_state_dir(root)
+    path = root / _MASTER_KEY_FILENAME
+    if path.exists() or path.is_symlink():
+        return _read_master_key(path)
+
+    key = secrets.token_bytes(_MASTER_KEY_BYTES)
+    scratch = root / (f".{_MASTER_KEY_FILENAME}.{os.getpid()}.{secrets.token_hex(8)}.tmp")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(scratch, flags, 0o600)
+    except OSError as exc:
+        raise SecretKeyError(f"Cannot stage secret master key in {root}: {exc}") from exc
+    try:
+        _write_all(fd, key)
+        os.fsync(fd)
+    except OSError:
+        os.close(fd)
+        scratch.unlink(missing_ok=True)
+        raise
+    else:
+        os.close(fd)
+    try:
+        # Hard-link publication is atomic and never overwrites an existing file
+        # or symlink. Concurrent creators either publish once or read the winner.
+        os.link(scratch, path, follow_symlinks=False)
+    except FileExistsError:
+        return _read_master_key(path)
+    except OSError as exc:
+        raise SecretKeyError(f"Cannot publish secret master key {path}: {exc}") from exc
+    finally:
+        scratch.unlink(missing_ok=True)
+    return _read_master_key(path)
 
 
 def _load_or_create_machine_salt() -> str:
@@ -30,11 +132,8 @@ def _load_or_create_machine_salt() -> str:
     return salt
 
 
-def derive_secret_key() -> bytes:
-    """
-    Device-bound key derivation.
-    Same machine → same key (deterministic, no user input).
-    """
+def _derive_legacy_secret_key() -> bytes:
+    """Derive the pre-v3.5.1 key so existing ciphertext can be migrated."""
     try:
         from consciousness_contracts.uri import device_id as get_device_id
 
@@ -57,29 +156,59 @@ def derive_secret_key() -> bytes:
     )
 
 
-def encrypt_secret(value: str) -> tuple[bytes, bytes]:
+def derive_secret_key(*, state_dir: Path | None = None) -> bytes:
+    """Load a random 256-bit master key from memo's private local state."""
+    return _load_or_create_master_key(state_dir)
+
+
+def encrypt_secret(
+    value: str,
+    *,
+    state_dir: Path | None = None,
+    associated_data: bytes | None = None,
+) -> tuple[bytes, bytes]:
     """
     Encrypt a secret value with AES-256-GCM.
     Returns: (ciphertext, nonce)
     """
-    key = derive_secret_key()
+    key = derive_secret_key(state_dir=state_dir)
     nonce = secrets.token_bytes(12)  # 96 bits for GCM
 
     cipher = AESGCM(key)
-    ciphertext = cipher.encrypt(nonce, value.encode("utf-8"), None)
+    ciphertext = cipher.encrypt(nonce, value.encode("utf-8"), associated_data)
 
-    return ciphertext, nonce
+    return _CIPHERTEXT_V2_PREFIX + ciphertext, nonce
 
 
-def decrypt_secret(ciphertext: bytes, nonce: bytes) -> str:
+def decrypt_secret(
+    ciphertext: bytes,
+    nonce: bytes,
+    *,
+    state_dir: Path | None = None,
+    associated_data: bytes | None = None,
+) -> str:
     """
     Decrypt a secret value.
     Raises cryptography.hazmat.primitives.ciphers.aead.InvalidTag if nonce/ciphertext invalid.
     """
-    key = derive_secret_key()
+    payload = bytes(ciphertext)
+    if payload.startswith(_CIPHERTEXT_V2_PREFIX):
+        key = derive_secret_key(state_dir=state_dir)
+        payload = payload[len(_CIPHERTEXT_V2_PREFIX) :]
+        aad = associated_data
+    else:
+        # Compatibility path for records created by the old predictable
+        # hostname/device/salt derivation. SecretOps rotates these on access.
+        key = _derive_legacy_secret_key()
+        aad = None
     cipher = AESGCM(key)
-    plaintext = cipher.decrypt(nonce, ciphertext, None)
+    plaintext = cipher.decrypt(nonce, payload, aad)
     return plaintext.decode("utf-8")
+
+
+def secret_ciphertext_needs_rotation(ciphertext: bytes) -> bool:
+    """Return True for ciphertext written by the legacy derivation scheme."""
+    return not bytes(ciphertext).startswith(_CIPHERTEXT_V2_PREFIX)
 
 
 # Detection patterns

--- a/src/memo/store/queries.py
+++ b/src/memo/store/queries.py
@@ -1007,6 +1007,21 @@ class _QueriesMixin(_BM25QueriesMixin, _SignalQueriesMixin):
             cursor = cx.execute("DELETE FROM secret_store WHERE name = ?", (name,))
             return cursor.rowcount > 0
 
+    def secret_store_update_encrypted(
+        self,
+        name: str,
+        encrypted_blob: bytes,
+        nonce: bytes,
+    ) -> None:
+        """Atomically rotate one secret's ciphertext and nonce."""
+        with self._tx() as cx:
+            cursor = cx.execute(
+                "UPDATE secret_store SET encrypted_blob = ?, nonce = ? WHERE name = ?",
+                (encrypted_blob, nonce, name),
+            )
+            if cursor.rowcount != 1:
+                raise KeyError(f"Secret not found during key rotation: {name}")
+
     def secret_store_increment_access(self, name: str) -> None:
         """Increment access count and update accessed_at timestamp."""
         now = datetime.now(UTC).isoformat(timespec="seconds")

--- a/src/memo/sync.py
+++ b/src/memo/sync.py
@@ -146,7 +146,11 @@ class BackupManager:
 
         memory_backup = backup_path / "memories"
         memory_backup.mkdir()
-        memory_files = list(self.memory_dir.rglob("*.md"))
+        memory_files = [
+            path
+            for path in self.memory_dir.rglob("*.md")
+            if path.relative_to(self.memory_dir).parts[:1] != ("secrets",)
+        ]
         for f in memory_files:
             # Preserve the per-project bucket layout (memory_dir/<project>/...)
             # so restore recreates it and same-named files in different buckets

--- a/src/memo/sync_git.py
+++ b/src/memo/sync_git.py
@@ -476,6 +476,10 @@ def _commit_local(cfg: Config, store: VecStore) -> tuple[Path, str, int]:
         )
     export_signal(store, signal_dir_for(cfg))
     _git(root, "add", "-A")
+    # Pre-isolation releases wrote metadata-only credential markers below a
+    # reserved secrets/ directory. They contain no ciphertext, but even names
+    # are sensitive metadata and must never enter cross-machine git sync.
+    _git(root, "reset", "-q", "--", ":(glob)**/secrets/**", check=False)
     staged = _git(root, "diff", "--cached", "--name-only").stdout.strip()
     n_files = len(staged.splitlines()) if staged else 0
     if staged:

--- a/src/memo/tiers.py
+++ b/src/memo/tiers.py
@@ -44,12 +44,18 @@ SECRET_KINDS: frozenset[str] = frozenset(
     }
 )
 
+# Historical releases allowed `type: secret` rows into the general index.
+# Keep a single defensive exclusion set for consumers while reindex purges
+# those legacy rows. New credential writes never create memory rows at all.
+SENSITIVE_TYPES: frozenset[str] = frozenset({"secret"})
+
 # Durable tiers: the source-of-truth surfaced automatically. Mirrors
 # `memory._VALID_TYPES` minus the reference tier. `procedure` (how-to
 # workflows: "to do X, run Y") and `failure_pattern` (structured mistake
 # notes: Pattern/Context/Wrong/Right) are the procedural-knowledge kinds
-# mined from execution (2026-07-03 ecosystem survey, Tier2 #7). `secret`
-# is for encrypted credentials (passwords, tokens, SSH keys, DB credentials).
+# mined from execution (2026-07-03 ecosystem survey, Tier2 #7). Credentials
+# deliberately are not a memory tier: the isolated secret store must never
+# enter recall, embeddings, briefing, consolidation, or git sync.
 DURABLE_TYPES: frozenset[str] = frozenset(
     {
         "decision",
@@ -62,7 +68,6 @@ DURABLE_TYPES: frozenset[str] = frozenset(
         "synthesis",
         "procedure",
         "failure_pattern",
-        "secret",
     }
 )
 
@@ -107,6 +112,7 @@ __all__ = [
     "EVICTION_PROTECTED_TYPES",
     "REFERENCE_TYPES",
     "SECRET_KINDS",
+    "SENSITIVE_TYPES",
     "VerificationState",
     "is_reference_candidate",
 ]

--- a/tests/test_ask_expand_synthesis.py
+++ b/tests/test_ask_expand_synthesis.py
@@ -19,6 +19,12 @@ def _stub_search_to(mem, rec):
     mem.search = lambda *a, **k: [mem.get(rec.id)]  # type: ignore[assignment]
 
 
+def _legacy_secret(mem, *, content: str, title: str):
+    record = mem.save(content=content, title=title)
+    mem.store.bulk_update_type([record.id], "secret")
+    return mem.get(record.id)
+
+
 def test_flag_off_no_expansion(mock_memory, monkeypatch):
     monkeypatch.delenv("MEMO_ASK_EXPAND_SYNTHESIS", raising=False)
     s1, _s2, synth = _seed(mock_memory)
@@ -78,10 +84,10 @@ def test_flag_on_prefers_source_memories_key(mock_memory, monkeypatch):
 
 def test_flag_on_skips_sensitive_sources_without_context_pack(mock_memory, monkeypatch):
     monkeypatch.setenv("MEMO_ASK_EXPAND_SYNTHESIS", "1")
-    secret = mock_memory.save(
+    secret = _legacy_secret(
+        mock_memory,
         content="SECRET-LEAK-REVIEW",
         title="Secret source",
-        type_="secret",
     )
     synth = mock_memory.save(
         content="tema",

--- a/tests/test_context_pack.py
+++ b/tests/test_context_pack.py
@@ -40,6 +40,12 @@ def _repo_hit(*, text: str) -> RepoSearchHit:
     )
 
 
+def _legacy_secret(mem: Memory, *, content: str, title: str):
+    record = mem.save(content=content, title=title)
+    mem.store.bulk_update_type([record.id], "secret")
+    return mem.get(record.id)
+
+
 def _capturing_stream(
     prompts: list[str],
     deltas: list[str],
@@ -296,10 +302,10 @@ def test_context_pack_fitter_handles_budget_smaller_than_row_overhead() -> None:
 
 
 def test_context_pack_omits_sensitive_expanded_memory(mem_with_stub, monkeypatch) -> None:
-    sensitive = mem_with_stub.save(
+    sensitive = _legacy_secret(
+        mem_with_stub,
         content="top secret",
         title="Sensitive source",
-        type_="secret",
     )
     synth = mem_with_stub.save(
         content="synthesis body",
@@ -359,7 +365,7 @@ def test_context_pack_expanded_memory_gets_quality_metadata(mem_with_stub, monke
 def test_context_pack_prevents_sensitive_top_hit_verbatim_bypass(
     mem_with_stub, monkeypatch
 ) -> None:
-    sensitive = mem_with_stub.save(content="secret literal leak", title="Secret", type_="secret")
+    sensitive = _legacy_secret(mem_with_stub, content="secret literal leak", title="Secret")
     safe = mem_with_stub.save(content="safe fallback context", title="Safe")
     captured: dict[str, str] = {}
 
@@ -384,13 +390,17 @@ def test_context_pack_prevents_sensitive_top_hit_verbatim_bypass(
     assert safe.id in {source["id"] for source in out["sources"]}
 
 
-def test_sensitive_top_hit_verbatim_short_circuit_is_preserved_without_context_pack(
-    mem_with_stub, monkeypatch
-) -> None:
-    sensitive = mem_with_stub.save(content="secret literal leak", title="Secret", type_="secret")
+def test_sensitive_top_hit_is_filtered_without_context_pack(mem_with_stub, monkeypatch) -> None:
+    sensitive = _legacy_secret(mem_with_stub, content="secret literal leak", title="Secret")
     safe = mem_with_stub.save(content="safe fallback context", title="Safe")
+    captured: dict[str, str] = {}
+
+    def _stub_chat(self, model, messages, options=None):
+        captured["user"] = messages[-1]["content"]
+        return {"message": {"content": "Filtered answer."}}
 
     monkeypatch.setenv("MEMO_CONTEXT_PACK", "0")
+    monkeypatch.setattr("memo.llm.MLXChat.chat", _stub_chat)
     monkeypatch.setattr(
         mem_with_stub,
         "search",
@@ -399,7 +409,10 @@ def test_sensitive_top_hit_verbatim_short_circuit_is_preserved_without_context_p
 
     out = mem_with_stub.ask("literal leak", k=2, include_repos=False)
 
-    assert out["answer"] == f"secret literal leak\n\n[{sensitive.id[:8]}]"
+    assert out["answer"] == "Filtered answer."
+    assert sensitive.id not in {source["id"] for source in out["sources"]}
+    assert "secret literal leak" not in captured["user"]
+    assert safe.id in {source["id"] for source in out["sources"]}
 
 
 def test_chat_ask_keeps_standard_prompt_when_context_pack_flag_is_on(

--- a/tests/test_quality_compact.py
+++ b/tests/test_quality_compact.py
@@ -29,6 +29,12 @@ def _env(tmp_path: Path) -> dict[str, str]:
     }
 
 
+def _legacy_secret(mem: Memory, *, content: str, title: str, tags: list[str], extra: dict):
+    record = mem.save(content=content, title=title, tags=tags, extra=extra)
+    mem.store.bulk_update_type([record.id], "secret")
+    return mem.get(record.id)
+
+
 def _seed_quality_compact_records(tmp_path: Path) -> tuple[dict[str, str], str]:
     env = _env(tmp_path)
     cfg = Config(
@@ -89,10 +95,10 @@ def test_quality_compact_preview_skips_cross_scope_and_sensitive_records(mock_me
         tags=["project:other"],
         extra={"canonical_id": canonical.id},
     )
-    mock_memory.save(
+    _legacy_secret(
+        mock_memory,
         content="Top secret duplicate.",
         title="Secret duplicate",
-        type_="secret",
         tags=["project:memo"],
         extra={"canonical_id": canonical.id},
     )

--- a/tests/test_secret_memory.py
+++ b/tests/test_secret_memory.py
@@ -1,10 +1,18 @@
-"""Tests for secret storage Memory integration."""
+"""Tests for isolated secret-storage Memory integration."""
 
+import secrets
+import sqlite3
+import stat
 from unittest.mock import MagicMock, patch
 
+import frontmatter
+import pytest
 from click.testing import CliRunner
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
+import memo.secret_store as secret_crypto
 from memo.cli import cli
+from memo.errors import MemoError
 
 
 # Memory mixin tests (placeholder)
@@ -18,6 +26,177 @@ def test_memory_has_secret_methods():
     assert hasattr(Memory, "get_secret")
     assert hasattr(Memory, "list_secrets")
     assert hasattr(Memory, "forget_secret")
+
+
+def test_secret_operations_require_explicit_opt_in(mem_with_stub, monkeypatch):
+    monkeypatch.delenv("MEMO_SECRET_STORAGE_ENABLED", raising=False)
+
+    with pytest.raises(MemoError, match="MEMO_SECRET_STORAGE_ENABLED=1"):
+        mem_with_stub.save_secret(value="credential", name="primary", interactive=False)
+
+
+def test_general_memory_api_refuses_secret_type(mem_with_stub):
+    with pytest.raises(ValueError, match="type_='secret'"):
+        mem_with_stub.save(content="plaintext", title="must not index", type_="secret")
+
+
+def test_secret_roundtrip_never_creates_searchable_markdown(mem_with_stub, monkeypatch):
+    monkeypatch.setenv("MEMO_SECRET_STORAGE_ENABLED", "1")
+    value = "sk_test_plaintext_must_never_leak_123456"
+
+    record = mem_with_stub.save_secret(
+        value=value,
+        name="primary-api-key",
+        kind="api_token",
+        interactive=False,
+    )
+
+    assert record.path.startswith("secret://")
+    assert list(mem_with_stub.cfg.memory_dir.rglob("*.md")) == []
+    assert mem_with_stub.search("plaintext must never leak") == []
+    assert mem_with_stub.get_secret("primary-api-key") == value
+    assert stat.S_IMODE(mem_with_stub.cfg.db_path.stat().st_mode) == 0o600
+    for path in mem_with_stub.cfg.state_dir.rglob("*"):
+        if path.is_file():
+            assert value.encode() not in path.read_bytes()
+
+    mem_with_stub.forget_secret("primary-api-key")
+    assert mem_with_stub.list_secrets() == []
+
+
+def test_failed_duplicate_save_preserves_existing_secret(mem_with_stub, monkeypatch):
+    monkeypatch.setenv("MEMO_SECRET_STORAGE_ENABLED", "1")
+    mem_with_stub.save_secret(
+        value="original",
+        name="same-name",
+        kind="generic",
+        interactive=False,
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        mem_with_stub.save_secret(
+            value="replacement",
+            name="same-name",
+            kind="generic",
+            interactive=False,
+        )
+
+    assert mem_with_stub.get_secret("same-name") == "original"
+
+
+def test_post_insert_security_failure_rolls_back_row(mem_with_stub, monkeypatch):
+    monkeypatch.setenv("MEMO_SECRET_STORAGE_ENABLED", "1")
+
+    def fail_to_secure() -> None:
+        raise PermissionError("cannot secure database")
+
+    monkeypatch.setattr(mem_with_stub, "_secure_secret_state_files", fail_to_secure)
+
+    with pytest.raises(PermissionError, match="cannot secure"):
+        mem_with_stub.save_secret(
+            value="credential",
+            name="rolled-back",
+            kind="generic",
+            interactive=False,
+        )
+
+    assert mem_with_stub.list_secrets() == []
+
+
+def test_secret_names_reject_log_injection(mem_with_stub, monkeypatch):
+    monkeypatch.setenv("MEMO_SECRET_STORAGE_ENABLED", "1")
+
+    with pytest.raises(ValueError, match="control whitespace"):
+        mem_with_stub.save_secret(
+            value="credential",
+            name="safe\nop=forged",
+            kind="generic",
+            interactive=False,
+        )
+
+
+def test_legacy_ciphertext_rotates_to_random_master_key_on_read(mem_with_stub, monkeypatch):
+    monkeypatch.setenv("MEMO_SECRET_STORAGE_ENABLED", "1")
+    legacy_key = b"l" * 32
+    nonce = secrets.token_bytes(12)
+    legacy_ciphertext = AESGCM(legacy_key).encrypt(nonce, b"legacy-value", None)
+    monkeypatch.setattr(secret_crypto, "_derive_legacy_secret_key", lambda: legacy_key)
+    mem_with_stub.store.secret_store_insert(
+        id="sec_legacy_crypto",
+        name="legacy-crypto",
+        kind="generic",
+        encrypted_blob=legacy_ciphertext,
+        nonce=nonce,
+        created_at="2026-07-14T00:00:00+00:00",
+        detection_method="manual",
+    )
+
+    assert mem_with_stub.get_secret("legacy-crypto") == "legacy-value"
+
+    rotated = mem_with_stub.store.secret_store_get("legacy-crypto")
+    assert rotated is not None
+    assert not secret_crypto.secret_ciphertext_needs_rotation(rotated["encrypted_blob"])
+
+
+def test_forget_removes_legacy_secret_marker(mem_with_stub, monkeypatch):
+    monkeypatch.setenv("MEMO_SECRET_STORAGE_ENABLED", "1")
+    record = mem_with_stub.save_secret(
+        value="credential",
+        name="legacy-key",
+        kind="generic",
+        interactive=False,
+    )
+    marker = mem_with_stub.cfg.memory_dir / "secrets" / "2026" / "07" / "legacy-key.md"
+    marker.parent.mkdir(parents=True)
+    marker.write_text(
+        frontmatter.dumps(
+            frontmatter.Post(
+                "[ENCRYPTED: AES-256-GCM]",
+                id=record.id,
+                type="secret",
+                name="legacy-key",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    mem_with_stub.forget_secret("legacy-key")
+
+    assert not marker.exists()
+
+
+def test_reindex_purges_legacy_secret_from_search_index(mem_with_stub, monkeypatch):
+    marker = mem_with_stub.cfg.memory_dir / "secrets" / "2026" / "07" / "legacy.md"
+    marker.parent.mkdir(parents=True)
+    marker.write_text(
+        frontmatter.dumps(
+            frontmatter.Post(
+                "[ENCRYPTED: AES-256-GCM]",
+                id="sec_legacy",
+                title="legacy-key",
+                type="secret",
+                created="2026-07-14T00:00:00+00:00",
+            )
+        ),
+        encoding="utf-8",
+    )
+    mem_with_stub.store.upsert(
+        id_="sec_legacy",
+        path=str(marker.relative_to(mem_with_stub.cfg.memory_dir)),
+        title="legacy-key",
+        type_="secret",
+        tags=[],
+        created="2026-07-14T00:00:00+00:00",
+        updated="2026-07-14T00:00:00+00:00",
+        body_hash="legacy",
+        embedding=[1.0, 0.0, 0.0, 0.0],
+        body_text="[ENCRYPTED: AES-256-GCM]",
+    )
+
+    counts = mem_with_stub.reindex(force=True)
+
+    assert counts["skipped"] == 1
+    assert mem_with_stub.store.get("sec_legacy") is None
 
 
 def test_secret_list_closes_memory(tmp_path):

--- a/tests/test_secret_store.py
+++ b/tests/test_secret_store.py
@@ -1,11 +1,15 @@
-"""Tests for secret storage (tier, flags, encryption, detection)."""
+"""Tests for secret storage (flags, encryption, key custody, detection)."""
 
+import os
 import secrets
+import stat
 
 import pytest
 from cryptography.exceptions import InvalidTag
 
+from memo.flags import REGISTRY
 from memo.secret_store import (
+    SecretKeyError,
     decrypt_secret,
     derive_secret_key,
     detect_secrets_heuristic,
@@ -15,9 +19,10 @@ from memo.secret_store import (
 from memo.tiers import DURABLE_TYPES, SECRET_KINDS
 
 
-def test_secret_in_durable_types():
-    """Secret tier should be in durable types."""
-    assert "secret" in DURABLE_TYPES
+def test_secret_storage_is_opt_in_and_not_a_recall_tier():
+    """Credential storage must not silently join searchable durable memory."""
+    assert REGISTRY["MEMO_SECRET_STORAGE_ENABLED"].default is False
+    assert "secret" not in DURABLE_TYPES
 
 
 def test_secret_kinds_defined():
@@ -27,39 +32,86 @@ def test_secret_kinds_defined():
 
 
 # Encryption tests
-def test_encrypt_decrypt_roundtrip():
+def test_encrypt_decrypt_roundtrip(tmp_path):
     """Secret should survive encrypt/decrypt cycle."""
     value = "sk_test_1234567890abcdef"
-    ciphertext, nonce = encrypt_secret(value)
-    decrypted = decrypt_secret(ciphertext, nonce)
+    ciphertext, nonce = encrypt_secret(value, state_dir=tmp_path)
+    decrypted = decrypt_secret(ciphertext, nonce, state_dir=tmp_path)
     assert decrypted == value
+    assert value.encode() not in ciphertext
 
 
-def test_key_derivation_deterministic():
+def test_master_key_is_random_private_and_reused(tmp_path):
+    first, nonce = encrypt_secret("first", state_dir=tmp_path)
+    key_path = tmp_path / "secret-master.key"
+    key = key_path.read_bytes()
+
+    assert len(key) == 32
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(tmp_path.stat().st_mode) == 0o700
+    assert decrypt_secret(first, nonce, state_dir=tmp_path) == "first"
+
+    encrypt_secret("second", state_dir=tmp_path)
+    assert key_path.read_bytes() == key
+
+
+def test_master_key_refuses_permissive_or_symlinked_files(tmp_path):
+    key_path = tmp_path / "secret-master.key"
+    key_path.write_bytes(os.urandom(32))
+    key_path.chmod(0o644)
+
+    with pytest.raises(SecretKeyError, match="permissions"):
+        encrypt_secret("blocked", state_dir=tmp_path)
+
+    key_path.unlink()
+    target = tmp_path / "elsewhere"
+    target.write_bytes(os.urandom(32))
+    key_path.symlink_to(target)
+    with pytest.raises(SecretKeyError, match="symlink"):
+        encrypt_secret("blocked", state_dir=tmp_path)
+
+
+def test_key_derivation_deterministic(tmp_path):
     """Same machine should derive same key twice."""
-    key1 = derive_secret_key()
-    key2 = derive_secret_key()
+    key1 = derive_secret_key(state_dir=tmp_path)
+    key2 = derive_secret_key(state_dir=tmp_path)
     assert key1 == key2
 
 
-def test_different_values_different_ciphertexts():
+def test_different_values_different_ciphertexts(tmp_path):
     """Different values should produce different ciphertexts."""
     value1 = "secret1"
     value2 = "secret2"
-    ct1, _nonce1 = encrypt_secret(value1)
-    ct2, _nonce2 = encrypt_secret(value2)
+    ct1, _nonce1 = encrypt_secret(value1, state_dir=tmp_path)
+    ct2, _nonce2 = encrypt_secret(value2, state_dir=tmp_path)
     # Even though nonce is random, ciphertexts should differ
     assert ct1 != ct2
 
 
-def test_invalid_nonce_raises():
+def test_invalid_nonce_raises(tmp_path):
     """Decrypting with wrong nonce should raise."""
     value = "secret"
-    ct, _nonce = encrypt_secret(value)
+    ct, _nonce = encrypt_secret(value, state_dir=tmp_path)
     wrong_nonce = secrets.token_bytes(12)
 
     with pytest.raises(InvalidTag):
-        decrypt_secret(ct, wrong_nonce)
+        decrypt_secret(ct, wrong_nonce, state_dir=tmp_path)
+
+
+def test_authenticated_metadata_prevents_row_swaps(tmp_path):
+    ciphertext, nonce = encrypt_secret(
+        "credential",
+        state_dir=tmp_path,
+        associated_data=b"memo-secret:primary:api_token",
+    )
+
+    with pytest.raises(InvalidTag):
+        decrypt_secret(
+            ciphertext,
+            nonce,
+            state_dir=tmp_path,
+            associated_data=b"memo-secret:other:api_token",
+        )
 
 
 # Detection tests

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -139,6 +139,18 @@ def test_backup_manager_create_compressed_backup(backup_manager, mock_memory):
     assert metadata.compressed_size < metadata.original_size
 
 
+def test_backup_excludes_legacy_secret_markdown(backup_manager, mock_memory):
+    mock_memory.save(content="safe memory", title="Safe")
+    marker = mock_memory.cfg.memory_dir / "secrets" / "2026" / "07" / "key.md"
+    marker.parent.mkdir(parents=True)
+    marker.write_text("---\nid: sec_old\ntype: secret\n---\n[ENCRYPTED]\n", encoding="utf-8")
+
+    metadata = backup_manager.create_backup(compress=False, name="without-secrets")
+
+    assert metadata.memory_count == 1
+    assert not (backup_manager.backup_dir / "without-secrets" / "memories" / "secrets").exists()
+
+
 @pytest.mark.parametrize(
     "name",
     ["../escaped", "nested/backup", r"nested\backup", ".", "..", ""],

--- a/tests/test_sync_git.py
+++ b/tests/test_sync_git.py
@@ -101,6 +101,38 @@ def test_push_clean_repo_is_noop(remote: Path, tmp_path: Path, monkeypatch):
         mem.close()
 
 
+def test_push_never_commits_legacy_secret_markers(remote: Path, tmp_path: Path, monkeypatch):
+    clone = _make_clone(remote, tmp_path / "A")
+    mem = _mem_for(clone, tmp_path / "stateA", monkeypatch)
+    try:
+        marker = clone / "memorias" / "secrets" / "2026" / "07" / "key.md"
+        marker.parent.mkdir(parents=True)
+        marker.write_text(
+            "---\nid: sec_old\ntype: secret\nname: production-key\n---\n[ENCRYPTED]\n",
+            encoding="utf-8",
+        )
+
+        assert sync_push(mem.cfg, mem.store)["pushed"] is True
+
+        tracked = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(clone),
+                "ls-files",
+                "--error-unmatch",
+                str(marker.relative_to(clone)),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert tracked.returncode != 0
+        assert marker.exists()
+    finally:
+        mem.close()
+
+
 def test_push_then_pull_propagates_memoria_and_signal(remote: Path, tmp_path: Path, monkeypatch):
     # --- Mac A: save a memoria, build signal, push ---
     clone_a = _make_clone(remote, tmp_path / "A")


### PR DESCRIPTION
## Summary
- make secret storage explicit opt-in and keep credentials out of Markdown, search, recall, context, backup, and sync surfaces
- replace machine-derived encryption with a random private master key, AES-GCM associated data, strict permissions, atomic creation, and legacy rotation
- validate inputs, roll back failed writes, remove legacy markers, and read secret values without process-argument exposure

## Verification
- 4213 passed, 29 skipped
- focused secret/sync/security tests
- Ruff check/format, mypy, quality gate, uv lock --check, git diff --check
- pre-push recall gate PASS