### PR TITLE
fix(deps): keep Dependabot below pytest 9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,14 @@ updates:
         dependency-type: "production"
       python-development:
         dependency-type: "development"
-    # transformers 5.13 is incompatible with the current mlx-lm tokenizer
-    # registration path. Keep Dependabot from widening pyproject's <5.13 cap
-    # and downgrading mlx-vlm/mlx-audio to manufacture a resolution.
+    # Keep Dependabot from widening compatibility caps and manufacturing an
+    # invalid resolution. transformers 5.13 breaks the current mlx-lm
+    # tokenizer path; pytest 9 conflicts with pytest-textual-snapshot 1.1.
     ignore:
       - dependency-name: "transformers"
         versions: [">=5.13"]
+      - dependency-name: "pytest"
+        versions: [">=9"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -36,6 +36,7 @@ def test_dependabot_respects_mlx_and_test_dependency_caps() -> None:
     }
 
     assert ">=5.13" in ignored_versions["transformers"]
+    assert ">=9" in ignored_versions["pytest"]
     assert any(
         dependency.startswith("transformers<5.13;") for dependency in project["dependencies"]
     )


### PR DESCRIPTION
## Summary

- ignore pytest >=9 in Dependabot as well as capping the project requirement
- prevent Dependabot from widening the cap into an unsatisfiable pytest-textual-snapshot resolution
- extend the supply-chain regression test to cover both constraints

## Verification

- uv run --no-sync ruff check tests/test_supply_chain.py
- uv run --no-sync pytest tests/test_supply_chain.py (7 passed)
- parsed .github/dependabot.yml successfully