### PR TITLE
fix(int8): decode vec blobs dtype-aware (float32-read broke under int8)

### DIFF
--- a/src/memo/cli_viz.py
+++ b/src/memo/cli_viz.py
@@ -18,6 +18,20 @@ from memo.html_security import (
 )
 
 
+def _decode_embedding(blob: bytes, dims: int) -> list[float]:
+    """Decode a raw `vec` blob to floats, dtype-aware by length.
+
+    int8 (MEMO_VEC_QUANTIZE=int8) is 1 B/dim, dequantized (÷127); float32 is
+    4 B/dim. Length-based detection keeps this independent of the running
+    config, since the blob's dtype is whatever it was indexed with.
+    """
+    import struct
+
+    if len(blob) == dims:
+        return [x / 127.0 for x in struct.unpack(f"{dims}b", blob)]
+    return list(struct.unpack(f"<{len(blob) // 4}f", blob))
+
+
 def _render_map_html(data: dict[str, object], *, nonce: str | None = None) -> str:
     """Render corpus data without allowing it to escape into executable HTML."""
     nonce = nonce or new_csp_nonce()
@@ -66,7 +80,6 @@ def map_cmd(output: str | None, open_browser: bool, limit: int, animate: bool) -
     """
     import json as _json
     import sqlite3 as _sqlite3
-    import struct
     import webbrowser as _wb
     from pathlib import Path as _Path
 
@@ -126,8 +139,7 @@ def map_cmd(output: str | None, open_browser: bool, limit: int, animate: bool) -
         blob = row["embedding"]
         if blob is None:
             continue
-        n = len(blob) // 4
-        vec = list(struct.unpack(f"<{n}f", blob))
+        vec = _decode_embedding(blob, cfg.embedder_dims)
         if not vec:
             continue
         ids.append(row["id"])

--- a/src/memo/memory/consolidate_ops.py
+++ b/src/memo/memory/consolidate_ops.py
@@ -218,11 +218,11 @@ class _ConsolidateOpsMixin(_MemoryBase):
         items: builtins.list[dict[str, Any]] = []
         for r in rows:
             blob = r["emb"]
-            if not blob or len(blob) % 4 != 0:
+            if not blob:
                 _log.warning("consolidate: skipping corrupt embedding for %s", r["id"][:12])
                 continue
             try:
-                emb = list(struct.unpack(f"<{len(blob) // 4}f", blob))
+                emb = self.store.unpack_embedding(blob)
             except struct.error:
                 _log.warning("consolidate: skipping corrupt embedding for %s", r["id"][:12])
                 continue

--- a/src/memo/web_build.py
+++ b/src/memo/web_build.py
@@ -80,7 +80,19 @@ def _iso_to_dt(value: str) -> datetime | None:
         return None
 
 
-def _read_vectors(db_path: Path, limit: int) -> list[dict[str, Any]]:
+def _decode_embedding(blob: bytes, dims: int) -> list[float]:
+    """Decode a raw `vec` blob to floats, dtype-aware by length.
+
+    int8 (MEMO_VEC_QUANTIZE=int8) is 1 B/dim, dequantized (÷127); float32 is
+    4 B/dim. Length-based detection keeps this independent of the running
+    config, since the blob's dtype is whatever it was indexed with.
+    """
+    if len(blob) == dims:
+        return [x / 127.0 for x in struct.unpack(f"{dims}b", blob)]
+    return list(struct.unpack(f"<{len(blob) // 4}f", blob))
+
+
+def _read_vectors(db_path: Path, limit: int, dims: int) -> list[dict[str, Any]]:
     """Pull embeddings + metadata straight from sqlite-vec (no MLX load)."""
     try:
         from memo.sqlite_compat import import_sqlite_vec
@@ -109,8 +121,7 @@ def _read_vectors(db_path: Path, limit: int) -> list[dict[str, Any]]:
         blob = row["embedding"]
         if blob is None:
             continue
-        n = len(blob) // 4
-        vec = list(struct.unpack(f"<{n}f", blob))
+        vec = _decode_embedding(blob, dims)
         if not vec:
             continue
         try:
@@ -869,7 +880,7 @@ def collect_data(
     drift: dict[str, int] | None = None
     if include_projection:
         drift = _body_hash_drift(cfg)
-        rows = _read_vectors(cfg.db_path, limit=limit)
+        rows = _read_vectors(cfg.db_path, limit=limit, dims=cfg.embedder_dims)
         if len(rows) >= 3:
             xs, ys, zs, method = _project_3d([r["vec"] for r in rows])
         else:

--- a/tests/test_vec_quantize.py
+++ b/tests/test_vec_quantize.py
@@ -251,6 +251,31 @@ def test_sync_int8_shard_skipped_by_float32_store(tmp_path: Path) -> None:
         store.close()
 
 
+# --------------------------------------------------------------------------- #
+# consolidate dedup pass: _pull_embeddings must dequantize int8, not read it   #
+# as float32 (regression — an int8 blob is 1 B/dim, quietly divisible by 4     #
+# too, so a naive float32 unpack "succeeds" and returns garbage magnitudes).   #
+# --------------------------------------------------------------------------- #
+def test_consolidate_pull_embeddings_decodes_int8_blob(tmp_path: Path) -> None:
+    from memo.memory.consolidate_ops import _ConsolidateOpsMixin
+
+    class _Harness(_ConsolidateOpsMixin):
+        def __init__(self, store: VecStore) -> None:
+            self.store = store
+
+    store = VecStore(tmp_path / "i8.db", dims=DIMS, vec_quant="int8")
+    try:
+        _row(store, "a", _unit(0.6, 0.5, 0.4, 0.3))
+        items = _Harness(store)._pull_embeddings()
+        assert len(items) == 1
+        emb = items[0]["emb"]
+        assert len(emb) == DIMS
+        norm = math.sqrt(sum(x * x for x in emb))
+        assert 0.5 < norm < 1.5
+    finally:
+        store.close()
+
+
 def test_shard_model_id_tags_int8(tmp_path: Path) -> None:
     from memo.sync_embed_cache import _shard_model_id
 


### PR DESCRIPTION
## Problem

PR#50 (int8 quantization) shipped three latent bugs: code paths that read the main `vec` table's embedding blob as **float32**. Harmless while the index was float32, but once `MEMO_VEC_QUANTIZE=int8` is active the blob is 1 byte/dim (int8), so these sites decode garbage. Surfaced by `memo dream run`:
```
numpy RuntimeWarning: overflow encountered in multiply  (s = (x.conj()*x).real)
```
in the consolidate/dedup pass — `2560`-byte int8 blob passes the `len % 4 == 0` guard and gets read as 640 float32 values → garbage → overflow (and wrong dedup similarity).

## Fix

- **`consolidate_ops.py`** (dream dedup pass) → route through the existing dtype-aware `VecStore.unpack_embedding(blob)` (int8 ÷127 / float32 unpack).
- **`web_build.py`**, **`cli_viz.py`** (raw sqlite conn, no VecStore) → length-based decode helper: `len(blob) == dims` ⇒ int8, else float32 (unambiguous — int8 is dims bytes, float32 is 4×dims).
- Grep audit: no other decode sites (queries.py delete+reinsert the raw blob unchanged; sync_embed_cache already dtype-aware; recall_logic/delete_ops already fixed).

## Note (not part of this diff)

`memo dream run` also showed `contradict`/`eval_recall` "expected int8, float32 provided" MATCH errors — those were a **wedged recall daemon** serving a stale float32 store, not a code bug; a clean daemon restart fixed them (socket search verified OK).

## Test plan

- New `tests/test_vec_quantize.py::test_consolidate_pull_embeddings_decodes_int8_blob` — drives the consolidate decode against a real int8 store; **fails pre-fix** (misdecodes int8 as float32), **passes post-fix** (unit-norm).
- Full non-slow suite: **4891 passed, 0 failed**. ruff/format/mypy/quality_gate all green.