### PR TITLE
ci: no-op twin for path-filtered required check "Ubuntu CPU backend (real)"

### DIFF
--- a/.github/workflows/linux-cpu-smoke-noop.yml
+++ b/.github/workflows/linux-cpu-smoke-noop.yml
@@ -1,0 +1,31 @@
+name: linux-cpu-smoke-noop
+
+# No-op twin of linux-cpu-smoke.yml for the "Ubuntu CPU backend (real)"
+# required status check. The real workflow is path-filtered, so a PR that does
+# not touch the CPU backend never runs it and the required context stays
+# "expected" forever, blocking the merge. This twin runs on the inverse path
+# set with the SAME job name, satisfying the requirement — GitHub's documented
+# pattern for skipped-but-required checks:
+# https://docs.github.com/en/actions/using-workflows/troubleshooting-workflows#handling-skipped-but-required-checks
+#
+# Keep `paths-ignore` here in exact sync with the real workflow's `paths` list.
+
+on:
+  pull_request:
+    paths-ignore:
+      - "src/memo/embedder_st.py"
+      - "src/memo/embedder_select.py"
+      - "src/memo/platform_detect.py"
+      - "src/memo/runtime/**"
+      - "pyproject.toml"
+      - ".github/workflows/linux-cpu-smoke.yml"
+
+permissions: {}
+
+jobs:
+  smoke:
+    name: Ubuntu CPU backend (real)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: echo "No CPU-backend paths touched; real smoke not required."


### PR DESCRIPTION
## Problem

The required status check **Ubuntu CPU backend (real)** comes from `linux-cpu-smoke.yml`, which is path-filtered (embedder_st / embedder_select / platform_detect / runtime/** / pyproject.toml / its own yml). Any PR that does not touch those paths never triggers the workflow, so the required context stays **"expected" forever** and the PR cannot merge. This blocked #35 (merged only via a temporary branch-protection edit) and currently blocks dependabot PRs.

## Fix

Add `linux-cpu-smoke-noop.yml` — the [GitHub-documented pattern for skipped-but-required checks](https://docs.github.com/en/actions/using-workflows/troubleshooting-workflows#handling-skipped-but-required-checks):

- Same job name (`Ubuntu CPU backend (real)`) → satisfies the same required context
- `paths-ignore` mirroring the real workflow's `paths` exactly → runs only when the real one doesn't
- Single echo step, `permissions: {}`, 5-min timeout

Backend-touching PRs still gate on the real smoke; everything else gets the no-op.

## Test plan
- [x] This PR itself doesn't touch backend paths → the no-op must run and turn the required check green (self-proving)
- [ ] After merge: update-branch the blocked dependabot PR and confirm it unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)