### PR TITLE
fix: keep Homebrew formula audit-clean

### DIFF
--- a/docs/homebrew/README.md
+++ b/docs/homebrew/README.md
@@ -72,8 +72,9 @@ After every `pyproject.toml` version bump and PyPI publish:
 ```bash
 # In the memo repo
 NEW_VERSION=<next-version>
-URL="https://github.com/jagoff/memo/archive/refs/tags/v${NEW_VERSION}.tar.gz"
-SHA=$(curl -sL "$URL" | shasum -a 256 | awk '{print $1}')
+PYPI_JSON=$(curl -fsSL "https://pypi.org/pypi/mlx-memo/${NEW_VERSION}/json")
+URL=$(jq -r '.urls[] | select(.packagetype == "sdist") | .url' <<<"$PYPI_JSON")
+SHA=$(jq -r '.urls[] | select(.packagetype == "sdist") | .digests.sha256' <<<"$PYPI_JSON")
 
 # Update the formula in this repo (docs/homebrew/mlx-memo.rb):
 #   url "..."  ← new URL
@@ -85,10 +86,10 @@ git commit -am "mlx-memo $NEW_VERSION"
 git push
 ```
 
-Do not bump this formula to a version until the matching GitHub tag exists and
-its source tarball `sha256` has been calculated. Between a source-tree version
-bump and a published tag, `memo release check` reports formula drift as a
-warning; use `memo release check --strict-docs` after tagging.
+Do not bump this formula to a version until the matching PyPI sdist exists and
+its published `sha256` has been copied into the formula. Between a source-tree
+version bump and a published sdist, `memo release check` reports formula drift
+as a warning; use `memo release check --strict-docs` after publishing.
 
 ## Why a personal tap, not homebrew-core?
 

--- a/docs/homebrew/mlx-memo.rb
+++ b/docs/homebrew/mlx-memo.rb
@@ -3,10 +3,9 @@
 # Lives in this source tree as a reference copy. To activate it for
 # end users, mirror this file to a tap repo named `homebrew-memo`
 # under your GitHub user (see `docs/homebrew/README.md`).
-# This file tracks the latest released git tag via GitHub's auto-generated
-# source tarball (no PyPI publish required). On each release, bump the tag
-# in the url below and recompute its sha256 by piping that tarball through
-# `shasum -a 256`.
+# This file tracks the exact source distribution URL published by PyPI.
+# On each release, copy the URL and sha256 from the PyPI JSON API before
+# mirroring the formula to the public tap.
 #
 # Users then install with:
 #
@@ -20,12 +19,12 @@
 class MlxMemo < Formula
   desc "Local MCP memory for AI agents — MLX-native, sqlite-vec, markdown vault"
   homepage "https://github.com/jagoff/memo"
-  url "https://github.com/jagoff/memo/archive/refs/tags/v3.8.1.tar.gz"
-  sha256 "cab3f23d349ee742187a04d0be1a0a16cb987e840f8846aab5165e8ea66566a2"
+  url "https://files.pythonhosted.org/packages/8a/17/90021f729860ccf7d343d3795455088fa857e99d00a8524236070a9c7dff/mlx_memo-3.8.1.tar.gz"
+  sha256 "1e2a9df6e201046dc09ba91f1aa37006d506afcf27ca56c9e191584e27674b98"
   license "MIT"
 
-  depends_on :macos
   depends_on arch: :arm64
+  depends_on :macos
   depends_on "python@3.13"
 
   # We let pip resolve the dep tree at install time rather than

--- a/src/memo/cli_release.py
+++ b/src/memo/cli_release.py
@@ -471,6 +471,25 @@ def _check_formula(
     if match and match.group(1) != version:
         _add_doc_drift(destination, path=formula, expected=version, found=match.group(1))
 
+    url_match = re.search(r'^\s*url\s+"(?P<url>[^"]+)"', text, flags=re.MULTILINE)
+    if url_match:
+        url = url_match.group("url")
+        if not re.fullmatch(
+            rf"https://files\.pythonhosted\.org/packages/(?!source/)[^\s]+/"
+            rf"mlx_memo-{re.escape(version)}\.tar\.gz",
+            url,
+        ):
+            destination.append(
+                f"{formula.relative_to(repo)} should use the exact PyPI source distribution URL"
+            )
+
+    arch_dependency = text.find("depends_on arch:")
+    macos_dependency = text.find("depends_on :macos")
+    if arch_dependency >= 0 and macos_dependency >= 0 and arch_dependency > macos_dependency:
+        destination.append(
+            f"{formula.relative_to(repo)} dependency order should put arch before macos"
+        )
+
 
 def release_check_report(repo: Path, *, strict_docs: bool = False) -> ReleaseCheckReport:
     """Validate that the checkout is release-ready.

--- a/tests/test_cli_release.py
+++ b/tests/test_cli_release.py
@@ -487,3 +487,30 @@ def test_release_check_reports_homebrew_formula_drift(tmp_path: Path) -> None:
     assert any("mlx-memo.rb" in warning for warning in report.warnings)
     assert strict.ok is False
     assert any("mlx-memo.rb" in issue for issue in strict.issues)
+
+
+def test_release_check_reports_homebrew_formula_audit_drift(tmp_path: Path) -> None:
+    repo = _fake_repo(tmp_path, "1.2.3")
+    formula = repo / "docs" / "homebrew" / "mlx-memo.rb"
+    formula.parent.mkdir(parents=True)
+    formula.write_text(
+        "\n".join(
+            [
+                'url "https://github.com/jagoff/memo/archive/refs/tags/v1.2.3.tar.gz"',
+                "depends_on :macos",
+                "depends_on arch: :arm64",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = release_check_report(repo)
+    strict = release_check_report(repo, strict_docs=True)
+
+    assert report.ok is True
+    assert any("PyPI source distribution" in warning for warning in report.warnings)
+    assert any("dependency order" in warning for warning in report.warnings)
+    assert strict.ok is False
+    assert any("PyPI source distribution" in issue for issue in strict.issues)
+    assert any("dependency order" in issue for issue in strict.issues)


### PR DESCRIPTION
## Summary
- switch the reference formula to the exact PyPI 3.8.1 sdist URL and verified SHA256
- put the architecture dependency before the macOS dependency as required by Homebrew
- make release check report both classes of audit drift
- update the release documentation to derive URL and SHA from the PyPI JSON API

## TDD evidence
- RED: test_release_check_reports_homebrew_formula_audit_drift failed because neither issue was detected
- GREEN: the focused RED target and version-drift test both pass
- full release tests: 33 passed
- ruff format/check: pass
- mypy: 400 source files clean
- release check strict docs: pass
- brew audit strict online: pass against the mirrored formula
- PyPI sdist SHA expected/actual: 1e2a9df6e201046dc09ba91f1aa37006d506afcf27ca56c9e191584e27674b98
- recall pre-push gate: precision 0.806, noise 0