### PR TITLE
feat(verbatim): ship private bounded transcript search

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ On a ~200-memory corpus, `memo roi` estimates **~80k tokens of model work avoide
 - **Contradiction radar.** Change your mind on an old decision and memo flags the now-stale version — the agent won't reintroduce what you already discarded.
 - **Time-machine / audit.** "What did we know about this bug last month?" Rewind the corpus to any date and see the state of knowledge at that point.
 - **Instant project onboarding.** A cold agent gets the project's durable decisions, facts, and preferences up front via the session-start briefing.
+- **Exact transcript lookup (opt-in).** `memo verbatim search` can find the precise wording of past local transcript turns through a private, lexical-only FTS5 index. It never enters ambient recall.
 - **Fewer tokens, not more.** Instead of re-deriving what you solved last week, recall injects the answer on a tight budget — and the default MCP surface is 14 tools, not 129.
 
 ## Requirements
@@ -179,6 +180,9 @@ memo save 'MLX prefill ~30% faster than Ollama on M3 Max' --title 'MLX bench' -t
 memo search 'how fast was the MLX benchmark'           # search by meaning, not just keywords
 memo list --limit 5                                    # most recent
 memo ask 'what changed in the embedder this month?'   # RAG — cites memories by id
+# Optional: build and query a private 90-day transcript index (no embeddings)
+memo verbatim index
+memo verbatim search 'exact deployment decision' --limit 10
 ```
 
 `memo config` is a native TUI for editing every persistent setting with search,

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -40,3 +40,25 @@ or markdown and memo's git sync excludes legacy `secrets/` markers. The local
 master key and ciphertext database are permission-restricted, but a process
 running as your OS user can still request plaintext; protect access to your
 account and use `memo secret get/export` only when disclosure is intended.
+
+## Optional verbatim transcript index
+
+Total Recall is off by default. `MEMO_VERBATIM_INDEX=1` enables its nightly
+index pass; `memo verbatim index` is the explicit one-shot equivalent. It reads
+local Claude transcript JSONL, keeps only timestamped user/assistant turns,
+applies memo's known-secret redactor, and writes a lexical FTS5 sidecar under
+`MEMO_STATE_DIR`. It uses no embeddings, never becomes Markdown, never enters
+ambient recall, and is not part of git sync.
+
+The default retention/backfill window is 90 days
+(`MEMO_VERBATIM_MAX_DAYS=90`). Rows without a valid timestamp are rejected so
+they cannot bypass pruning. The state directory is restricted to mode `0700`
+and the database, SQLite sidecars, and watermark to `0600`; CLI and MCP searches
+are explicitly invoked and capped at 100 results.
+
+Known-secret redaction is defense in depth, not a guarantee that arbitrary
+sensitive prose can be recognized. Enabling this feature creates a second local
+copy of transcript text that any process running as your OS user can query.
+Leave it disabled if that duplication is not acceptable, and delete
+`MEMO_STATE_DIR/verbatim.db` plus `verbatim-index.json` to remove the derived
+index.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -653,6 +653,12 @@ memo reindex                      # absorb edits made directly in Obsidian
 memo stats
 memo ask 'what changed in the embedder this month?'
 
+# ── Optional exact transcript lookup (private FTS5, 90-day default) ─────────
+memo verbatim index --dry-run
+memo verbatim index
+memo verbatim search 'exact phrase' --session <session-id> --since 2026-07-01 --limit 10
+memo verbatim status
+
 # ── History & audit ────────────────────────────────────────────────────────
 memo record-history <id>                # chronological audit trail for one record with field diffs
 memo history                      # recent save/update/delete events across all records

--- a/src/memo/cli.py
+++ b/src/memo/cli.py
@@ -142,6 +142,7 @@ from memo.cli_tokens import tokens_cmd
 from memo.cli_transcripts import mine_git, mine_history, reflect
 from memo.cli_tui import hook_log, logs, tui
 from memo.cli_usefulness import usefulness as usefulness_cmd
+from memo.cli_verbatim import verbatim_group
 from memo.cli_version import version_group
 from memo.cli_viz import map_cmd
 from memo.runtime.shims import install_shims_cmd
@@ -377,6 +378,7 @@ cli.add_command(invalidate_cmd)
 cli.add_command(synthesize_cmd)
 cli.add_command(retier_cmd)
 cli.add_command(usefulness_cmd)
+cli.add_command(verbatim_group)
 cli.add_command(roi_cmd)
 cli.add_command(gaps_cmd)
 cli.add_command(outcome_cmd)

--- a/src/memo/cli_dream.py
+++ b/src/memo/cli_dream.py
@@ -632,6 +632,28 @@ def dream_run(
                 receipt["errors"].append(f"hype: {type(exc).__name__}: {exc}")
                 progress.update(step, description="[hype] [yellow]warn[/yellow]")
 
+        # Verbatim — nightly lexical turn-level transcript index (Total Recall F1,
+        # never enters the recall hook) -----------------------------------------
+        if flag_bool("MEMO_VERBATIM_INDEX"):
+            progress.update(step, description="[verbatim] indexing transcript turns...")
+            try:
+                from memo import verbatim_index
+
+                receipt["verbatim"] = verbatim_index.run_verbatim_index_pass(
+                    cfg,
+                    dry_run=dry_run,
+                )
+                if receipt["verbatim"].get("status") == "error":
+                    receipt["errors"].append(f"verbatim: {receipt['verbatim'].get('error')}")
+                _vb = receipt["verbatim"]
+                progress.update(
+                    step,
+                    description=f"[verbatim] [green]✓[/green]  {_vb.get('status')}",
+                )
+            except Exception as exc:
+                receipt["errors"].append(f"verbatim: {type(exc).__name__}: {exc}")
+                progress.update(step, description="[verbatim] [yellow]warn[/yellow]")
+
         if flag_bool("MEMO_DREAM_GRADUATION_ENABLED"):
             progress.update(step, description="[graduate] quarantined captures...")
             try:

--- a/src/memo/cli_dream.py
+++ b/src/memo/cli_dream.py
@@ -63,6 +63,31 @@ from memo.memory.record import derived_save_scope
 _log = _logging.getLogger(__name__)
 
 
+def _run_verbatim_pass(
+    cfg: Config,
+    *,
+    dry_run: bool,
+    receipt: dict[str, Any],
+    progress: Any,
+    step: Any,
+) -> None:
+    """Run the optional private transcript index outside dream_run's budget."""
+    from memo import verbatim_index
+    from memo.flags import flag_bool
+
+    if not flag_bool("MEMO_VERBATIM_INDEX"):
+        return
+    progress.update(step, description="[verbatim] indexing transcript turns...")
+    receipt["verbatim"] = verbatim_index.run_verbatim_index_pass(cfg, dry_run=dry_run)
+    verbatim = receipt["verbatim"]
+    if verbatim.get("status") == "error":
+        receipt["errors"].append(f"verbatim: {verbatim.get('error')}")
+    progress.update(
+        step,
+        description=f"[verbatim] [green]✓[/green]  {verbatim.get('status')}",
+    )
+
+
 def _run_graduation_pass(
     cfg: Config, mem: Any, *, dry_run: bool, receipt: dict[str, Any]
 ) -> dict[str, Any]:
@@ -632,27 +657,13 @@ def dream_run(
                 receipt["errors"].append(f"hype: {type(exc).__name__}: {exc}")
                 progress.update(step, description="[hype] [yellow]warn[/yellow]")
 
-        # Verbatim — nightly lexical turn-level transcript index (Total Recall F1,
-        # never enters the recall hook) -----------------------------------------
-        if flag_bool("MEMO_VERBATIM_INDEX"):
-            progress.update(step, description="[verbatim] indexing transcript turns...")
-            try:
-                from memo import verbatim_index
-
-                receipt["verbatim"] = verbatim_index.run_verbatim_index_pass(
-                    cfg,
-                    dry_run=dry_run,
-                )
-                if receipt["verbatim"].get("status") == "error":
-                    receipt["errors"].append(f"verbatim: {receipt['verbatim'].get('error')}")
-                _vb = receipt["verbatim"]
-                progress.update(
-                    step,
-                    description=f"[verbatim] [green]✓[/green]  {_vb.get('status')}",
-                )
-            except Exception as exc:
-                receipt["errors"].append(f"verbatim: {type(exc).__name__}: {exc}")
-                progress.update(step, description="[verbatim] [yellow]warn[/yellow]")
+        _run_verbatim_pass(
+            cfg,
+            dry_run=dry_run,
+            receipt=receipt,
+            progress=progress,
+            step=step,
+        )
 
         if flag_bool("MEMO_DREAM_GRADUATION_ENABLED"):
             progress.update(step, description="[graduate] quarantined captures...")

--- a/src/memo/cli_verbatim.py
+++ b/src/memo/cli_verbatim.py
@@ -1,0 +1,45 @@
+"""`memo verbatim` — lexical turn-level transcript index (Total Recall F1).
+
+Only the `index` subcommand ships here (Task V3). `search`/`status` land in
+Task V4 in this same module.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from memo.cli_common import console
+from memo.config import Config
+
+
+@click.group(name="verbatim")
+def verbatim_group() -> None:
+    """Lexical (FTS5, no embeddings) turn-level index over transcript JSONL."""
+
+
+@verbatim_group.command(name="index")
+@click.option("--dry-run", is_flag=True, help="Report what would be indexed without writing.")
+@click.option("--json", "as_json", is_flag=True, help="Output raw JSON.")
+def index_cmd(dry_run: bool, as_json: bool) -> None:
+    """Incrementally index transcript turns into the verbatim FTS5 store."""
+    from memo.verbatim_index import run_verbatim_index_pass
+
+    cfg = Config.from_env()
+    result = run_verbatim_index_pass(cfg, dry_run=dry_run)
+
+    if as_json:
+        click.echo(json.dumps(result, indent=2, ensure_ascii=False))
+        return
+
+    console.print(f"[bold]verbatim index:[/bold] {result.get('status')}")
+    console.print(f"  sessions indexed: {result.get('sessions_indexed', 0)}")
+    console.print(f"  turns indexed:    {result.get('turns_indexed', 0)}")
+    console.print(f"  skipped unchanged: {result.get('skipped_unchanged', 0)}")
+    console.print(f"  pruned:           {result.get('pruned', 0)}")
+    if result.get("status") == "error":
+        console.print(f"  [red]error:[/red] {result.get('error')}")
+
+
+__all__ = ["verbatim_group"]

--- a/src/memo/cli_verbatim.py
+++ b/src/memo/cli_verbatim.py
@@ -1,16 +1,17 @@
 """`memo verbatim` — lexical turn-level transcript index (Total Recall F1).
 
-Only the `index` subcommand ships here (Task V3). `search`/`status` land in
-Task V4 in this same module.
+The index is explicit and opt-in; search is a pure FTS5 lookup and never
+constructs a `Memory` or enters automatic recall.
 """
 
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import click
 
-from memo.cli_common import console
+from memo.cli_common import console, log_cli_consult
 from memo.config import Config
 
 
@@ -40,6 +41,101 @@ def index_cmd(dry_run: bool, as_json: bool) -> None:
     console.print(f"  pruned:           {result.get('pruned', 0)}")
     if result.get("status") == "error":
         console.print(f"  [red]error:[/red] {result.get('error')}")
+
+
+@verbatim_group.command(name="search")
+@click.argument("query")
+@click.option("--session", "session_id", default=None, help="Restrict to one session id.")
+@click.option("--since", default=None, help="ISO8601 lower bound on turn timestamp.")
+@click.option("--limit", default=10, type=click.IntRange(1, 100), show_default=True)
+@click.option("--json", "as_json", is_flag=True, help="Output raw JSON.")
+@click.option(
+    "--source",
+    default=None,
+    help="Attribute this consult in `memo usefulness` (falls back to MEMO_SOURCE).",
+)
+def search_cmd(
+    query: str,
+    session_id: str | None,
+    since: str | None,
+    limit: int,
+    as_json: bool,
+    source: str | None,
+) -> None:
+    """Lexical search over explicitly indexed transcript turns."""
+    import time
+
+    from memo.store.turn_store import TurnStore
+
+    cfg = Config.from_env()
+    t0 = int(time.time() * 1000)
+    hits: list[dict[str, Any]] = []
+    if cfg.verbatim_db.is_file():
+        store = TurnStore(cfg.verbatim_db)
+        try:
+            hits = store.search(query, limit=limit, session_id=session_id, since=since)
+        finally:
+            store.close()
+    log_cli_consult(cfg, verb="verbatim_search", query=query, hits=hits, t0_ms=t0, source=source)
+
+    if as_json:
+        click.echo(json.dumps(hits, ensure_ascii=False, indent=2))
+        return
+    if not hits:
+        console.print("[dim]no results[/dim]")
+        return
+    for hit in hits:
+        console.print(
+            f"[dim][{str(hit.get('session_id') or '')[:8]}][/dim] "
+            f"turn {hit.get('turn_idx')} [bold]{hit.get('role')}[/bold] "
+            f"[dim]{hit.get('ts') or ''}[/dim]  {hit.get('snippet') or ''}"
+        )
+
+
+@verbatim_group.command(name="status")
+@click.option("--json", "as_json", is_flag=True, help="Output raw JSON.")
+def status_cmd(as_json: bool) -> None:
+    """Report private index statistics and watermark metadata."""
+    import time
+
+    from memo.store.turn_store import TurnStore
+    from memo.verbatim_index import _WATERMARK_FILE
+
+    cfg = Config.from_env()
+    stats = {"sessions": 0, "turns": 0}
+    if cfg.verbatim_db.is_file():
+        store = TurnStore(cfg.verbatim_db)
+        try:
+            stats = store.stats()
+        finally:
+            store.close()
+
+    watermark_path = cfg.state_dir / _WATERMARK_FILE
+    watermark: dict[str, Any] = {"exists": False}
+    if watermark_path.is_file():
+        metadata = watermark_path.stat()
+        watermark = {
+            "exists": True,
+            "path": str(watermark_path),
+            "size_bytes": metadata.st_size,
+            "age_seconds": max(0, int(time.time() - metadata.st_mtime)),
+        }
+    result = {**stats, "db_path": str(cfg.verbatim_db), "watermark": watermark}
+
+    if as_json:
+        click.echo(json.dumps(result, indent=2, ensure_ascii=False))
+        return
+    console.print("[bold]verbatim status:[/bold]")
+    console.print(f"  sessions: {stats['sessions']}")
+    console.print(f"  turns:    {stats['turns']}")
+    console.print(f"  db path:  {cfg.verbatim_db}")
+    if watermark.get("exists"):
+        console.print(
+            f"  watermark: {watermark['path']} "
+            f"({watermark['size_bytes']}b, {watermark['age_seconds']}s old)"
+        )
+    else:
+        console.print("  watermark: [dim](none — index never ran)[/dim]")
 
 
 __all__ = ["verbatim_group"]

--- a/src/memo/config.py
+++ b/src/memo/config.py
@@ -490,6 +490,11 @@ class Config(BaseModel):
         Rebuildable from markdown-derived extraction; collapses onto `db_path`."""
         return self.db_path if self.single_db else self.state_dir / "fact_edges.db"
 
+    @property
+    def verbatim_db(self) -> Path:
+        """Lexical turn-level FTS5 sidecar. Rebuildable from transcripts; collapses onto db_path under single_db."""
+        return self.db_path if self.single_db else self.state_dir / "verbatim.db"
+
     # ── Construction ─────────────────────────────────────────────────────
 
     @classmethod

--- a/src/memo/flags_ingest.py
+++ b/src/memo/flags_ingest.py
@@ -218,4 +218,28 @@ SPECS: tuple[FlagSpec, ...] = (
         "kNN pool size over the question index during the read-path fold.",
         min_val=5,
     ),
+    # verbatim turn-level index (Total Recall F1)
+    _spec(
+        "MEMO_VERBATIM_INDEX",
+        "bool",
+        False,
+        "ingest",
+        "Nightly lexical turn-level index over transcript JSONL (Total Recall F1). Default off.",
+    ),
+    _spec(
+        "MEMO_VERBATIM_MAX_DAYS",
+        "int",
+        90,
+        "ingest",
+        "Retention/backfill window for the verbatim turn index.",
+        min_val=1,
+    ),
+    _spec(
+        "MEMO_VERBATIM_MIN_CHARS",
+        "int",
+        20,
+        "ingest",
+        "Turns shorter than this are not indexed.",
+        min_val=0,
+    ),
 )

--- a/src/memo/server.py
+++ b/src/memo/server.py
@@ -64,6 +64,7 @@ from memo import server_session_patterns as _srv_session_patterns
 from memo import server_sync as _srv_sync
 from memo import server_synthesis as _srv_synthesis
 from memo import server_temporal as _srv_temporal
+from memo import server_verbatim as _srv_verbatim
 from memo import server_version as _srv_version
 from memo._trace import TRACE_HEADER, trace_scope
 from memo.config import Config
@@ -158,6 +159,7 @@ def build_server(memory: Memory | None = None, *, auth: Any | None = None) -> Fa
         _srv_graph.register(server, memory)
         _srv_related.register(server, memory)
         _srv_around.register(server, memory)
+        _srv_verbatim.register(server, memory)
         _srv_health.register(server, memory)
         _srv_context_pack.register(server, memory)
         _srv_contextual.register(server, memory)

--- a/src/memo/server_verbatim.py
+++ b/src/memo/server_verbatim.py
@@ -1,0 +1,54 @@
+"""MCP surface for explicit lexical transcript search."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from memo.memory import Memory
+from memo.server_annotations import READ_ONLY, annotated_tool
+from memo.server_common import log_consult, now_ms
+from memo.store.turn_store import MAX_VERBATIM_RESULTS
+
+
+def register(server: Any, memory: Memory) -> None:
+    @annotated_tool(server, **READ_ONLY)
+    def memo_verbatim_search(
+        query: str,
+        session_id: str | None = None,
+        since: str | None = None,
+        limit: int = 10,
+        source: str = "",
+    ) -> dict[str, Any]:
+        """Search explicitly indexed transcript turns with FTS5.
+
+        Read-only and excluded from automatic recall. Results are bounded to
+        100; `session_id` and ISO8601 `since` narrow the private local index.
+        """
+        from memo.store.turn_store import TurnStore
+
+        t0 = now_ms()
+        bounded_limit = max(1, min(int(limit), MAX_VERBATIM_RESULTS))
+        hits: list[dict[str, Any]] = []
+        if memory.cfg.verbatim_db.is_file():
+            store = TurnStore(memory.cfg.verbatim_db)
+            try:
+                hits = store.search(
+                    query,
+                    limit=bounded_limit,
+                    session_id=session_id,
+                    since=since,
+                )
+            finally:
+                store.close()
+        log_consult(
+            memory,
+            tool="verbatim_search",
+            query=query,
+            hits=hits,
+            t0_ms=t0,
+            source=source,
+        )
+        return {"hits": hits}
+
+
+__all__ = ["register"]

--- a/src/memo/store/turn_store.py
+++ b/src/memo/store/turn_store.py
@@ -21,6 +21,7 @@ from .connection import _ConnectionMixin
 from .schema import _BM25_ES_STOPWORDS
 
 _TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+MAX_VERBATIM_RESULTS = 100
 
 
 class TurnStore(_ConnectionMixin):
@@ -31,8 +32,20 @@ class TurnStore(_ConnectionMixin):
         self._local = threading.local()
         self._conn_holders: weakref.WeakSet[object] = weakref.WeakSet()
         self._conn_holders_lock = threading.Lock()
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.db_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self.db_path.parent.chmod(0o700)
         self._ensure_schema()
+        self._secure_storage()
+
+    def _secure_storage(self) -> None:
+        """Transcript text and SQLite sidecars are private to the current user."""
+        for path in (
+            self.db_path,
+            Path(f"{self.db_path}-wal"),
+            Path(f"{self.db_path}-shm"),
+        ):
+            if path.exists():
+                path.chmod(0o600)
 
     def _load_vec0(self, conn: sqlite3.Connection) -> None:
         # Turns are scalar rows indexed by FTS5; no vector extension needed.
@@ -122,7 +135,7 @@ class TurnStore(_ConnectionMixin):
             sql += "AND turns.ts >= ? "
             params.append(since)
         sql += "ORDER BY bm25_score ASC LIMIT ?"
-        params.append(max(1, int(limit)))
+        params.append(max(1, min(int(limit), MAX_VERBATIM_RESULTS)))
         try:
             return list(self._conn.execute(sql, params).fetchall())
         except sqlite3.OperationalError:
@@ -170,19 +183,21 @@ class TurnStore(_ConnectionMixin):
     def prune_older_than(self, days: int) -> int:
         """Delete turns whose `ts` is older than `days` ago. Returns rows removed.
 
-        Comparison is lexicographic over ISO8601 `ts` strings (same as
-        `since` in `search`). Turns with a null/missing `ts` are never
-        pruned (nothing to compare against).
+        Timestamps are canonical UTC ISO8601 strings. Legacy null or malformed
+        rows are removed conservatively so they cannot bypass retention.
         """
         from datetime import UTC, datetime, timedelta
 
-        cutoff = (datetime.now(UTC) - timedelta(days=int(days))).isoformat()
+        cutoff = (datetime.now(UTC) - timedelta(days=max(1, int(days)))).isoformat(
+            timespec="seconds"
+        )
+        stale = "ts IS NULL OR datetime(ts) IS NULL OR datetime(ts) < datetime(?)"
         with self._tx() as cx:
             rows = cx.execute(
-                "SELECT session_id, turn_idx FROM turns WHERE ts IS NOT NULL AND ts < ?",
+                f"SELECT session_id, turn_idx FROM turns WHERE {stale}",  # noqa: S608
                 (cutoff,),
             ).fetchall()
-            cur = cx.execute("DELETE FROM turns WHERE ts IS NOT NULL AND ts < ?", (cutoff,))
+            cur = cx.execute(f"DELETE FROM turns WHERE {stale}", (cutoff,))  # noqa: S608
             for row in rows:
                 cx.execute(
                     "DELETE FROM turns_fts WHERE session_id = ? AND turn_idx = ?",
@@ -205,4 +220,4 @@ class TurnStore(_ConnectionMixin):
         return {"sessions": int(sessions), "turns": int(turns)}
 
 
-__all__ = ["TurnStore"]
+__all__ = ["MAX_VERBATIM_RESULTS", "TurnStore"]

--- a/src/memo/store/turn_store.py
+++ b/src/memo/store/turn_store.py
@@ -1,0 +1,208 @@
+"""TurnStore — lexical (FTS5, no embeddings) turn-level verbatim index.
+
+Sidecar over `.claude/projects/**/*.jsonl` transcripts already on disk: "what
+did we say EXACTLY when we fixed X". Rebuildable from the transcripts; never
+enters the recall hook (CLAUDE.md — cognition verbs stay off memo's automatic
+surfaces; this is an on-demand, explicit-query-only store). Folds into
+`memvec.db` when `MEMO_SINGLE_DB` is on; otherwise lives in its own
+`verbatim.db` (see `Config.verbatim_db`).
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+import threading
+import weakref
+from pathlib import Path
+from typing import Any
+
+from .connection import _ConnectionMixin
+from .schema import _BM25_ES_STOPWORDS
+
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+class TurnStore(_ConnectionMixin):
+    """sqlite FTS5-backed store of transcript turns. No vectors — lexical only."""
+
+    def __init__(self, db_path: Path | str) -> None:
+        self.db_path = Path(db_path)
+        self._local = threading.local()
+        self._conn_holders: weakref.WeakSet[object] = weakref.WeakSet()
+        self._conn_holders_lock = threading.Lock()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._ensure_schema()
+
+    def _load_vec0(self, conn: sqlite3.Connection) -> None:
+        # Turns are scalar rows indexed by FTS5; no vector extension needed.
+        return None
+
+    def _ensure_schema(self) -> None:
+        conn = self._conn
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS turns (
+                session_id TEXT NOT NULL,
+                turn_idx INTEGER NOT NULL,
+                agent TEXT,
+                role TEXT,
+                ts TEXT,
+                text TEXT,
+                PRIMARY KEY (session_id, turn_idx)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_turns_ts ON turns(ts);
+            """
+        )
+        conn.execute(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS turns_fts USING fts5("
+            "session_id UNINDEXED, turn_idx UNINDEXED, text, "
+            "tokenize='unicode61 remove_diacritics 2'"
+            ")"
+        )
+        conn.commit()
+
+    def replace_session(self, session_id: str, agent: str, turns: list[dict[str, Any]]) -> int:
+        """Delete + insert all turns for `session_id` (transactional).
+
+        Idempotent — re-ingesting a session that grew (or was re-parsed)
+        simply swaps its rows in both `turns` and `turns_fts`.
+        """
+        with self._tx() as cx:
+            cx.execute("DELETE FROM turns WHERE session_id = ?", (session_id,))
+            cx.execute("DELETE FROM turns_fts WHERE session_id = ?", (session_id,))
+            for turn in turns:
+                idx = int(turn["idx"])
+                role = turn.get("role")
+                ts = turn.get("ts")
+                text = turn.get("text") or ""
+                cx.execute(
+                    "INSERT INTO turns (session_id, turn_idx, agent, role, ts, text) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (session_id, idx, agent, role, ts, text),
+                )
+                cx.execute(
+                    "INSERT INTO turns_fts (session_id, turn_idx, text) VALUES (?, ?, ?)",
+                    (session_id, idx, text),
+                )
+        return len(turns)
+
+    def _match_expr(self, query: str) -> list[str] | None:
+        raw_tokens = [t for t in _TOKEN_RE.findall(query) if t]
+        if not raw_tokens:
+            return None
+        filtered = [t for t in raw_tokens if t.lower() not in _BM25_ES_STOPWORDS]
+        return filtered if len(filtered) >= 2 else raw_tokens
+
+    def _run_search(
+        self,
+        tokens: list[str],
+        joiner: str,
+        *,
+        limit: int,
+        session_id: str | None,
+        since: str | None,
+    ) -> list[sqlite3.Row]:
+        expr = joiner.join(f'"{t}"' for t in tokens)
+        sql = (
+            "SELECT turns.session_id AS session_id, turns.turn_idx AS turn_idx, "
+            "turns.role AS role, turns.ts AS ts, "
+            "snippet(turns_fts, 2, '[', ']', '...', 10) AS snippet, "
+            "bm25(turns_fts) AS bm25_score "
+            "FROM turns_fts JOIN turns "
+            "ON turns.session_id = turns_fts.session_id AND turns.turn_idx = turns_fts.turn_idx "
+            "WHERE turns_fts MATCH ? "
+        )
+        params: list[Any] = [expr]
+        if session_id is not None:
+            sql += "AND turns.session_id = ? "
+            params.append(session_id)
+        if since is not None:
+            sql += "AND turns.ts >= ? "
+            params.append(since)
+        sql += "ORDER BY bm25_score ASC LIMIT ?"
+        params.append(max(1, int(limit)))
+        try:
+            return list(self._conn.execute(sql, params).fetchall())
+        except sqlite3.OperationalError:
+            return []
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        session_id: str | None = None,
+        since: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """FTS5 MATCH over indexed turns.
+
+        Tokenizes on `\\w+`, AND-joins tokens (each phrase-quoted) so a
+        multi-word query matches any turn containing all tokens (order-
+        independent), stripping Spanish stopwords when ≥2 content tokens
+        remain. Falls back to an OR-join only when the AND match returns
+        zero rows. `session_id`/`since` filter the join (`since` compares
+        ISO-formatted `ts` lexicographically). Ranked by FTS5 bm25().
+        """
+        tokens = self._match_expr(query)
+        if not tokens:
+            return []
+        rows = self._run_search(tokens, " ", limit=limit, session_id=session_id, since=since)
+        if not rows and len(tokens) >= 2:
+            rows = self._run_search(tokens, " OR ", limit=limit, session_id=session_id, since=since)
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            bm = float(row["bm25_score"])
+            score = 1.0 - 1.0 / (1.0 + abs(bm)) if bm < 0 else 0.0
+            out.append(
+                {
+                    "session_id": row["session_id"],
+                    "turn_idx": row["turn_idx"],
+                    "role": row["role"],
+                    "ts": row["ts"],
+                    "snippet": row["snippet"],
+                    "score": score,
+                }
+            )
+        return out
+
+    def prune_older_than(self, days: int) -> int:
+        """Delete turns whose `ts` is older than `days` ago. Returns rows removed.
+
+        Comparison is lexicographic over ISO8601 `ts` strings (same as
+        `since` in `search`). Turns with a null/missing `ts` are never
+        pruned (nothing to compare against).
+        """
+        from datetime import UTC, datetime, timedelta
+
+        cutoff = (datetime.now(UTC) - timedelta(days=int(days))).isoformat()
+        with self._tx() as cx:
+            rows = cx.execute(
+                "SELECT session_id, turn_idx FROM turns WHERE ts IS NOT NULL AND ts < ?",
+                (cutoff,),
+            ).fetchall()
+            cur = cx.execute("DELETE FROM turns WHERE ts IS NOT NULL AND ts < ?", (cutoff,))
+            for row in rows:
+                cx.execute(
+                    "DELETE FROM turns_fts WHERE session_id = ? AND turn_idx = ?",
+                    (row["session_id"], row["turn_idx"]),
+                )
+        return int(cur.rowcount)
+
+    def sessions_watermark(self) -> dict[str, int]:
+        """Map of `session_id -> max turn_idx` currently indexed."""
+        rows = self._conn.execute(
+            "SELECT session_id, MAX(turn_idx) AS max_idx FROM turns GROUP BY session_id"
+        ).fetchall()
+        return {row["session_id"]: int(row["max_idx"]) for row in rows}
+
+    def stats(self) -> dict[str, int]:
+        sessions = self._conn.execute(
+            "SELECT COUNT(DISTINCT session_id) AS n FROM turns"
+        ).fetchone()["n"]
+        turns = self._conn.execute("SELECT COUNT(*) AS n FROM turns").fetchone()["n"]
+        return {"sessions": int(sessions), "turns": int(turns)}
+
+
+__all__ = ["TurnStore"]

--- a/src/memo/verbatim_index.py
+++ b/src/memo/verbatim_index.py
@@ -83,6 +83,7 @@ def parse_turns(transcript_path: Path) -> list[dict[str, Any]]:
 def run_verbatim_index_pass(
     cfg: Config,
     *,
+    root: Path | None = None,
     max_days: float | None = None,
     dry_run: bool = False,
 ) -> dict[str, Any]:
@@ -108,7 +109,7 @@ def run_verbatim_index_pass(
         if effective_max_days is None:
             effective_max_days = 90
 
-        root = Path.home() / ".claude" / "projects"
+        root = root or Path.home() / ".claude" / "projects"
         files = find_transcripts(root, since_days=effective_max_days)
 
         state = _load_state(cfg.state_dir, name=_WATERMARK_FILE)

--- a/src/memo/verbatim_index.py
+++ b/src/memo/verbatim_index.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import json
 import logging
+import sqlite3
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -32,6 +34,46 @@ _log = logging.getLogger(__name__)
 _WATERMARK_FILE = "verbatim-index.json"
 
 
+def _normalize_timestamp(value: Any) -> str | None:
+    """Return a UTC ISO timestamp so every indexed row remains pruneable."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC).isoformat(timespec="seconds")
+
+
+def _parse_turn_line(line: str, *, min_chars: int) -> dict[str, Any] | None:
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    role = obj.get("type") or obj.get("role")
+    if role not in ("user", "assistant"):
+        return None
+    timestamp = _normalize_timestamp(obj.get("timestamp"))
+    if timestamp is None:
+        return None
+    message = obj.get("message", obj)
+    content = message.get("content") if isinstance(message, dict) else None
+    text = _extract_text(content)
+    if not text:
+        return None
+    text = redact_secrets(text).text
+    if len(text) < min_chars:
+        return None
+    return {"role": role, "ts": timestamp, "text": text}
+
+
 def parse_turns(transcript_path: Path) -> list[dict[str, Any]]:
     """Parse a JSONL transcript into timestamped, redacted turns.
 
@@ -46,7 +88,7 @@ def parse_turns(transcript_path: Path) -> list[dict[str, Any]]:
         return []
     try:
         lines = transcript_path.read_text(encoding="utf-8").splitlines()
-    except Exception as exc:
+    except (OSError, UnicodeError) as exc:
         _log.debug("verbatim: transcript read failed (%s): %s", transcript_path, exc)
         return []
 
@@ -55,28 +97,11 @@ def parse_turns(transcript_path: Path) -> list[dict[str, Any]]:
         min_chars = 20
 
     turns: list[dict[str, Any]] = []
-    idx = 0
     for line in lines:
-        line = line.strip()
-        if not line:
+        turn = _parse_turn_line(line, min_chars=min_chars)
+        if turn is None:
             continue
-        try:
-            obj = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        role = obj.get("type") or obj.get("role")
-        if role not in ("user", "assistant"):
-            continue
-        msg = obj.get("message", obj)
-        content = msg.get("content") if isinstance(msg, dict) else None
-        text = _extract_text(content)
-        if not text:
-            continue
-        text = redact_secrets(text).text
-        if len(text) < min_chars:
-            continue
-        turns.append({"idx": idx, "role": role, "ts": obj.get("timestamp"), "text": text})
-        idx += 1
+        turns.append({"idx": len(turns), **turn})
     return turns
 
 
@@ -108,12 +133,13 @@ def run_verbatim_index_pass(
         )
         if effective_max_days is None:
             effective_max_days = 90
+        effective_max_days = max(1, int(effective_max_days))
 
         root = root or Path.home() / ".claude" / "projects"
         files = find_transcripts(root, since_days=effective_max_days)
 
         state = _load_state(cfg.state_dir, name=_WATERMARK_FILE)
-        store = TurnStore(cfg.verbatim_db)
+        store = None if dry_run else TurnStore(cfg.verbatim_db)
         try:
             for f in files:
                 key = str(f)
@@ -133,20 +159,23 @@ def run_verbatim_index_pass(
 
                 turns = parse_turns(f)
                 if not dry_run:
+                    assert store is not None
                     n = store.replace_session(session_id=f.stem, agent="claude-code", turns=turns)
                     result["sessions_indexed"] += 1
                     result["turns_indexed"] += n
                     state[key] = {"lines_processed": line_count, "mtime": mtime}
                     _save_state(cfg.state_dir, state, name=_WATERMARK_FILE)
+                    (cfg.state_dir / _WATERMARK_FILE).chmod(0o600)
                 else:
                     result["sessions_indexed"] += 1
                     result["turns_indexed"] += len(turns)
 
-            if not dry_run:
-                result["pruned"] = store.prune_older_than(int(effective_max_days))
+            if store is not None:
+                result["pruned"] = store.prune_older_than(effective_max_days)
         finally:
-            store.close()
-    except Exception as exc:
+            if store is not None:
+                store.close()
+    except (OSError, RuntimeError, sqlite3.Error, TypeError, ValueError) as exc:
         _log.warning("verbatim index pass failed: %s", exc)
         result["status"] = "error"
         result["error"] = f"{type(exc).__name__}: {exc}"

--- a/src/memo/verbatim_index.py
+++ b/src/memo/verbatim_index.py
@@ -1,0 +1,155 @@
+"""Incremental turn-level indexer for the verbatim (lexical) index.
+
+Parses `~/.claude/projects/**/*.jsonl` transcripts into timestamped turns and
+feeds them into `TurnStore` (FTS5, no embeddings). Watermarked so a nightly
+pass only re-ingests sessions that grew since the last run — the watermark
+format mirrors `transcript_miner.py`'s `mine-history.json`
+(`{path: {lines_processed, mtime}}`).
+
+Never enters the recall hook (CLAUDE.md); this is the on-demand `memo
+verbatim` surface's ingestion side. `run_verbatim_index_pass` never raises —
+callers (the nightly `memo dream run`) always get a status dict back.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from memo.capture_core import _extract_text
+from memo.flags import flag_int
+from memo.redact import redact_secrets
+from memo.store.turn_store import TurnStore
+from memo.transcript_miner import _load_state, _save_state, find_transcripts
+
+if TYPE_CHECKING:
+    from memo.config import Config
+
+_log = logging.getLogger(__name__)
+
+_WATERMARK_FILE = "verbatim-index.json"
+
+
+def parse_turns(transcript_path: Path) -> list[dict[str, Any]]:
+    """Parse a JSONL transcript into timestamped, redacted turns.
+
+    Variant of `capture_core._parse_transcript` that PRESERVES the JSONL
+    `timestamp` field `_parse_transcript` discards. Text is the same
+    tool-evidence-capped projection (`_extract_text`), then redacted
+    (`redact_secrets`). Turns shorter than `MEMO_VERBATIM_MIN_CHARS` (default
+    20) are skipped. Returns `[{idx, role, ts, text}]`, `idx` a running index
+    over the surviving turns.
+    """
+    if not transcript_path.is_file():
+        return []
+    try:
+        lines = transcript_path.read_text(encoding="utf-8").splitlines()
+    except Exception as exc:
+        _log.debug("verbatim: transcript read failed (%s): %s", transcript_path, exc)
+        return []
+
+    min_chars = flag_int("MEMO_VERBATIM_MIN_CHARS")
+    if min_chars is None:
+        min_chars = 20
+
+    turns: list[dict[str, Any]] = []
+    idx = 0
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        role = obj.get("type") or obj.get("role")
+        if role not in ("user", "assistant"):
+            continue
+        msg = obj.get("message", obj)
+        content = msg.get("content") if isinstance(msg, dict) else None
+        text = _extract_text(content)
+        if not text:
+            continue
+        text = redact_secrets(text).text
+        if len(text) < min_chars:
+            continue
+        turns.append({"idx": idx, "role": role, "ts": obj.get("timestamp"), "text": text})
+        idx += 1
+    return turns
+
+
+def run_verbatim_index_pass(
+    cfg: Config,
+    *,
+    max_days: float | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Incrementally index transcript turns into `TurnStore`. Never raises.
+
+    Walks `~/.claude/projects/**/*.jsonl` (via `find_transcripts`), skipping
+    any file whose line count/mtime match the watermark from the last run.
+    Changed files are re-parsed and their session fully replaced
+    (`TurnStore.replace_session`, idempotent). Ends with a
+    `prune_older_than(max_days or MEMO_VERBATIM_MAX_DAYS)` sweep.
+    """
+    result: dict[str, Any] = {
+        "status": "ok",
+        "sessions_indexed": 0,
+        "turns_indexed": 0,
+        "pruned": 0,
+        "skipped_unchanged": 0,
+    }
+    try:
+        effective_max_days = (
+            max_days if max_days is not None else flag_int("MEMO_VERBATIM_MAX_DAYS")
+        )
+        if effective_max_days is None:
+            effective_max_days = 90
+
+        root = Path.home() / ".claude" / "projects"
+        files = find_transcripts(root, since_days=effective_max_days)
+
+        state = _load_state(cfg.state_dir, name=_WATERMARK_FILE)
+        store = TurnStore(cfg.verbatim_db)
+        try:
+            for f in files:
+                key = str(f)
+                prev = state.get(key, {})
+                prev_count = prev.get("lines_processed", 0)
+                prev_mtime = prev.get("mtime")
+                try:
+                    text = f.read_text(encoding="utf-8")
+                    line_count = text.count("\n") + 1 if text else 0
+                    mtime = f.stat().st_mtime
+                except (OSError, UnicodeDecodeError):
+                    continue
+
+                if line_count <= prev_count and mtime == prev_mtime:
+                    result["skipped_unchanged"] += 1
+                    continue
+
+                turns = parse_turns(f)
+                if not dry_run:
+                    n = store.replace_session(session_id=f.stem, agent="claude-code", turns=turns)
+                    result["sessions_indexed"] += 1
+                    result["turns_indexed"] += n
+                    state[key] = {"lines_processed": line_count, "mtime": mtime}
+                    _save_state(cfg.state_dir, state, name=_WATERMARK_FILE)
+                else:
+                    result["sessions_indexed"] += 1
+                    result["turns_indexed"] += len(turns)
+
+            if not dry_run:
+                result["pruned"] = store.prune_older_than(int(effective_max_days))
+        finally:
+            store.close()
+    except Exception as exc:
+        _log.warning("verbatim index pass failed: %s", exc)
+        result["status"] = "error"
+        result["error"] = f"{type(exc).__name__}: {exc}"
+    return result
+
+
+__all__ = ["parse_turns", "run_verbatim_index_pass"]

--- a/tests/test_cli_mcp_surface_smoke.py
+++ b/tests/test_cli_mcp_surface_smoke.py
@@ -105,7 +105,7 @@ def test_mcp_full_profile_registers_every_decorated_server_tool(
     registered = _mcp_tool_names(tmp_path, monkeypatch, "full")
 
     assert expected <= registered
-    assert len(registered) == 130
+    assert len(registered) == 131
 
 
 @pytest.mark.parametrize(
@@ -113,7 +113,7 @@ def test_mcp_full_profile_registers_every_decorated_server_tool(
     [
         ("agent", 14),
         ("core", 34),
-        ("full", 130),
+        ("full", 131),
     ],
 )
 def test_mcp_profile_tool_counts(

--- a/tests/test_cli_verbatim.py
+++ b/tests/test_cli_verbatim.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+
+def _env(tmp_path: Path) -> dict[str, str]:
+    return {
+        "MEMO_CONFIG_FILE": str(tmp_path / "missing.toml"),
+        "MEMO_DATA_DIR": str(tmp_path / "data"),
+        "MEMO_STATE_DIR": str(tmp_path / "state"),
+        "MEMO_VAULT_PATH": str(tmp_path / "vault"),
+    }
+
+
+def test_verbatim_search_and_status_json(tmp_path: Path):
+    from memo.cli import cli
+    from memo.config import Config
+    from memo.store.turn_store import TurnStore
+
+    env = _env(tmp_path)
+    cfg = Config(data_dir=Path(env["MEMO_DATA_DIR"]), state_dir=Path(env["MEMO_STATE_DIR"]))
+    store = TurnStore(cfg.verbatim_db)
+    try:
+        store.replace_session(
+            "session-1",
+            "claude-code",
+            [
+                {
+                    "idx": 0,
+                    "role": "user",
+                    "ts": "2026-07-13T10:00:00+00:00",
+                    "text": "the exact deployment decision lived here",
+                }
+            ],
+        )
+    finally:
+        store.close()
+
+    runner = CliRunner()
+    search = runner.invoke(cli, ["verbatim", "search", "deployment", "--json"], env=env)
+    assert search.exit_code == 0, search.output
+    hits = json.loads(search.output)
+    assert hits[0]["session_id"] == "session-1"
+
+    status = runner.invoke(cli, ["verbatim", "status", "--json"], env=env)
+    assert status.exit_code == 0, status.output
+    report = json.loads(status.output)
+    assert report["sessions"] == 1
+    assert report["turns"] == 1
+
+
+def test_verbatim_search_rejects_unbounded_cli_limit(tmp_path: Path):
+    from memo.cli import cli
+
+    result = CliRunner().invoke(
+        cli,
+        ["verbatim", "search", "deployment", "--limit", "10000", "--json"],
+        env=_env(tmp_path),
+    )
+
+    assert result.exit_code != 0
+    assert "100" in result.output

--- a/tests/test_server_verbatim.py
+++ b/tests/test_server_verbatim.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _make_server_and_tools():
+    server, tools = MagicMock(), {}
+
+    def tool_decorator():
+        def wrapper(fn):
+            tools[fn.__name__] = fn
+            return fn
+
+        return wrapper
+
+    server.tool = tool_decorator
+    return server, tools
+
+
+def test_register_exposes_bounded_verbatim_search(tmp_cfg):
+    from memo.memory import Memory
+    from memo.server_verbatim import register
+
+    memory = MagicMock(spec=Memory)
+    memory.cfg = tmp_cfg
+    tmp_cfg.state_dir.mkdir(parents=True, exist_ok=True)
+    tmp_cfg.verbatim_db.touch()
+    server, tools = _make_server_and_tools()
+    register(server, memory)
+
+    fake_store = MagicMock()
+    fake_store.search.return_value = []
+    with (
+        patch("memo.store.turn_store.TurnStore", return_value=fake_store),
+        patch("memo.server_verbatim.log_consult") as log_consult,
+    ):
+        result = tools["memo_verbatim_search"](query="exact decision", limit=10_000, source="codex")
+
+    assert result == {"hits": []}
+    fake_store.search.assert_called_once_with(
+        "exact decision", limit=100, session_id=None, since=None
+    )
+    fake_store.close.assert_called_once_with()
+    log_consult.assert_called_once()
+    assert log_consult.call_args.kwargs["source"] == "codex"
+
+
+def test_build_server_wires_verbatim_registration():
+    import memo.server as srv
+
+    source = Path(srv.__file__).read_text(encoding="utf-8")
+    assert re.search(r"^from memo import server_verbatim as _srv_verbatim$", source, re.M)
+    assert "_srv_verbatim.register(server, memory)" in source

--- a/tests/test_turn_store.py
+++ b/tests/test_turn_store.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from memo.config import Config
+from memo.store.turn_store import TurnStore
 
 
 def test_verbatim_flags_registered_defaults():
@@ -39,3 +42,150 @@ def test_verbatim_db_from_env(monkeypatch, tmp_path: Path):
     cfg = Config.from_env()
     assert cfg.single_db is True
     assert cfg.verbatim_db == cfg.db_path
+
+
+# ── TurnStore (Task V2) ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def store(tmp_path: Path):
+    ts = TurnStore(tmp_path / "verbatim.db")
+    yield ts
+    ts.close()
+
+
+def test_replace_session_returns_count(store: TurnStore):
+    turns = [
+        {"idx": 0, "role": "user", "ts": "2026-07-01T10:00:00", "text": "hola"},
+        {"idx": 1, "role": "assistant", "ts": "2026-07-01T10:00:05", "text": "que tal"},
+    ]
+    n = store.replace_session("sess-1", "claude-code", turns)
+    assert n == 2
+    assert store.stats() == {"sessions": 1, "turns": 2}
+
+
+def test_replace_session_idempotent_swaps_rows(store: TurnStore):
+    """Re-replacing a session swaps its rows; count stays stable, no dupes/orphans."""
+    first = [
+        {"idx": 0, "role": "user", "ts": "2026-07-01T10:00:00", "text": "primero"},
+        {"idx": 1, "role": "assistant", "ts": "2026-07-01T10:00:05", "text": "segundo"},
+    ]
+    store.replace_session("sess-1", "claude-code", first)
+
+    grown = [
+        {"idx": 0, "role": "user", "ts": "2026-07-01T10:00:00", "text": "primero editado"},
+        {"idx": 1, "role": "assistant", "ts": "2026-07-01T10:00:05", "text": "segundo"},
+        {"idx": 2, "role": "user", "ts": "2026-07-01T10:00:10", "text": "tercero nuevo"},
+    ]
+    n = store.replace_session("sess-1", "claude-code", grown)
+
+    assert n == 3
+    assert store.stats() == {"sessions": 1, "turns": 3}
+    assert store.sessions_watermark() == {"sess-1": 2}
+    # search must reflect the new content, not the stale first-pass row.
+    hits = store.search("editado")
+    assert len(hits) == 1
+    assert hits[0]["turn_idx"] == 0
+
+
+def test_search_and_multitoken_diacritics_fold(store: TurnStore):
+    """AND multi-token match, and 'decision' (no accent) matches 'decisión'."""
+    turns = [
+        {
+            "idx": 0,
+            "role": "assistant",
+            "ts": "2026-07-01T10:00:00",
+            "text": "la decisión que tomamos fue clara",
+        },
+        {"idx": 1, "role": "user", "ts": "2026-07-01T10:00:05", "text": "otro turno sin relación"},
+    ]
+    store.replace_session("sess-1", "claude-code", turns)
+
+    hits = store.search("decision")
+    assert len(hits) == 1
+    assert hits[0]["turn_idx"] == 0
+
+    hits_multi = store.search("decision tomamos")
+    assert len(hits_multi) == 1
+    assert hits_multi[0]["turn_idx"] == 0
+
+
+def test_search_or_fallback_on_zero_and_results(store: TurnStore):
+    """Two turns each with one distinct token → AND finds nothing, OR fallback returns both."""
+    turns = [
+        {"idx": 0, "role": "user", "ts": "2026-07-01T10:00:00", "text": "queso banana"},
+        {"idx": 1, "role": "assistant", "ts": "2026-07-01T10:00:05", "text": "manzana durazno"},
+    ]
+    store.replace_session("sess-1", "claude-code", turns)
+
+    hits = store.search("queso durazno")
+    assert {h["turn_idx"] for h in hits} == {0, 1}
+
+
+def test_search_session_id_filter(store: TurnStore):
+    store.replace_session(
+        "sess-a",
+        "claude-code",
+        [{"idx": 0, "role": "user", "ts": "2026-07-01T10:00:00", "text": "palabra clave"}],
+    )
+    store.replace_session(
+        "sess-b",
+        "claude-code",
+        [{"idx": 0, "role": "user", "ts": "2026-07-01T10:00:00", "text": "palabra clave"}],
+    )
+
+    hits = store.search("palabra clave", session_id="sess-a")
+    assert len(hits) == 1
+    assert hits[0]["session_id"] == "sess-a"
+
+
+def test_search_since_filter(store: TurnStore):
+    turns = [
+        {"idx": 0, "role": "user", "ts": "2026-01-01T00:00:00", "text": "palabra vieja"},
+        {"idx": 1, "role": "user", "ts": "2026-07-10T00:00:00", "text": "palabra nueva"},
+    ]
+    store.replace_session("sess-1", "claude-code", turns)
+
+    hits = store.search("palabra", since="2026-06-01T00:00:00")
+    assert len(hits) == 1
+    assert hits[0]["turn_idx"] == 1
+
+
+def test_prune_older_than_removes_old_rows_from_both_tables(store: TurnStore):
+    from datetime import UTC, datetime, timedelta
+
+    old_ts = (datetime.now(UTC) - timedelta(days=200)).isoformat()
+    recent_ts = datetime.now(UTC).isoformat()
+    turns = [
+        {"idx": 0, "role": "user", "ts": old_ts, "text": "contenido antiguo unico"},
+        {"idx": 1, "role": "user", "ts": recent_ts, "text": "contenido reciente unico"},
+    ]
+    store.replace_session("sess-1", "claude-code", turns)
+
+    removed = store.prune_older_than(90)
+    assert removed == 1
+    assert store.stats() == {"sessions": 1, "turns": 1}
+    # FTS side-table must be pruned too — search for the old text finds nothing.
+    assert store.search("antiguo") == []
+    assert len(store.search("reciente")) == 1
+
+
+def test_sessions_watermark(store: TurnStore):
+    store.replace_session(
+        "sess-a",
+        "claude-code",
+        [
+            {"idx": 0, "role": "user", "ts": "2026-07-01T10:00:00", "text": "a"},
+            {"idx": 3, "role": "user", "ts": "2026-07-01T10:00:05", "text": "b"},
+        ],
+    )
+    store.replace_session(
+        "sess-b",
+        "claude-code",
+        [{"idx": 1, "role": "user", "ts": "2026-07-01T10:00:00", "text": "c"}],
+    )
+    assert store.sessions_watermark() == {"sess-a": 3, "sess-b": 1}
+
+
+def test_stats_empty_store(store: TurnStore):
+    assert store.stats() == {"sessions": 0, "turns": 0}

--- a/tests/test_turn_store.py
+++ b/tests/test_turn_store.py
@@ -1,6 +1,8 @@
 """Tests for the verbatim turn-level FTS5 index (flags + TurnStore config property)."""
+
 from __future__ import annotations
 
+import stat
 from pathlib import Path
 
 import pytest
@@ -159,14 +161,16 @@ def test_prune_older_than_removes_old_rows_from_both_tables(store: TurnStore):
     turns = [
         {"idx": 0, "role": "user", "ts": old_ts, "text": "contenido antiguo unico"},
         {"idx": 1, "role": "user", "ts": recent_ts, "text": "contenido reciente unico"},
+        {"idx": 2, "role": "user", "ts": None, "text": "contenido sin fecha legado"},
     ]
     store.replace_session("sess-1", "claude-code", turns)
 
     removed = store.prune_older_than(90)
-    assert removed == 1
+    assert removed == 2
     assert store.stats() == {"sessions": 1, "turns": 1}
     # FTS side-table must be pruned too — search for the old text finds nothing.
     assert store.search("antiguo") == []
+    assert store.search("legado") == []
     assert len(store.search("reciente")) == 1
 
 
@@ -189,3 +193,39 @@ def test_sessions_watermark(store: TurnStore):
 
 def test_stats_empty_store(store: TurnStore):
     assert store.stats() == {"sessions": 0, "turns": 0}
+
+
+def test_store_enforces_private_directory_and_database_modes(tmp_path: Path):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(mode=0o777)
+    state_dir.chmod(0o777)
+
+    private_store = TurnStore(state_dir / "verbatim.db")
+    try:
+        assert stat.S_IMODE(state_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(private_store.db_path.stat().st_mode) == 0o600
+        for suffix in ("-wal", "-shm"):
+            sidecar = Path(f"{private_store.db_path}{suffix}")
+            if sidecar.exists():
+                assert stat.S_IMODE(sidecar.stat().st_mode) == 0o600
+    finally:
+        private_store.close()
+
+
+def test_search_result_limit_is_bounded(store: TurnStore):
+    store.replace_session(
+        "many-turns",
+        "claude-code",
+        [
+            {
+                "idx": idx,
+                "role": "assistant",
+                "ts": "2026-07-01T10:00:00+00:00",
+                "text": f"bounded common result number {idx}",
+            }
+            for idx in range(125)
+        ],
+    )
+
+    assert len(store.search("common", limit=10_000)) == 100
+    assert len(store.search("common", limit=0)) == 1

--- a/tests/test_turn_store.py
+++ b/tests/test_turn_store.py
@@ -1,0 +1,41 @@
+"""Tests for the verbatim turn-level FTS5 index (flags + TurnStore config property)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from memo.config import Config
+
+
+def test_verbatim_flags_registered_defaults():
+    """All three verbatim flags are registered with correct defaults."""
+    from memo.flags import REGISTRY
+
+    assert REGISTRY["MEMO_VERBATIM_INDEX"].default is False
+    assert REGISTRY["MEMO_VERBATIM_MAX_DAYS"].default == 90
+    assert REGISTRY["MEMO_VERBATIM_MIN_CHARS"].default == 20
+
+
+def test_verbatim_db_separate_when_single_db_off(tmp_path: Path):
+    """When single_db is False (default), verbatim_db is a separate file in state_dir."""
+    cfg = Config(data_dir=tmp_path / "d", state_dir=tmp_path / "s")
+    assert cfg.single_db is False
+    assert cfg.verbatim_db == cfg.state_dir / "verbatim.db"
+    assert cfg.verbatim_db != cfg.db_path
+
+
+def test_verbatim_db_collapses_with_single_db_true(tmp_path: Path):
+    """When single_db is True, verbatim_db collapses onto db_path."""
+    cfg = Config(data_dir=tmp_path / "d", state_dir=tmp_path / "s", single_db=True)
+    assert cfg.single_db is True
+    assert cfg.verbatim_db == cfg.db_path
+
+
+def test_verbatim_db_from_env(monkeypatch, tmp_path: Path):
+    """MEMO_SINGLE_DB env var controls verbatim_db collapse."""
+    monkeypatch.setenv("MEMO_CONFIG_FILE", str(tmp_path / "none.toml"))
+    monkeypatch.setenv("MEMO_DATA_DIR", str(tmp_path / "d"))
+    monkeypatch.setenv("MEMO_STATE_DIR", str(tmp_path / "s"))
+    monkeypatch.setenv("MEMO_SINGLE_DB", "1")
+    cfg = Config.from_env()
+    assert cfg.single_db is True
+    assert cfg.verbatim_db == cfg.db_path

--- a/tests/test_verbatim_index.py
+++ b/tests/test_verbatim_index.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import stat
 from pathlib import Path
 
 import pytest
@@ -52,7 +53,7 @@ def test_parse_turns_preserves_timestamp(tmp_path: Path):
     )
     turns = parse_turns(f)
     assert len(turns) == 2
-    assert turns[0]["ts"] == "2026-07-13T10:00:00.000Z"
+    assert turns[0]["ts"] == "2026-07-13T10:00:00+00:00"
     assert turns[0]["role"] == "user"
     assert turns[0]["idx"] == 0
     assert turns[1]["idx"] == 1
@@ -97,6 +98,24 @@ def test_parse_turns_redacts_secrets(tmp_path: Path):
 
 def test_parse_turns_missing_file_returns_empty(tmp_path: Path):
     assert parse_turns(tmp_path / "nope.jsonl") == []
+
+
+def test_parse_turns_skips_missing_or_invalid_timestamps(tmp_path: Path):
+    f = tmp_path / "sess.jsonl"
+    _write_transcript(
+        f,
+        [
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"content": _long("missing timestamp should not persist")},
+                }
+            ),
+            _line("assistant", _long("invalid timestamp should not persist"), "not-a-date"),
+        ],
+    )
+
+    assert parse_turns(f) == []
 
 
 # ── run_verbatim_index_pass ──────────────────────────────────────────────
@@ -200,11 +219,37 @@ def test_dry_run_writes_nothing(cfg: Config, tmp_path: Path):
     assert result["sessions_indexed"] == 1
     assert result["turns_indexed"] == 1
 
-    assert not cfg.verbatim_db.exists() or TurnStore(cfg.verbatim_db).stats() == {
-        "sessions": 0,
-        "turns": 0,
-    }
+    assert not cfg.verbatim_db.exists()
     assert not (cfg.state_dir / "verbatim-index.json").exists()
+
+
+def test_pass_clamps_retention_to_at_least_one_day(cfg: Config, tmp_path: Path, monkeypatch):
+    observed: dict[str, float] = {}
+
+    def _find(root: Path, *, since_days: float):
+        observed["since_days"] = since_days
+        return []
+
+    monkeypatch.setattr("memo.verbatim_index.find_transcripts", _find)
+    result = run_verbatim_index_pass(cfg, root=tmp_path, max_days=-30, dry_run=True)
+
+    assert result["status"] == "ok"
+    assert observed["since_days"] == 1
+
+
+def test_index_files_are_private(cfg: Config, claude_projects_root: Path):
+    f = claude_projects_root / "sess-private.jsonl"
+    _write_transcript(
+        f,
+        [_line("user", _long("private indexed transcript turn"), "2026-07-13T10:00:00Z")],
+    )
+
+    result = run_verbatim_index_pass(cfg)
+    assert result["status"] == "ok"
+    assert stat.S_IMODE(cfg.state_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE(cfg.verbatim_db.stat().st_mode) == 0o600
+    watermark = cfg.state_dir / "verbatim-index.json"
+    assert stat.S_IMODE(watermark.stat().st_mode) == 0o600
 
 
 def test_never_raises_on_store_failure(cfg: Config, claude_projects_root: Path, monkeypatch):

--- a/tests/test_verbatim_index.py
+++ b/tests/test_verbatim_index.py
@@ -186,13 +186,16 @@ def test_grown_file_reingests_whole_session(cfg: Config, claude_projects_root: P
         store.close()
 
 
-def test_dry_run_writes_nothing(cfg: Config, claude_projects_root: Path):
-    f = claude_projects_root / "sess-1.jsonl"
+def test_dry_run_writes_nothing(cfg: Config, tmp_path: Path):
+    """Test dry run using injectable root param directly (no monkeypatch needed)."""
+    root = tmp_path / "projects"
+    root.mkdir(parents=True, exist_ok=True)
+    f = root / "sess-1.jsonl"
     _write_transcript(
         f,
         [_line("user", _long("hello there, a long enough turn"), "2026-07-13T10:00:00.000Z")],
     )
-    result = run_verbatim_index_pass(cfg, dry_run=True)
+    result = run_verbatim_index_pass(cfg, root=root, dry_run=True)
     assert result["status"] == "ok"
     assert result["sessions_indexed"] == 1
     assert result["turns_indexed"] == 1

--- a/tests/test_verbatim_index.py
+++ b/tests/test_verbatim_index.py
@@ -1,0 +1,271 @@
+"""Tests for the verbatim turn-level indexer (parser + incremental pass, Task V3)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memo.config import Config
+from memo.store.turn_store import TurnStore
+from memo.verbatim_index import parse_turns, run_verbatim_index_pass
+
+_FAKE_AWS_KEY = "AKIA" + "IOSFODNN7EXAMPLE"
+
+
+def _line(role: str, text: str, ts: str) -> str:
+    return json.dumps(
+        {
+            "type": role,
+            "message": {"role": role, "content": text},
+            "timestamp": ts,
+        }
+    )
+
+
+def _write_transcript(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ── parse_turns ──────────────────────────────────────────────────────────
+
+
+def test_parse_turns_preserves_timestamp(tmp_path: Path):
+    f = tmp_path / "sess.jsonl"
+    _write_transcript(
+        f,
+        [
+            _line(
+                "user",
+                "this is a long enough user turn to survive the min-chars filter",
+                "2026-07-13T10:00:00.000Z",
+            ),
+            _line(
+                "assistant",
+                "this is a long enough assistant reply to survive the min-chars filter",
+                "2026-07-13T10:00:05.000Z",
+            ),
+        ],
+    )
+    turns = parse_turns(f)
+    assert len(turns) == 2
+    assert turns[0]["ts"] == "2026-07-13T10:00:00.000Z"
+    assert turns[0]["role"] == "user"
+    assert turns[0]["idx"] == 0
+    assert turns[1]["idx"] == 1
+
+
+def test_parse_turns_skips_short_turns(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("MEMO_VERBATIM_MIN_CHARS", "20")
+    f = tmp_path / "sess.jsonl"
+    _write_transcript(
+        f,
+        [
+            _line("user", "short", "2026-07-13T10:00:00.000Z"),
+            _line(
+                "assistant",
+                "this reply is long enough to clear the minimum characters filter",
+                "2026-07-13T10:00:05.000Z",
+            ),
+        ],
+    )
+    turns = parse_turns(f)
+    assert len(turns) == 1
+    assert turns[0]["role"] == "assistant"
+
+
+def test_parse_turns_redacts_secrets(tmp_path: Path):
+    f = tmp_path / "sess.jsonl"
+    _write_transcript(
+        f,
+        [
+            _line(
+                "user",
+                f"here is my key {_FAKE_AWS_KEY} please do not leak it anywhere ever",
+                "2026-07-13T10:00:00.000Z",
+            ),
+        ],
+    )
+    turns = parse_turns(f)
+    assert len(turns) == 1
+    assert _FAKE_AWS_KEY not in turns[0]["text"]
+    assert "****" in turns[0]["text"]
+
+
+def test_parse_turns_missing_file_returns_empty(tmp_path: Path):
+    assert parse_turns(tmp_path / "nope.jsonl") == []
+
+
+# ── run_verbatim_index_pass ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def cfg(tmp_path: Path, monkeypatch) -> Config:
+    monkeypatch.setenv("MEMO_CONFIG_FILE", str(tmp_path / "none.toml"))
+    return Config(data_dir=tmp_path / "data", state_dir=tmp_path / "state")
+
+
+@pytest.fixture
+def claude_projects_root(tmp_path: Path, monkeypatch) -> Path:
+    """`run_verbatim_index_pass` walks `Path.home() / ".claude" / "projects"`."""
+    root = tmp_path / ".claude" / "projects"
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _long(text: str) -> str:
+    """Pad text past the default MEMO_VERBATIM_MIN_CHARS (20)."""
+    return text + " " * max(0, 25 - len(text))
+
+
+def test_pass_ingests_turns(cfg: Config, claude_projects_root: Path):
+    f = claude_projects_root / "sess-1.jsonl"
+    _write_transcript(
+        f,
+        [
+            _line("user", _long("hello there, a long enough turn"), "2026-07-13T10:00:00.000Z"),
+            _line("assistant", _long("hi back, also long enough"), "2026-07-13T10:00:05.000Z"),
+        ],
+    )
+    result = run_verbatim_index_pass(cfg)
+    assert result["status"] == "ok"
+    assert result["sessions_indexed"] == 1
+    assert result["turns_indexed"] == 2
+    assert result["skipped_unchanged"] == 0
+
+    store = TurnStore(cfg.verbatim_db)
+    try:
+        assert store.stats() == {"sessions": 1, "turns": 2}
+    finally:
+        store.close()
+
+
+def test_second_run_skips_unchanged(cfg: Config, claude_projects_root: Path):
+    f = claude_projects_root / "sess-1.jsonl"
+    _write_transcript(
+        f,
+        [_line("user", _long("hello there, a long enough turn"), "2026-07-13T10:00:00.000Z")],
+    )
+    first = run_verbatim_index_pass(cfg)
+    assert first["sessions_indexed"] == 1
+
+    second = run_verbatim_index_pass(cfg)
+    assert second["sessions_indexed"] == 0
+    assert second["skipped_unchanged"] == 1
+
+
+def test_grown_file_reingests_whole_session(cfg: Config, claude_projects_root: Path):
+    f = claude_projects_root / "sess-1.jsonl"
+    _write_transcript(
+        f,
+        [_line("user", _long("hello there, a long enough turn"), "2026-07-13T10:00:00.000Z")],
+    )
+    run_verbatim_index_pass(cfg)
+
+    _write_transcript(
+        f,
+        [
+            _line("user", _long("hello there, a long enough turn"), "2026-07-13T10:00:00.000Z"),
+            _line(
+                "assistant", _long("a brand new second turn appended"), "2026-07-13T10:00:05.000Z"
+            ),
+        ],
+    )
+    result = run_verbatim_index_pass(cfg)
+    assert result["sessions_indexed"] == 1
+    assert result["turns_indexed"] == 2
+
+    store = TurnStore(cfg.verbatim_db)
+    try:
+        assert store.stats() == {"sessions": 1, "turns": 2}
+    finally:
+        store.close()
+
+
+def test_dry_run_writes_nothing(cfg: Config, claude_projects_root: Path):
+    f = claude_projects_root / "sess-1.jsonl"
+    _write_transcript(
+        f,
+        [_line("user", _long("hello there, a long enough turn"), "2026-07-13T10:00:00.000Z")],
+    )
+    result = run_verbatim_index_pass(cfg, dry_run=True)
+    assert result["status"] == "ok"
+    assert result["sessions_indexed"] == 1
+    assert result["turns_indexed"] == 1
+
+    assert not cfg.verbatim_db.exists() or TurnStore(cfg.verbatim_db).stats() == {
+        "sessions": 0,
+        "turns": 0,
+    }
+    assert not (cfg.state_dir / "verbatim-index.json").exists()
+
+
+def test_never_raises_on_store_failure(cfg: Config, claude_projects_root: Path, monkeypatch):
+    f = claude_projects_root / "sess-1.jsonl"
+    _write_transcript(
+        f,
+        [_line("user", _long("hello there, a long enough turn"), "2026-07-13T10:00:00.000Z")],
+    )
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("store exploded")
+
+    monkeypatch.setattr("memo.verbatim_index.TurnStore", _boom)
+    result = run_verbatim_index_pass(cfg)
+    assert result["status"] == "error"
+    assert "error" in result
+    assert "store exploded" in result["error"]
+
+
+# ── CLI: memo verbatim index ─────────────────────────────────────────────
+
+
+def _cli_env(tmp_path: Path) -> dict[str, str]:
+    return {
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_DATA_DIR": str(tmp_path / "data"),
+        "MEMO_STATE_DIR": str(tmp_path / "state"),
+        "MEMO_VAULT_PATH": str(tmp_path / "vault"),
+        "MEMO_EMBEDDER_VIA_DAEMON": "0",
+        "MEMO_SKIP_MODEL_VERSION_CHECK": "1",
+    }
+
+
+def test_cli_verbatim_index_json(tmp_path: Path, monkeypatch):
+    fake_result = {
+        "status": "ok",
+        "sessions_indexed": 2,
+        "turns_indexed": 5,
+        "pruned": 0,
+        "skipped_unchanged": 1,
+    }
+    # cli_verbatim.index_cmd imports run_verbatim_index_pass lazily from
+    # memo.verbatim_index — patch it at the source module.
+    import memo.verbatim_index as verbatim_index_module
+
+    monkeypatch.setattr(
+        verbatim_index_module, "run_verbatim_index_pass", lambda cfg, **kw: fake_result
+    )
+
+    from memo.cli import cli
+
+    res = CliRunner().invoke(cli, ["verbatim", "index", "--json"], env=_cli_env(tmp_path))
+    assert res.exit_code == 0, res.output
+    data = json.loads(res.output)
+    assert data == fake_result
+
+
+def test_cli_verbatim_index_help(tmp_path: Path):
+    from memo.cli import cli
+
+    res = CliRunner().invoke(cli, ["verbatim", "--help"])
+    assert res.exit_code == 0
+    assert "verbatim" in res.output.lower()
+
+    res2 = CliRunner().invoke(cli, ["verbatim", "index", "--help"])
+    assert res2.exit_code == 0
+    assert "index" in res2.output.lower()


### PR DESCRIPTION
## Summary
- integrate the existing Total Recall F1 work as a lexical, embedding-free transcript index with CLI, nightly opt-in, and advanced MCP search
- keep the feature default-off and outside Markdown, ambient recall, and git sync
- enforce 90-day retention, reject unpruneable timestamps, make dry-run non-writing, cap searches at 100 results, and restrict state/index files to 0700/0600
- document the duplicate-data privacy boundary and explicit removal path

## Verification
- 4252 passed, 29 skipped
- 358 CLI/MCP surface and architecture tests passed
- focused verbatim store/index/CLI/MCP tests passed
- Ruff, format, mypy, quality gate, and diff checks passed
- pre-push recall gate PASS