### PR TITLE
feat: int8 vector quantization behind MEMO_VEC_QUANTIZE (default off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+### Added
+
+- `MEMO_VEC_QUANTIZE=int8` (default `off`, dark flag): store the main `vec`
+  table as `int8[dims]` (1 B/dim) instead of `float32[dims]` (4 B/dim) via
+  sqlite-vec `vec_quantize_int8(...,'unit')`, cutting the vec table and the
+  cross-machine embed-cache sync shard ~4×. Safe only for L2-normalised vectors
+  (memo's are). It changes the vec0 column *type*, so it takes effect on
+  `memo reindex --rebuild` only; a DDL-derived guard raises `StorageError` on a
+  precision/index mismatch. Manual, eval-gated graduation — never auto-tuned.
+
 ## [3.8.2] - 2026-07-21
 
 Second-round QA hardening pass (bug fixes only, no behavior/API changes).

--- a/src/memo/cli_ingest.py
+++ b/src/memo/cli_ingest.py
@@ -344,6 +344,7 @@ def ingest(
         cfg.db_path,
         dims=cfg.embedder_dims,
         embedder_model=active_embedder_identity(cfg),
+        vec_quant=_flag_str("MEMO_VEC_QUANTIZE"),
     )
 
     skipped_id = skipped_empty = skipped_unchanged = added = updated = errors = 0

--- a/src/memo/flags_search.py
+++ b/src/memo/flags_search.py
@@ -468,4 +468,18 @@ SPECS: tuple[FlagSpec, ...] = (
         "dossier's ⚔ marker) instead of silently demoting the older side by "
         "MEMO_CONTRADICT_PENALTY. Default off = legacy silent demote.",
     ),
+    _spec(
+        "MEMO_VEC_QUANTIZE",
+        "str",
+        "off",
+        "search",
+        "vec0 storage precision for the main `vec` table. 'off' = float32[dims] "
+        "(4 B/dim); 'int8' = int8[dims] (1 B/dim, ~4x smaller on disk and in the "
+        "base64 sync shard) via vec_quantize_int8(...,'unit'). SAFE only for "
+        "L2-normalised vectors (norm-guard store/queries.py). This is a vec0 column "
+        "TYPE change: it takes effect ONLY on `memo reindex --rebuild`, never at "
+        "runtime. Rebuild-required flag — MANUAL graduation only; never register in "
+        "dream_flags.GATES. Eval-gate before flipping.",
+        choices=("off", "int8"),
+    ),
 )

--- a/src/memo/memory/delete_ops.py
+++ b/src/memo/memory/delete_ops.py
@@ -108,9 +108,7 @@ class _DeleteOpsMixin(_MemoryBase):
         had_vector = self.store.has_vector(id_)
         blob = self.store.get_embedding_blob(id_) if had_vector else None
         if isinstance(blob, (bytes, bytearray)):
-            import struct
-
-            stored_embedding = list(struct.unpack(f"<{len(blob) // 4}f", blob))
+            stored_embedding = self.store.unpack_embedding(bytes(blob))
         elif isinstance(blob, (list, tuple)):
             stored_embedding = list(blob)
         stored_body_text = self.store.get_fts_body(id_)

--- a/src/memo/memory/facade.py
+++ b/src/memo/memory/facade.py
@@ -146,10 +146,13 @@ class Memory(
             from memo.flags import flag_int as _flag_int
 
             self.embedder = make_embedder(cfg, cache_size=_flag_int("MEMO_QUERY_CACHE_SIZE"))
+        from memo.flags import flag_str as _flag_str
+
         self.store = VecStore(
             cfg.db_path,
             dims=cfg.embedder_dims,
             embedder_model=_expected_embedder_model,
+            vec_quant=_flag_str("MEMO_VEC_QUANTIZE"),
         )
         # History store — cheap to open (just sqlite); creating eagerly.
         # Audit failures never propagate to the caller — HistoryStore

--- a/src/memo/recall_logic.py
+++ b/src/memo/recall_logic.py
@@ -4,7 +4,6 @@ import contextlib
 import json
 import logging
 import re
-import struct
 import sys
 import time
 from collections.abc import Callable
@@ -854,7 +853,7 @@ def make_vec_cosine(mem: Any, prompt: str) -> Callable[[Any], float | None]:
             try:
                 blob = mem.store.get_embedding_blob(h.id)
                 if blob:
-                    doc = struct.unpack(f"<{len(blob) // 4}f", blob)
+                    doc = mem.store.unpack_embedding(blob)
                     if len(doc) == len(q):
                         cos = sum(x * y for x, y in zip(q, doc, strict=True))
             except Exception as exc:

--- a/src/memo/repo_index.py
+++ b/src/memo/repo_index.py
@@ -81,11 +81,13 @@ class RepoCorpus:
         self.cfg = cfg
         cfg.ensure_dirs()
         from memo.embedder_select import active_embedder_identity
+        from memo.flags import flag_str as _flag_str_q
 
         self.store = store or VecStore(
             cfg.db_path,
             dims=cfg.embedder_dims,
             embedder_model=active_embedder_identity(cfg),
+            vec_quant=_flag_str_q("MEMO_VEC_QUANTIZE"),
         )
         # make_embedder picks MLX (Apple Silicon) or the CPU sentence-transformers
         # backend (Linux/Ubuntu) — never hard-construct MLXEmbedder here.

--- a/src/memo/store/_base.py
+++ b/src/memo/store/_base.py
@@ -18,6 +18,8 @@ class _StoreBase:
     db_path: Path
     dims: int
     embedder_model: str
+    vec_quant: str
+    _quant_int8: bool
     _has_pattern_cols: bool
     _local: threading.local
     tantivy_index_dir: Path
@@ -34,6 +36,10 @@ class _StoreBase:
     def _rebuild_tantivy_from_sqlite(self) -> None: ...
     def _mark_tantivy_unhealthy(self) -> None: ...
     def _vec_table_dims(self, table: str) -> int | None: ...
+    def _vec_table_dtype(self, table: str) -> str: ...  # type: ignore[empty-body]
+    def _vec_dtype_ddl(self) -> str: ...  # type: ignore[empty-body]
+    def _vec_bind_new(self) -> str: ...  # type: ignore[empty-body]
+    def _vec_bind_stored(self) -> str: ...  # type: ignore[empty-body]
     def _create_vec_tables(self, conn: sqlite3.Connection) -> None: ...
     def _run_migrations(self) -> None: ...
     def set_user_version(self, version: int) -> None: ...

--- a/src/memo/store/queries.py
+++ b/src/memo/store/queries.py
@@ -130,7 +130,7 @@ class _QueriesMixin(_BM25QueriesMixin, _SignalQueriesMixin):
             )
         cx.execute("DELETE FROM vec WHERE id = ?", (id_,))
         cx.execute(
-            "INSERT INTO vec (id, embedding, type) VALUES (?, ?, ?)",
+            f"INSERT INTO vec (id, embedding, type) VALUES (?, {self._vec_bind_new()}, ?)",
             (id_, serialize_float32(embedding), type_),
         )
         cx.execute("DELETE FROM fts WHERE id = ?", (id_,))
@@ -349,6 +349,10 @@ class _QueriesMixin(_BM25QueriesMixin, _SignalQueriesMixin):
                 *(sidecar_dims[sidecar[0]] for sidecar in present_sidecars),
             )
         ) or (stored_dims is not None and stored_dims != self.dims)
+        # A quant flip (float32 <-> int8) is baked into the `vec` vec0 column
+        # TYPE, so — like a dims change — the table must be recreated. But it
+        # touches ONLY `vec`; repo_vec/source_feedback_vec stay float32.
+        quant_changed = self._vec_table_dtype("vec") != self.vec_quant
 
         with self._tx() as cx:
             previous_count = int(cx.execute("SELECT COUNT(*) FROM meta").fetchone()[0])
@@ -363,7 +367,14 @@ class _QueriesMixin(_BM25QueriesMixin, _SignalQueriesMixin):
                 cx.execute("DROP TABLE source_feedback_vec")
                 self._create_vec_tables(cx)
             else:
-                cx.execute("DELETE FROM vec")
+                if quant_changed:
+                    # Recreate ONLY `vec` at the new precision; _create_vec_tables
+                    # is IF NOT EXISTS, so repo_vec/source_feedback_vec are left
+                    # intact (the 62 MB reference/repo tier is not wiped).
+                    cx.execute("DROP TABLE vec")
+                    self._create_vec_tables(cx)
+                else:
+                    cx.execute("DELETE FROM vec")
                 if model_changed:
                     # Same width does not imply the same vector space.
                     cx.execute("DELETE FROM repo_vec")
@@ -555,9 +566,27 @@ class _QueriesMixin(_BM25QueriesMixin, _SignalQueriesMixin):
         return row is not None
 
     def get_embedding_blob(self, id_: str) -> bytes | None:
-        """Return the raw embedding blob for ``id_``, or None if missing."""
+        """Return the raw embedding blob for ``id_``, or None if missing.
+
+        The blob is 4 B/dim float32 by default, 1 B/dim int8 under
+        MEMO_VEC_QUANTIZE=int8 — decode it with :meth:`unpack_embedding`, not a
+        hardcoded float32 unpack.
+        """
         row = self._conn.execute("SELECT embedding FROM vec WHERE id = ?", (id_,)).fetchone()
         return row["embedding"] if row else None
+
+    def unpack_embedding(self, blob: bytes) -> list[float]:
+        """Decode a raw `vec` blob to ``list[float]``, dtype-aware.
+
+        Under int8 the stored blob is 1 B/dim signed int8; dequantize (÷127)
+        back to the ~unit-norm float range so callers that historically decoded
+        float32 (recall vec-cosine boost, delete rollback) keep working.
+        """
+        import struct
+
+        if self._quant_int8:
+            return [x / 127.0 for x in struct.unpack(f"{len(blob)}b", blob)]
+        return list(struct.unpack(f"<{len(blob) // 4}f", blob))
 
     def export_embed_rows(self, *, limit: int = 0) -> list[dict[str, Any]]:
         """Rows whose embeddings are safe to export to the cross-machine sync
@@ -720,7 +749,7 @@ class _QueriesMixin(_BM25QueriesMixin, _SignalQueriesMixin):
                 if existing_emb is not None:
                     cx.execute("DELETE FROM vec WHERE id = ?", (id_,))
                     cx.execute(
-                        "INSERT INTO vec (id, embedding, type) VALUES (?, ?, ?)",
+                        f"INSERT INTO vec (id, embedding, type) VALUES (?, {self._vec_bind_stored()}, ?)",
                         (id_, existing_emb["embedding"], type_),
                     )
                 was_updated = cur.rowcount > 0
@@ -1089,7 +1118,7 @@ class _QueriesMixin(_BM25QueriesMixin, _SignalQueriesMixin):
             "       meta.created, meta.updated, meta.body_hash, meta.extra_json, "
             "       meta.verification_state, meta.verified_at "
             f"FROM vec JOIN meta ON vec.id = meta.id AND {deleted_filter} "
-            "WHERE vec.embedding MATCH ? AND vec.k = ? "
+            f"WHERE vec.embedding MATCH {self._vec_bind_new()} AND vec.k = ? "
         )
         params: list[Any] = [serialize_float32(embedding), k_fetch]
         for clause in push_clauses:
@@ -1286,7 +1315,7 @@ class _QueriesMixin(_BM25QueriesMixin, _SignalQueriesMixin):
             if to_update:
                 cx.executemany("DELETE FROM vec WHERE id = ?", to_update)
                 cx.executemany(
-                    "INSERT INTO vec (id, embedding, type) VALUES (?, ?, ?)",
+                    f"INSERT INTO vec (id, embedding, type) VALUES (?, {self._vec_bind_stored()}, ?)",
                     [(id_, vec_rows[id_], new_type) for (id_,) in to_update],
                 )
         return len(ids)

--- a/src/memo/store/queries.py
+++ b/src/memo/store/queries.py
@@ -287,6 +287,48 @@ class _QueriesMixin(_BM25QueriesMixin, _SignalQueriesMixin):
                     )
                     self._mark_tantivy_unhealthy()
 
+    def _reset_sidecar_vec_tables(
+        self,
+        cx: sqlite3.Connection,
+        *,
+        dimensions_changed: bool,
+        present_sidecars: list[tuple[str, str, str, str]],
+        stamp_identity: bool,
+        current_model: str,
+    ) -> None:
+        """Invalidate HyPE / episode sidecar vectors + metadata on a rebuild that
+        changed the vector space. They share this DB file but keep independent
+        watermarks, so equal body/content hashes would otherwise make their
+        rebuilders skip incompatible old vectors."""
+        for vec_table, meta_table, schema_table, id_column in present_sidecars:
+            if dimensions_changed:
+                cx.execute(f"DROP TABLE {vec_table}")
+                cx.execute(
+                    f"CREATE VIRTUAL TABLE {vec_table} USING vec0("
+                    f"{id_column} TEXT PRIMARY KEY, "
+                    f"embedding FLOAT[{self.dims}] distance_metric=cosine)"
+                )
+            else:
+                cx.execute(f"DELETE FROM {vec_table}")
+            cx.execute(f"DELETE FROM {meta_table}")
+            if stamp_identity:
+                cx.execute(
+                    f"CREATE TABLE IF NOT EXISTS {schema_table} ("
+                    "key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+                )
+                cx.execute(
+                    f"INSERT INTO {schema_table} (key, value) "
+                    "VALUES ('embedder_model', ?) "
+                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    (current_model,),
+                )
+                cx.execute(
+                    f"INSERT INTO {schema_table} (key, value) "
+                    "VALUES ('embedder_dims', ?) "
+                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    (str(self.dims),),
+                )
+
     def replace_memory_index(self, rows: list[dict[str, Any]]) -> int:
         """Atomically replace markdown-derived meta/vector/FTS rows.
 
@@ -380,38 +422,13 @@ class _QueriesMixin(_BM25QueriesMixin, _SignalQueriesMixin):
                     cx.execute("DELETE FROM repo_vec")
                     cx.execute("DELETE FROM source_feedback_vec")
             if dimensions_changed or model_changed:
-                # HyPE and (under MEMO_SINGLE_DB) episode vectors share this
-                # file but have independent watermarks.  Invalidate the vector
-                # and metadata together, otherwise equal body/content hashes
-                # would make their rebuilders skip incompatible old vectors.
-                for vec_table, meta_table, schema_table, id_column in present_sidecars:
-                    if dimensions_changed:
-                        cx.execute(f"DROP TABLE {vec_table}")
-                        cx.execute(
-                            f"CREATE VIRTUAL TABLE {vec_table} USING vec0("
-                            f"{id_column} TEXT PRIMARY KEY, "
-                            f"embedding FLOAT[{self.dims}] distance_metric=cosine)"
-                        )
-                    else:
-                        cx.execute(f"DELETE FROM {vec_table}")
-                    cx.execute(f"DELETE FROM {meta_table}")
-                    if stamp_identity:
-                        cx.execute(
-                            f"CREATE TABLE IF NOT EXISTS {schema_table} ("
-                            "key TEXT PRIMARY KEY, value TEXT NOT NULL)"
-                        )
-                        cx.execute(
-                            f"INSERT INTO {schema_table} (key, value) "
-                            "VALUES ('embedder_model', ?) "
-                            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                            (current_model,),
-                        )
-                        cx.execute(
-                            f"INSERT INTO {schema_table} (key, value) "
-                            "VALUES ('embedder_dims', ?) "
-                            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                            (str(self.dims),),
-                        )
+                self._reset_sidecar_vec_tables(
+                    cx,
+                    dimensions_changed=dimensions_changed,
+                    present_sidecars=present_sidecars,
+                    stamp_identity=stamp_identity,
+                    current_model=current_model,
+                )
             for source_row in rows:
                 row = dict(source_row)
                 verification_state = str(row.pop("verification_state", "unverified"))

--- a/src/memo/store/schema.py
+++ b/src/memo/store/schema.py
@@ -351,6 +351,9 @@ class _SchemaMixin(_StoreBase):
         # whether the DB was just created or already existed — a binary upgraded
         # over an old DB hits the second path. Both are cheap no-ops once current.
         self._validate_vec_dims()
+        # Guard quant mode BEFORE _validate_vec_schema, whose in-place migration
+        # re-inserts stored `vec` blobs — a dtype mismatch there would corrupt.
+        self._validate_vec_quant()
         self._validate_vec_schema()
         self._ensure_secondary_indices()
         self._ensure_schema_meta_table()
@@ -528,9 +531,48 @@ class _SchemaMixin(_StoreBase):
         if not row or not row["sql"]:
             return None
         # Matches `embedding FLOAT[N]` (vec/repo_vec) and `query_emb FLOAT[N]`
-        # (source_feedback_vec) alike.
-        match = re.search(r"FLOAT\[(\d+)\]", str(row["sql"]))
+        # (source_feedback_vec) alike. Also `int8[N]` once the `vec` table is
+        # quantized — otherwise an int8 DDL would return None and silently
+        # disable the dims-mismatch guard.
+        match = re.search(r"(?:FLOAT|int8)\[(\d+)\]", str(row["sql"]))
         return int(match.group(1)) if match else None
+
+    def _vec_table_dtype(self, table: str) -> str:
+        """Physical vec0 element dtype for `table`, derived from its live DDL.
+
+        Returns ``"int8"`` when the column is declared ``int8[N]``, else
+        ``"off"`` (float32 — the historical default). The DDL is the single
+        source of truth for the quant guard: a self-written schema_meta stamp
+        would self-bless a legacy float32 DB opened under an int8 flag.
+        """
+        row = self._conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table,),
+        ).fetchone()
+        if not row or not row["sql"]:
+            return "off"
+        return "int8" if re.search(r"\bint8\[\d+\]", str(row["sql"])) else "off"
+
+    def _vec_dtype_ddl(self) -> str:
+        """vec0 column type token for the main `vec` table (quant-dependent)."""
+        return "int8" if self._quant_int8 else "FLOAT"
+
+    def _vec_bind_new(self) -> str:
+        """Bind expression for a FRESH float32 embedding param going into `vec`.
+
+        Under int8 the L2-normalised float32 vector is quantized in SQL via
+        vec_quantize_int8(...,'unit'); the bound param stays serialize_float32
+        bytes either way (embeddings never leave float32 in RAM — MLX invariant).
+        """
+        return "vec_quantize_int8(vec_f32(?), 'unit')" if self._quant_int8 else "?"
+
+    def _vec_bind_stored(self) -> str:
+        """Bind expression for re-inserting a blob ALREADY read from `vec`.
+
+        Under int8 that blob is already 1 B/dim int8 bytes, so it must be typed
+        with vec_int8() (never re-quantized through vec_f32, which would
+        reinterpret the bytes as float32 and corrupt the vector)."""
+        return "vec_int8(?)" if self._quant_int8 else "?"
 
     def _create_vec_tables(self, conn: sqlite3.Connection) -> None:
         """(Re)create the three vec0 virtual tables at the current dimensionality.
@@ -552,7 +594,7 @@ class _SchemaMixin(_StoreBase):
         """
         conn.execute(
             f"CREATE VIRTUAL TABLE IF NOT EXISTS vec USING vec0("
-            f"id TEXT PRIMARY KEY, embedding FLOAT[{self.dims}] distance_metric=cosine, "
+            f"id TEXT PRIMARY KEY, embedding {self._vec_dtype_ddl()}[{self.dims}] distance_metric=cosine, "
             f"type TEXT)"
         )
         conn.execute(
@@ -634,9 +676,13 @@ class _SchemaMixin(_StoreBase):
                 cx.execute(f"DROP TABLE {table}")
                 self._create_vec_tables(cx)
                 if payload:
+                    # The `vec` blob is already the stored dtype (int8 bytes
+                    # when quantized) — re-type it with vec_int8(), never
+                    # re-quantize. repo_vec/source_feedback_vec stay float32.
+                    vec_bind = self._vec_bind_stored() if table == "vec" else "?"
                     cx.executemany(
                         f"INSERT INTO {table} ({pk_col}, {new_col}, {vec_col}) "  # noqa: S608
-                        f"VALUES (?, ?, ?)",
+                        f"VALUES (?, ?, {vec_bind})",
                         payload,
                     )
             _log.info("migrated `%s`: %d vectors preserved", table, len(payload))
@@ -675,6 +721,36 @@ class _SchemaMixin(_StoreBase):
                     f"Or check your model profile: MEMO_MODEL_PROFILE (current: {self.dims}D) "
                     f"or MEMO_EMBEDDER_DIMS (current: {self.dims})."
                 )
+
+    def _validate_vec_quant(self) -> None:
+        """Guard the on-disk `vec` element dtype against the configured quant mode.
+
+        DDL-derived (never a self-written stamp): the physical `vec` column type
+        is the source of truth. A float32 index opened under MEMO_VEC_QUANTIZE=int8
+        (or vice-versa) would bind the wrong SQL expression and corrupt vectors,
+        so raise before any read/write. Honours MEMO_SKIP_MODEL_VERSION_CHECK so
+        `memo reindex --rebuild` can open a mismatched store to rebuild it.
+        """
+        import os
+
+        # See _validate_vec_dims for why the store layer reads env directly.
+        if os.environ.get("MEMO_SKIP_MODEL_VERSION_CHECK", "").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }:
+            return
+        stored = self._vec_table_dtype("vec")
+        if stored != self.vec_quant:
+            from ..errors import StorageError
+
+            raise StorageError(
+                f"vec storage precision mismatch: index `vec` table is "
+                f"{stored!r} but config expects MEMO_VEC_QUANTIZE={self.vec_quant!r}. "
+                f"Switching int8 <-> float32 changes the vec0 column type.\n"
+                f"Fix: Run 'memo reindex --rebuild' to rebuild `vec` at the new precision."
+            )
 
     def _ensure_schema_meta_table(self) -> None:
         """Create schema_meta if it does not exist (existing DBs predate it).

--- a/src/memo/store/store.py
+++ b/src/memo/store/store.py
@@ -90,10 +90,21 @@ class VecStore(
     instantiate their own `VecStore` (cheap — ~1ms cold open).
     """
 
-    def __init__(self, db_path: Path, dims: int = 1024, embedder_model: str = "") -> None:
+    def __init__(
+        self,
+        db_path: Path,
+        dims: int = 1024,
+        embedder_model: str = "",
+        vec_quant: str = "off",
+    ) -> None:
         self.db_path = db_path
         self.dims = dims
         self.embedder_model = embedder_model
+        # vec0 storage precision for the main `vec` table. "off" = float32,
+        # "int8" = int8 (1 B/dim) via vec_quantize_int8(...,'unit'). Baked into
+        # the vec0 column TYPE at DDL time, so it only takes effect on a rebuild.
+        self.vec_quant = vec_quant
+        self._quant_int8 = vec_quant == "int8"
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         # One sqlite connection PER THREAD. A single shared connection is
         # unsafe under the FastMCP HTTP transport, which dispatches sync

--- a/src/memo/sync_embed_cache.py
+++ b/src/memo/sync_embed_cache.py
@@ -97,6 +97,14 @@ def _contextual_evidence(cfg: Config) -> bool:
     return False
 
 
+def _shard_model_id(store: VecStore) -> str:
+    """Shard identity used for cross-machine matching. Appends `+int8` under
+    quantization so a lossy int8 shard is never merged into a float32 index
+    (and vice-versa). The LOCAL `repo_embedding_cache` row key stays the plain
+    `store.embedder_model`, so a warm rebuild still hits it with ~zero embeds."""
+    return f"{store.embedder_model}+int8" if store.vec_quant == "int8" else store.embedder_model
+
+
 def export_embed_cache(mem: Memory, cache_dir: Path) -> dict:
     """Write this machine's shard: `{sha256(embed_text): b64(f32 vector)}` for
     every durable memory (and durable-parented chunk) in the live index.
@@ -113,18 +121,24 @@ def export_embed_cache(mem: Memory, cache_dir: Path) -> dict:
     store = mem.store
     if _contextual_evidence(mem.cfg):
         return {"rows": 0, "written": False, "path": "", "skipped": "contextual-retrieval"}
+    # Under int8 the vec blob is 1 B/dim, so the shard is ~4x smaller for free.
+    bytes_per_dim = 1 if store.vec_quant == "int8" else 4
     pairs: dict[str, str] = {}
     for row in store.export_embed_rows(limit=flag_int("MEMO_SYNC_EMBED_CACHE_MAX_ROWS")):
         blob = store.get_embedding_blob(str(row["id"]))
-        if blob is None or len(blob) != store.dims * 4:
-            continue  # embed-pending or dims drift — nothing exportable for this row
+        if blob is None or len(blob) != store.dims * bytes_per_dim:
+            continue  # embed-pending or dims/quant drift — nothing exportable for this row
         text = _compose_plain(str(row["title"]), str(row["body"]))
         pairs[sha256_full(text)] = base64.b64encode(bytes(blob)).decode("ascii")
 
     payload = {
         "schema": EMBED_CACHE_SCHEMA,
-        "model": store.embedder_model,
+        # `+int8` isolates a quantized shard so a float32 index never imports
+        # lossy int8 vectors (and vice-versa) — cross-precision shards are
+        # skipped whole and re-embedded locally.
+        "model": _shard_model_id(store),
         "dims": store.dims,
+        "quant": store.vec_quant,
         "rows": pairs,
     }
     data = json.dumps(payload, indent=1, sort_keys=True, ensure_ascii=False) + "\n"
@@ -162,11 +176,15 @@ def import_embed_cache(store: VecStore, cache_dir: Path) -> dict:
         if (
             not isinstance(rows, dict)
             or doc.get("schema") != EMBED_CACHE_SCHEMA
-            or doc.get("model") != store.embedder_model
+            or doc.get("model") != _shard_model_id(store)
             or doc.get("dims") != store.dims
         ):
+            # A float32 shard vs an int8 index (or vice-versa) fails the
+            # `+int8`-tagged model match and is skipped whole → re-embed locally.
             out["skipped_shards"] += 1
             continue
+        shard_quant = "int8" if doc.get("quant") == "int8" else "off"
+        shard_bpd = 1 if shard_quant == "int8" else 4
         out["shards"] += 1
         hashes = [h for h in rows if isinstance(h, str)]
         present = store.get_repo_embedding_cache(
@@ -183,11 +201,15 @@ def import_embed_cache(store: VecStore, cache_dir: Path) -> dict:
                 raw = base64.b64decode(encoded, validate=True)
             except (ValueError, TypeError):
                 continue
-            if len(raw) != store.dims * 4:
+            if len(raw) != store.dims * shard_bpd:
                 continue
-            # Native f32 order mirrors sqlite-vec's serialize_float32 (LE on
-            # every supported platform), so the bytes round-trip exactly.
-            vec = list(struct.unpack(f"{store.dims}f", raw))
+            if shard_quant == "int8":
+                # int8 shard: dequantize (÷127) back to the ~unit float range.
+                vec = [x / 127.0 for x in struct.unpack(f"{store.dims}b", raw)]
+            else:
+                # Native f32 order mirrors sqlite-vec's serialize_float32 (LE on
+                # every supported platform), so the bytes round-trip exactly.
+                vec = list(struct.unpack(f"{store.dims}f", raw))
             # A poisoned/corrupt row (NaN/Inf/zero-norm) must be skipped here:
             # a cached hit is served into the vec table on reindex, and a bad
             # vector would fail that write and de-index the memory.

--- a/src/memo/sync_embed_cache.py
+++ b/src/memo/sync_embed_cache.py
@@ -97,6 +97,34 @@ def _contextual_evidence(cfg: Config) -> bool:
     return False
 
 
+def _decode_shard_row(
+    encoded: object, dims: int, shard_quant: str, shard_bpd: int
+) -> list[float] | None:
+    """Decode one base64 shard vector to a validated ~unit-norm float list.
+
+    Returns None to skip the row (non-string, corrupt base64, wrong width, or a
+    poisoned NaN/Inf/zero-norm vector that would fail the vec-table write and
+    de-index the memory on reindex). int8 shards are dequantized (÷127) back to
+    the ~unit float range; float32 bytes round-trip exactly (LE serialize_float32).
+    """
+    if not isinstance(encoded, str):
+        return None
+    try:
+        raw = base64.b64decode(encoded, validate=True)
+    except (ValueError, TypeError):
+        return None
+    if len(raw) != dims * shard_bpd:
+        return None
+    if shard_quant == "int8":
+        vec = [x / 127.0 for x in struct.unpack(f"{dims}b", raw)]
+    else:
+        vec = list(struct.unpack(f"{dims}f", raw))
+    norm = math.fsum(x * x for x in vec) ** 0.5
+    if not math.isfinite(norm) or not (0.5 < norm < 1.5):
+        return None
+    return vec
+
+
 def _shard_model_id(store: VecStore) -> str:
     """Shard identity used for cross-machine matching. Appends `+int8` under
     quantization so a lossy int8 shard is never merged into a float32 index
@@ -194,29 +222,9 @@ def import_embed_cache(store: VecStore, cache_dir: Path) -> dict:
         for input_hash in hashes:
             if input_hash in present:
                 continue
-            encoded = rows[input_hash]
-            if not isinstance(encoded, str):
-                continue
-            try:
-                raw = base64.b64decode(encoded, validate=True)
-            except (ValueError, TypeError):
-                continue
-            if len(raw) != store.dims * shard_bpd:
-                continue
-            if shard_quant == "int8":
-                # int8 shard: dequantize (÷127) back to the ~unit float range.
-                vec = [x / 127.0 for x in struct.unpack(f"{store.dims}b", raw)]
-            else:
-                # Native f32 order mirrors sqlite-vec's serialize_float32 (LE on
-                # every supported platform), so the bytes round-trip exactly.
-                vec = list(struct.unpack(f"{store.dims}f", raw))
-            # A poisoned/corrupt row (NaN/Inf/zero-norm) must be skipped here:
-            # a cached hit is served into the vec table on reindex, and a bad
-            # vector would fail that write and de-index the memory.
-            norm = math.fsum(x * x for x in vec) ** 0.5
-            if not math.isfinite(norm) or not (0.5 < norm < 1.5):
-                continue
-            to_add.append((input_hash, vec))
+            vec = _decode_shard_row(rows[input_hash], store.dims, shard_quant, shard_bpd)
+            if vec is not None:
+                to_add.append((input_hash, vec))
         if to_add:
             store.upsert_repo_embedding_cache(
                 model=store.embedder_model,

--- a/tests/test_vec_quantize.py
+++ b/tests/test_vec_quantize.py
@@ -153,9 +153,7 @@ def test_rebuild_flip_bypasses_guard_via_skip_env(
 # --------------------------------------------------------------------------- #
 # quant-flip rebuild recreates ONLY `vec`; repo_vec (reference tier) survives #
 # --------------------------------------------------------------------------- #
-def test_rebuild_flip_preserves_repo_vec(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_rebuild_flip_preserves_repo_vec(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     db = tmp_path / "vec.db"
     off = VecStore(db, dims=DIMS, embedder_model="realmodel", vec_quant="off")
     _row(off, "m1", _unit(1, 0))
@@ -229,9 +227,7 @@ def test_sync_int8_shard_imports_into_int8_store(tmp_path: Path) -> None:
         out = import_embed_cache(store, cache_dir)
         assert out["shards"] == 1
         assert out["imported"] == 1
-        cached = store.get_repo_embedding_cache(
-            model="realmodel", dims=DIMS, input_hashes=["h1"]
-        )
+        cached = store.get_repo_embedding_cache(model="realmodel", dims=DIMS, input_hashes=["h1"])
         assert "h1" in cached
         assert 0.5 < math.sqrt(sum(x * x for x in cached["h1"])) < 1.5
     finally:

--- a/tests/test_vec_quantize.py
+++ b/tests/test_vec_quantize.py
@@ -1,0 +1,268 @@
+"""int8 vector quantization (MEMO_VEC_QUANTIZE=int8).
+
+Exercises the vec0 store, the DDL-derived quant guard, the quant-flip rebuild,
+and the sync-shard int8 round-trip — all without the MLX runtime (pure
+sqlite-vec + hand-built unit vectors).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import math
+import struct
+from pathlib import Path
+
+import pytest
+
+from memo.errors import StorageError
+from memo.sqlite_compat import import_sqlite_vec
+from memo.store import VecStore
+
+serialize_float32 = import_sqlite_vec().serialize_float32
+
+DIMS = 8
+
+
+def _unit(*xs: float) -> list[float]:
+    padded = list(xs) + [0.0] * (DIMS - len(xs))
+    norm = math.sqrt(sum(x * x for x in padded)) or 1.0
+    return [x / norm for x in padded]
+
+
+def _row(store: VecStore, id_: str, emb: list[float]) -> None:
+    store.upsert(
+        id_=id_,
+        path=f"memory/{id_}.md",
+        title=id_,
+        type_="fact",
+        tags=[],
+        created="2026-01-01",
+        updated="2026-01-01",
+        body_hash=id_,
+        embedding=emb,
+        body_text=f"body {id_}",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# helper unit tests                                                           #
+# --------------------------------------------------------------------------- #
+def test_bind_helpers_collapse_to_noop_when_off(tmp_path: Path) -> None:
+    s = VecStore(tmp_path / "off.db", dims=DIMS, vec_quant="off")
+    try:
+        assert s._vec_dtype_ddl() == "FLOAT"
+        assert s._vec_bind_new() == "?"
+        assert s._vec_bind_stored() == "?"
+    finally:
+        s.close()
+
+
+def test_bind_helpers_int8(tmp_path: Path) -> None:
+    s = VecStore(tmp_path / "i8.db", dims=DIMS, vec_quant="int8")
+    try:
+        assert s._vec_dtype_ddl() == "int8"
+        assert s._vec_bind_new() == "vec_quantize_int8(vec_f32(?), 'unit')"
+        assert s._vec_bind_stored() == "vec_int8(?)"
+        assert s._vec_table_dtype("vec") == "int8"
+    finally:
+        s.close()
+
+
+# --------------------------------------------------------------------------- #
+# round-trip: int8 stores 1 B/dim and preserves cosine ranking               #
+# --------------------------------------------------------------------------- #
+def test_int8_blob_is_one_byte_per_dim(tmp_path: Path) -> None:
+    off = VecStore(tmp_path / "off.db", dims=DIMS, vec_quant="off")
+    i8 = VecStore(tmp_path / "i8.db", dims=DIMS, vec_quant="int8")
+    try:
+        _row(off, "a", _unit(1, 0, 0))
+        _row(i8, "a", _unit(1, 0, 0))
+        off_blob = off.get_embedding_blob("a")
+        i8_blob = i8.get_embedding_blob("a")
+        assert off_blob is not None and i8_blob is not None
+        assert len(off_blob) == DIMS * 4
+        assert len(i8_blob) == DIMS * 1
+    finally:
+        off.close()
+        i8.close()
+
+
+def test_int8_search_ranking_matches_float32(tmp_path: Path) -> None:
+    vectors = {"a": _unit(1, 0.1), "b": _unit(0, 1), "c": _unit(0.9, 0.4)}
+    query = _unit(0.95, 0.1)
+
+    def top_ids(mode: str) -> list[str]:
+        s = VecStore(tmp_path / f"{mode}.db", dims=DIMS, vec_quant=mode)
+        try:
+            for id_, v in vectors.items():
+                _row(s, id_, v)
+            return [h["id"] for h in s.search(query, limit=3)]
+        finally:
+            s.close()
+
+    assert top_ids("int8") == top_ids("off")
+
+
+def test_int8_dequant_roundtrip_is_unit_norm(tmp_path: Path) -> None:
+    s = VecStore(tmp_path / "i8.db", dims=DIMS, vec_quant="int8")
+    try:
+        _row(s, "a", _unit(0.6, 0.5, 0.4, 0.3))
+        blob = s.get_embedding_blob("a")
+        assert blob is not None
+        doc = s.unpack_embedding(blob)
+        assert len(doc) == DIMS
+        assert 0.5 < math.sqrt(sum(x * x for x in doc)) < 1.5
+    finally:
+        s.close()
+
+
+# --------------------------------------------------------------------------- #
+# DDL-derived guard: a precision mismatch at open raises (both directions)    #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    ("built", "reopened"),
+    [("off", "int8"), ("int8", "off")],
+)
+def test_quant_mismatch_open_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, built: str, reopened: str
+) -> None:
+    # A real (non-stub) model + no SKIP env so the guard is not bypassed.
+    monkeypatch.delenv("MEMO_SKIP_MODEL_VERSION_CHECK", raising=False)
+    db = tmp_path / "vec.db"
+    s = VecStore(db, dims=DIMS, embedder_model="realmodel", vec_quant=built)
+    _row(s, "a", _unit(1, 0))
+    s.close()
+
+    with pytest.raises(StorageError, match="storage precision mismatch"):
+        VecStore(db, dims=DIMS, embedder_model="realmodel", vec_quant=reopened)
+
+
+def test_rebuild_flip_bypasses_guard_via_skip_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "vec.db"
+    s = VecStore(db, dims=DIMS, embedder_model="realmodel", vec_quant="off")
+    s.close()
+    # `memo reindex --rebuild` sets this so it can open a mismatched store.
+    monkeypatch.setenv("MEMO_SKIP_MODEL_VERSION_CHECK", "1")
+    s2 = VecStore(db, dims=DIMS, embedder_model="realmodel", vec_quant="int8")
+    s2.close()  # no raise
+
+
+# --------------------------------------------------------------------------- #
+# quant-flip rebuild recreates ONLY `vec`; repo_vec (reference tier) survives #
+# --------------------------------------------------------------------------- #
+def test_rebuild_flip_preserves_repo_vec(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "vec.db"
+    off = VecStore(db, dims=DIMS, embedder_model="realmodel", vec_quant="off")
+    _row(off, "m1", _unit(1, 0))
+    # Seed a reference-tier repo_vec row directly (bypassing the repo API).
+    with off._tx() as cx:
+        cx.execute(
+            "INSERT INTO repo_vec (id, repo_id, embedding) VALUES (?, ?, ?)",
+            ("r1", "repo1", serialize_float32(_unit(0, 1))),
+        )
+    off.close()
+
+    monkeypatch.setenv("MEMO_SKIP_MODEL_VERSION_CHECK", "1")
+    i8 = VecStore(db, dims=DIMS, embedder_model="realmodel", vec_quant="int8")
+    try:
+        i8.replace_memory_index(
+            [
+                {
+                    "id_": "m1",
+                    "path": "memory/m1.md",
+                    "title": "m1",
+                    "type_": "fact",
+                    "tags": [],
+                    "created": "2026-01-01",
+                    "updated": "2026-01-01",
+                    "body_hash": "m1",
+                    "embedding": _unit(1, 0),
+                    "body_text": "body m1",
+                }
+            ]
+        )
+        assert i8._vec_table_dtype("vec") == "int8"
+        # repo_vec untouched by a quant-only flip.
+        repo_n = i8._conn.execute("SELECT COUNT(*) FROM repo_vec").fetchone()[0]
+        assert repo_n == 1
+        assert i8._vec_table_dtype("repo_vec") == "off"
+        # `vec` repopulated from the markdown row.
+        m1_blob = i8.get_embedding_blob("m1")
+        assert m1_blob is not None
+        assert len(m1_blob) == DIMS * 1
+    finally:
+        i8.close()
+
+
+# --------------------------------------------------------------------------- #
+# sync shard: int8 round-trips; cross-precision shards are skipped whole      #
+# --------------------------------------------------------------------------- #
+def _int8_shard(cache_dir: Path, *, model: str, ihash: str, vec: list[float]) -> None:
+    from memo.sync_embed_cache import EMBED_CACHE_SCHEMA
+
+    q = [max(-127, min(127, round(x * 127))) for x in vec]
+    raw = struct.pack(f"{len(q)}b", *q)
+    payload = {
+        "schema": EMBED_CACHE_SCHEMA,
+        "model": f"{model}+int8",
+        "dims": DIMS,
+        "quant": "int8",
+        "rows": {ihash: base64.b64encode(raw).decode("ascii")},
+    }
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / "peer.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_sync_int8_shard_imports_into_int8_store(tmp_path: Path) -> None:
+    from memo.sync_embed_cache import import_embed_cache
+
+    cache_dir = tmp_path / "embed_cache"
+    _int8_shard(cache_dir, model="realmodel", ihash="h1", vec=_unit(0.6, 0.5, 0.4))
+
+    store = VecStore(tmp_path / "i8.db", dims=DIMS, embedder_model="realmodel", vec_quant="int8")
+    try:
+        out = import_embed_cache(store, cache_dir)
+        assert out["shards"] == 1
+        assert out["imported"] == 1
+        cached = store.get_repo_embedding_cache(
+            model="realmodel", dims=DIMS, input_hashes=["h1"]
+        )
+        assert "h1" in cached
+        assert 0.5 < math.sqrt(sum(x * x for x in cached["h1"])) < 1.5
+    finally:
+        store.close()
+
+
+def test_sync_int8_shard_skipped_by_float32_store(tmp_path: Path) -> None:
+    from memo.sync_embed_cache import import_embed_cache
+
+    cache_dir = tmp_path / "embed_cache"
+    _int8_shard(cache_dir, model="realmodel", ihash="h1", vec=_unit(0.6, 0.5, 0.4))
+
+    store = VecStore(tmp_path / "off.db", dims=DIMS, embedder_model="realmodel", vec_quant="off")
+    try:
+        out = import_embed_cache(store, cache_dir)
+        # `realmodel+int8` != `realmodel` → skipped whole (re-embed locally).
+        assert out["shards"] == 0
+        assert out["skipped_shards"] == 1
+        assert out["imported"] == 0
+    finally:
+        store.close()
+
+
+def test_shard_model_id_tags_int8(tmp_path: Path) -> None:
+    from memo.sync_embed_cache import _shard_model_id
+
+    off = VecStore(tmp_path / "off.db", dims=DIMS, embedder_model="m", vec_quant="off")
+    i8 = VecStore(tmp_path / "i8.db", dims=DIMS, embedder_model="m", vec_quant="int8")
+    try:
+        assert _shard_model_id(off) == "m"
+        assert _shard_model_id(i8) == "m+int8"
+    finally:
+        off.close()
+        i8.close()


### PR DESCRIPTION
## What

Adds `MEMO_VEC_QUANTIZE=off|int8` (default **off**, dark flag). Under `int8`, the main `vec` table is stored as `int8[dims]` (1 B/dim) instead of `float32[dims]` (4 B/dim) via sqlite-vec `vec_quantize_int8(...,'unit')` — cutting the `vec` table **and** the cross-machine embed-cache sync shard **~4×** (the 62 MB / cap-1000 shard pain).

Idea sourced from an eval of `DeusData/codebase-memory-mcp` (which stores int8 vectors); this is the one technique that ports cleanly and pays off memo-alone.

## Mechanism (Path B)

`vec_quantize_int8(vec_f32(?), 'unit')` on both insert and search. memo already L2-normalises every vector (norm guard in `store/queries.py`), so `'unit'`'s [-1,1]→[-127,127] contract holds. **Embeddings stay float32 in RAM** — the 4 MLX invariants are untouched; quantization lives strictly at the SQL/store boundary.

It changes the vec0 column **type**, so it takes effect on `memo reindex --rebuild` only — never at runtime.

## Safety

- **DDL-derived guard** (`_validate_vec_quant`): a precision/index mismatch raises `StorageError`; reads the physical column type, never a self-written stamp (which would self-bless a legacy float32 DB opened under int8). Honours `MEMO_SKIP_MODEL_VERSION_CHECK` so a rebuild can open a mismatched store.
- **Quant-only rebuild recreates ONLY `vec`** — `repo_vec`/`source_feedback_vec` (the reference/repo tier) are not wiped.
- `unpack_embedding()` is dtype-aware, so the recall vec-cosine boost and delete rollback keep working under int8.
- Sync shard is tagged `model+int8` so a float32 index never imports lossy int8 vectors (and vice-versa); the local `repo_embedding_cache` stays float32 on the plain key → warm rebuild still issues ~zero embeds.

## Not enabled

Default `off` = zero effect on existing float32 installs. Flipping to `int8` needs a rebuild and a magnitude study (`'unit'` is a fixed global scale ≈ 5 effective bits) before any graduation to default. Manual, eval-gated graduation — never registered in `dream_flags.GATES`.

## Test plan

- `tests/test_vec_quantize.py` (12 tests): round-trip ranking parity int8 vs float32, 1 B/dim storage, guard both directions, quant-flip rebuild preserves `repo_vec`, sync int8 round-trip + cross-precision shard skip.
- Full non-slow suite: **4842 passed, 29 skipped, 0 failed**. mypy + ruff clean.