### PR TITLE
ci: enforce contract and dependency security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-runtime:
+        dependency-type: "production"
+      python-development:
+        dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+

--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -1,0 +1,42 @@
+name: dependency security
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "17 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  python-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Set up Python 3.13
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: "3.13"
+      - name: Install pinned uv
+        run: pip install uv==0.11.21
+      - name: Export the committed runtime lock
+        run: |
+          uv export --frozen --no-dev --all-extras --no-extra dev --no-extra contracts \
+            --no-emit-project --output-file /tmp/memo-requirements.txt
+      - name: Audit known Python vulnerabilities
+        run: |
+          uv tool run --from pip-audit==2.10.1 \
+            pip-audit --strict --disable-pip --require-hashes \
+              --requirement /tmp/memo-requirements.txt
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Reject vulnerable dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,25 @@ jobs:
         # tests. --cov + fail_under (pyproject) gates coverage regressions.
         run: .venv/bin/python -m pytest -m "not slow" -n auto --timeout=120 --cov=memo --cov-report=term-missing
 
-  test-with-contracts:
+  contract-stub-compatibility:
+    # Public, always-on interface gate. The stub only models the contract API
+    # memo consumes and forces every optional integration import down its live
+    # branch without exposing the private implementation repository.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Set up Python 3.13
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: "3.13"
+      - name: Install uv
+        run: pip install uv==0.11.21
+      - name: Install package + dev dependencies
+        run: uv sync --frozen --extra dev --python 3.13
+      - name: Exercise public contract interface
+        run: .venv/bin/python -m pytest tests/test_contract_stub_compatibility.py
+
+  private-contract-integration:
     # The default `test` job mirrors a CLEAN install: consciousness_contracts is
     # absent, so every contract import takes its fallback branch and the
     # INTEGRATION path (cache / uri / ledger / run_json / EmbedderProfile) is
@@ -53,10 +71,10 @@ jobs:
     # runtime that *does* have the contract but wires it wrong.
     #
     # consciousness-contracts is a PRIVATE sibling repo, so a public-repo CI
-    # can't read it with the default GITHUB_TOKEN. This job is therefore a
-    # green no-op until a `CONTRACTS_TOKEN` secret (a fine-grained PAT with read
-    # access to jagoff/consciousness-contracts) is set; then it installs the
-    # contract and runs the suite WITH the integration path live.
+    # can't read it with the default GITHUB_TOKEN. This job is therefore an
+    # optional private integration until a `CONTRACTS_TOKEN` secret (a
+    # fine-grained PAT with read access to jagoff/consciousness-contracts) is
+    # set; the public contract-stub-compatibility gate above always runs.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -72,7 +90,7 @@ jobs:
           CONTRACTS_TOKEN: ${{ secrets.CONTRACTS_TOKEN }}
         run: |
           if [ -z "$CONTRACTS_TOKEN" ]; then
-            echo "::notice::CONTRACTS_TOKEN not set — skipping the with-contracts run."
+            echo "::notice::CONTRACTS_TOKEN not set — skipping optional private integration."
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ exact flags and boundaries.
 
 memo is built to **spend fewer tokens, not more**.
 
-- **~90% smaller MCP surface.** The default `agent` profile exposes **14 tools / ~1.4k schema tokens**, versus **129 tools / ~15k tokens** for the full surface — that overhead is paid *every session, in every client*. memo trims it to almost nothing.
+- **~90% smaller MCP surface.** The default `agent` profile exposes **14 tools / ~1.4k schema tokens**, versus **131 tools / ~15k tokens** for the full surface — that overhead is paid *every session, in every client*. memo trims it to almost nothing.
 - **Recall injects the answer instead of re-deriving it.** Ambient recall surfaces the top memory *before* the agent answers, on a tight **~160-token budget**. The agent stops re-explaining what it already figured out last week.
 
 On a ~200-memory corpus, `memo roi` estimates **~80k tokens of model work avoided** per session. The number is corpus-specific; it grows as memo learns more.
@@ -112,7 +112,7 @@ On a ~200-memory corpus, `memo roi` estimates **~80k tokens of model work avoide
 - **Time-machine / audit.** "What did we know about this bug last month?" Rewind the corpus to any date and see the state of knowledge at that point.
 - **Instant project onboarding.** A cold agent gets the project's durable decisions, facts, and preferences up front via the session-start briefing.
 - **Exact transcript lookup (opt-in).** `memo verbatim search` can find the precise wording of past local transcript turns through a private, lexical-only FTS5 index. It never enters ambient recall.
-- **Fewer tokens, not more.** Instead of re-deriving what you solved last week, recall injects the answer on a tight budget — and the default MCP surface is 14 tools, not 129.
+- **Fewer tokens, not more.** Instead of re-deriving what you solved last week, recall injects the answer on a tight budget — and the default MCP surface is 14 tools, not 131.
 
 ## Requirements
 
@@ -369,20 +369,20 @@ memo runs four background daemons:
 | ingest-daemon | `memo ingest-daemon start` | Bulk vault ingestion |
 | maint-daemon | `memo maint-daemon start` | Background cleanup + synthesis |
 
-### All 112 visible CLI commands
+### All 125 top-level CLI commands
 
 <details>
 <summary>Click to expand</summary>
 
 **Core:** `save` `search` `ask` `get` `edit` `rename` `delete` `list`
 
-**Recall & Hooks:** `recall` `recall-hook` `context` `briefing` `continuity` `prewarm` `capture-tick` `capture-stop`
+**Recall & Hooks:** `recall` `recall-hook` `context` `briefing` `continuity` `prewarm` `capture-tick` `capture-stop` `interject` `ask-gaps` `guard`
 
-**Session & History:** `history` `as-of` `diff` `record-history` `session` `resume` `reflect` `mine-history` `episodes`
+**Session & History:** `history` `as-of` `diff` `record-history` `session` `resume` `reflect` `mine-history` `episodes` `chronicle`
 
 **Maintenance:** `reindex` `maintain` `dream` `consolidate` `synthesize` `dedupe` `cross-dedup` `retier` `contradict` `invalidate` `temporal` `compress-context`
 
-**Analysis & Quality:** `health` `stats` `doctor` `lint` `analytics` `eval` `roi` `tokens` `token-savings` `usefulness` `gaps` `outcome` `profile`
+**Analysis & Quality:** `health` `stats` `doctor` `lint` `analytics` `eval` `roi` `tokens` `token-savings` `usefulness` `gaps` `outcome` `profile` `confidence` `graduation` `hype`
 
 **Knowledge Graph:** `graph` `entities` `entity` `extract-entities` `links` `version` `related`
 
@@ -392,11 +392,11 @@ memo runs four background daemons:
 
 **Visualization:** `tui` `dashboard` `map` `logs` `hook-log`
 
-**Setup & Config:** `init` `config` `install-mcp` `install-watcher` `uninstall-watcher` `install-slash` `install-statusline` `install-recall-hook` `install-shell-wrapper` `install-shims` `startup-banner` `migrate` `migrate-vault` `update` `watch` `release`
+**Setup & Config:** `init` `config` `install-mcp` `install-watcher` `uninstall-watcher` `install-slash` `install-statusline` `install-recall-hook` `install-shell-wrapper` `install-shims` `startup-banner` `migrate` `migrate-vault` `update` `upgrade` `self-update` `watch` `release` `onboard`
 
 **Daemons:** `recall-daemon` `ingest-daemon` `maint-daemon` `embed-daemon` `idle-daemon`
 
-**Other:** `backend-native` `collaborative` `feedback` `query` `mandate` `sleep-cycle` `ocr-image` `provenance` `secret` `mcp-command` `codex-badge` `debug-recall` `http-api` `mine-git` `token-gate`
+**Other:** `backend-native` `collaborative` `feedback` `query` `mandate` `sleep-cycle` `ocr-image` `provenance` `secret` `verbatim` `mcp-command` `codex-badge` `debug-recall` `http-api` `mine-git` `token-gate` `fix` `undo`
 
 </details>
 
@@ -406,7 +406,7 @@ memo runs four background daemons:
 |---|---|---|---|
 | `agent` (default) | 14 | ~1.4k | Standard agent work — max token economy |
 | `core` / `slim` | 34 | ~3.0k | Constrained clients (Codex, OpenCode), admin-lite |
-| `full` / `default` | 129 | ~15k | Power users, debugging |
+| `full` / `default` | 131 | ~15k | Power users, debugging |
 
 Set via `MEMO_MCP_PROFILE=full` or in each client's MCP env config.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,14 @@ Markdown on disk plus local sqlite files. Concretely:
   and optional local Unix sockets for the recall/embedder daemons. `memo http-api`
   and HTTP MCP transport are opt-in localhost surfaces, not hosted services.
 - **No telemetry.** memo emits no usage data.
-- **No credentials.** memo does not request, store, or transmit API keys.
+- **Credentials are isolated and opt-in.** Secret storage is disabled unless
+  `MEMO_SECRET_STORAGE_ENABLED=1`. When enabled, values are AES-256-GCM sealed
+  under a random private master key and excluded from Markdown, indexing,
+  recall, generated context, backup, and git sync. Explicit `secret get` and
+  `secret export` commands disclose plaintext to the invoking user.
+- **Network APIs authenticate by default.** Every `/api/*` route requires
+  `Authorization: Bearer <token>`; non-loopback REST and MCP HTTP binds require
+  an explicit acknowledgement and cannot disable authentication.
 
 Reasonable threats memo aims to mitigate:
 
@@ -46,5 +53,5 @@ Out of scope:
 
 ## Supported versions
 
-Only the latest minor release (currently the `2.12.x` line) receives security
+Only the latest minor release (currently the `3.5.x` line) receives security
 fixes. Older releases will not be backported.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -182,7 +182,7 @@ Tools surface inside the agent as `mcp__memo__memo_*`. Agent installs default to
 a 14-tool surface (`ask`, `context`, `get`, `graph`, `offload`, `rename`, `save`,
 `search`, `unified_briefing`, `version`, and session/capture notification
 helpers) so administrative schemas don't consume model context — set
-`MEMO_MCP_PROFILE=core`/`slim` (34 tools) or `full`/`default` (129 tools) only
+`MEMO_MCP_PROFILE=core`/`slim` (34 tools) or `full`/`default` (131 tools) only
 for clients that genuinely need the larger administrative surface.
 
 ### Claude Code
@@ -320,7 +320,7 @@ The live MCP server is profile-gated by `MEMO_MCP_PROFILE`:
 |---|---:|---|
 | `agent` (default) | 14 | Minimal always-on agent surface; optimized for schema-token cost. |
 | `core` / `slim` | 34 | CRUD, search, embeddings, history, sessions, lint, and lightweight graph/offload. |
-| `full` / `default` | 129 | Every advanced domain module and compatibility tool. |
+| `full` / `default` | 131 | Every advanced domain module and compatibility tool. |
 
 The default `agent` profile exposes exactly:
 

--- a/src/memo/__init__.py
+++ b/src/memo/__init__.py
@@ -10,7 +10,7 @@
 - Storage of record: markdown files under `MEMO_DATA_DIR`, or under
   `<vault>/<SYSTEM_DIR>/AI/memory/` when `MEMO_MEMORIES_IN_VAULT=1`.
 - MCP server: `fastmcp`, profile-gated from the 14-tool `agent`
-  surface through the 129-tool `full` surface.
+  surface through the 131-tool `full` surface.
 
 Public API:
 

--- a/src/memo/cli_install_mcp.py
+++ b/src/memo/cli_install_mcp.py
@@ -279,7 +279,7 @@ def _report(result: dict[str, Any]) -> None:
     default="",
     type=click.Choice(["", "core", "slim", "default"], case_sensitive=False),
     help="MCP surface profile. 'core'/'slim' expose 34 tools (~3.0k tokens); "
-    "'default' exposes all 129 tools (~15k tokens). "
+    "'default' exposes all 131 tools (~15k tokens). "
     "Constrained clients (codex, opencode) default to 'core' automatically.",
 )
 def install_mcp(

--- a/src/memo/server.py
+++ b/src/memo/server.py
@@ -144,7 +144,7 @@ def build_server(memory: Memory | None = None, *, auth: Any | None = None) -> Fa
     # Stable and advanced domain tool modules register their @server.tool()
     # closures here. Presence on the MCP surface does not by itself mean a
     # feature is part of memo's stable core contract; see experimental_index.md.
-    # Skip when MEMO_MCP_SLIM=1 — reduces 129 tools to the 34-tool core surface
+    # Skip when MEMO_MCP_SLIM=1 — reduces 131 tools to the 34-tool core surface
     # for local/constrained LLMs where tool-definition tokens are expensive.
     from memo.surface import mcp_include_advanced_tools
 

--- a/src/memo/store/store.py
+++ b/src/memo/store/store.py
@@ -48,10 +48,9 @@ import contextlib
 import logging
 import sqlite3
 import threading
-import weakref
 from pathlib import Path
 
-from .connection import _ConnectionMixin
+from .connection import _ConnectionHolder, _ConnectionMixin
 from .feedback_store import _FeedbackMixin
 from .migrations import _MigrationsMixin
 from .queries import _QueriesMixin
@@ -106,7 +105,12 @@ class VecStore(
         # The CLI and recall daemon are single-threaded / lock-serialised,
         # so they simply reuse their one thread-local connection.
         self._local = threading.local()
-        self._conn_holders: weakref.WeakSet[object] = weakref.WeakSet()
+        # Strong references are intentional: CPython does not guarantee the
+        # order in which a terminating thread clears its ``threading.local``
+        # values and finalizes sqlite connections.  Retain every holder so
+        # ``close()`` is the single deterministic lifecycle boundary on all
+        # supported platforms.
+        self._conn_holders: set[_ConnectionHolder] = set()
         self._conn_holders_lock = threading.Lock()
         try:
             self._connect()

--- a/src/memo/surface.py
+++ b/src/memo/surface.py
@@ -150,5 +150,5 @@ def mcp_profile_token_cost(profile: str | None = None) -> tuple[str, str, bool]:
     (or the active profile when ``None``). ``is_reduced`` is False only for the
     full/default surface — the costly one doctor warns about."""
     resolved = profile if profile is not None else mcp_profile()
-    count, cost = _PROFILE_TOKEN_COST.get(resolved, ("129", "~15k"))
+    count, cost = _PROFILE_TOKEN_COST.get(resolved, ("131", "~15k"))
     return count, cost, resolved in _PROFILE_TOKEN_COST

--- a/tests/contract_stub/consciousness_contracts/__init__.py
+++ b/tests/contract_stub/consciousness_contracts/__init__.py
@@ -1,0 +1,178 @@
+"""Public test double for the optional consciousness-contracts interface.
+
+This package is deliberately outside ``src`` and is only placed on PYTHONPATH
+by the compatibility test.  It keeps memo's public integration branches
+testable without granting public CI access to the private implementation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+TRACE_HEADER = "x-synapse-trace-id"
+PROVENANCE_KEYS: frozenset[str] = frozenset(
+    {
+        "synapse_trace_id",
+        "synapse_route_reason",
+        "synapse_write_policy_schema",
+        "synapse_write_target",
+        "synapse_agent_id",
+        "synapse_agent_signature",
+    }
+)
+SUPPORTED_AGENTS: tuple[str, ...] = ("claude-code", "codex")
+
+_TRACE: ContextVar[str] = ContextVar("contract_stub_trace", default="")
+
+
+def current_trace() -> str:
+    return _TRACE.get()
+
+
+@contextmanager
+def trace_scope(trace_id: str) -> Iterator[str]:
+    normalized = (trace_id or "").strip()
+    token = _TRACE.set(normalized)
+    try:
+        yield normalized
+    finally:
+        _TRACE.reset(token)
+
+
+class BackendError(RuntimeError):
+    """Contract subprocess failure."""
+
+
+def run_json(
+    binary: str,
+    args: Sequence[str],
+    *,
+    timeout: float,
+    env: dict[str, str],
+    backend_name: str,
+    trace_id: str,
+) -> Any:
+    try:
+        result = subprocess.run(
+            [binary, *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise BackendError(f"{backend_name}: {trace_id}: {exc}") from exc
+    if result.returncode != 0:
+        raise BackendError(f"{backend_name}: exit {result.returncode}")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise BackendError(f"{backend_name}: invalid JSON") from exc
+
+
+@dataclass(frozen=True)
+class EmbedderProfile:
+    model_id: str
+    dims: int
+    normalization: str = "l2"
+    max_seq_len: int | None = None
+    quantization: str | None = None
+    provider: str = "memo"
+    schema: str = field(default="consciousness.embedder_profile.v1", init=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> EmbedderProfile:
+        fields = {key: val for key, val in value.items() if key != "schema"}
+        return cls(**fields)
+
+    def fingerprint(self) -> str:
+        payload = json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    def is_compatible_with(self, other: EmbedderProfile) -> bool:
+        return (
+            self.model_id == other.model_id
+            and self.dims == other.dims
+            and self.normalization == other.normalization
+        )
+
+
+@dataclass(frozen=True)
+class AgentMcpServer:
+    name: str
+    command: str
+    env: dict[str, str]
+
+
+@dataclass(frozen=True)
+class _GenericPreset:
+    config_path: str
+    json_key: str = "mcpServers"
+
+
+def generic_preset(*, config_path: str, json_key: str = "mcpServers") -> _GenericPreset:
+    return _GenericPreset(config_path=config_path, json_key=json_key)
+
+
+def register_agent_mcp(
+    agent: str,
+    server: AgentMcpServer,
+    *,
+    write: bool,
+    preset: _GenericPreset | None = None,
+) -> dict[str, Any]:
+    return {"agent": agent, "server": server.name, "write": write, "preset": preset}
+
+
+class _DictModel:
+    schema = ""
+
+    def __init__(self, **values: Any) -> None:
+        for key, value in values.items():
+            setattr(self, key, value)
+
+    def to_dict(self) -> dict[str, Any]:
+        result = dict(vars(self))
+        if self.schema:
+            result = {"schema": self.schema, **result}
+        return result
+
+
+class EvidenceRef(_DictModel):
+    schema = "consciousness.evidence_ref.v1"
+
+
+class WriteReceipt(_DictModel):
+    schema = "consciousness.write_receipt.v1"
+
+
+class Anomaly(_DictModel):
+    schema = "consciousness.anomaly.v1"
+
+
+class ConsciousnessEvent(_DictModel):
+    schema = "consciousness.event.v1"
+
+
+class LedgerWriter:
+    def __init__(self, *, on_error: Any | None = None) -> None:
+        self.on_error = on_error
+
+    def emit(self, event: ConsciousnessEvent) -> bool:
+        return bool(event.to_dict().get("event_id"))
+
+
+def generate_anomaly_id(kind: str, subject: str) -> str:
+    digest = hashlib.sha256(f"{kind}:{subject}".encode()).hexdigest()[:24]
+    return f"anomaly-{digest}"

--- a/tests/contract_stub/consciousness_contracts/cache.py
+++ b/tests/contract_stub/consciousness_contracts/cache.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class ContentHashCache:
+    def __init__(self) -> None:
+        self._items: dict[str, Any] = {}
+
+    def get(self, key: str) -> Any | None:
+        return self._items.get(key)
+
+    def put(self, key: str, value: Any) -> None:
+        self._items[key] = value
+
+
+_DEFAULT_CACHE = ContentHashCache()
+
+
+def get_default_cache() -> ContentHashCache:
+    return _DEFAULT_CACHE

--- a/tests/contract_stub/consciousness_contracts/uri.py
+++ b/tests/contract_stub/consciousness_contracts/uri.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import hashlib
+import platform
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+
+@dataclass(frozen=True)
+class MemoUri:
+    resource_type: str
+    resource_id: str | None
+    subpath: str | None
+
+
+def is_memo_uri(uri: str) -> bool:
+    return uri.startswith("memo://")
+
+
+def parse_uri(uri: str) -> MemoUri | None:
+    parsed = urlparse(uri)
+    if parsed.scheme != "memo" or not parsed.netloc:
+        return None
+    parts = [part for part in parsed.path.split("/") if part]
+    return MemoUri(
+        resource_type=parsed.netloc,
+        resource_id=parts[0] if parts else None,
+        subpath="/".join(parts[1:]) if len(parts) > 1 else None,
+    )
+
+
+def device_id() -> str:
+    return hashlib.sha256(platform.node().encode()).hexdigest()[:16]

--- a/tests/test_contract_stub_compatibility.py
+++ b/tests/test_contract_stub_compatibility.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+STUB_ROOT = ROOT / "tests" / "contract_stub"
+
+
+def test_public_contract_stub_exercises_every_memo_integration_branch() -> None:
+    script = r"""
+from consciousness_contracts import (
+    AgentMcpServer,
+    Anomaly,
+    BackendError,
+    ConsciousnessEvent,
+    EmbedderProfile,
+    EvidenceRef,
+    LedgerWriter,
+    PROVENANCE_KEYS,
+    TRACE_HEADER,
+    WriteReceipt,
+    current_trace,
+    generate_anomaly_id,
+    run_json,
+    trace_scope,
+)
+from consciousness_contracts.cache import get_default_cache
+from consciousness_contracts.uri import device_id, is_memo_uri, parse_uri
+
+assert TRACE_HEADER == "x-synapse-trace-id"
+with trace_scope("trace-public-contract"):
+    assert current_trace() == "trace-public-contract"
+
+profile = EmbedderProfile(model_id="stub-model", dims=8, provider="memo")
+assert EmbedderProfile.from_dict(profile.to_dict()).is_compatible_with(profile)
+assert profile.fingerprint()
+assert PROVENANCE_KEYS
+assert AgentMcpServer(name="memo", command="memo-mcp", env={}).name == "memo"
+assert issubclass(BackendError, RuntimeError)
+assert callable(run_json)
+
+cache = get_default_cache()
+cache.put("key", [1.0])
+assert cache.get("key") == [1.0]
+assert is_memo_uri("memo://memoria/abc")
+assert parse_uri("memo://memoria/abc").resource_id == "abc"
+assert device_id()
+
+event = ConsciousnessEvent(
+    event_id="evt-1",
+    ts="2026-07-14T00:00:00+00:00",
+    source="memo",
+    op="save",
+    subject_uri="memo://memoria/abc",
+)
+assert event.to_dict()["schema"] == "consciousness.event.v1"
+assert LedgerWriter().emit(event)
+assert EvidenceRef(source="memo", uri="memo://memoria/abc").to_dict()["uri"].endswith("abc")
+assert WriteReceipt(backend="memo", receipt_id="abc").to_dict()["receipt_id"] == "abc"
+anomaly_id = generate_anomaly_id("semantic_contradiction", "memo:a:b")
+assert anomaly_id
+assert Anomaly(
+    anomaly_id=anomaly_id,
+    kind="semantic_contradiction",
+    state="detected",
+    summary="stub",
+    detected_at="2026-07-14T00:00:00+00:00",
+    source_backend="memo",
+).to_dict()["anomaly_id"] == anomaly_id
+
+import memo._trace as trace_integration
+import memo.consciousness_ledger as ledger_integration
+import memo.contradict as anomaly_integration
+import memo.embedder as cache_integration
+import memo.memory.record as provenance_integration
+import memo.memory.replay_ops as uri_integration
+import memo.synapse_backend as backend_integration
+import memo.synapse_client as subprocess_integration
+
+assert trace_integration.HAS_TRACE_CONTEXT
+assert ledger_integration._CONTRACTS_AVAILABLE
+assert anomaly_integration._HAS_CONFLICT_CONTRACTS
+assert cache_integration._HAS_SHARED_CACHE
+assert provenance_integration._PROVENANCE_KEYS == PROVENANCE_KEYS
+assert uri_integration._HAS_URI_HELPERS
+assert backend_integration._CONTRACTS_AVAILABLE
+assert subprocess_integration._HAS_CONTRACTS_SUBPROCESS
+"""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join((str(STUB_ROOT), str(ROOT / "src")))
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_sqlite_cleanup.py
+++ b/tests/test_sqlite_cleanup.py
@@ -74,7 +74,11 @@ def test_vec_store_closes_worker_thread_connections(tmp_path: Path) -> None:
             thread.start()
         for thread in threads:
             thread.join()
+        # The store must retain every worker connection until explicit close;
+        # relying on thread-local finalizers is platform dependent.
+        assert len(store._conn_holders) == 5  # main thread + four workers
+        store.close()
         gc.collect()
 
-    store.close()
+    assert len(store._conn_holders) == 0
     assert not any(issubclass(w.category, ResourceWarning) for w in captured)

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import yaml
+
+from memo.cli import cli
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def test_dependabot_covers_every_shipped_dependency_surface() -> None:
+    config = yaml.safe_load((ROOT / ".github" / "dependabot.yml").read_text(encoding="utf-8"))
+
+    assert config["version"] == 2
+    updates = config["updates"]
+    assert {entry["package-ecosystem"] for entry in updates} == {
+        "docker",
+        "github-actions",
+        "uv",
+    }
+    assert all(entry["directory"] == "/" for entry in updates)
+    assert all(entry["schedule"]["interval"] == "weekly" for entry in updates)
+
+
+def test_dependency_security_workflow_is_frozen_and_enforcing() -> None:
+    workflow = (WORKFLOWS / "dependency-security.yml").read_text(encoding="utf-8")
+
+    assert "uv export --frozen" in workflow
+    assert "pip-audit==2.10.1" in workflow
+    assert "pip-audit --strict" in workflow
+    assert "actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294" in workflow
+    assert "pull_request:" in workflow
+    assert "schedule:" in workflow
+
+
+def test_contract_ci_has_public_gate_and_clearly_optional_private_integration() -> None:
+    workflow = (WORKFLOWS / "test.yml").read_text(encoding="utf-8")
+
+    assert "contract-stub-compatibility:" in workflow
+    assert "tests/test_contract_stub_compatibility.py" in workflow
+    assert "private-contract-integration:" in workflow
+    assert "CONTRACTS_TOKEN" in workflow
+    assert "optional private integration" in workflow.lower()
+
+
+def test_security_policy_matches_current_release_and_opt_in_surfaces() -> None:
+    policy = (ROOT / "SECURITY.md").read_text(encoding="utf-8")
+    version = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"][
+        "version"
+    ]
+    release_line = ".".join(version.split(".")[:2]) + ".x"
+
+    assert release_line in policy
+    assert "2.12.x" not in policy
+    assert "No credentials" not in policy
+    assert "MEMO_SECRET_STORAGE_ENABLED=1" in policy
+    assert "Authorization: Bearer" in policy
+
+
+def test_readme_surface_counts_and_top_level_command_inventory_are_exact() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    heading = f"### All {len(cli.commands)} top-level CLI commands"
+    start = readme.index(heading)
+    block = readme[start : readme.index("</details>", start)]
+    documented = set(re.findall(r"`([a-z][a-z0-9-]*)`", block))
+
+    assert documented == set(cli.commands)
+    assert "| `full` / `default` | 131 |" in readme
+    assert "versus **131 tools / ~15k tokens**" in readme
+    assert "default MCP surface is 14 tools, not 131" in readme

--- a/tests/test_surface_profiles.py
+++ b/tests/test_surface_profiles.py
@@ -177,7 +177,7 @@ def test_token_cost_full_is_not_reduced() -> None:
 
     for profile in ("full", "default"):
         count, cost, reduced = mcp_profile_token_cost(profile)
-        assert count == "129"
+        assert count == "131"
         assert cost == "~15k"
         assert reduced is False
 


### PR DESCRIPTION
## Summary
- add an always-on public contract-stub compatibility gate while retaining the authenticated private integration as explicitly optional
- add weekly Dependabot coverage for uv, GitHub Actions, and Docker plus frozen pip-audit and pull-request dependency review
- align SECURITY.md and public CLI/MCP surface documentation with release 3.5.1

## Verification
- 4251 passed, 29 skipped (`pytest -m "not slow" -n auto --timeout=120`)
- ruff format/check
- mypy: 388 source files
- quality gate: 159 complexity / 151 exception budgets
- `uv lock --check`
- pip-audit 2.10.1: no known vulnerabilities