### PR TITLE
ci: run a meaningful test subset under MEMO_VEC_QUANTIZE=int8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,34 @@ jobs:
         # tests. --cov + fail_under (pyproject) gates coverage regressions.
         run: .venv/bin/python -m pytest -m "not slow" -n auto --timeout=120 --cov=memo --cov-report=term-missing
 
+  test-int8:
+    # MEMO_VEC_QUANTIZE now defaults to int8 for fresh installs (v3.10.0), but
+    # the `test` job above forces it `off` (tests/conftest.py) because many
+    # pre-quantization asserts pin exact float32 cosine values
+    # (`pytest.approx(..., abs=1e-6)`) that int8's ~1/127 precision breaks —
+    # so the shipped default was otherwise only exercised by
+    # tests/test_vec_quantize.py. This lane re-runs the same non-slow suite
+    # with int8 forced on, deselecting only the tests marked
+    # `float32_precision` (legitimately float32-only asserts) — everything
+    # else must behave identically under quantization.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Set up Python 3.13
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: "3.13"
+      - name: Install uv
+        run: pip install uv==0.11.21
+      - name: Install package + dev deps
+        run: uv sync --frozen --extra dev --extra cpu --extra http --python 3.13
+      - name: Tests under MEMO_VEC_QUANTIZE=int8 (excluding slow + float32-only precision asserts)
+        env:
+          MEMO_VEC_QUANTIZE: int8
+        run: .venv/bin/python -m pytest -m "not slow and not float32_precision" -n auto --timeout=120
+
   contract-stub-compatibility:
     # Public, always-on interface gate. The stub only models the contract API
     # memo consumes and forces every optional integration import down its live

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,7 @@ addopts = ["--import-mode=importlib"]
 markers = [
     "requires_mlx: smoke test que carga modelos MLX reales (Apple Silicon only). Auto-skipea sin mlx_lm.",
     "slow: tests >1s (real MLX model loads); no default deselection — CI jobs pass `-m 'not slow'` explicitly (nightly slow-tests runs them).",
+    "float32_precision: asserts an exact float32 value/representation (tight-tolerance cosine, raw blob bytes, or a float32-only model tag) that legitimately diverges under MEMO_VEC_QUANTIZE=int8; deselected by the int8 CI lane.",
 ]
 
 [tool.mypy]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,12 +126,13 @@ for _trust_flag in (
 # int8 vec quantization (memo v3.9.0+) graduated to the default. Existing
 # fixtures/tests that build a `Memory`/`VecStore` and assert exact float32
 # cosine scores (e.g. `pytest.approx(1.0, abs=1e-6)`) predate quantization and
-# would flake against int8's ~1/127 precision. Hard-set off (overrides a
-# developer's exported `=int8`) so the suite is hermetic; the dedicated
-# `tests/test_vec_quantize.py` opts back in via `monkeypatch.delenv`/
+# would flake against int8's ~1/127 precision. Soft-set off (`setdefault`, like
+# the other pins above) so the suite is hermetic by default, but the CI int8
+# lane can still export `MEMO_VEC_QUANTIZE=int8` and have it take effect; the
+# dedicated `tests/test_vec_quantize.py` opts back in via `monkeypatch.delenv`/
 # `monkeypatch.setenv`, and direct `VecStore(...)` construction without
 # `vec_quant=` is unaffected (its own default is independent of this env var).
-os.environ["MEMO_VEC_QUANTIZE"] = "off"
+os.environ.setdefault("MEMO_VEC_QUANTIZE", "off")
 
 
 @pytest.fixture

--- a/tests/test_cli_debug_recall.py
+++ b/tests/test_cli_debug_recall.py
@@ -184,6 +184,7 @@ def _strip_ansi(text: str) -> str:
     return _ANSI_RE.sub("", text)
 
 
+@pytest.mark.float32_precision  # asserts vec_sim == 1.0 within abs=1e-6; int8 cosine is ~1/127-quantized
 def test_debug_recall_json_shape(tmp_cfg: Config, monkeypatch: pytest.MonkeyPatch) -> None:
     _install_keyword_stub(monkeypatch)
     alpha_id, beta_id = _seed(tmp_cfg)

--- a/tests/test_hype_fold.py
+++ b/tests/test_hype_fold.py
@@ -212,6 +212,7 @@ def test_flag_off_results_identical_with_populated_hype_store(
     assert [r.score for r in after] == [r.score for r in before]
 
 
+@pytest.mark.float32_precision  # asserts score == 0.8 within abs=1e-3; int8 cosine is ~1/127-quantized
 def test_flag_on_question_space_candidate_surfaces(
     hype_mem, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_memory_write.py
+++ b/tests/test_memory_write.py
@@ -150,6 +150,7 @@ def test_two_memory_instances_do_not_duplicate_topic_key(tmp_cfg: Config):
         second.close()
 
 
+@pytest.mark.float32_precision  # compares raw embedding blob to serialize_float32(); int8 blobs are 1B/dim
 def test_concurrent_topic_key_save_keeps_markdown_fts_and_vector_coherent(tmp_cfg: Config):
     first = Memory(tmp_cfg)
     second = Memory(tmp_cfg)

--- a/tests/test_sync_embed_cache.py
+++ b/tests/test_sync_embed_cache.py
@@ -80,6 +80,7 @@ def _shard_files(cache_dir: Path) -> list[Path]:
     return sorted(cache_dir.glob("*.json"))
 
 
+@pytest.mark.float32_precision  # asserts doc["model"] == "stub"; int8 stores tag shards "stub+int8" by design
 def test_export_import_roundtrip(remote: Path, tmp_path: Path, monkeypatch):
     """Export derives (hash → vector) pairs from A's live index; importing them
     into a fresh store makes the exact vectors available under the same keys."""
@@ -222,6 +223,8 @@ def test_export_covers_chunks_of_durable_parents(remote: Path, tmp_path: Path, m
     assert out["rows"] == n_rows
 
 
+@pytest.mark.float32_precision  # shard doc is hand-crafted model="stub" (float32); int8 store expects
+# "stub+int8" and by-design skips the whole (foreign-profile) shard, not just poisoned rows
 def test_import_skips_invalid_vectors(remote: Path, tmp_path: Path, monkeypatch):
     """A poisoned shard row (zero-norm / NaN) is skipped; valid rows import."""
     import base64


### PR DESCRIPTION
## Why

int8 is now the **default** (v3.10.0), but `conftest.py` pins `MEMO_VEC_QUANTIZE=off` for the whole suite (int8's ~1/127 precision breaks exact-cosine asserts), so the shipped default was exercised only by `tests/test_vec_quantize.py`. History shows int8-only bugs slip past a float32 suite (the `af6d5273` decode fix). This closes the gap — the #1 follow-up from the graduation review.

## What

- `conftest.py`: the `MEMO_VEC_QUANTIZE` pin → `setdefault` so a lane can force int8 (normal runs still default `off`, deterministic).
- New `test-int8` job in `.github/workflows/test.yml` runs `MEMO_VEC_QUANTIZE=int8 pytest -m "not slow and not float32_precision"` — **4904 tests under int8**.
- 5 tests marked `@pytest.mark.float32_precision` (registered in pyproject) — traced each to a legitimate float32-only reason (exact cosine `abs=1e-6`, raw-blob byte compare, stub-model shard tagging). **No real int8 bug found** — int8 is solid.

Tests + CI only, no production code. Local: int8 lane 4904 passed / 0 failed; normal run 4909 passed / 0 failed.