### PR TITLE
release: v3.6.0 — dark-feature graduation pipeline

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "memo",
   "description": "Local MCP memory for AI agents — MLX on Apple Silicon or CPU sentence-transformers on Linux/Ubuntu, sqlite-vec store, markdown-on-disk in your Obsidian vault. Zero Ollama, zero cloud APIs.",
-  "version": "3.5.2",
+  "version": "3.6.0",
   "author": {
     "name": "Fernando Ferrari",
     "email": "fernandoferrari@gmail.com",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: publish
 
 on:
+  push:
+    tags: ["v*"]
   release:
     types: [published]
   workflow_dispatch:
@@ -43,6 +45,39 @@ jobs:
           python -m pip install uv==0.11.21
           uv sync --frozen --no-dev
           uv run --no-sync memo release check
+
+  github-release:
+    # Pushing a release tag is the only manual step: this job creates the
+    # GitHub Release from the tag's CHANGELOG section, so the publish chain
+    # (Release -> PyPI -> MCP registry) can never silently freeze again.
+    # No-op when the release already exists (release-event and re-run paths).
+    name: GitHub Release
+    needs: verify-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Create GitHub Release from CHANGELOG
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "release $GITHUB_REF_NAME already exists"
+            exit 0
+          fi
+          version="${GITHUB_REF_NAME#v}"
+          awk -v ver="$version" '
+            /^## \[/ { if (found) exit; if (index($0, "[" ver "]")) { found = 1; next } }
+            found { print }
+          ' CHANGELOG.md > /tmp/notes.md
+          if ! [ -s /tmp/notes.md ]; then
+            echo "See CHANGELOG.md for details." > /tmp/notes.md
+          fi
+          gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" \
+            --notes-file /tmp/notes.md --verify-tag
 
   build:
     name: Build distributions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+### Added
+
+- Dark-feature graduation pipeline (`memo dream graduate-flags`, module
+  `dream_flags.py`): every default-off `*_ENABLED` flag now declares a
+  graduation gate (`recall` = nightly ON/OFF A/B through the recall-faithful
+  eval; `tuner` = owned by an existing tuner pass; `manual` = documented
+  reason). Recall-gated flags that win `MEMO_FLAG_GRADUATION_WIN_NIGHTS`
+  consecutive measurements (latency + curated no-regression gated) graduate
+  to ON via the tuned overlay, reversibly — a later regression reverts them.
+  Flags still dark after `MEMO_FLAG_GRADUATION_DEADLINE_DAYS` surface as
+  cull candidates in `--status`. Gate completeness is CI-enforced: a new
+  dark flag cannot merge without declaring its gate. Nightly pass gated by
+  `MEMO_DREAM_FLAG_GRADUATION_ENABLED` (default off).
+
 ## [3.5.2] - 2026-07-15
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+## [3.6.0] - 2026-07-15
+
 ### Added
 
 - Dark-feature graduation pipeline (`memo dream graduate-flags`, module

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,16 @@ Wiring is `src/memo/cli_dream.py` (Click) + `src/memo/cli_dream_passes.py`
   - **Anticipate** (`dream_anticipate.py`, `MEMO_DREAM_ANTICIPATE_ENABLED`):
     surfaces recurring unmet gaps (`outcome.detect_gaps`) + hot queries into the
     receipt/briefing and pre-warms their embeddings. Never fabricates.
+  - **Flag graduation** (`dream_flags.py`, `MEMO_DREAM_FLAG_GRADUATION_ENABLED`):
+    every default-off `*_ENABLED` flag declares a gate in `dream_flags.GATES`
+    (`recall` A/B via the eval `flag_overrides` seam / `tuner`-owned / `manual`
+    + reason) — completeness CI-enforced by `test_dream_flags.py`, so a new
+    dark flag cannot merge without declaring its gate. Winners graduate to ON
+    via the overlay after `MEMO_FLAG_GRADUATION_WIN_NIGHTS` consecutive wins
+    (latency + curated gates), auto-revert on regression; flags un-graduated
+    past `MEMO_FLAG_GRADUATION_DEADLINE_DAYS` become cull candidates in
+    `memo dream graduate-flags --status` (deletion stays human). Distinct from
+    `dream_graduate.py` (quarantined-memory graduation).
 
 **Tuned-params overlay** (`src/memo/tuned_overlay.py`) is the only place
 auto-tuning touches live behavior: the tuner writes `state_dir/tuned_params.json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ master advances underneath you, and a `git checkout` in another session moves
 
 ## Architecture
 
-**`Memory` facade** (`src/memo/memory/facade.py`) multiply-inherits ten operation mixins — `_WriteOpsMixin`, `_UpdateOpsMixin`, `_DeleteOpsMixin`, `_SearchOpsMixin`, `_AskOpsMixin`, `_RerankOpsMixin`, `_RepoOpsMixin`, `_MaintainOpsMixin`, `_ConsolidateOpsMixin`, `_ReplayOpsMixin` — each in their own `src/memo/memory/<op>_ops.py` file. Module-level constants, prompts, and pure helpers are in `src/memo/memory/record.py`. Never import from a mixin directly; always go through `Memory`.
+**`Memory` facade** (`src/memo/memory/facade.py`) multiply-inherits twelve operation mixins — `_WriteOpsMixin`, `_UpdateOpsMixin`, `_DeleteOpsMixin`, `_SearchOpsMixin`, `_AskOpsMixin`, `_ChatAskOpsMixin`, `_RerankOpsMixin`, `_RepoOpsMixin`, `_MaintainOpsMixin`, `_ConsolidateOpsMixin`, `_ReplayOpsMixin`, `_SecretOpsMixin` — each in their own `src/memo/memory/<op>_ops.py` file. Module-level constants, prompts, and pure helpers are in `src/memo/memory/record.py`. Never import from a mixin directly; always go through `Memory`.
 
 **MCP server** (`src/memo/server.py`) registers tools via `build_server()`. Each domain is a `server_<domain>.py` module that exports `register(server, memory)` — called once in `build_server()`. Adding a new MCP tool = create `src/memo/server_<domain>.py` + add one `register` call in `server.py`. The `_MaintainOpsMixin` method is directly callable from tests via `mock_memory.<method>()`.
 
@@ -58,7 +58,7 @@ master advances underneath you, and a `git checkout` in another session moves
 
 **CLI** is in `src/memo/cli.py` (entry-point wiring only) + `src/memo/cli_<domain>.py` files. Each domain file exports a Click command or group imported and registered in `cli.py`.
 
-**Flags** (`src/memo/flags.py`) is the single registry for all `MEMO_*` env vars — it aggregates `FlagSpec`s defined in the per-domain `flags_<group>.py` modules (`flags_recall/search/behavior/ingest/misc.py`, base types in `flags_base.py`). Add a new flag in the matching `flags_<group>.py`. Use `flag_bool/int/float/str(name)` — never `os.environ.get("MEMO_...")` inline. `memo config validate` parses every set flag.
+**Flags** (`src/memo/flags.py`) is the single registry for all `MEMO_*` env vars — it aggregates `FlagSpec`s defined in the per-domain `flags_<group>.py` modules (`flags_recall/search/behavior/capture/ingest/misc.py`, base types in `flags_base.py`). Add a new flag in the matching `flags_<group>.py`. Use `flag_bool/int/float/str(name)` — never `os.environ.get("MEMO_...")` inline. `memo config validate` parses every set flag.
 
 **Cache** (`src/memo/embedder.py`): query embeddings use shared LRU cache from `consciousness_contracts.cache` when `MEMO_QUERY_CACHE_SIZE > 0`. This eliminates duplication with Synapse's embed cache and ensures consistent cache behavior across the trinity.
 
@@ -210,6 +210,7 @@ The `.md` files are canonical; the sqlite index is **derived and replayable**:
 ## Config & errors
 
 - `MEMO_*` behavioral flags live in `src/memo/flags.py` (registry + typed accessors). Storage/model config lives in `src/memo/config.py` (typed `Config` dataclass). Prefer `flag_bool/int/float/str` over raw `os.environ`. `memo config validate` catches typos.
+- **User-facing config is the persistent Markdown config** (`src/memo/config_md.py`): `memo config` / `memo config set <key> <value>` (dotted keys, e.g. `recall.top_k`) writes `~/.config/memo/*-config.md` — reaches daemons/MCP/hooks, unlike a per-terminal `export MEMO_*`. Flag resolution: **env var > markdown config > tuned overlay > built-in default**.
 - Domain errors live in `src/memo/errors.py` (`MemoError` base). Raise/catch
   those rather than bare `Exception` in non-defensive code.
 
@@ -343,8 +344,9 @@ Wiring is `src/memo/cli_dream.py` (Click) + `src/memo/cli_dream_passes.py`
 
 **Tuned-params overlay** (`src/memo/tuned_overlay.py`) is the only place
 auto-tuning touches live behavior: the tuner writes `state_dir/tuned_params.json`
-and `flags.flag()` consults it, so flag resolution is **env var > overlay >
-built-in default** (an explicit `MEMO_*` env var is never overridden). Delete the
+and `flags.flag()` consults it, so flag resolution is **env var > markdown
+config > overlay > built-in default** (an explicit `MEMO_*` env var or
+`memo config set` value is never overridden). Delete the
 file or `memo dream tune --rollback` to revert. The enable flags live in the
 nightly LaunchAgent's `EnvironmentVariables` (launchd does not inherit the shell)
 — see `~/repos/memo/launchd/com.memo.dream.plist`.

--- a/packaging/mcpb-node/manifest.json
+++ b/packaging/mcpb-node/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "memo",
   "display_name": "memo - local-first memory (Node)",
-  "version": "3.5.2",
+  "version": "3.6.0",
   "description": "Local-first long-term memory for AI agents. 100% offline: no cloud API, no keys.",
   "long_description": "memo gives Claude a persistent, local-first memory: decisions, facts and preferences saved today are recalled automatically in future sessions.\n\n- Hybrid retrieval: vector (sqlite-vec) + BM25 fused with RRF, optional cross-encoder rerank\n- Embeddings run in-process - MLX on Apple Silicon, CPU sentence-transformers elsewhere - so nothing ever leaves your machine\n- Markdown files are the source of truth (Obsidian-compatible); the sqlite index is fully rebuildable\n- Time-machine queries (ask what was known at any past date), contradiction detection, nightly synthesis\n- Small MCP surface (13 tools, ~1.2k tokens)\n\nRequires the `uv` runtime. For supply-chain safety the bootstrap never downloads and executes a remote shell script; install uv from the official Astral documentation before first launch. The first launch then installs the exactly pinned memo package and can take 1-2 minutes.",
   "author": {

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "memo",
   "display_name": "memo - local-first memory",
-  "version": "3.5.2",
+  "version": "3.6.0",
   "description": "Local-first long-term memory for AI agents. 100% offline: no cloud API, no keys.",
   "long_description": "memo gives Claude a persistent, local-first memory: decisions, facts and preferences saved today are recalled automatically in future sessions.\n\n- Hybrid retrieval: vector (sqlite-vec) + BM25 fused with RRF, optional cross-encoder rerank\n- Embeddings run in-process - MLX on Apple Silicon, CPU sentence-transformers elsewhere - so nothing ever leaves your machine\n- Markdown files are the source of truth (Obsidian-compatible); the sqlite index is fully rebuildable\n- Time-machine queries (ask what was known at any past date), contradiction detection, nightly synthesis\n- Small MCP surface (13 tools, ~1.2k tokens)\n\nRequires the `uv` Python runtime (https://docs.astral.sh/uv/) and Python 3.13+. First launch downloads the package and the embedding model; subsequent launches are instant.",
   "author": {
@@ -23,7 +23,7 @@
     "entry_point": "server/main.py",
     "mcp_config": {
       "command": "uvx",
-      "args": ["--from", "mlx-memo==3.5.2", "memo-mcp"]
+      "args": ["--from", "mlx-memo==3.6.0", "memo-mcp"]
     }
   },
   "keywords": ["memory", "mcp", "local-first", "rag", "obsidian", "offline", "mlx"],

--- a/plugins/memo/.codex-plugin/plugin.json
+++ b/plugins/memo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memo",
-  "version": "3.5.2",
+  "version": "3.6.0",
   "description": "Slash skill and MCP wiring for memo, the local memory system: MLX on Apple Silicon or CPU on Linux/Intel.",
   "author": {
     "name": "Fernando Ferrari",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 # only the PyPI distribution moved. Back-compat: existing users on
 # `memo-mcp ≤ 0.4.3` keep working; new installs use `pip install mlx-memo`.
 name = "mlx-memo"
-version = "3.5.2"
+version = "3.6.0"
 description = "Local-first semantic memory for AI agents — MLX (Apple Silicon) or CPU sentence-transformers (Linux/Ubuntu) embeddings + sqlite-vec, MCP server. No cloud, no API keys."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/jagoff/memo",
     "source": "github"
   },
-  "version": "3.5.2",
+  "version": "3.6.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mlx-memo",
-      "version": "3.5.2",
+      "version": "3.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/memo/cli_dream.py
+++ b/src/memo/cli_dream.py
@@ -502,6 +502,37 @@ def dream_run(
                 receipt["errors"].append(f"hyde_tuner: {type(exc).__name__}: {exc}")
                 progress.update(step, description="[tune] hyde A/B [yellow]warn[/yellow]")
 
+        # Dark-feature (flag) graduation: A/B-measure default-off *_ENABLED
+        # flags with a recall gate, flip winners ON via the overlay, sweep
+        # deadline cull candidates (separate opt-in).
+        if flag_bool("MEMO_DREAM_FLAG_GRADUATION_ENABLED"):
+            progress.update(step, description="[graduate] dark flags A/B...")
+            try:
+                from memo import dream_flags
+                from memo.flags import flag_float
+
+                receipt["flag_graduation"] = dream_flags.run_flag_graduation_pass(
+                    cfg,
+                    mem,
+                    k=5 if (_k := flag_int("MEMO_DREAM_TUNE_K")) is None else _k,
+                    min_used_score=0.5
+                    if (_mus := flag_float("MEMO_DREAM_MINE_MIN_USED_SCORE")) is None
+                    else _mus,
+                    dry_run=dry_run,
+                )
+                _fg = receipt["flag_graduation"]
+                if _fg.get("status") == "error":
+                    receipt["errors"].append(f"flag_graduation: {_fg.get('error')}")
+                progress.update(
+                    step,
+                    description=(
+                        f"[graduate] dark flags [green]✓[/green]  {_fg.get('status')}"
+                    ),
+                )
+            except Exception as exc:
+                receipt["errors"].append(f"flag_graduation: {type(exc).__name__}: {exc}")
+                progress.update(step, description="[graduate] dark flags [yellow]warn[/yellow]")
+
         # Online-only project-boost explorer (separate opt-in; no offline gate).
         if flag_bool("MEMO_DREAM_TUNE_BOOST_ENABLED"):
             try:
@@ -1673,6 +1704,57 @@ def dream_tune_cmd(dry_run: bool, do_rollback: bool, show_status: bool) -> None:
         mem,
         k=5 if (_k := flag_int("MEMO_DREAM_TUNE_K")) is None else _k,
         max_evals=20 if (_me := flag_int("MEMO_DREAM_TUNE_MAX_EVALS")) is None else _me,
+        min_used_score=0.5
+        if (_mus := flag_float("MEMO_DREAM_MINE_MIN_USED_SCORE")) is None
+        else _mus,
+        dry_run=dry_run,
+    )
+    click.echo(json.dumps(res, indent=2, ensure_ascii=False))
+
+
+@dream_cmd.command(name="graduate-flags")
+@click.option("--dry-run", is_flag=True, help="Measure, write nothing (no state, no overlay).")
+@click.option("--status", "show_status", is_flag=True, help="Inventory: every dark flag + verdict.")
+@click.option("--json", "as_json", is_flag=True, help="Emit result as JSON.")
+def dream_graduate_flags_cmd(dry_run: bool, show_status: bool, as_json: bool) -> None:
+    """Dark-feature graduation: A/B-measure default-off *_ENABLED flags and
+    flip winners ON via the tuned overlay (reversible); report cull candidates."""
+    from memo import dream_flags
+    from memo.flags import flag_float, flag_int
+
+    cfg = Config.from_env()
+    if show_status:
+        rows = dream_flags.status_rows(cfg)
+        if as_json:
+            click.echo(json.dumps(rows, indent=2, ensure_ascii=False))
+            return
+        from rich.table import Table
+
+        table = Table(title="dark-flag graduation")
+        for col in ("flag", "kind", "status", "streak", "days left", "reason"):
+            table.add_column(col)
+        for r in rows:
+            style = {
+                "graduated": "green",
+                "human_graduated": "green",
+                "cull_candidate": "red",
+                "reverted": "yellow",
+            }.get(str(r["status"]), "")
+            table.add_row(
+                r["flag"],
+                r["kind"],
+                f"[{style}]{r['status']}[/{style}]" if style else str(r["status"]),
+                str(r["streak"]),
+                "-" if r["days_left"] is None else str(r["days_left"]),
+                r["reason"],
+            )
+        console.print(table)
+        return
+    mem = _get_memory(cfg)
+    res = dream_flags.run_flag_graduation_pass(
+        cfg,
+        mem,
+        k=5 if (_k := flag_int("MEMO_DREAM_TUNE_K")) is None else _k,
         min_used_score=0.5
         if (_mus := flag_float("MEMO_DREAM_MINE_MIN_USED_SCORE")) is None
         else _mus,

--- a/src/memo/dream_flags.py
+++ b/src/memo/dream_flags.py
@@ -1,0 +1,455 @@
+"""`memo dream graduate-flags` — dark-feature (flag) graduation pipeline.
+
+Every default-off ``*_ENABLED`` bool flag MUST declare a :class:`GateSpec` in
+``GATES`` (enforced by ``tests/test_dream_flags.py`` — a new dark feature
+cannot merge without declaring its graduation gate):
+
+- ``recall``  — auto-measurable: a nightly ON/OFF A/B through the
+  recall-faithful eval (``Cfg.flag_overrides`` env-pin seam, same corpus and
+  (precision@K, -noise@K) objective as ``dream_tune``). A flag that wins
+  ``MEMO_FLAG_GRADUATION_WIN_NIGHTS`` consecutive measurements — each also
+  passing the latency-headroom and curated no-regression gates — graduates to
+  ON via the tuned overlay. Reversible: a later night whose live metrics
+  regress vs the graduation baseline reverts it (retry after a cooldown).
+- ``tuner``   — already owned by an existing nightly tuner pass (e.g. HyDE /
+  graph-retrieval); tracked here for the deadline sweep, never double-measured.
+- ``manual``  — not auto-measurable by the recall eval (UX banners, ingest
+  quality, ops, meta passes); ``reason`` documents why. A human graduates it
+  by setting the flag via env or ``memo config set``.
+
+Deadline sweep: any dark flag still un-graduated after
+``MEMO_FLAG_GRADUATION_DEADLINE_DAYS`` becomes a ``cull_candidate`` in the
+receipt and ``memo dream graduate-flags --status`` — flip it with a real gate
+or delete the code path. Deletion stays human.
+
+Distinct from ``dream_graduate.py`` (quarantined-MEMORY graduation): this
+module graduates FEATURE FLAGS. OFF by default
+(``MEMO_DREAM_FLAG_GRADUATION_ENABLED``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Literal
+
+from memo.dream_tune import _curated_label_set, _regressed, _scalar_overlay, build_labels
+from memo.eval_recall import Cfg, LabelSet, evaluate, gate_metrics, limit_label_set
+from memo.flags import REGISTRY, FlagSpec, flag_float, flag_int
+from memo.tuned_overlay import read_overlay, write_overlay
+
+_STATE_FILE = "flag_graduation.json"
+_MIN_SIM = "MEMO_RECALL_MIN_SIM"
+_TRUTHY = ("1", "true", "yes", "on")
+# A winning candidate whose eval p50 exceeds the OFF config's p50 by more than
+# this factor is rejected regardless of precision (same guard as the rank-knob
+# tuner; skipped when the OFF p50 rounds to 0 — stub/tiny corpora).
+FLAG_LATENCY_HEADROOM = 1.25
+
+GateKind = Literal["recall", "tuner", "manual"]
+
+
+@dataclass(frozen=True)
+class GateSpec:
+    """How one dark ``*_ENABLED`` flag earns (or is exempted from) auto-ON."""
+
+    flag: str
+    kind: GateKind
+    # tuner: which pass owns it; manual: why it cannot auto-measure.
+    reason: str
+    # Eval mode for recall gates (vec keeps the A/B on the fast hook path).
+    mode: str = "vec"
+    # Companion env pins required for the ON measurement (and written to the
+    # overlay alongside the flag when it graduates).
+    extra_flags: tuple[tuple[str, str], ...] = ()
+
+
+def _g(
+    flag: str,
+    kind: GateKind,
+    reason: str,
+    *,
+    mode: str = "vec",
+    extra_flags: tuple[tuple[str, str], ...] = (),
+) -> tuple[str, GateSpec]:
+    return flag, GateSpec(flag, kind, reason, mode=mode, extra_flags=extra_flags)
+
+
+# The graduation contract: one entry per dark *_ENABLED flag. Completeness is
+# enforced by tests — adding a dark flag without declaring its gate fails CI.
+GATES: dict[str, GateSpec] = dict(
+    (
+        # --- recall: nightly ON/OFF A/B via the eval flag_overrides seam ------
+        _g("MEMO_HYPE_ENABLED", "recall", "read-path HyPE fold; measurable in vec retrieval"),
+        _g("MEMO_ENTITY_RETRIEVAL_ENABLED", "recall", "query-time entity-overlap boost"),
+        _g("MEMO_CONTRADICT_PENALTY_ENABLED", "recall", "rank-time penalty on contradicted hits"),
+        _g("MEMO_GRAPH_SIGNAL_ENABLED", "recall", "graph ranking signal; doc says eval-gated"),
+        _g(
+            "MEMO_GRAPH_OUTCOME_SIGNAL_ENABLED",
+            "recall",
+            "roi modulation of graph boosts; needs the graph signal on",
+            extra_flags=(("MEMO_GRAPH_SIGNAL_ENABLED", "1"),),
+        ),
+        # --- tuner: an existing nightly pass owns the flip --------------------
+        _g("MEMO_HYDE_ENABLED", "tuner", "owned by dream_tune.run_hyde_pass"),
+        _g("MEMO_GRAPH_RETRIEVAL_ENABLED", "tuner", "owned by run_graph_retrieval_pass"),
+        _g("MEMO_GRAPH_EXPANSION_ENABLED", "tuner", "owned by run_graph_retrieval_pass"),
+        # --- manual: not recall-measurable; human flips via env/config set ----
+        _g("MEMO_GUARD_ENABLED", "manual", "UX banner; gate = user judgement on interjections"),
+        _g("MEMO_INTERJECT_ENABLED", "manual", "UX banner; gate = user judgement"),
+        _g("MEMO_GRAPH_REASON_ENABLED", "manual", "attribution metadata only, no ranking effect"),
+        _g("MEMO_VERDICT_ENABLED", "manual", "next-turn reaction telemetry; no retrieval effect"),
+        _g("MEMO_MAINT_SLEEP_CYCLE_ENABLED", "manual", "background maintenance; op cost decision"),
+        _g("MEMO_SYNC_MEMFLOW_ENABLED", "manual", "memflow integration; op decision"),
+        _g("MEMO_CRUSHER_ENABLED", "manual", "ingest token economy; gate = memo eval tokens"),
+        _g("MEMO_VLM_CAPTION_ENABLED", "manual", "ingest-time VLM cost; gate = ingest quality"),
+        _g("MEMO_UPDATE_CHECK_ENABLED", "manual", "ops/update policy; human-only"),
+        _g("MEMO_ASK_GAPS_ENABLED", "manual", "ask-path UX nudge; no retrieval metric"),
+        _g("MEMO_SECRET_STORAGE_ENABLED", "manual", "security opt-in; human-only, never auto"),
+        _g("MEMO_GRADUATION_CONTROLLER_ENABLED", "manual", "memory graduation; own shadow eval"),
+        # --- manual (meta): flags gating nightly passes themselves ------------
+        _g("MEMO_DREAM_TUNE_ENABLED", "manual", "meta: gates the tuner pass; op cost decision"),
+        _g("MEMO_DREAM_TUNE_BOOST_ENABLED", "manual", "meta: gates the boost explorer"),
+        _g("MEMO_DREAM_HYDE_TUNE_ENABLED", "manual", "meta: gates the HyDE A/B pass"),
+        _g("MEMO_DREAM_RETRIEVAL_TUNE_ENABLED", "manual", "meta: gates the retrieval tuner"),
+        _g("MEMO_DREAM_ANTICIPATE_ENABLED", "manual", "meta: gates the anticipate pass"),
+        _g("MEMO_DREAM_HYPE_ENABLED", "manual", "meta: gates the nightly HyPE indexer"),
+        _g("MEMO_DREAM_COMMUNITIES_ENABLED", "manual", "meta: gates the communities pass"),
+        _g("MEMO_DREAM_ENTITY_CANON_ENABLED", "manual", "meta: gates the entity-canon pass"),
+        _g("MEMO_DREAM_FOLDER_ABSTRACTS_ENABLED", "manual", "meta: gates folder abstracts"),
+        _g("MEMO_DREAM_DISTILL_ENABLED", "manual", "meta: gates the distill pass"),
+        _g("MEMO_DREAM_BRIDGES_ENABLED", "manual", "meta: gates the bridges pass"),
+        _g(
+            "MEMO_DREAM_CONSOLIDATE_EPISODES_ENABLED", "manual", "meta: gates episode consolidation"
+        ),
+        _g("MEMO_DREAM_PROFILE_ENABLED", "manual", "meta: gates profile distillation"),
+        _g("MEMO_DREAM_RETAG_GLOBAL_ENABLED", "manual", "meta: gates the retag pass"),
+        _g("MEMO_DREAM_GRADUATION_ENABLED", "manual", "meta: gates quarantine graduation"),
+        _g("MEMO_DREAM_CHRONICLE_ENABLED", "manual", "meta: gates the chronicle diary pass"),
+        _g("MEMO_DREAM_FLAG_GRADUATION_ENABLED", "manual", "meta: gates this pass itself"),
+    )
+)
+
+
+def dark_flags() -> list[FlagSpec]:
+    """Every default-off ``*_ENABLED`` bool flag in the registry — the set
+    ``GATES`` must cover."""
+    return [
+        s
+        for s in REGISTRY.values()
+        if s.kind == "bool" and s.name.endswith("_ENABLED") and not s.opt_out and not s.default
+    ]
+
+
+def _human_value(name: str) -> str | None:
+    """The human-pinned raw value for ``name`` (env first, then markdown
+    config); None when not pinned. Graduation never overrides a human decision
+    (env/config beat the overlay in flag resolution)."""
+    v = os.environ.get(name)
+    if v is not None:
+        return v
+    try:
+        from memo.config_md import flag_values
+
+        return flag_values(os.environ).get(name)
+    except Exception:
+        return None
+
+
+def human_owned(name: str) -> bool:
+    return _human_value(name) is not None
+
+
+# --- state --------------------------------------------------------------------
+
+
+def _state_path(state_dir: Path) -> Path:
+    return Path(state_dir) / _STATE_FILE
+
+
+def load_state(state_dir: Path) -> dict[str, Any]:
+    try:
+        doc = json.loads(_state_path(state_dir).read_text(encoding="utf-8"))
+        return doc if isinstance(doc, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def save_state(state_dir: Path, state: dict[str, Any]) -> None:
+    p = _state_path(state_dir)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+
+# --- measurement ----------------------------------------------------------------
+
+
+def measure_flag(
+    mem: Any, labels: LabelSet, *, k: int, spec: GateSpec, enabled: bool, floor: float
+) -> dict[str, float]:
+    """prec@K / noise@K / p50 with ``spec.flag`` pinned on/off through the
+    ``Cfg.flag_overrides`` env-pin seam (generalises ``measure_hyde`` — the seam
+    for flags read inside ``Memory.search``/ranking that RankKnobs can't reach)."""
+    pins = {spec.flag: "1" if enabled else "0"}
+    if enabled:
+        pins.update(dict(spec.extra_flags))
+    cfg = Cfg(
+        name=f"{spec.flag}={'on' if enabled else 'off'}",
+        mode=spec.mode,
+        floor=floor,
+        exclude_archived=True,
+        flag_overrides=pins,
+    )
+    rows = evaluate(mem, k=k, labels=labels, configs=[cfg])
+    metrics = gate_metrics(rows)
+    metrics["latency_ms_p50"] = round(rows[0].latency_ms_p50, 1) if rows else 0.0
+    return metrics
+
+
+def _wins(on: dict[str, float], off: dict[str, float]) -> bool:
+    return (on["precision_at_k"], -on["noise_at_k"]) > (
+        off["precision_at_k"],
+        -off["noise_at_k"],
+    )
+
+
+# --- pass -----------------------------------------------------------------------
+
+
+def _knobs() -> dict[str, int]:
+    def _i(name: str, default: int) -> int:
+        v = flag_int(name)
+        return default if v is None else v
+
+    return {
+        "win_nights": _i("MEMO_FLAG_GRADUATION_WIN_NIGHTS", 3),
+        "max_per_night": _i("MEMO_FLAG_GRADUATION_MAX_PER_NIGHT", 3),
+        "deadline_days": _i("MEMO_FLAG_GRADUATION_DEADLINE_DAYS", 45),
+        "retry_days": _i("MEMO_FLAG_GRADUATION_RETRY_DAYS", 14),
+        "max_prompts": _i("MEMO_FLAG_GRADUATION_MAX_PROMPTS", 80),
+    }
+
+
+def _age_days(entry: dict[str, Any], field: str, today: date) -> int | None:
+    raw = entry.get(field)
+    if not raw:
+        return None
+    try:
+        return (today - date.fromisoformat(str(raw))).days
+    except ValueError:
+        return None
+
+
+def run_flag_graduation_pass(
+    cfg: Any,
+    mem: Any,
+    *,
+    k: int = 5,
+    min_used_score: float = 0.5,
+    dry_run: bool = False,
+    today: date | None = None,
+) -> dict[str, Any]:
+    """One nightly flag-graduation pass. Returns a receipt fragment; never
+    raises (mirrors the dream_tune passes). ``dry_run`` measures but never
+    writes state or overlay."""
+    res: dict[str, Any] = {"status": "noop", "flags": {}}
+    try:
+        today = today or date.today()
+        knobs = _knobs()
+        state = load_state(cfg.state_dir)
+        flags_state: dict[str, Any] = state.setdefault("flags", {})
+
+        # Track every dark flag from the night it first appears.
+        for spec_reg in dark_flags():
+            flags_state.setdefault(
+                spec_reg.name,
+                {"first_tracked": today.isoformat(), "streak": 0, "status": "tracking"},
+            )
+
+        # Human-pinned truthy flag = graduated by the human, not by us.
+        for name, entry in flags_state.items():
+            hv = _human_value(name)
+            if hv is not None and hv.strip().lower() in _TRUTHY:
+                entry["status"] = "human_graduated"
+
+        labels, curated_used = build_labels(cfg, min_used_score=min_used_score)
+        labels = limit_label_set(labels, knobs["max_prompts"])
+        res["n_labels"] = len(labels.prompts)
+        res["curated_used"] = curated_used
+        floor = flag_float(_MIN_SIM)
+        floor = 0.5 if floor is None else floor
+        overlay = read_overlay(cfg.state_dir)
+
+        # Post-graduation regression guard: an overlay-graduated flag whose
+        # live metrics regressed vs its graduation baseline is reverted (its
+        # overlay key removed -> default OFF restored), then cools down.
+        if labels.prompts:
+            for name, entry in flags_state.items():
+                gate = GATES.get(name)
+                if (
+                    gate is None
+                    or entry.get("status") != "graduated"
+                    or not isinstance(entry.get("baseline"), dict)
+                    or not overlay.get(name)
+                ):
+                    continue
+                live = measure_flag(mem, labels, k=k, spec=gate, enabled=True, floor=floor)
+                res["flags"][name] = {"verdict": "guard", "live": live}
+                if _regressed(live, entry["baseline"]) and not dry_run:
+                    params = _scalar_overlay(cfg.state_dir)
+                    params.pop(name, None)
+                    for extra, _v in gate.extra_flags:
+                        params.pop(extra, None)
+                    write_overlay(cfg.state_dir, params, {"set_by": "dream-flag-grad-revert"})
+                    overlay = read_overlay(cfg.state_dir)
+                    entry.update(
+                        {"status": "reverted", "streak": 0, "reverted_at": today.isoformat()}
+                    )
+                    res["flags"][name]["verdict"] = "reverted"
+
+        # Candidates: recall-gated, resolved OFF, not human-pinned, not cooling
+        # down after a revert. Least-recently-measured first; cap per night.
+        def _eligible(name: str) -> bool:
+            gate = GATES.get(name)
+            entry = flags_state[name]
+            if gate is None or gate.kind != "recall":
+                return False
+            if entry.get("status") in ("graduated", "human_graduated"):
+                return False
+            if human_owned(name) or overlay.get(name):
+                return False
+            cooled = _age_days(entry, "reverted_at", today)
+            return not (cooled is not None and cooled < knobs["retry_days"])
+
+        candidates = sorted(
+            (n for n in flags_state if _eligible(n)),
+            key=lambda n: str(flags_state[n].get("last_measured") or ""),
+        )[: knobs["max_per_night"]]
+        res["measured"] = candidates
+
+        if labels.prompts:
+            curated = _curated_label_set(cfg.state_dir)
+            for name in candidates:
+                gate = GATES[name]
+                entry = flags_state[name]
+                off = measure_flag(mem, labels, k=k, spec=gate, enabled=False, floor=floor)
+                on = measure_flag(mem, labels, k=k, spec=gate, enabled=True, floor=floor)
+                verdict: dict[str, Any] = {"off": off, "on": on}
+                win = _wins(on, off)
+                budget = off.get("latency_ms_p50", 0.0) * FLAG_LATENCY_HEADROOM
+                if win and budget > 0 and on.get("latency_ms_p50", 0.0) > budget:
+                    win, verdict["latency_rejected"] = False, True
+                if win and curated is not None:
+                    c_off = measure_flag(mem, curated, k=k, spec=gate, enabled=False, floor=floor)
+                    c_on = measure_flag(mem, curated, k=k, spec=gate, enabled=True, floor=floor)
+                    verdict["curated"] = {"off": c_off, "on": c_on}
+                    if _regressed(c_on, c_off):
+                        win, verdict["curated_rejected"] = False, True
+                entry["streak"] = entry.get("streak", 0) + 1 if win else 0
+                entry["last_measured"] = today.isoformat()
+                verdict["streak"] = entry["streak"]
+                verdict["verdict"] = "win" if win else "lose"
+                if win and entry["streak"] >= knobs["win_nights"]:
+                    if dry_run:
+                        verdict["verdict"] = "would_graduate"
+                    else:
+                        params = _scalar_overlay(cfg.state_dir)
+                        params[name] = True
+                        for extra, v in gate.extra_flags:
+                            params[extra] = v.strip().lower() in _TRUTHY
+                        write_overlay(
+                            cfg.state_dir,
+                            params,
+                            {
+                                "set_by": "dream-flag-graduation",
+                                "flag": name,
+                                "baseline_prec": on["precision_at_k"],
+                                "baseline_noise": on["noise_at_k"],
+                            },
+                        )
+                        overlay = read_overlay(cfg.state_dir)
+                        entry.update({"status": "graduated", "baseline": on})
+                        verdict["verdict"] = "graduated"
+                res["flags"][name] = verdict
+        elif candidates:
+            res["status"] = "no_labels"
+
+        # Deadline sweep: still un-graduated past the deadline -> cull candidate.
+        culls: list[str] = []
+        for name, entry in flags_state.items():
+            if entry.get("status") not in ("tracking", "reverted", "cull_candidate"):
+                continue
+            age = _age_days(entry, "first_tracked", today)
+            if age is not None and age > knobs["deadline_days"]:
+                entry["status"] = "cull_candidate"
+                culls.append(name)
+        res["cull_candidates"] = sorted(culls)
+        res["graduated"] = sorted(
+            n for n, v in res["flags"].items() if v.get("verdict") == "graduated"
+        )
+        res["reverted"] = sorted(
+            n for n, v in res["flags"].items() if v.get("verdict") == "reverted"
+        )
+        if res["status"] == "noop" and res["measured"]:
+            res["status"] = "measured"
+        if res["graduated"] or res["reverted"]:
+            res["status"] = "applied"
+
+        if not dry_run:
+            save_state(cfg.state_dir, state)
+    except Exception as exc:  # surfaced into the receipt, never silent
+        res["status"] = "error"
+        res["error"] = f"{type(exc).__name__}: {exc}"
+    return res
+
+
+# --- status (CLI) ---------------------------------------------------------------
+
+
+def status_rows(cfg: Any, *, today: date | None = None) -> list[dict[str, Any]]:
+    """One row per dark flag: gate kind, status, streak, tracked-for days and
+    days left before the cull deadline — the inventory view behind
+    ``memo dream graduate-flags --status``."""
+    today = today or date.today()
+    knobs = _knobs()
+    flags_state = load_state(cfg.state_dir).get("flags", {})
+    overlay = read_overlay(cfg.state_dir)
+    rows = []
+    for spec_reg in sorted(dark_flags(), key=lambda s: s.name):
+        gate = GATES.get(spec_reg.name)
+        entry = flags_state.get(spec_reg.name, {})
+        age = _age_days(entry, "first_tracked", today)
+        status = entry.get("status", "untracked")
+        hv = _human_value(spec_reg.name)
+        if hv is not None and hv.strip().lower() in _TRUTHY:
+            status = "human_graduated"
+        rows.append(
+            {
+                "flag": spec_reg.name,
+                "kind": gate.kind if gate else "MISSING_GATE",
+                "reason": gate.reason if gate else "",
+                "status": status,
+                "streak": entry.get("streak", 0),
+                "tracked_days": age,
+                "days_left": None if age is None else max(0, knobs["deadline_days"] - age),
+                "overlay_on": bool(overlay.get(spec_reg.name)),
+            }
+        )
+    return rows
+
+
+__all__ = [
+    "FLAG_LATENCY_HEADROOM",
+    "GATES",
+    "GateSpec",
+    "dark_flags",
+    "human_owned",
+    "load_state",
+    "measure_flag",
+    "run_flag_graduation_pass",
+    "save_state",
+    "status_rows",
+]

--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -1009,6 +1009,64 @@ SPECS: tuple[FlagSpec, ...] = (
         "this budget is rejected to protect the 5s recall-hook budget.",
         min_val=0.0,
     ),
+    _spec(
+        "MEMO_DREAM_FLAG_GRADUATION_ENABLED",
+        "bool",
+        False,
+        "misc",
+        "Enable the nightly dark-feature (flag) graduation pass inside `memo dream run`. "
+        "OFF by default. Every default-off *_ENABLED flag has a declared gate in "
+        "dream_flags.GATES; recall-gated flags get an ON/OFF A/B against the mined+curated "
+        "labels and graduate to ON via the tuned overlay after "
+        "MEMO_FLAG_GRADUATION_WIN_NIGHTS consecutive wins (latency + curated gates). "
+        "Reversible: a regression vs the graduation baseline reverts the flag. Flags that "
+        "never graduate within MEMO_FLAG_GRADUATION_DEADLINE_DAYS surface as cull "
+        "candidates in `memo dream graduate-flags --status` (deletion stays human).",
+    ),
+    _spec(
+        "MEMO_FLAG_GRADUATION_WIN_NIGHTS",
+        "int",
+        3,
+        "misc",
+        "Consecutive winning A/B measurements a recall-gated dark flag needs before the "
+        "flag-graduation pass flips it ON via the tuned overlay.",
+        min_val=1,
+    ),
+    _spec(
+        "MEMO_FLAG_GRADUATION_MAX_PER_NIGHT",
+        "int",
+        3,
+        "misc",
+        "Max dark flags A/B-measured per flag-graduation night (cost ceiling; "
+        "least-recently-measured first).",
+        min_val=1,
+    ),
+    _spec(
+        "MEMO_FLAG_GRADUATION_DEADLINE_DAYS",
+        "int",
+        45,
+        "misc",
+        "Days a dark flag may stay tracked without graduating before it is reported as a "
+        "cull candidate (flip it with a real gate or delete the code path).",
+        min_val=1,
+    ),
+    _spec(
+        "MEMO_FLAG_GRADUATION_RETRY_DAYS",
+        "int",
+        14,
+        "misc",
+        "Cooldown after a flag-graduation revert before the same flag is A/B-measured again.",
+        min_val=0,
+    ),
+    _spec(
+        "MEMO_FLAG_GRADUATION_MAX_PROMPTS",
+        "int",
+        80,
+        "misc",
+        "Label-corpus cap per flag-graduation measurement (each candidate costs two "
+        "retrieval evals over this many prompts).",
+        min_val=1,
+    ),
     _spec("MEMO_DREAM_TUNE_K", "int", 5, "misc", "K for precision@K/noise@K during dream tuning."),
     _spec(
         "MEMO_DREAM_TUNE_MAX_EVALS",

--- a/tests/test_dream_flags.py
+++ b/tests/test_dream_flags.py
@@ -1,0 +1,308 @@
+"""dream_flags — dark-feature (flag) graduation: gate completeness, A/B
+streaks, overlay apply/revert, cooldown, deadline cull, dry-run."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from memo import dream_flags as df
+from memo.eval_recall import LabelSet, Prompt
+from memo.flags import REGISTRY
+from memo.tuned_overlay import read_overlay, write_overlay
+
+TODAY = date(2026, 7, 15)
+
+
+# --- the program's lock: every dark flag declares its gate ---------------------
+
+
+def test_every_dark_flag_has_a_gate():
+    """A new default-off *_ENABLED flag cannot merge without declaring its
+    graduation gate in dream_flags.GATES (recall / tuner / manual + reason)."""
+    missing = sorted({s.name for s in df.dark_flags()} - set(df.GATES))
+    assert not missing, (
+        f"dark flags without a declared graduation gate: {missing}. "
+        "Add a GateSpec to dream_flags.GATES — kind 'recall' if the flag is "
+        "measurable via the eval flag_overrides seam, 'tuner' if an existing "
+        "nightly pass owns it, else 'manual' with the reason."
+    )
+
+
+def test_no_stale_gates():
+    stale = sorted(set(df.GATES) - set(REGISTRY))
+    assert not stale, f"GATES entries for flags no longer in the registry: {stale}"
+
+
+def test_gate_reasons_are_documented():
+    assert all(g.reason.strip() for g in df.GATES.values())
+
+
+def test_recall_gates_extra_flags_exist():
+    for g in df.GATES.values():
+        for extra, _v in g.extra_flags:
+            assert extra in REGISTRY, f"{g.flag}: unknown companion flag {extra}"
+
+
+# --- helpers -------------------------------------------------------------------
+
+
+_FLAG = "MEMO_TEST_DARK_ENABLED"
+
+
+def _mini_registry(monkeypatch, *, kind="recall", extra_flags=()):
+    """Shrink the world to ONE tracked dark flag so selection is deterministic."""
+    gate = df.GateSpec(_FLAG, kind, "test", extra_flags=tuple(extra_flags))
+
+    class _Spec:
+        name = _FLAG
+
+    monkeypatch.setattr(df, "GATES", {_FLAG: gate})
+    monkeypatch.setattr(df, "dark_flags", lambda: [_Spec()])
+    monkeypatch.setattr(df, "_human_value", lambda name: None)
+    monkeypatch.setattr(df, "_curated_label_set", lambda sd: None)
+    monkeypatch.setattr(
+        df,
+        "build_labels",
+        lambda cfg, **kw: (
+            LabelSet(prompts=[Prompt("q", relevant=True, expect_ids=["aaaa1111"])]),
+            False,
+        ),
+    )
+    return gate
+
+
+def _metrics(prec, noise=0.0, p50=10.0):
+    return {"precision_at_k": prec, "noise_at_k": noise, "latency_ms_p50": p50}
+
+
+def _stub_measure(monkeypatch, *, on, off):
+    calls = []
+
+    def fake(mem, labels, *, k, spec, enabled, floor):
+        calls.append((spec.flag, enabled))
+        return dict(on if enabled else off)
+
+    monkeypatch.setattr(df, "measure_flag", fake)
+    return calls
+
+
+# --- streak / graduation ---------------------------------------------------------
+
+
+def test_win_streak_graduates_flag_to_overlay(tmp_cfg, monkeypatch):
+    _mini_registry(monkeypatch)
+    _stub_measure(monkeypatch, on=_metrics(0.8), off=_metrics(0.4))
+    monkeypatch.setenv("MEMO_FLAG_GRADUATION_WIN_NIGHTS", "2")
+
+    r1 = df.run_flag_graduation_pass(tmp_cfg, mem=None, today=TODAY)
+    assert r1["flags"][_FLAG]["verdict"] == "win"
+    assert df.load_state(tmp_cfg.state_dir)["flags"][_FLAG]["streak"] == 1
+    assert not read_overlay(tmp_cfg.state_dir).get(_FLAG)
+
+    r2 = df.run_flag_graduation_pass(tmp_cfg, mem=None, today=TODAY + timedelta(days=1))
+    assert r2["flags"][_FLAG]["verdict"] == "graduated"
+    assert r2["status"] == "applied"
+    assert read_overlay(tmp_cfg.state_dir)[_FLAG] is True
+    entry = df.load_state(tmp_cfg.state_dir)["flags"][_FLAG]
+    assert entry["status"] == "graduated"
+    assert entry["baseline"]["precision_at_k"] == 0.8
+
+
+def test_lose_resets_streak(tmp_cfg, monkeypatch):
+    _mini_registry(monkeypatch)
+    _stub_measure(monkeypatch, on=_metrics(0.8), off=_metrics(0.4))
+    df.run_flag_graduation_pass(tmp_cfg, mem=None, today=TODAY)
+    _stub_measure(monkeypatch, on=_metrics(0.4), off=_metrics(0.8))
+    res = df.run_flag_graduation_pass(tmp_cfg, mem=None, today=TODAY + timedelta(days=1))
+    assert res["flags"][_FLAG]["verdict"] == "lose"
+    assert df.load_state(tmp_cfg.state_dir)["flags"][_FLAG]["streak"] == 0
+
+
+def test_graduation_writes_companion_flags(tmp_cfg, monkeypatch):
+    _mini_registry(monkeypatch, extra_flags=(("MEMO_TEST_COMPANION_ENABLED", "1"),))
+    _stub_measure(monkeypatch, on=_metrics(0.8), off=_metrics(0.4))
+    monkeypatch.setenv("MEMO_FLAG_GRADUATION_WIN_NIGHTS", "1")
+    res = df.run_flag_graduation_pass(tmp_cfg, mem=None, today=TODAY)
+    assert res["flags"][_FLAG]["verdict"] == "graduated"
+    ov = read_overlay(tmp_cfg.state_dir)
+    assert ov[_FLAG] is True and ov["MEMO_TEST_COMPANION_ENABLED"] is True
+
+
+# --- gates: latency + curated ----------------------------------------------------
+
+
+def test_latency_headroom_rejects_win(tmp_cfg, monkeypatch):
+    _mini_registry(monkeypatch)
+    _stub_measure(monkeypatch, on=_metrics(0.8, p50=100.0), off=_metrics(0.4, p50=10.0))
+    res = df.run_flag_graduation_pass(tmp_cfg, mem=None, today=TODAY)
+    assert res["flags"][_FLAG]["verdict"] == "lose"
+    assert res["flags"][_FLAG]["latency_rejected"] is True
+
+
+def test_curated_regression_rejects_win(tmp_cfg, monkeypatch):
+    _mini_registry(monkeypatch)
+    curated = LabelSet(prompts=[Prompt("c", relevant=True, expect_ids=["bbbb2222"])])
+    monkeypatch.setattr(df, "_curated_label_set", lambda sd: curated)
+
+    def fake(mem, labels, *, k, spec, enabled, floor):
+        if labels is curated:  # curated set regresses when ON
+            return _metrics(0.1) if enabled else _metrics(0.9)
+        return _metrics(0.8) if enabled else _metrics(0.4)
+
+    monkeypatch.setattr(df, "measure_flag", fake)
+    res = df.run_flag_graduation_pass(tmp_cfg, mem=None, today=TODAY)
+    assert res["flags"][_FLAG]["verdict"] == "lose"
+    assert res["flags"][_FLAG]["curated_rejected"] is True
+
+
+# --- post-graduation guard / cooldown --------------------------------------------
+
+
+def _seed_graduated(tmp_cfg, baseline_prec=0.8):
+    write_overlay(tmp_cfg.state_dir, {_FLAG: True}, {"set_by": "test"})
+    df.save_state(
+        tmp_cfg.state_dir,
+        {
+            "flags": {
+                _FLAG: {
+                    "first_tracked": TODAY.isoformat(),
+                    "streak": 3,
+                    "status": "graduated",
+                    "baseline": _metrics(baseline_prec),
+                }
+            }
+        },
+    )
+
+
+def test_regression_guard_reverts_graduated_flag(tmp_cfg, monkeypatch):
+    _mini_registry(monkeypatch)
+    _seed_graduated(tmp_cfg)
+    _stub_measure(monkeypatch, on=_metrics(0.2), off=_metrics(0.2))  # live ON regressed
+    res = df.run_flag_graduation_pass(tmp_cfg, mem=None, today=TODAY + timedelta(days=3))
+    assert res["flags"][_FLAG]["verdict"] == "reverted"
+    assert _FLAG not in read_overlay(tmp_cfg.state_dir) or not read_overlay(tmp_cfg.state_dir).get(
+        _FLAG
+    )
+    entry = df.load_state(tmp_cfg.state_dir)["flags"][_FLAG]
+    assert entry["status"] == "reverted" and entry["streak"] == 0
+
+
+def test_reverted_flag_cools_down_before_remeasure(tmp_cfg, monkeypatch):
+    _mini_registry(monkeypatch)
+    _stub_measure(monkeypatch, on=_metrics(0.8), off=_metrics(0.4))
+    df.save_state(
+        tmp_cfg.state_dir,
+        {
+            "flags": {
+                _FLAG: {
+                    "first_tracked": TODAY.isoformat(),
+                    "streak": 0,
+                    "status": "reverted",
+                    "reverted_at": (TODAY - timedelta(days=5)).isoformat(),
+                }
+            }
+        },
+    )
+    res = df.run_flag_graduation_pass(tmp_cfg, mem=None, today=TODAY)
+    assert res["measured"] == []  # still cooling down (retry default 14d)
+    late = df.run_flag_graduation_pass(tmp_cfg, mem=None, today=TODAY + timedelta(days=20))
+    assert late["measured"] == [_FLAG]
+
+
+# --- ownership / deadline / dry-run ----------------------------------------------
+
+
+def test_human_pinned_flag_is_human_graduated_and_skipped(tmp_cfg, monkeypatch):
+    _mini_registry(monkeypatch)
+    monkeypatch.setattr(df, "_human_value", lambda name: "1")
+    calls = _stub_measure(monkeypatch, on=_metrics(0.8), off=_metrics(0.4))
+    res = df.run_flag_graduation_pass(tmp_cfg, mem=None, today=TODAY)
+    assert res["measured"] == [] and calls == []
+    assert df.load_state(tmp_cfg.state_dir)["flags"][_FLAG]["status"] == "human_graduated"
+
+
+def test_deadline_marks_cull_candidate(tmp_cfg, monkeypatch):
+    _mini_registry(monkeypatch, kind="manual")
+    df.save_state(
+        tmp_cfg.state_dir,
+        {
+            "flags": {
+                _FLAG: {
+                    "first_tracked": (TODAY - timedelta(days=60)).isoformat(),
+                    "streak": 0,
+                    "status": "tracking",
+                }
+            }
+        },
+    )
+    res = df.run_flag_graduation_pass(tmp_cfg, mem=None, today=TODAY)
+    assert res["cull_candidates"] == [_FLAG]
+    assert df.load_state(tmp_cfg.state_dir)["flags"][_FLAG]["status"] == "cull_candidate"
+
+
+def test_dry_run_writes_nothing(tmp_cfg, monkeypatch):
+    _mini_registry(monkeypatch)
+    _stub_measure(monkeypatch, on=_metrics(0.8), off=_metrics(0.4))
+    monkeypatch.setenv("MEMO_FLAG_GRADUATION_WIN_NIGHTS", "1")
+    res = df.run_flag_graduation_pass(tmp_cfg, mem=None, today=TODAY, dry_run=True)
+    assert res["flags"][_FLAG]["verdict"] == "would_graduate"
+    assert read_overlay(tmp_cfg.state_dir) == {}
+    assert df.load_state(tmp_cfg.state_dir) == {}
+
+
+def test_pass_never_raises(tmp_cfg, monkeypatch):
+    def boom(cfg, **kw):
+        raise RuntimeError("labels exploded")
+
+    monkeypatch.setattr(df, "build_labels", boom)
+    res = df.run_flag_graduation_pass(tmp_cfg, mem=None, today=TODAY)
+    assert res["status"] == "error" and "labels exploded" in res["error"]
+
+
+# --- status view -----------------------------------------------------------------
+
+
+def test_status_rows_cover_every_dark_flag(tmp_cfg, monkeypatch):
+    monkeypatch.setattr(df, "_human_value", lambda name: None)
+    rows = df.status_rows(tmp_cfg, today=TODAY)
+    assert {r["flag"] for r in rows} == {s.name for s in df.dark_flags()}
+    assert all(r["kind"] != "MISSING_GATE" for r in rows)
+
+
+# --- measure_flag plumbing (no MLX: stub search) -----------------------------------
+
+
+class _Hit:
+    def __init__(self, id, score):
+        self.id, self.score, self.title = id, score, "t"
+        self.tags, self.path, self.body = [], "p", "some body text"
+
+
+class _StubMem:
+    def search(self, query, limit, mode="vec", exclude_types=None, exclude_tags=None):
+        return [_Hit("aaaa1111", 0.9)]
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_measure_flag_pins_env_through_eval(monkeypatch, enabled):
+    spec = df.GateSpec(_FLAG, "recall", "test", extra_flags=(("MEMO_TEST_EXTRA", "1"),))
+    seen = {}
+
+    import os
+
+    real_evaluate = df.evaluate
+
+    def spying_evaluate(mem, *, k, labels, configs):
+        seen["pins"] = dict(configs[0].flag_overrides or {})
+        return real_evaluate(mem, k=k, labels=labels, configs=configs)
+
+    monkeypatch.setattr(df, "evaluate", spying_evaluate)
+    labels = LabelSet(prompts=[Prompt("q", relevant=True, expect_ids=["aaaa1111"])])
+    m = df.measure_flag(_StubMem(), labels, k=3, spec=spec, enabled=enabled, floor=0.5)
+    assert "precision_at_k" in m and "latency_ms_p50" in m
+    assert seen["pins"][_FLAG] == ("1" if enabled else "0")
+    assert ("MEMO_TEST_EXTRA" in seen["pins"]) is enabled
+    assert os.environ.get(_FLAG) is None  # pins restored after the run


### PR DESCRIPTION
## Summary

- **Dark-feature graduation pipeline** (`dream_flags.py` + `memo dream graduate-flags`): every default-off `*_ENABLED` flag declares a graduation gate (`recall` A/B / `tuner`-owned / `manual`+reason). Recall-gated flags A/B-measure nightly via the eval `flag_overrides` seam and graduate to ON through the tuned overlay after 3 consecutive wins (latency + curated no-regression gated), auto-reverting on regression. Flags un-graduated past 45 days surface as cull candidates in `--status`.
- **CI enforcement**: `test_dream_flags.py` fails if a new dark flag merges without a declared gate.
- Docs: CLAUDE.md sync (12 mixins, flags_capture, markdown-config resolution order).
- Release manifests bumped 3.5.2 → 3.6.0.

## Test plan

- [x] 18 new unit tests (streak/apply/revert/cooldown/cull/dry-run/enforcement)
- [x] mypy clean (393 files), ruff clean
- [x] Live dry-run: measured MEMO_GRAPH_SIGNAL_ENABLED ON/OFF → verdict lose (writes nothing)
- [x] Local pre-push recall gate: PASS (prec@5 0.800 ≥ 0.776, noise 0.000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)