### PR TITLE
test: drop dead MEMO_RECALL_ADAPTIVE_CONTEXT env key

### DIFF
--- a/tests/test_recall_empty_marker.py
+++ b/tests/test_recall_empty_marker.py
@@ -101,7 +101,6 @@ def _hook_env(tmp_cfg: Config, **extra: str) -> dict[str, str]:
         "MEMO_RECALL_SKIP_BELOW": "0.0",
         "MEMO_EMBEDDER_VIA_DAEMON": "0",
         "MEMO_RECALL_EXPAND_CONTEXT": "0",
-        "MEMO_RECALL_ADAPTIVE_CONTEXT": "0",
         "MEMO_RECALL_CONTEXTUAL": "0",
     }
     env.update(extra)

--- a/tests/test_recall_metrics.py
+++ b/tests/test_recall_metrics.py
@@ -312,7 +312,6 @@ def test_hook_subprocess_hits_are_post_session_dedup(
         "MEMO_RECALL_MIN_BODY_CHARS": "0",
         "MEMO_RECALL_TOKEN_BUDGET": "0",
         "MEMO_RECALL_EXPAND_CONTEXT": "0",
-        "MEMO_RECALL_ADAPTIVE_CONTEXT": "0",
         "MEMO_RECALL_CONTEXTUAL": "0",
         # Isolate SESSION dedup: the A/B fixture bodies differ by one word, so
         # the default-ON pre-top-K paraphrase collapse would strip B — off here.

--- a/tests/test_session_recalled.py
+++ b/tests/test_session_recalled.py
@@ -119,7 +119,6 @@ def test_subprocess_path_dedup_short_ref_on_second_turn(tmp_cfg, monkeypatch) ->
         "MEMO_RECALL_SKIP_BELOW": "0.0",
         "MEMO_EMBEDDER_VIA_DAEMON": "0",
         "MEMO_RECALL_EXPAND_CONTEXT": "0",
-        "MEMO_RECALL_ADAPTIVE_CONTEXT": "0",
         "MEMO_RECALL_CONTEXTUAL": "0",
         "MEMO_RECALL_FEEDBACK_HINT": "0",
         "MEMO_RECALL_DIRECTIVE_ONCE": "0",


### PR DESCRIPTION
Trivial cleanup: the `MEMO_RECALL_ADAPTIVE_CONTEXT` flag was deleted in the close-loops refactor (#63); three test env dicts still set it as a dead no-op. This removes the last dangling reference to a removed flag. Tests unchanged in behavior (the flag had no consumer).