### PR TITLE
fix(security): possessive quantifier in sentence-split regex (ReDoS)

### DIFF
--- a/docs/homebrew/mlx-memo.rb
+++ b/docs/homebrew/mlx-memo.rb
@@ -20,8 +20,8 @@
 class MlxMemo < Formula
   desc "Local MCP memory for AI agents — MLX-native, sqlite-vec, markdown vault"
   homepage "https://github.com/jagoff/memo"
-  url "https://github.com/jagoff/memo/archive/refs/tags/v3.2.0.tar.gz"
-  sha256 "6d012891cb0a43e2d470fedd890079c156d4f1e7630d7b876b5587be926af140"
+  url "https://github.com/jagoff/memo/archive/refs/tags/v3.7.0.tar.gz"
+  sha256 "667a371c0af30b219830878e03b3aeeea05a9cfdd0d1b0a00193efee498fdcf4"
   license "MIT"
 
   depends_on :macos

--- a/src/memo/chunker.py
+++ b/src/memo/chunker.py
@@ -52,7 +52,10 @@ class Chunk(TypedDict):
 
 
 _PARAGRAPH_BREAK_RE = re.compile(r"\n\s*\n")
-_SENTENCE_RE = re.compile(r"(?<=[.!?])\s+(?=[A-ZÁÉÍÓÚÑ])")
+# \s++ (possessive) — backtracking never helps here (the lookahead can only
+# match at the end of a whitespace run) and it removes the polynomial-ReDoS
+# surface on attacker-controlled bodies (CodeQL py/polynomial-redos, alert 38).
+_SENTENCE_RE = re.compile(r"(?<=[.!?])\s++(?=[A-ZÁÉÍÓÚÑ])")
 
 
 def chunk_markdown(


### PR DESCRIPTION
Fixes CodeQL alert [#38](https://github.com/jagoff/memo/security/code-scanning/38) (py/polynomial-redos, security-severity high).

`_SENTENCE_RE`'s `\s+` followed by a failable lookahead backtracks over long whitespace runs reachable from the HTTP API body (`server_http.py:191` → `chunk_markdown` → `_split_sentences`). `\s++` (possessive, Python ≥3.11; repo requires ≥3.13) removes the backtracking entirely.

Semantics are identical: the lookahead `(?=[A-ZÁÉÍÓÚÑ])` can only match at the end of a whitespace run, so backtracking never yields a different match — verified with parity checks on ES/EN samples.

## Test plan
- [x] `pytest tests/test_chunk_ingest.py` — 20/20 pass
- [x] `ruff check` + `ruff format --check` clean
- [x] pre-push recall gate PASS (prec@k 0.800 ≥ 0.776, noise@k 0.000)
- [ ] CodeQL re-scan closes alert 38 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)