### PR TITLE
feat(hype): support raw question embeddings

### DIFF
--- a/src/memo/cli_dream.py
+++ b/src/memo/cli_dream.py
@@ -1465,6 +1465,9 @@ def dream_chronicle_cmd(day: str | None, dry_run: bool, as_json: bool) -> None:
 @click.option("--json", "as_json", is_flag=True, help="Emit the pass receipt as JSON.")
 def dream_hype_cmd(dry_run: bool, reembed: bool, as_json: bool) -> None:
     """Nightly HyPE pass — generate + index hypothetical questions per memory (see MEMO_DREAM_HYPE_ENABLED)."""
+    if dry_run and reembed:
+        raise click.UsageError("--dry-run cannot be combined with --reembed")
+
     from memo import dream_hype
     from memo.flags import flag_int
 

--- a/src/memo/cli_dream.py
+++ b/src/memo/cli_dream.py
@@ -1454,14 +1454,32 @@ def dream_chronicle_cmd(day: str | None, dry_run: bool, as_json: bool) -> None:
 
 @dream_cmd.command(name="hype")
 @click.option("--dry-run", is_flag=True, help="Compute the backlog, generate nothing.")
+@click.option(
+    "--reembed",
+    is_flag=True,
+    help=(
+        "Re-embed stored HyPE questions into the currently active variant "
+        "(see MEMO_HYPE_EMBED_RAW) instead of running the generation pass."
+    ),
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit the pass receipt as JSON.")
-def dream_hype_cmd(dry_run: bool, as_json: bool) -> None:
+def dream_hype_cmd(dry_run: bool, reembed: bool, as_json: bool) -> None:
     """Nightly HyPE pass — generate + index hypothetical questions per memory (see MEMO_DREAM_HYPE_ENABLED)."""
     from memo import dream_hype
     from memo.flags import flag_int
 
     cfg = Config.from_env()
     mem = _get_memory(cfg)
+    if reembed:
+        res = dream_hype.run_hype_reembed(cfg, mem)
+        if as_json:
+            click.echo(json.dumps(res, indent=2, ensure_ascii=False))
+            return
+        console.print(f"[bold]hype reembed:[/bold] {res.get('status')}")
+        console.print(
+            f"  reembedded: {res.get('reembedded', 0)} · skipped: {res.get('skipped', 0)}"
+        )
+        return
     res = dream_hype.run_hype_pass(
         cfg,
         mem,

--- a/src/memo/cli_hype.py
+++ b/src/memo/cli_hype.py
@@ -22,7 +22,7 @@ def hype_group() -> None:
 @click.option("--json", "as_json", is_flag=True, help="Output raw JSON.")
 def status_cmd(as_json: bool) -> None:
     """Show HyPE index coverage: memories indexed, questions, backlog."""
-    from memo.dream_hype import select_backlog
+    from memo.dream_hype import _active_variant, select_backlog
 
     cfg = Config.from_env()
     mem = _get_memory(cfg)
@@ -48,6 +48,8 @@ def status_cmd(as_json: bool) -> None:
         result = {
             "indexed_memories": stats["memories"],
             "questions": stats["questions"],
+            "variants": stats.get("by_variant", {}),
+            "active_variant": _active_variant(),
             "durable_total": durable_total,
             "coverage_pct": coverage_pct,
             "backlog": len(backlog),
@@ -60,6 +62,11 @@ def status_cmd(as_json: bool) -> None:
                 f"Indexed:  {stats['memories']}/{durable_total} memories ({coverage_pct:.1f}%)"
             )
             click.echo(f"Questions: {stats['questions']}")
+            variants = ", ".join(
+                f"{variant}={count}"
+                for variant, count in sorted(stats.get("by_variant", {}).items())
+            )
+            click.echo(f"Variants:  {variants or 'none'} (active={_active_variant()})")
             click.echo(f"Backlog:  {len(backlog)} pending")
     finally:
         store.close()

--- a/src/memo/dream_hype.py
+++ b/src/memo/dream_hype.py
@@ -14,6 +14,7 @@ Building this index costs nothing for anyone who hasn't flipped the fold on.
 from __future__ import annotations
 
 import json as _json
+import sqlite3
 from typing import TYPE_CHECKING, Any
 
 from .tiers import DURABLE_TYPES
@@ -31,6 +32,15 @@ _SYS = (
 
 _MIN_QUESTION_LEN = 12
 _MAX_QUESTION_LEN = 200
+_REEMBED_ERRORS = (
+    sqlite3.Error,
+    OSError,
+    RuntimeError,
+    ValueError,
+    TypeError,
+    KeyError,
+    IndexError,
+)
 
 
 def _active_variant() -> str:
@@ -262,12 +272,12 @@ def run_hype_reembed(cfg: Any, mem: Any) -> dict[str, Any]:
                 pairs = [(r["question"], _embed_question(mem, r["question"])) for r in rows]
                 store.replace_for_memory(memory_id, body_hash, model, pairs, variant=variant)
                 res["reembedded"] += 1
-            except Exception:  # one memory must never abort the reembed pass
+            except _REEMBED_ERRORS:  # one memory must never abort the reembed pass
                 res["skipped"] += 1
                 continue
 
         res["status"] = "done"
-    except Exception as exc:  # surfaced via receipt["errors"], never silent
+    except _REEMBED_ERRORS as exc:  # surfaced to the CLI, never silent
         res["status"] = "error"
         res["error"] = f"{type(exc).__name__}: {exc}"
     finally:

--- a/src/memo/dream_hype.py
+++ b/src/memo/dream_hype.py
@@ -33,6 +33,33 @@ _MIN_QUESTION_LEN = 12
 _MAX_QUESTION_LEN = 200
 
 
+def _active_variant() -> str:
+    """Which embedding scale new/reembedded HyPE questions should use.
+
+    'raw' (document-side, no query prefix) when MEMO_HYPE_EMBED_RAW is on,
+    else 'query' (the historical default: `embed_query`, prefixed).
+    """
+    from .flags import flag_bool
+
+    return "raw" if flag_bool("MEMO_HYPE_EMBED_RAW") else "query"
+
+
+def _embed_question(mem: Any, question: str) -> list[float]:
+    """Embed one HyPE question in the currently active variant.
+
+    Query-side (default): `embed_query(question)` — asymmetric retrieval
+    prefix, matches how live search queries are embedded.
+    Raw/document-side (`MEMO_HYPE_EMBED_RAW=1`): `embed([question])[0]` — no
+    prefix, so fold scores share the same cosine scale as the doc vectors.
+    NOTE the MLX invariant: `embed()` takes a list, never a bare str.
+    """
+    from .flags import flag_bool
+
+    if flag_bool("MEMO_HYPE_EMBED_RAW"):
+        return list(mem.embedder.embed([question])[0])
+    return list(mem.embedder.embed_query(question))
+
+
 def select_backlog(mem: Any, store: HypeStore, *, cap: int) -> list[dict[str, Any]]:
     """Durable memories (`tiers.DURABLE_TYPES`) whose `body_hash` differs from
     the one saved in `hype_questions` (or has no rows yet). Ordered by ROI
@@ -162,9 +189,14 @@ def run_hype_pass(
                 res["errors_items"] += 1
                 continue
             try:
-                pairs = [(q, mem.embedder.embed_query(q)) for q in questions]
+                variant = _active_variant()
+                pairs = [(q, _embed_question(mem, q)) for q in questions]
                 inserted = store.replace_for_memory(
-                    item["id"], item["body_hash"], mem.cfg.helper_model, pairs
+                    item["id"],
+                    item["body_hash"],
+                    mem.cfg.helper_model,
+                    pairs,
+                    variant=variant,
                 )
                 res["generated"] += inserted
                 res["memories"] += 1
@@ -195,4 +227,53 @@ def run_hype_pass(
     return res
 
 
-__all__ = ["run_hype_pass", "select_backlog"]
+def run_hype_reembed(cfg: Any, mem: Any) -> dict[str, Any]:
+    """Re-embed every stored HyPE question whose `variant` differs from the
+    currently active one (`MEMO_HYPE_EMBED_RAW`) — the index holds ONE
+    variant at a time, so flipping the flag requires converting the backlog
+    rather than mixing scales.
+
+    Question TEXT is already stored (`hype_questions.question`) — no LLM call
+    needed, only a re-embed. Batched per memory via `replace_for_memory` (the
+    existing transactional swap) so a memory's rows never end up half-old,
+    half-new. `body_hash`/`model` are preserved from the stored rows. Never
+    raises — returns `{status, reembedded, skipped}`.
+    """
+    res: dict[str, Any] = {"status": "skipped", "reembedded": 0, "skipped": 0}
+    store: HypeStore | None = None
+    try:
+        from .store.hype_store import HypeStore
+
+        store = HypeStore(cfg.db_path, cfg.embedder_dims)
+        variant = _active_variant()
+        stale_ids = store.memories_with_variant_other_than(variant)
+        if not stale_ids:
+            res["status"] = "skipped"
+            return res
+
+        for memory_id in stale_ids:
+            rows = store.questions_for_memory(memory_id)
+            if not rows:
+                res["skipped"] += 1
+                continue
+            try:
+                body_hash = rows[0]["body_hash"]
+                model = rows[0]["model"]
+                pairs = [(r["question"], _embed_question(mem, r["question"])) for r in rows]
+                store.replace_for_memory(memory_id, body_hash, model, pairs, variant=variant)
+                res["reembedded"] += 1
+            except Exception:  # one memory must never abort the reembed pass
+                res["skipped"] += 1
+                continue
+
+        res["status"] = "done"
+    except Exception as exc:  # surfaced via receipt["errors"], never silent
+        res["status"] = "error"
+        res["error"] = f"{type(exc).__name__}: {exc}"
+    finally:
+        if store is not None:
+            store.close()
+    return res
+
+
+__all__ = ["run_hype_pass", "run_hype_reembed", "select_backlog"]

--- a/src/memo/flags_ingest.py
+++ b/src/memo/flags_ingest.py
@@ -218,6 +218,15 @@ SPECS: tuple[FlagSpec, ...] = (
         "kNN pool size over the question index during the read-path fold.",
         min_val=5,
     ),
+    _spec(
+        "MEMO_HYPE_EMBED_RAW",
+        "bool",
+        False,
+        "ingest",
+        "Embed stored HyPE questions WITHOUT the query prefix (document-side), "
+        "so fold scores share the doc-cosine scale. Changing this requires "
+        "`memo dream hype --reembed`.",
+    ),
     # verbatim turn-level index (Total Recall F1)
     _spec(
         "MEMO_VERBATIM_INDEX",

--- a/src/memo/memory/search_ops.py
+++ b/src/memo/memory/search_ops.py
@@ -77,6 +77,10 @@ class _SearchOpsMixin(_MemoryBase):
     # Lazily-built HyPE question index (MEMO_HYPE_ENABLED read path). Created
     # on first folded search, reused afterwards; never constructed flag-off.
     _hype_store: HypeStore | None = None
+    # Cached result of the one-time variant-mismatch check below — computed
+    # once per Memory instance (cheap `stats()` query), not per search.
+    _hype_variant_checked: bool = False
+    _hype_variant_warning: str | None = None
 
     # -- search -------------------------------------------------------------
 
@@ -210,7 +214,13 @@ class _SearchOpsMixin(_MemoryBase):
                 rows = self._hype_fold_candidates(
                     rows, emb, limit, type_=type_, exclude_types=exclude_types
                 )
-                _add_trace("hype_fold", input_count=before_hype, output_count=len(rows))
+                variant_warning = self._hype_variant_mismatch_warning()
+                _add_trace(
+                    "hype_fold",
+                    input_count=before_hype,
+                    output_count=len(rows),
+                    **({"warning": variant_warning} if variant_warning else {}),
+                )
         else:
             emb = None  # set below in hybrid's vec branch; used by feedback boost
             # hybrid — fetch a wider candidate set from each side and
@@ -763,6 +773,44 @@ class _SearchOpsMixin(_MemoryBase):
         except Exception as exc:
             _log.warning("hype_fold failed, using doc hits: %s", exc, exc_info=True)
             return rows
+
+    def _hype_variant_mismatch_warning(self) -> str | None:
+        """One cheap `stats()` query (cached for the life of this `Memory`
+        instance) checking whether the HyPE store's dominant embedding
+        variant matches the currently active `MEMO_HYPE_EMBED_RAW` setting.
+
+        A mismatch means most stored question vectors were embedded on the
+        OTHER scale (query-prefixed vs raw) than what live queries now use —
+        the fold still runs (never hard-fails search), this only surfaces a
+        trace note so the mismatch is diagnosable instead of silently
+        degrading scores. Resolved by `memo dream hype --reembed`.
+        """
+        if self._hype_variant_checked:
+            return self._hype_variant_warning
+        self._hype_variant_checked = True
+        try:
+            from memo.dream_hype import _active_variant
+
+            store = self._hype_store
+            if store is None:
+                return None  # not yet constructed this call; nothing to check
+            by_variant = store.stats().get("by_variant", {})
+            if not by_variant:
+                return None
+            dominant = max(by_variant, key=lambda k: by_variant[k])
+            active = _active_variant()
+            if dominant != active:
+                warning = (
+                    f"hype store dominant variant={dominant!r} != active={active!r} "
+                    f"(run `memo dream hype --reembed`)"
+                )
+                self._hype_variant_warning = warning
+                _log.warning(warning)
+                return warning
+            return None
+        except Exception as exc:
+            _log.debug("hype variant check skipped: %s", exc)
+            return None
 
     def _fetch_fact_candidates(
         self,

--- a/src/memo/memory/search_ops.py
+++ b/src/memo/memory/search_ops.py
@@ -776,11 +776,11 @@ class _SearchOpsMixin(_MemoryBase):
 
     def _hype_variant_mismatch_warning(self) -> str | None:
         """One cheap `stats()` query (cached for the life of this `Memory`
-        instance) checking whether the HyPE store's dominant embedding
-        variant matches the currently active `MEMO_HYPE_EMBED_RAW` setting.
+        instance) checking whether every HyPE row uses the currently active
+        `MEMO_HYPE_EMBED_RAW` embedding variant.
 
-        A mismatch means most stored question vectors were embedded on the
-        OTHER scale (query-prefixed vs raw) than what live queries now use —
+        A mismatch means some stored question vectors were embedded on a
+        different scale (query-prefixed vs raw) than what live queries use —
         the fold still runs (never hard-fails search), this only surfaces a
         trace note so the mismatch is diagnosable instead of silently
         degrading scores. Resolved by `memo dream hype --reembed`.
@@ -797,11 +797,14 @@ class _SearchOpsMixin(_MemoryBase):
             by_variant = store.stats().get("by_variant", {})
             if not by_variant:
                 return None
-            dominant = max(by_variant, key=lambda k: by_variant[k])
             active = _active_variant()
-            if dominant != active:
+            stale_variants = sorted(variant for variant in by_variant if variant != active)
+            if stale_variants:
+                counts = ", ".join(
+                    f"{variant}={by_variant[variant]}" for variant in sorted(by_variant)
+                )
                 warning = (
-                    f"hype store dominant variant={dominant!r} != active={active!r} "
+                    f"hype store variants ({counts}) include values != active={active!r} "
                     f"(run `memo dream hype --reembed`)"
                 )
                 self._hype_variant_warning = warning

--- a/src/memo/memory/search_ops.py
+++ b/src/memo/memory/search_ops.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import contextlib
 import dataclasses
 import math
+import sqlite3
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -811,7 +812,7 @@ class _SearchOpsMixin(_MemoryBase):
                 _log.warning(warning)
                 return warning
             return None
-        except Exception as exc:
+        except (sqlite3.Error, OSError, RuntimeError, TypeError, ValueError) as exc:
             _log.debug("hype variant check skipped: %s", exc)
             return None
 

--- a/src/memo/store/hype_store.py
+++ b/src/memo/store/hype_store.py
@@ -76,9 +76,7 @@ class HypeStore(_ConnectionMixin):
         # needs the column backfilled — its rows were all embedded with the
         # query prefix (the only variant that ever existed then), so 'query'
         # is the honest default for pre-existing rows.
-        cols = {
-            row["name"] for row in conn.execute("PRAGMA table_info(hype_questions)").fetchall()
-        }
+        cols = {row["name"] for row in conn.execute("PRAGMA table_info(hype_questions)").fetchall()}
         if "variant" not in cols:
             conn.execute(
                 "ALTER TABLE hype_questions ADD COLUMN variant TEXT NOT NULL DEFAULT 'query'"

--- a/src/memo/store/hype_store.py
+++ b/src/memo/store/hype_store.py
@@ -69,9 +69,20 @@ class HypeStore(_ConnectionMixin):
             "CREATE TABLE IF NOT EXISTS hype_questions ("
             "question_id TEXT PRIMARY KEY, memory_id TEXT NOT NULL, "
             "question TEXT NOT NULL, body_hash TEXT NOT NULL, model TEXT NOT NULL, "
-            "created_at TEXT NOT NULL)"
+            "created_at TEXT NOT NULL, variant TEXT NOT NULL DEFAULT 'query')"
         )
         conn.execute("CREATE INDEX IF NOT EXISTS idx_hype_mem ON hype_questions(memory_id)")
+        # Inline ALTER-guard migration: a DB created before `variant` existed
+        # needs the column backfilled — its rows were all embedded with the
+        # query prefix (the only variant that ever existed then), so 'query'
+        # is the honest default for pre-existing rows.
+        cols = {
+            row["name"] for row in conn.execute("PRAGMA table_info(hype_questions)").fetchall()
+        }
+        if "variant" not in cols:
+            conn.execute(
+                "ALTER TABLE hype_questions ADD COLUMN variant TEXT NOT NULL DEFAULT 'query'"
+            )
         conn.commit()
 
     def replace_for_memory(
@@ -80,10 +91,13 @@ class HypeStore(_ConnectionMixin):
         body_hash: str,
         model: str,
         questions: list[tuple[str, list[float]]],
+        variant: str = "query",
     ) -> int:
         """Delete old rows for `memory_id`, insert `(question_text, embedding)` rows.
 
         `question_id = sha256(f"{memory_id}:{text}").hexdigest()[:32]`.
+        `variant` records which embedding scale the vectors were built in
+        ("query" = `embed_query` prefix, "raw" = document-side, no prefix).
         Returns the inserted count.
         """
         created_at = _now_iso()
@@ -112,9 +126,9 @@ class HypeStore(_ConnectionMixin):
                 )
                 cx.execute(
                     "INSERT INTO hype_questions "
-                    "(question_id, memory_id, question, body_hash, model, created_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
-                    (qid, memory_id, text, body_hash, model, created_at),
+                    "(question_id, memory_id, question, body_hash, model, created_at, variant) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (qid, memory_id, text, body_hash, model, created_at, variant),
                 )
         return len(questions)
 
@@ -173,15 +187,46 @@ class HypeStore(_ConnectionMixin):
                 removed += cur.rowcount
         return removed
 
-    def stats(self) -> dict[str, int]:
+    def stats(self) -> dict[str, Any]:
         memories = self._conn.execute(
             "SELECT COUNT(DISTINCT memory_id) AS n FROM hype_questions"
         ).fetchone()
         questions = self._conn.execute("SELECT COUNT(*) AS n FROM hype_questions").fetchone()
+        variant_rows = self._conn.execute(
+            "SELECT variant, COUNT(*) AS n FROM hype_questions GROUP BY variant"
+        ).fetchall()
         return {
             "memories": int(memories["n"]) if memories else 0,
             "questions": int(questions["n"]) if questions else 0,
+            "by_variant": {str(r["variant"]): int(r["n"]) for r in variant_rows},
         }
+
+    def memories_with_variant_other_than(self, variant: str) -> list[str]:
+        """Distinct `memory_id`s that have at least one question row whose
+        `variant` differs from `variant` — the reembed backlog."""
+        rows = self._conn.execute(
+            "SELECT DISTINCT memory_id FROM hype_questions WHERE variant != ?",
+            (variant,),
+        ).fetchall()
+        return [str(r["memory_id"]) for r in rows]
+
+    def questions_for_memory(self, memory_id: str) -> list[dict[str, Any]]:
+        """All question rows for `memory_id` (text + body_hash + model),
+        in insertion order — used by the reembed pass to recover the stored
+        question text without needing the LLM again."""
+        rows = self._conn.execute(
+            "SELECT question, body_hash, model FROM hype_questions "
+            "WHERE memory_id = ? ORDER BY rowid",
+            (memory_id,),
+        ).fetchall()
+        return [
+            {
+                "question": str(r["question"]),
+                "body_hash": str(r["body_hash"]),
+                "model": str(r["model"]),
+            }
+            for r in rows
+        ]
 
 
 __all__ = ["HypeStore"]

--- a/tests/test_cli_hype.py
+++ b/tests/test_cli_hype.py
@@ -41,10 +41,45 @@ def test_hype_status_json_empty(tmp_path):
     assert "durable_total" in data
     assert "coverage_pct" in data
     assert "backlog" in data
+    assert "variants" in data
     assert data["indexed_memories"] == 0
     assert data["questions"] == 0
     assert data["durable_total"] == 0
     assert data["coverage_pct"] == 0.0
+    assert data["variants"] == {}
+
+
+def test_hype_status_surfaces_variant_counts(tmp_path, monkeypatch):
+    """Operators can verify whether a flag flip needs `--reembed`."""
+
+    class _FakeStore:
+        def all_ids(self):
+            return []
+
+        def get(self, memory_id):
+            return None
+
+    class _FakeMemory:
+        store = _FakeStore()
+
+    class _FakeHypeStore:
+        def __init__(self, db_path, dims):
+            pass
+
+        def stats(self):
+            return {"memories": 2, "questions": 3, "by_variant": {"query": 2, "raw": 1}}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("memo.cli_hype._get_memory", lambda cfg: _FakeMemory())
+    monkeypatch.setattr("memo.cli_hype.HypeStore", _FakeHypeStore)
+    monkeypatch.setattr("memo.dream_hype.select_backlog", lambda mem, store, cap: [])
+
+    result = CliRunner().invoke(cli, ["hype", "status", "--json"], env=_env(tmp_path))
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["variants"] == {"query": 2, "raw": 1}
 
 
 def test_hype_status_help(tmp_path):

--- a/tests/test_dream_hype.py
+++ b/tests/test_dream_hype.py
@@ -40,9 +40,16 @@ class _FakeStore:
 class _FakeEmbedder:
     def __init__(self, dims: int = 4):
         self._fn = _fake_embed_query(dims)
+        self.query_calls: list[str] = []
+        self.embed_calls: list[list[str]] = []
 
     def embed_query(self, text: str) -> list[float]:
+        self.query_calls.append(text)
         return self._fn(text)
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        self.embed_calls.append(list(texts))
+        return [self._fn(t) for t in texts]
 
 
 class _FakeCfg:
@@ -191,6 +198,38 @@ def test_llm_questions_strips_plain_markdown_fence(monkeypatch):
     assert questions == ["question one here", "question two here"]
 
 
+# --- _embed_question ---------------------------------------------------------
+
+
+def test_embed_question_uses_embed_query_by_default(monkeypatch):
+    """MEMO_HYPE_EMBED_RAW off (default) -> the query-prefixed embed_query
+    path is used, not the raw embed() list path."""
+    monkeypatch.delenv("MEMO_HYPE_EMBED_RAW", raising=False)
+    mem = _FakeMem({})
+    vec = dh._embed_question(mem, "What is X?")
+    assert mem.embedder.query_calls == ["What is X?"]
+    assert mem.embedder.embed_calls == []
+    assert vec == mem.embedder._fn("What is X?")
+
+
+def test_embed_question_uses_raw_embed_when_flag_on(monkeypatch):
+    """MEMO_HYPE_EMBED_RAW=1 -> the document-side embed([text]) path is used
+    (list form, per the MLX invariant: embed() never takes a bare str)."""
+    monkeypatch.setenv("MEMO_HYPE_EMBED_RAW", "1")
+    mem = _FakeMem({})
+    vec = dh._embed_question(mem, "What is X?")
+    assert mem.embedder.embed_calls == [["What is X?"]]
+    assert mem.embedder.query_calls == []
+    assert vec == mem.embedder._fn("What is X?")
+
+
+def test_active_variant_reflects_flag(monkeypatch):
+    monkeypatch.delenv("MEMO_HYPE_EMBED_RAW", raising=False)
+    assert dh._active_variant() == "query"
+    monkeypatch.setenv("MEMO_HYPE_EMBED_RAW", "1")
+    assert dh._active_variant() == "raw"
+
+
 # --- run_hype_pass ---------------------------------------------------------------
 
 
@@ -211,7 +250,7 @@ def test_run_hype_pass_generates_and_persists(tmp_path, monkeypatch):
     store = HypeStore(cfg.db_path, dims=4)
     try:
         stats = store.stats()
-        assert stats == {"memories": 1, "questions": 2}
+        assert stats == {"memories": 1, "questions": 2, "by_variant": {"query": 2}}
     finally:
         store.close()
 
@@ -303,7 +342,7 @@ def test_run_hype_pass_dry_run_computes_backlog_without_writing(tmp_path, monkey
 
     store = HypeStore(cfg.db_path, dims=4)
     try:
-        assert store.stats() == {"memories": 0, "questions": 0}
+        assert store.stats() == {"memories": 0, "questions": 0, "by_variant": {}}
     finally:
         store.close()
 
@@ -374,6 +413,84 @@ def test_run_hype_pass_prunes_orphans(tmp_path, monkeypatch):
         verify_store.close()
 
 
+# --- run_hype_reembed ---------------------------------------------------------
+
+
+def test_run_hype_reembed_converts_query_rows_to_raw(tmp_path, monkeypatch):
+    """Seed rows at variant='query', flip MEMO_HYPE_EMBED_RAW on, reembed ->
+    rows become variant='raw' and the embedder is called via the list-form
+    embed() (not embed_query), per the active (raw) variant."""
+    cfg = _FakeCfg(tmp_path / "memvec.db")
+    store = HypeStore(cfg.db_path, dims=4)
+    store.replace_for_memory(
+        "id1", "h1", "m", [("question one?", [0.0, 0.0, 0.0, 0.0])], variant="query"
+    )
+    store.close()
+
+    monkeypatch.setenv("MEMO_HYPE_EMBED_RAW", "1")
+    mem = _FakeMem({}, state_dir=tmp_path)
+
+    res = dh.run_hype_reembed(cfg, mem)
+
+    assert res["status"] == "done"
+    assert res["reembedded"] == 1
+    assert res["skipped"] == 0
+    assert mem.embedder.embed_calls, "raw variant must call embed() list-form, not embed_query"
+    assert mem.embedder.query_calls == []
+
+    verify_store = HypeStore(cfg.db_path, dims=4)
+    try:
+        stats = verify_store.stats()
+        assert stats["by_variant"] == {"raw": 1}
+        row = verify_store._conn.execute(
+            "SELECT question, body_hash FROM hype_questions WHERE memory_id = ?", ("id1",)
+        ).fetchone()
+        assert row["question"] == "question one?"
+        assert row["body_hash"] == "h1"
+    finally:
+        verify_store.close()
+
+
+def test_run_hype_reembed_second_run_skips_already_converted_rows(tmp_path, monkeypatch):
+    cfg = _FakeCfg(tmp_path / "memvec.db")
+    store = HypeStore(cfg.db_path, dims=4)
+    store.replace_for_memory("id1", "h1", "m", [("q?", [0.0, 0.0, 0.0, 0.0])], variant="query")
+    store.close()
+
+    monkeypatch.setenv("MEMO_HYPE_EMBED_RAW", "1")
+    mem = _FakeMem({}, state_dir=tmp_path)
+
+    first = dh.run_hype_reembed(cfg, mem)
+    assert first["status"] == "done"
+    assert first["reembedded"] == 1
+
+    second = dh.run_hype_reembed(cfg, mem)
+    assert second["status"] == "skipped"
+    assert second["reembedded"] == 0
+
+
+def test_run_hype_reembed_noop_when_nothing_stale(tmp_path):
+    """No rows at all -> nothing to convert, status='skipped'."""
+    cfg = _FakeCfg(tmp_path / "memvec.db")
+    mem = _FakeMem({}, state_dir=tmp_path)
+    res = dh.run_hype_reembed(cfg, mem)
+    assert res["status"] == "skipped"
+    assert res["reembedded"] == 0
+
+
+def test_run_hype_reembed_never_raises_on_store_failure(tmp_path, monkeypatch):
+    cfg = _FakeCfg(tmp_path / "memvec.db")
+    mem = _FakeMem({}, state_dir=tmp_path)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("memo.store.hype_store.HypeStore", _boom)
+    res = dh.run_hype_reembed(cfg, mem)
+    assert res["status"] == "error"
+    assert "boom" in res.get("error", "")
+
+
 def test_dream_hype_subcommand_json(tmp_path, monkeypatch):
     from click.testing import CliRunner
 
@@ -396,6 +513,36 @@ def test_dream_hype_subcommand_json(tmp_path, monkeypatch):
     result = CliRunner().invoke(cli, ["dream", "hype", "--json"], env=env)
     assert result.exit_code == 0, result.output
     assert '"status": "done"' in result.output
+
+
+def test_dream_hype_subcommand_reembed_json(tmp_path, monkeypatch):
+    """`memo dream hype --reembed` routes to run_hype_reembed, not run_hype_pass."""
+    from click.testing import CliRunner
+
+    from memo import dream_hype as dh_mod
+    from memo.cli import cli
+
+    pass_called = []
+    monkeypatch.setattr(
+        dh_mod, "run_hype_pass", lambda cfg, mem, **kw: pass_called.append(1) or {}
+    )
+    monkeypatch.setattr(
+        dh_mod,
+        "run_hype_reembed",
+        lambda cfg, mem: {"status": "done", "reembedded": 3, "skipped": 0},
+    )
+    env = {
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_DATA_DIR": str(tmp_path / "data"),
+        "MEMO_STATE_DIR": str(tmp_path / "state"),
+        "MEMO_VAULT_PATH": str(tmp_path / "vault"),
+        "MEMO_EMBEDDER_VIA_DAEMON": "0",
+        "MEMO_SKIP_MODEL_VERSION_CHECK": "1",
+    }
+    result = CliRunner().invoke(cli, ["dream", "hype", "--reembed", "--json"], env=env)
+    assert result.exit_code == 0, result.output
+    assert '"reembedded": 3' in result.output
+    assert not pass_called, "run_hype_pass must not run when --reembed is passed"
 
 
 def test_run_hype_pass_embed_failure_isolates_one_memory(tmp_path, monkeypatch):

--- a/tests/test_dream_hype.py
+++ b/tests/test_dream_hype.py
@@ -523,9 +523,7 @@ def test_dream_hype_subcommand_reembed_json(tmp_path, monkeypatch):
     from memo.cli import cli
 
     pass_called = []
-    monkeypatch.setattr(
-        dh_mod, "run_hype_pass", lambda cfg, mem, **kw: pass_called.append(1) or {}
-    )
+    monkeypatch.setattr(dh_mod, "run_hype_pass", lambda cfg, mem, **kw: pass_called.append(1) or {})
     monkeypatch.setattr(
         dh_mod,
         "run_hype_reembed",
@@ -543,6 +541,34 @@ def test_dream_hype_subcommand_reembed_json(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     assert '"reembedded": 3' in result.output
     assert not pass_called, "run_hype_pass must not run when --reembed is passed"
+
+
+def test_dream_hype_rejects_reembed_with_dry_run_before_writing(tmp_path, monkeypatch):
+    """`--dry-run` must never silently perform the mutating re-embed pass."""
+    from click.testing import CliRunner
+
+    from memo import dream_hype as dh_mod
+    from memo.cli import cli
+
+    pass_called = []
+    reembed_called = []
+    monkeypatch.setattr(dh_mod, "run_hype_pass", lambda cfg, mem, **kw: pass_called.append(1) or {})
+    monkeypatch.setattr(dh_mod, "run_hype_reembed", lambda cfg, mem: reembed_called.append(1) or {})
+    env = {
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_DATA_DIR": str(tmp_path / "data"),
+        "MEMO_STATE_DIR": str(tmp_path / "state"),
+        "MEMO_VAULT_PATH": str(tmp_path / "vault"),
+        "MEMO_EMBEDDER_VIA_DAEMON": "0",
+        "MEMO_SKIP_MODEL_VERSION_CHECK": "1",
+    }
+
+    result = CliRunner().invoke(cli, ["dream", "hype", "--reembed", "--dry-run", "--json"], env=env)
+
+    assert result.exit_code == 2
+    assert "cannot be combined" in result.output
+    assert not pass_called
+    assert not reembed_called
 
 
 def test_run_hype_pass_embed_failure_isolates_one_memory(tmp_path, monkeypatch):

--- a/tests/test_hype_fold.py
+++ b/tests/test_hype_fold.py
@@ -269,8 +269,11 @@ def test_fold_variant_mismatch_warns_in_trace_but_still_folds(
     hs = HypeStore(hype_mem.cfg.db_path, 4)
     try:
         hs.replace_for_memory(
-            rec_b.id, "bodyhash", "test-model",
-            [("what is zzbeta about?", list(_QUERY_VEC))], variant="raw",
+            rec_b.id,
+            "bodyhash",
+            "test-model",
+            [("what is zzbeta about?", list(_QUERY_VEC))],
+            variant="raw",
         )
     finally:
         hs.close()
@@ -283,6 +286,44 @@ def test_fold_variant_mismatch_warns_in_trace_but_still_folds(
     # Fold still ran and still surfaced results — a mismatch never hard-fails.
     assert rec_a.id in [r.id for r in out]
     assert rec_b.id in [r.id for r in out]
+
+    hype_stage = next(entry for entry in trace if entry["stage"] == "hype_fold")
+    assert "warning" in hype_stage
+    assert "raw" in hype_stage["warning"] and "query" in hype_stage["warning"]
+
+
+def test_fold_mixed_variants_warns_even_when_active_variant_is_dominant(
+    hype_mem, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Any stale minority variant makes cosine scores incomparable.
+
+    A dominant-variant-only check misses a partially re-embedded index, so the
+    trace must warn whenever *any* stored rows differ from the active variant.
+    """
+    from memo.store.hype_store import HypeStore
+
+    monkeypatch.delenv("MEMO_HYPE_EMBED_RAW", raising=False)  # active = "query"
+    rec_query_1 = hype_mem.save(content="zzalpha first", title="First zzalpha")
+    rec_query_2 = hype_mem.save(content="zzalpha second", title="Second zzalpha")
+    rec_raw = hype_mem.save(content="zzbeta stale", title="Stale zzbeta")
+    _populate_hype(hype_mem.cfg, rec_query_1.id, list(_QUERY_VEC))
+    _populate_hype(hype_mem.cfg, rec_query_2.id, list(_QUERY_VEC))
+
+    hs = HypeStore(hype_mem.cfg.db_path, 4)
+    try:
+        hs.replace_for_memory(
+            rec_raw.id,
+            "bodyhash",
+            "test-model",
+            [("what is stale zzbeta about?", list(_QUERY_VEC))],
+            variant="raw",
+        )
+    finally:
+        hs.close()
+
+    monkeypatch.setenv("MEMO_HYPE_ENABLED", "1")
+    trace: list[dict] = []
+    hype_mem.search("zzquery topic", mode="vec", limit=5, _trace=trace)
 
     hype_stage = next(entry for entry in trace if entry["stage"] == "hype_fold")
     assert "warning" in hype_stage

--- a/tests/test_hype_fold.py
+++ b/tests/test_hype_fold.py
@@ -253,6 +253,58 @@ def test_flag_on_fold_appended_candidate_respects_type_filter(
     assert [r.id for r in out] == [rec_a.id]
 
 
+def test_fold_variant_mismatch_warns_in_trace_but_still_folds(
+    hype_mem, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The HyPE store's stored questions were embedded 'raw' (document-side),
+    but MEMO_HYPE_EMBED_RAW is OFF (active variant='query') — a scale
+    mismatch. Search must still fold (never hard-fail) and record a warning
+    trace note so the mismatch is diagnosable via `memo dream hype --reembed`."""
+    from memo.store.hype_store import HypeStore
+
+    monkeypatch.delenv("MEMO_HYPE_EMBED_RAW", raising=False)  # active variant = "query"
+    rec_a = hype_mem.save(content="zzalpha note body", title="Alpha zzalpha")
+    rec_b = hype_mem.save(content="zzbeta note body", title="Beta zzbeta")
+
+    hs = HypeStore(hype_mem.cfg.db_path, 4)
+    try:
+        hs.replace_for_memory(
+            rec_b.id, "bodyhash", "test-model",
+            [("what is zzbeta about?", list(_QUERY_VEC))], variant="raw",
+        )
+    finally:
+        hs.close()
+
+    monkeypatch.setenv("MEMO_HYPE_ENABLED", "1")
+
+    trace: list[dict] = []
+    out = hype_mem.search("zzquery topic", mode="vec", limit=5, _trace=trace)
+
+    # Fold still ran and still surfaced results — a mismatch never hard-fails.
+    assert rec_a.id in [r.id for r in out]
+    assert rec_b.id in [r.id for r in out]
+
+    hype_stage = next(entry for entry in trace if entry["stage"] == "hype_fold")
+    assert "warning" in hype_stage
+    assert "raw" in hype_stage["warning"] and "query" in hype_stage["warning"]
+
+
+def test_fold_variant_match_has_no_warning_in_trace(
+    hype_mem, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the store's variant matches the active flag, no warning is added."""
+    rec_b = hype_mem.save(content="zzbeta note body", title="Beta zzbeta")
+    _populate_hype(hype_mem.cfg, rec_b.id, list(_QUERY_VEC))  # default variant="query"
+    monkeypatch.delenv("MEMO_HYPE_EMBED_RAW", raising=False)  # active variant = "query"
+    monkeypatch.setenv("MEMO_HYPE_ENABLED", "1")
+
+    trace: list[dict] = []
+    hype_mem.search("zzquery topic", mode="vec", limit=5, _trace=trace)
+
+    hype_stage = next(entry for entry in trace if entry["stage"] == "hype_fold")
+    assert "warning" not in hype_stage
+
+
 def test_close_closes_hype_store(hype_mem, monkeypatch: pytest.MonkeyPatch) -> None:
     """Once a folded vec search materializes `_hype_store`, `Memory.close()`
     must close its underlying sqlite connection too — otherwise it leaks a

--- a/tests/test_hype_store.py
+++ b/tests/test_hype_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -19,6 +20,45 @@ def test_hype_flags_registered_defaults():
     assert REGISTRY["MEMO_HYPE_QUESTIONS_PER_MEMORY"].default == 3
     assert REGISTRY["MEMO_HYPE_NIGHT_CAP"].default == 400
     assert REGISTRY["MEMO_HYPE_FOLD_POOL"].default == 30
+    assert REGISTRY["MEMO_HYPE_EMBED_RAW"].default is False
+
+
+def test_variant_column_migration_backfills_existing_rows_as_query(tmp_path: Path):
+    """A pre-existing hype_questions table created WITHOUT the `variant`
+    column (the pre-migration schema) must not crash HypeStore's schema
+    guard, and its old rows must read back as variant='query' (the only
+    scale that ever existed before this column)."""
+    db_path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "CREATE TABLE hype_questions ("
+            "question_id TEXT PRIMARY KEY, memory_id TEXT NOT NULL, "
+            "question TEXT NOT NULL, body_hash TEXT NOT NULL, model TEXT NOT NULL, "
+            "created_at TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO hype_questions VALUES (?, ?, ?, ?, ?, ?)",
+            ("qid1", "mem-old", "old question?", "hash-old", "model-old", "2026-01-01T00:00:00"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    legacy_store = HypeStore(db_path, dims=DIMS)
+    try:
+        cols = {
+            row["name"]
+            for row in legacy_store._conn.execute("PRAGMA table_info(hype_questions)").fetchall()
+        }
+        assert "variant" in cols
+        row = legacy_store._conn.execute(
+            "SELECT variant FROM hype_questions WHERE memory_id = ?", ("mem-old",)
+        ).fetchone()
+        assert row["variant"] == "query"
+        assert legacy_store.stats()["by_variant"] == {"query": 1}
+    finally:
+        legacy_store.close()
 
 
 @pytest.fixture
@@ -39,7 +79,7 @@ def test_replace_for_memory_inserts_and_reinsert_swaps_rows(store: HypeStore):
         ],
     )
     assert inserted == 2
-    assert store.stats() == {"memories": 1, "questions": 2}
+    assert store.stats() == {"memories": 1, "questions": 2, "by_variant": {"query": 2}}
 
     # Re-replace with a new question set (e.g. after a body edit) swaps rows —
     # old questions must be gone, not merely appended to.
@@ -50,7 +90,7 @@ def test_replace_for_memory_inserts_and_reinsert_swaps_rows(store: HypeStore):
         [("What is Y?", [0.0, 0.0, 1.0, 0.0])],
     )
     assert inserted_again == 1
-    assert store.stats() == {"memories": 1, "questions": 1}
+    assert store.stats() == {"memories": 1, "questions": 1, "by_variant": {"query": 1}}
 
     rows = store._conn.execute(
         "SELECT question FROM hype_questions WHERE memory_id = ?", ("mem-1",)
@@ -58,6 +98,40 @@ def test_replace_for_memory_inserts_and_reinsert_swaps_rows(store: HypeStore):
     questions = {r["question"] for r in rows}
     assert questions == {"What is Y?"}
     assert store.body_hash_for("mem-1") == "hash-b"
+
+
+def test_replace_for_memory_persists_variant(store: HypeStore):
+    store.replace_for_memory(
+        "mem-1", "hash-a", "helper-model", [("What is X?", [1.0, 0.0, 0.0, 0.0])], variant="raw"
+    )
+    row = store._conn.execute(
+        "SELECT variant FROM hype_questions WHERE memory_id = ?", ("mem-1",)
+    ).fetchone()
+    assert row["variant"] == "raw"
+    assert store.stats()["by_variant"] == {"raw": 1}
+
+
+def test_replace_for_memory_variant_defaults_to_query(store: HypeStore):
+    store.replace_for_memory(
+        "mem-1", "hash-a", "helper-model", [("What is X?", [1.0, 0.0, 0.0, 0.0])]
+    )
+    row = store._conn.execute(
+        "SELECT variant FROM hype_questions WHERE memory_id = ?", ("mem-1",)
+    ).fetchone()
+    assert row["variant"] == "query"
+
+
+def test_stats_reports_mixed_variant_counts(store: HypeStore):
+    store.replace_for_memory(
+        "mem-1", "hash-a", "helper-model", [("q1", [1.0, 0.0, 0.0, 0.0])], variant="query"
+    )
+    store.replace_for_memory(
+        "mem-2", "hash-b", "helper-model", [("q2", [0.0, 1.0, 0.0, 0.0])], variant="raw"
+    )
+    stats = store.stats()
+    assert stats["by_variant"] == {"query": 1, "raw": 1}
+    assert stats["memories"] == 2
+    assert stats["questions"] == 2
 
 
 def test_body_hash_for_unknown_memory_returns_none(store: HypeStore):
@@ -119,14 +193,14 @@ def test_prune_orphans_removes_vec_and_text_rows(store: HypeStore):
     removed = store.prune_orphans({"mem-1"})
 
     assert removed == 1
-    assert store.stats() == {"memories": 1, "questions": 1}
+    assert store.stats() == {"memories": 1, "questions": 1, "by_variant": {"query": 1}}
     assert store.body_hash_for("mem-2") is None
     remaining_vec = store._conn.execute("SELECT COUNT(*) AS n FROM hype_vec").fetchone()
     assert remaining_vec["n"] == 1
 
 
 def test_stats_counts_memories_and_questions(store: HypeStore):
-    assert store.stats() == {"memories": 0, "questions": 0}
+    assert store.stats() == {"memories": 0, "questions": 0, "by_variant": {}}
 
     store.replace_for_memory(
         "mem-1",
@@ -141,4 +215,4 @@ def test_stats_counts_memories_and_questions(store: HypeStore):
         "mem-2", "hash-b", "helper-model", [("question three", [0.0, 0.0, 1.0, 0.0])]
     )
 
-    assert store.stats() == {"memories": 2, "questions": 3}
+    assert store.stats() == {"memories": 2, "questions": 3, "by_variant": {"query": 3}}


### PR DESCRIPTION
## Summary

- add an opt-in raw/document-side embedding variant for HyPE questions
- persist and expose embedding variants, with warnings for any mixed or stale index
- add a no-LLM re-embed workflow and reject unsafe dry-run combinations
- preserve the historical query-prefixed behavior by default

## Verification

- 4269 passed, 29 skipped; coverage 75.22%
- ruff format and lint
- mypy on src/memo
- progressive quality gate
- uv lock --check
- recall pre-push gate: PASS
- 7-day verbatim dogfood: 451 sessions indexed, 22658 turns processed, 21796 retained; search returned 3 bounded hits