### PR TITLE
fix: close CLI memory and sync Homebrew formula

### DIFF
--- a/docs/homebrew/mlx-memo.rb
+++ b/docs/homebrew/mlx-memo.rb
@@ -19,8 +19,8 @@
 class MlxMemo < Formula
   desc "Local MCP memory for AI agents — MLX-native, sqlite-vec, markdown vault"
   homepage "https://github.com/jagoff/memo"
-  url "https://files.pythonhosted.org/packages/8a/17/90021f729860ccf7d343d3795455088fa857e99d00a8524236070a9c7dff/mlx_memo-3.8.1.tar.gz"
-  sha256 "1e2a9df6e201046dc09ba91f1aa37006d506afcf27ca56c9e191584e27674b98"
+  url "https://files.pythonhosted.org/packages/e1/d1/162faaba41ec4de5cc2a439c2592a7db5fae5e1962f358047f1ed7852861/mlx_memo-3.8.2.tar.gz"
+  sha256 "58e4dbfad30b6daf902edc20bbc4c290cd93c70124e8969c65b46eef6067ca0e"
   license "MIT"
 
   depends_on arch: :arm64

--- a/src/memo/cli_common.py
+++ b/src/memo/cli_common.py
@@ -23,10 +23,21 @@ console = Console(force_terminal=False)
 
 def get_memory(cfg: Config) -> Any:
     """Build a Memory instance. Deferred import keeps module load light and
-    avoids a cli -> memory -> … import cycle at startup."""
+    avoids a cli -> memory -> … import cycle at startup.
+
+    Click may run commands in-process (CliRunner, notebooks, SDK wrappers), so
+    process exit is not a valid SQLite lifecycle boundary.  Register the
+    instance with the active command context to close every sidecar database
+    deterministically after the command finishes.  Callers outside Click keep
+    the normal explicit ``Memory.close()`` contract.
+    """
     from memo.memory import Memory
 
-    return Memory(cfg)
+    memory = Memory(cfg)
+    context = click.get_current_context(silent=True)
+    if context is not None:
+        context.call_on_close(memory.close)
+    return memory
 
 
 def log_cli_consult(

--- a/tests/test_recall_associative.py
+++ b/tests/test_recall_associative.py
@@ -160,10 +160,23 @@ def test_build_nudge_exception_returns_empty(monkeypatch):
     assert nudge == []
 
 
-def test_cli_related_json(tmp_path):
+def test_cli_related_json(tmp_path, monkeypatch):
+    import sqlite3
+
+    import pytest
     from click.testing import CliRunner
 
     from memo.cli import cli
+    from memo.cli_common import get_memory
+
+    connections = []
+
+    def tracked_get_memory(cfg):
+        memory = get_memory(cfg)
+        connections.append(memory.store.connection)
+        return memory
+
+    monkeypatch.setattr("memo.cli_related._get_memory", tracked_get_memory)
 
     env = {
         "MEMO_DATA_DIR": str(tmp_path / "d"),
@@ -177,6 +190,9 @@ def test_cli_related_json(tmp_path):
     res = CliRunner().invoke(cli, ["related", "nonexistent-x", "--json"], env=env)
     assert res.exit_code == 0
     assert res.output.strip().startswith("[")  # JSON list (empty on no data)
+    assert len(connections) == 1
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        connections[0].execute("SELECT 1")
 
 
 def test_build_nudge_skips_forgotten(monkeypatch):


### PR DESCRIPTION
## Summary
- close shared CLI Memory instances at the end of the active Click context
- add a CliRunner regression proving the SQLite connection is closed
- sync the reference Homebrew formula to the published 3.8.2 sdist and SHA-256

## Validation
- ruff and mypy green
- 4,826 fast tests passed; 29 skipped; coverage 77.45%
- full suite also passed with ResourceWarning and PytestUnraisableExceptionWarning treated as errors
- 7 slow/MLX tests passed; 4 skipped
- strict release check, uv lock check, and wheel/sdist build passed
- pre-push recall gate passed: precision@k 0.806, noise@k 0.000