### PR TITLE
docs: publish Homebrew formula for 3.8.1

### DIFF
--- a/docs/homebrew/README.md
+++ b/docs/homebrew/README.md
@@ -72,7 +72,7 @@ After every `pyproject.toml` version bump and PyPI publish:
 ```bash
 # In the memo repo
 NEW_VERSION=<next-version>
-URL="https://files.pythonhosted.org/packages/source/m/mlx-memo/mlx_memo-${NEW_VERSION}.tar.gz"
+URL="https://github.com/jagoff/memo/archive/refs/tags/v${NEW_VERSION}.tar.gz"
 SHA=$(curl -sL "$URL" | shasum -a 256 | awk '{print $1}')
 
 # Update the formula in this repo (docs/homebrew/mlx-memo.rb):
@@ -85,10 +85,10 @@ git commit -am "mlx-memo $NEW_VERSION"
 git push
 ```
 
-Do not bump this formula to a version until the matching sdist exists on PyPI
-and its `sha256` has been calculated. Between a source-tree version bump and a
-published sdist, `memo release check` reports formula drift as a warning; use
-`memo release check --strict-docs` after PyPI publish.
+Do not bump this formula to a version until the matching GitHub tag exists and
+its source tarball `sha256` has been calculated. Between a source-tree version
+bump and a published tag, `memo release check` reports formula drift as a
+warning; use `memo release check --strict-docs` after tagging.
 
 ## Why a personal tap, not homebrew-core?
 

--- a/docs/homebrew/mlx-memo.rb
+++ b/docs/homebrew/mlx-memo.rb
@@ -20,8 +20,8 @@
 class MlxMemo < Formula
   desc "Local MCP memory for AI agents — MLX-native, sqlite-vec, markdown vault"
   homepage "https://github.com/jagoff/memo"
-  url "https://github.com/jagoff/memo/archive/refs/tags/v3.8.0.tar.gz"
-  sha256 "5051078235ed46b65d9e8363f10ff906f7bab878d797282374a4692e05762c05"
+  url "https://github.com/jagoff/memo/archive/refs/tags/v3.8.1.tar.gz"
+  sha256 "cab3f23d349ee742187a04d0be1a0a16cb987e840f8846aab5165e8ea66566a2"
   license "MIT"
 
   depends_on :macos


### PR DESCRIPTION
## Summary
- bump the reference Homebrew formula to v3.8.1 with the verified GitHub source-tarball SHA256
- align the release instructions with the formula's actual GitHub-tag source

## Verification
- `memo release check --strict-docs`
- `ruby -c docs/homebrew/mlx-memo.rb`
- 50 focused release/workflow tests
- Ruff
- recall pre-push gate (precision@k 0.806, noise 0)