### PR TITLE
docs: add project website to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 **Local-first semantic memory for AI agents — with time-travel, contradiction radar, and automatic synthesis.**
 
+**[Explore the memo website →](https://memo-web-sigma.vercel.app)**
+
 [![PyPI](https://img.shields.io/pypi/v/mlx-memo.svg)](https://pypi.org/project/mlx-memo/)
 [![Downloads](https://static.pepy.tech/badge/mlx-memo)](https://pepy.tech/project/mlx-memo)
 [![Python](https://img.shields.io/pypi/pyversions/mlx-memo.svg)](https://pypi.org/project/mlx-memo/)


### PR DESCRIPTION
## Summary
- add the memo landing page below the README introduction
- keep the project website visible before the badges

## Verification
- website returns HTTP 200
- git diff --check passes
- pre-push recall regression gate passes