### PR TITLE
fix: make Homebrew formula installable

### DIFF
--- a/docs/homebrew/mlx-memo.rb
+++ b/docs/homebrew/mlx-memo.rb
@@ -17,6 +17,8 @@
 # `depends_on arch: :arm64` so brew refuses early.
 
 class MlxMemo < Formula
+  include Language::Python::Virtualenv
+
   desc "Local MCP memory for AI agents — MLX-native, sqlite-vec, markdown vault"
   homepage "https://github.com/jagoff/memo"
   url "https://files.pythonhosted.org/packages/e1/d1/162faaba41ec4de5cc2a439c2592a7db5fae5e1962f358047f1ed7852861/mlx_memo-3.8.2.tar.gz"
@@ -27,19 +29,24 @@ class MlxMemo < Formula
   depends_on :macos
   depends_on "python@3.13"
 
+  preserve_rpath
+
   # We let pip resolve the dep tree at install time rather than
   # vendoring every `resource` block (mlx, mlx-lm, fastmcp, sqlite-vec,
   # frontmatter, watchdog, etc. — ~30 deps). This is fine for a
   # personal tap; homebrew-core would require explicit resources.
   def install
-    venv = virtualenv_create(libexec, "python3.13")
-    venv.pip_install_and_link buildpath
+    virtualenv_create(libexec, "python3.13", system_site_packages: false)
+    system "python3.13", "-m", "pip", "--python=#{libexec}/bin/python",
+           "install", "--no-compile", buildpath
+    bin.install_symlink libexec/"bin/memo"
+    bin.install_symlink libexec/"bin/memo-mcp"
   end
 
   test do
     assert_match "memo, version", shell_output("#{bin}/memo --version")
     assert_match "Usage:", shell_output("#{bin}/memo --help")
-    # MCP server entry point must be importable too.
-    system bin/"memo-mcp", "--help"
+    # Import the MCP entry point without starting its blocking stdio loop.
+    system libexec/"bin/python", "-c", "import memo.server"
   end
 end

--- a/src/memo/cli_release.py
+++ b/src/memo/cli_release.py
@@ -521,9 +521,7 @@ def _check_formula(
             f"{formula.relative_to(repo)} dependency order should put arch before macos"
         )
 
-    _check_formula_runtime_contracts(
-        repo=repo, formula=formula, text=text, destination=destination
-    )
+    _check_formula_runtime_contracts(repo=repo, formula=formula, text=text, destination=destination)
 
 
 def release_check_report(repo: Path, *, strict_docs: bool = False) -> ReleaseCheckReport:

--- a/src/memo/cli_release.py
+++ b/src/memo/cli_release.py
@@ -490,6 +490,33 @@ def _check_formula(
             f"{formula.relative_to(repo)} dependency order should put arch before macos"
         )
 
+    if "virtualenv_create(" in text and not re.search(
+        r"^\s*include\s+Language::Python::Virtualenv\s*$", text, flags=re.MULTILINE
+    ):
+        destination.append(
+            f"{formula.relative_to(repo)} must include Language::Python::Virtualenv "
+            "before calling virtualenv_create"
+        )
+
+    if re.search(r"\.\s*pip_install(?:_and_link)?\s+buildpath\b", text):
+        destination.append(
+            f"{formula.relative_to(repo)} must not install buildpath with Homebrew's "
+            "virtualenv pip helpers because they pass --no-deps"
+        )
+
+    if "--python=#{libexec}/bin/python" in text and not re.search(
+        r"^\s*preserve_rpath\s*$", text, flags=re.MULTILINE
+    ):
+        destination.append(
+            f"{formula.relative_to(repo)} must preserve_rpath for binary Python wheels"
+        )
+
+    if re.search(r'system\s+bin/"memo-mcp",\s*"--help"', text):
+        destination.append(
+            f"{formula.relative_to(repo)} must not start memo-mcp --help in its test "
+            "because the stdio server blocks waiting for input"
+        )
+
 
 def release_check_report(repo: Path, *, strict_docs: bool = False) -> ReleaseCheckReport:
     """Validate that the checkout is release-ready.

--- a/src/memo/cli_release.py
+++ b/src/memo/cli_release.py
@@ -453,6 +453,37 @@ def _check_changelog(repo: Path, version: str, issues: list[str]) -> None:
         issues.append(f"CHANGELOG.md section for {version} still contains TODO text")
 
 
+def _check_formula_runtime_contracts(
+    *, repo: Path, formula: Path, text: str, destination: list[str]
+) -> None:
+    if "virtualenv_create(" in text and not re.search(
+        r"^\s*include\s+Language::Python::Virtualenv\s*$", text, flags=re.MULTILINE
+    ):
+        destination.append(
+            f"{formula.relative_to(repo)} must include Language::Python::Virtualenv "
+            "before calling virtualenv_create"
+        )
+
+    if re.search(r"\.\s*pip_install(?:_and_link)?\s+buildpath\b", text):
+        destination.append(
+            f"{formula.relative_to(repo)} must not install buildpath with Homebrew's "
+            "virtualenv pip helpers because they pass --no-deps"
+        )
+
+    if "--python=#{libexec}/bin/python" in text and not re.search(
+        r"^\s*preserve_rpath\s*$", text, flags=re.MULTILINE
+    ):
+        destination.append(
+            f"{formula.relative_to(repo)} must preserve_rpath for binary Python wheels"
+        )
+
+    if re.search(r'system\s+bin/"memo-mcp",\s*"--help"', text):
+        destination.append(
+            f"{formula.relative_to(repo)} must not start memo-mcp --help in its test "
+            "because the stdio server blocks waiting for input"
+        )
+
+
 def _check_formula(
     repo: Path, version: str, *, strict_docs: bool, issues: list[str], warnings: list[str]
 ) -> None:
@@ -490,32 +521,9 @@ def _check_formula(
             f"{formula.relative_to(repo)} dependency order should put arch before macos"
         )
 
-    if "virtualenv_create(" in text and not re.search(
-        r"^\s*include\s+Language::Python::Virtualenv\s*$", text, flags=re.MULTILINE
-    ):
-        destination.append(
-            f"{formula.relative_to(repo)} must include Language::Python::Virtualenv "
-            "before calling virtualenv_create"
-        )
-
-    if re.search(r"\.\s*pip_install(?:_and_link)?\s+buildpath\b", text):
-        destination.append(
-            f"{formula.relative_to(repo)} must not install buildpath with Homebrew's "
-            "virtualenv pip helpers because they pass --no-deps"
-        )
-
-    if "--python=#{libexec}/bin/python" in text and not re.search(
-        r"^\s*preserve_rpath\s*$", text, flags=re.MULTILINE
-    ):
-        destination.append(
-            f"{formula.relative_to(repo)} must preserve_rpath for binary Python wheels"
-        )
-
-    if re.search(r'system\s+bin/"memo-mcp",\s*"--help"', text):
-        destination.append(
-            f"{formula.relative_to(repo)} must not start memo-mcp --help in its test "
-            "because the stdio server blocks waiting for input"
-        )
+    _check_formula_runtime_contracts(
+        repo=repo, formula=formula, text=text, destination=destination
+    )
 
 
 def release_check_report(repo: Path, *, strict_docs: bool = False) -> ReleaseCheckReport:

--- a/tests/test_cli_release.py
+++ b/tests/test_cli_release.py
@@ -514,3 +514,128 @@ def test_release_check_reports_homebrew_formula_audit_drift(tmp_path: Path) -> N
     assert strict.ok is False
     assert any("PyPI source distribution" in issue for issue in strict.issues)
     assert any("dependency order" in issue for issue in strict.issues)
+
+
+def test_release_check_reports_homebrew_formula_missing_virtualenv_mixin(tmp_path: Path) -> None:
+    repo = _fake_repo(tmp_path, "1.2.3")
+    formula = repo / "docs" / "homebrew" / "mlx-memo.rb"
+    formula.parent.mkdir(parents=True)
+    formula.write_text(
+        "\n".join(
+            [
+                "class MlxMemo < Formula",
+                '  url "https://files.pythonhosted.org/packages/aa/bb/mlx_memo-1.2.3.tar.gz"',
+                "  depends_on arch: :arm64",
+                "  depends_on :macos",
+                "  def install",
+                '    virtualenv_create(libexec, "python3.13")',
+                "  end",
+                "end",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = release_check_report(repo)
+    strict = release_check_report(repo, strict_docs=True)
+
+    assert report.ok is True
+    assert any("Language::Python::Virtualenv" in warning for warning in report.warnings)
+    assert strict.ok is False
+    assert any("Language::Python::Virtualenv" in issue for issue in strict.issues)
+
+
+def test_release_check_reports_homebrew_formula_no_deps_helper(tmp_path: Path) -> None:
+    repo = _fake_repo(tmp_path, "1.2.3")
+    formula = repo / "docs" / "homebrew" / "mlx-memo.rb"
+    formula.parent.mkdir(parents=True)
+    formula.write_text(
+        "\n".join(
+            [
+                "class MlxMemo < Formula",
+                "  include Language::Python::Virtualenv",
+                '  url "https://files.pythonhosted.org/packages/aa/bb/mlx_memo-1.2.3.tar.gz"',
+                "  depends_on arch: :arm64",
+                "  depends_on :macos",
+                "  def install",
+                '    venv = virtualenv_create(libexec, "python3.13")',
+                "    venv.pip_install_and_link buildpath",
+                "  end",
+                "end",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = release_check_report(repo)
+    strict = release_check_report(repo, strict_docs=True)
+
+    assert report.ok is True
+    assert any("--no-deps" in warning for warning in report.warnings)
+    assert strict.ok is False
+    assert any("--no-deps" in issue for issue in strict.issues)
+
+
+def test_release_check_reports_homebrew_formula_missing_preserve_rpath(tmp_path: Path) -> None:
+    repo = _fake_repo(tmp_path, "1.2.3")
+    formula = repo / "docs" / "homebrew" / "mlx-memo.rb"
+    formula.parent.mkdir(parents=True)
+    formula.write_text(
+        "\n".join(
+            [
+                "class MlxMemo < Formula",
+                "  include Language::Python::Virtualenv",
+                '  url "https://files.pythonhosted.org/packages/aa/bb/mlx_memo-1.2.3.tar.gz"',
+                "  depends_on arch: :arm64",
+                "  depends_on :macos",
+                "  def install",
+                '    virtualenv_create(libexec, "python3.13")',
+                '    system "python3.13", "-m", "pip", "--python=#{libexec}/bin/python",',
+                '           "install", buildpath',
+                "  end",
+                "end",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = release_check_report(repo)
+    strict = release_check_report(repo, strict_docs=True)
+
+    assert report.ok is True
+    assert any("preserve_rpath" in warning for warning in report.warnings)
+    assert strict.ok is False
+    assert any("preserve_rpath" in issue for issue in strict.issues)
+
+
+def test_release_check_reports_blocking_homebrew_mcp_test(tmp_path: Path) -> None:
+    repo = _fake_repo(tmp_path, "1.2.3")
+    formula = repo / "docs" / "homebrew" / "mlx-memo.rb"
+    formula.parent.mkdir(parents=True)
+    formula.write_text(
+        "\n".join(
+            [
+                "class MlxMemo < Formula",
+                '  url "https://files.pythonhosted.org/packages/aa/bb/mlx_memo-1.2.3.tar.gz"',
+                "  depends_on arch: :arm64",
+                "  depends_on :macos",
+                "  test do",
+                '    system bin/"memo-mcp", "--help"',
+                "  end",
+                "end",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = release_check_report(repo)
+    strict = release_check_report(repo, strict_docs=True)
+
+    assert report.ok is True
+    assert any("blocks waiting for input" in warning for warning in report.warnings)
+    assert strict.ok is False
+    assert any("blocks waiting for input" in issue for issue in strict.issues)


### PR DESCRIPTION
## Summary
- load the Homebrew Python virtualenv mixin and install the full dependency graph
- preserve wheel rpaths so Homebrew linkage repair succeeds
- make the formula MCP smoke non-blocking
- add release-check regressions for all four packaging failures

## Validation
- `ruff check`
- `mypy src/memo` (400 files)
- `pytest tests/test_cli_release.py` (37 passed)
- `memo release check --strict-docs`
- `brew style jagoff/memo/mlx-memo`
- `brew audit --strict --online --formula jagoff/memo/mlx-memo`
- clean `brew reinstall jagoff/memo/mlx-memo`
- `brew test jagoff/memo/mlx-memo`
- pre-push recall gate (precision 0.806, noise 0)