### PR TITLE
fix(security): harden repository workflows

### DIFF
--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up Python 3.13
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
@@ -38,5 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Reject vulnerable dependency changes
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Verify release version
         id: version
         shell: bash

--- a/.github/workflows/linux-cpu-smoke.yml
+++ b/.github/workflows/linux-cpu-smoke.yml
@@ -25,6 +25,9 @@ on:
       - "pyproject.toml"
       - ".github/workflows/linux-cpu-smoke.yml"
 
+permissions:
+  contents: read
+
 concurrency:
   group: linux-cpu-smoke-${{ github.ref }}
   cancel-in-progress: true
@@ -42,6 +45,8 @@ jobs:
       HF_HUB_DISABLE_TELEMETRY: "1"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: "3.13"

--- a/.github/workflows/macos-smoke.yml
+++ b/.github/workflows/macos-smoke.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     # memo is an Apple-Silicon-first product; this workflow covers the real
@@ -13,6 +16,8 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Install Python 3.13 + uv via Homebrew
         # actions/setup-python ships a CPython whose sqlite3 lacks
         # enable_load_extension, so sqlite-vec (core to memo) cannot load.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: "3.13"
@@ -36,6 +38,8 @@ jobs:
     needs: pypi
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Install mcp-publisher
         run: |
           curl --fail --location --output /tmp/mcp-publisher_linux_amd64.tar.gz \

--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -7,6 +7,8 @@ on:
     - cron: "0 23 * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   ghrs:
     name: github-repo-stats

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Python 3.13 + uv via Homebrew
         run: brew install python@3.13 uv
       - name: Install package + dev deps
-        run: uv sync --frozen --extra dev --python "$(brew --prefix python@3.13)/bin/python3.13"
+        run: uv sync --frozen --extra dev --extra http --python "$(brew --prefix python@3.13)/bin/python3.13"
       - name: Run slow tests
         run: .venv/bin/python -m pytest -m "slow" --timeout=300 -v
 

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -6,12 +6,17 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:  # manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   slow:
     # MLX slow tests require Apple Silicon — use macos runner for real inference
     runs-on: macos-14
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Install Python 3.13 + uv via Homebrew
         run: brew install python@3.13 uv
       - name: Install package + dev deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     # Linux runner is enough — `mlx`/`mlx-lm` deps are gated to
@@ -18,6 +21,8 @@ jobs:
         python-version: ["3.13", "3.14"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
@@ -52,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up Python 3.13
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
@@ -78,6 +85,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up Python 3.13
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,9 @@
 ## Reporting a vulnerability
 
 If you find a security issue in memo, please **do not open a public issue**.
-Instead, email <fernandoferrari@gmail.com> with:
+Submit a [private vulnerability report](https://github.com/jagoff/memo/security/advisories/new)
+so the discussion, affected versions, and remediation stay confidential. If
+GitHub reporting is unavailable, email <fernandoferrari@gmail.com> with:
 
 - A description of the vulnerability
 - Steps to reproduce (or a minimal proof-of-concept)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ dev = [
     "pytest-timeout>=2.3",
     "pytest-asyncio>=1.4,<2",
     "pytest-textual-snapshot>=1.1,<2",
+    # Starlette >=1.3 deprecates the legacy httpx TestClient transport.
+    "httpx2>=2.5,<3",
     "freezegun>=1.5",
     "ruff==0.15.21",
     "mypy>=1.10",

--- a/src/memo/server.py
+++ b/src/memo/server.py
@@ -355,11 +355,19 @@ def main() -> None:
         _ensure_idle_daemon()
         port = flag_int("MEMO_MCP_PORT")
         # transport is validated against the allowed set just above.
+        transport_options: dict[str, Any] = {}
+        if transport != "sse":
+            # FastMCP's JSON response mode avoids allocating a long-lived SSE
+            # receive stream for each ordinary request. Besides fitting memo's
+            # request/response tools, this keeps SDK 1.28 from leaking that
+            # stream after a completed response.
+            transport_options["json_response"] = True
         server.run(
             transport=cast(Any, transport),
             host=host,
             port=port,
             middleware=build_http_middleware(),
+            **transport_options,
         )
     else:
         _start_background_tasks()

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 # These tests intentionally exercise rejection/acknowledgement of wildcard binds.
 # ruff: noqa: S104
+import gc
 import stat
+import warnings
 
 import pytest
 from fastmcp import FastMCP
@@ -97,7 +99,9 @@ def test_mcp_http_auth_protects_protocol_endpoint(
     def ping() -> str:
         return "pong"
 
-    app = server.http_app(stateless_http=True)
+    # JSON responses avoid allocating the SDK's SSE stream for ordinary RPC
+    # replies. MCP SDK 1.28 leaves that receive stream open after the response.
+    app = server.http_app(json_response=True, stateless_http=True)
     payload = {
         "jsonrpc": "2.0",
         "id": 1,
@@ -110,24 +114,29 @@ def test_mcp_http_auth_protects_protocol_endpoint(
     }
     accept = {"Accept": "application/json, text/event-stream"}
 
-    with TestClient(app) as client:
-        assert client.post("/mcp", json=payload, headers=accept).status_code == 401
-        assert (
-            client.post(
-                "/mcp",
-                json=payload,
-                headers={**accept, "Authorization": "Bearer wrong"},
-            ).status_code
-            == 401
-        )
-        assert (
-            client.post(
-                "/mcp",
-                json=payload,
-                headers={**accept, "Authorization": f"Bearer {_TOKEN}"},
-            ).status_code
-            == 200
-        )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", ResourceWarning)
+        with TestClient(app) as client:
+            assert client.post("/mcp", json=payload, headers=accept).status_code == 401
+            assert (
+                client.post(
+                    "/mcp",
+                    json=payload,
+                    headers={**accept, "Authorization": "Bearer wrong"},
+                ).status_code
+                == 401
+            )
+            assert (
+                client.post(
+                    "/mcp",
+                    json=payload,
+                    headers={**accept, "Authorization": f"Bearer {_TOKEN}"},
+                ).status_code
+                == 200
+            )
+        gc.collect()
+
+    assert not [warning for warning in caught if issubclass(warning.category, ResourceWarning)]
 
 
 def test_shared_http_middleware_rate_limits_and_hardens_responses() -> None:
@@ -241,5 +250,6 @@ def test_mcp_main_runs_http_with_shared_auth(
         "transport": "http",
         "host": "127.0.0.1",
         "port": 18768,
+        "json_response": True,
     }
     assert len(middleware) == 2

--- a/tests/test_sqlite_cleanup.py
+++ b/tests/test_sqlite_cleanup.py
@@ -42,7 +42,13 @@ def test_cleanup_warning_capture_ignores_preexisting_garbage(tmp_path: Path) -> 
     holder = CyclicConnectionHolder()
     del holder
 
-    warnings_seen = _cleanup_without_warnings(lambda: VersionStore(tmp_path / "versions.db"))
+    # The preexisting connection is deliberately leaked to exercise the
+    # attribution boundary. Capture its warning here so it does not pollute the
+    # suite summary; the helper's inner filter still records warnings produced
+    # by VersionStore itself.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ResourceWarning)
+        warnings_seen = _cleanup_without_warnings(lambda: VersionStore(tmp_path / "versions.db"))
     assert not any(issubclass(w.category, ResourceWarning) for w in warnings_seen)
 
 

--- a/tests/test_sqlite_resource_hygiene.py
+++ b/tests/test_sqlite_resource_hygiene.py
@@ -19,6 +19,14 @@ def _sqlite_resource_warnings(
     ]
 
 
+def _drain_preexisting_resource_warnings() -> None:
+    """Collect garbage from earlier tests outside the attribution window."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ResourceWarning)
+        gc.collect()
+        gc.collect()
+
+
 def test_memory_close_releases_sqlite_connections(
     tmp_cfg: Config,
     monkeypatch: pytest.MonkeyPatch,
@@ -29,6 +37,7 @@ def test_memory_close_releases_sqlite_connections(
         lambda self, inputs: [embedding for _ in inputs],
     )
 
+    _drain_preexisting_resource_warnings()
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always", ResourceWarning)
         mem = Memory(tmp_cfg)
@@ -51,6 +60,7 @@ def test_memory_close_is_idempotent_after_lazy_connections(
         lambda self, inputs: [embedding for _ in inputs],
     )
 
+    _drain_preexisting_resource_warnings()
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always", ResourceWarning)
         mem = Memory(tmp_cfg)
@@ -72,6 +82,7 @@ def test_memory_finalizer_releases_sqlite_connections(
         lambda self, inputs: [[1.0] + [0.0] * (tmp_cfg.embedder_dims - 1) for _ in inputs],
     )
 
+    _drain_preexisting_resource_warnings()
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always", ResourceWarning)
         mem = Memory(tmp_cfg)

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -67,6 +67,12 @@ def test_dependency_security_workflow_is_frozen_and_enforcing() -> None:
     assert "schedule:" in workflow
 
 
+def test_slow_test_workflow_installs_test_collection_dependencies() -> None:
+    workflow = (WORKFLOWS / "slow-tests.yml").read_text(encoding="utf-8")
+
+    assert "uv sync --frozen --extra dev --extra http" in workflow
+
+
 def test_every_workflow_job_declares_explicit_permissions() -> None:
     jobs_without_permissions: list[str] = []
 

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -12,6 +12,13 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
 
 
+def _workflow_configs() -> list[tuple[Path, dict[str, object]]]:
+    return [
+        (path, yaml.safe_load(path.read_text(encoding="utf-8")))
+        for path in sorted(WORKFLOWS.glob("*.yml"))
+    ]
+
+
 def test_dependabot_covers_every_shipped_dependency_surface() -> None:
     config = yaml.safe_load((ROOT / ".github" / "dependabot.yml").read_text(encoding="utf-8"))
 
@@ -43,6 +50,12 @@ def test_dependabot_respects_mlx_and_test_dependency_caps() -> None:
     assert "pytest>=8.0,<9" in project["optional-dependencies"]["dev"]
 
 
+def test_starlette_test_client_uses_the_supported_http_transport() -> None:
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
+
+    assert "httpx2>=2.5,<3" in project["optional-dependencies"]["dev"]
+
+
 def test_dependency_security_workflow_is_frozen_and_enforcing() -> None:
     workflow = (WORKFLOWS / "dependency-security.yml").read_text(encoding="utf-8")
 
@@ -52,6 +65,64 @@ def test_dependency_security_workflow_is_frozen_and_enforcing() -> None:
     assert "actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294" in workflow
     assert "pull_request:" in workflow
     assert "schedule:" in workflow
+
+
+def test_every_workflow_job_declares_explicit_permissions() -> None:
+    jobs_without_permissions: list[str] = []
+
+    for path, config in _workflow_configs():
+        workflow_permissions = config.get("permissions")
+        jobs = config.get("jobs", {})
+        assert isinstance(jobs, dict)
+        for job_name, job in jobs.items():
+            assert isinstance(job, dict)
+            if workflow_permissions is None and "permissions" not in job:
+                jobs_without_permissions.append(f"{path.name}:{job_name}")
+
+    assert jobs_without_permissions == []
+
+
+def test_checkout_never_persists_github_credentials() -> None:
+    insecure_checkouts: list[str] = []
+
+    for path, config in _workflow_configs():
+        jobs = config.get("jobs", {})
+        assert isinstance(jobs, dict)
+        for job_name, job in jobs.items():
+            assert isinstance(job, dict)
+            steps = job.get("steps", [])
+            assert isinstance(steps, list)
+            for step in steps:
+                assert isinstance(step, dict)
+                if str(step.get("uses", "")).startswith("actions/checkout@"):
+                    options = step.get("with", {})
+                    assert isinstance(options, dict)
+                    if options.get("persist-credentials") is not False:
+                        insecure_checkouts.append(f"{path.name}:{job_name}")
+
+    assert insecure_checkouts == []
+
+
+def test_third_party_actions_are_pinned_to_full_commit_shas() -> None:
+    unpinned_actions: list[str] = []
+
+    for path, config in _workflow_configs():
+        jobs = config.get("jobs", {})
+        assert isinstance(jobs, dict)
+        for job_name, job in jobs.items():
+            assert isinstance(job, dict)
+            steps = job.get("steps", [])
+            assert isinstance(steps, list)
+            for step in steps:
+                assert isinstance(step, dict)
+                action = str(step.get("uses", ""))
+                if not action or action.startswith("./"):
+                    continue
+                _name, separator, revision = action.rpartition("@")
+                if separator != "@" or re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+                    unpinned_actions.append(f"{path.name}:{job_name}:{action}")
+
+    assert unpinned_actions == []
 
 
 def test_macos_model_cache_survives_tooling_only_project_changes() -> None:
@@ -84,6 +155,8 @@ def test_security_policy_matches_current_release_and_opt_in_surfaces() -> None:
     assert "No credentials" not in policy
     assert "MEMO_SECRET_STORAGE_ENABLED=1" in policy
     assert "Authorization: Bearer" in policy
+    assert "/security/advisories/new" in policy
+    assert "private vulnerability report" in policy.lower()
 
 
 def test_readme_surface_counts_and_top_level_command_inventory_are_exact() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -787,6 +787,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/fe/6a3f9f1a8bb8733326140737446aaf72fddb8b54b8f202302f5c84960613/httpcore2-2.7.0.tar.gz", hash = "sha256:6dc0fedf329a52a990930a5579edfebaea81118ea700ea0dd7de2b5e5be49efc", size = 65593, upload-time = "2026-07-14T20:40:01.111Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/6c/62e2e279e63fc4f7a5ee841ef13175a8bbc613f258e9dcc186e9de803a42/httpcore2-2.7.0-py3-none-any.whl", hash = "sha256:1452f589fe23f55b44546cd884294c41a29330af902bc0b71a761fd52d18f92b", size = 81506, upload-time = "2026-07-14T20:39:58.053Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -808,6 +821,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/4a/129b2e21b90ac2985d3928d96792bccc39bc6dfe796c5eee2d8ec06d4105/httpx2-2.7.0.tar.gz", hash = "sha256:8b30709aed5c8465b0dd3b95c09ce301c8f79e7e7a2d00ab0af551e0d0375b07", size = 94487, upload-time = "2026-07-14T20:40:02.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/b8/c341bba6411bdfda786020343c47a75ef472f6085caf82391b142b1a3ad9/httpx2-2.7.0-py3-none-any.whl", hash = "sha256:ed2a2719c696789e09493bd8e2bec3d8bd925cc6e26b68389ec25ade132f7bf4", size = 90234, upload-time = "2026-07-14T20:39:59.531Z" },
 ]
 
 [[package]]
@@ -1283,6 +1311,7 @@ cpu = [
 ]
 dev = [
     { name = "freezegun" },
+    { name = "httpx2" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1317,6 +1346,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'http'", specifier = ">=0.115" },
     { name = "fastmcp", specifier = ">=0.5,<4" },
     { name = "freezegun", marker = "extra == 'dev'", specifier = ">=1.5" },
+    { name = "httpx2", marker = "extra == 'dev'", specifier = ">=2.5,<3" },
     { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.18,<1" },
     { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.18" },
     { name = "mlx-vlm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'multimodal'", specifier = ">=0.1.12" },
@@ -2990,6 +3020,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
     { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
     { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- grant every workflow only explicit GitHub token permissions and prevent checkout credential persistence
- enforce workflow permission, credential, and immutable action-pin invariants with regression tests
- enable private vulnerability reporting guidance and update Starlette's supported test transport
- eliminate SQLite resource-warning noise and harden parallel-test warning attribution

## Verification
- `ruff format --check .`
- `ruff check src/ tests/ scripts/`
- `mypy src/memo`
- `python scripts/quality_gate.py`
- `pytest -m "not slow" -n auto --timeout=120 --cov=memo --cov-report=term-missing` (4275 passed, 29 skipped, 75.22%)
- `uv lock --check`
- `uv build`
- `pip-audit --strict --disable-pip --require-hashes`
- workflow YAML parsing and `memo config validate`
