### PR TITLE
fix(release): make package builds reproducible

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,10 @@ jobs:
       - name: Build distribution
         run: |
           python -m pip install uv==0.11.21
-          uv sync --frozen --extra dev --python 3.13
-          .venv/bin/python -m build
+          uv lock --check
+          uv build --out-dir dist
+          test -n "$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+          test -n "$(find dist -maxdepth 1 -name '*.tar.gz' -print -quit)"
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import re
+import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -48,3 +50,28 @@ def test_python_ci_uses_committed_frozen_uv_lock() -> None:
     ):
         text = (WORKFLOWS / workflow).read_text(encoding="utf-8")
         assert "uv sync --frozen" in text, workflow
+
+
+def test_publish_workflow_builds_from_project_metadata_with_uv() -> None:
+    publish = (WORKFLOWS / "publish.yml").read_text(encoding="utf-8")
+
+    assert "uv build --out-dir dist" in publish
+    assert "python -m build" not in publish
+    assert "uv sync" not in publish
+
+
+def test_release_metadata_and_lock_versions_match() -> None:
+    project_version = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))[
+        "project"
+    ]["version"]
+    lock = tomllib.loads((ROOT / "uv.lock").read_text(encoding="utf-8"))
+    local_package = next(
+        package
+        for package in lock["package"]
+        if package["name"] == "mlx-memo" and package.get("source") == {"editable": "."}
+    )
+    server = json.loads((ROOT / "server.json").read_text(encoding="utf-8"))
+
+    assert local_package["version"] == project_version, "run `uv lock` after a version bump"
+    assert server["version"] == project_version, "update server.json version"
+    assert server["packages"][0]["version"] == project_version, "update server.json package version"

--- a/uv.lock
+++ b/uv.lock
@@ -1257,7 +1257,7 @@ wheels = [
 
 [[package]]
 name = "mlx-memo"
-version = "3.5.0"
+version = "3.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- build release artifacts directly with pinned uv and fail when the committed lock is stale
- require both wheel and source distribution before publishing
- align the lockfile with version 3.5.1 and gate project, lock, and MCP registry versions

## Verification
- uv lock --check
- uv build produced mlx_memo-3.5.1 wheel and sdist
- 18 release workflow/bundle tests passed
- Ruff and diff checks passed
- pre-push recall gate PASS