### PR TITLE
feat(mcp): expose passport export/import as MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ memo sync bootstrap git@github.com:yourname/memo-sync.git   # restore from git
 
 memo is built to **spend fewer tokens, not more**.
 
-- **~90% smaller MCP surface.** The default `agent` profile exposes **14 tools / ~1.4k schema tokens**, versus **131 tools / ~15k tokens** for the full surface — that overhead is paid *every session, in every client*. memo trims it to almost nothing.
+- **~90% smaller MCP surface.** The default `agent` profile exposes **14 tools / ~1.4k schema tokens**, versus **133 tools / ~15k tokens** for the full surface — that overhead is paid *every session, in every client*. memo trims it to almost nothing.
 - **Recall injects the answer instead of re-deriving it.** Ambient recall surfaces the top memory *before* the agent answers, on a tight **~160-token budget**. The agent stops re-explaining what it already figured out last week.
 
 On a ~200-memory corpus, `memo roi` estimates **~80k tokens of model work avoided** per session. The number is corpus-specific; it grows as memo learns more.
@@ -163,7 +163,7 @@ On a ~200-memory corpus, `memo roi` estimates **~80k tokens of model work avoide
 - **Time-machine / audit.** "What did we know about this bug last month?" Rewind the corpus to any date and see the state of knowledge at that point.
 - **Instant project onboarding.** A cold agent gets the project's durable decisions, facts, and preferences up front via the session-start briefing.
 - **Exact transcript lookup (opt-in).** `memo verbatim search` can find the precise wording of past local transcript turns through a private, lexical-only FTS5 index. It never enters ambient recall.
-- **Fewer tokens, not more.** Instead of re-deriving what you solved last week, recall injects the answer on a tight budget — and the default MCP surface is 14 tools, not 131.
+- **Fewer tokens, not more.** Instead of re-deriving what you solved last week, recall injects the answer on a tight budget — and the default MCP surface is 14 tools, not 133.
 
 ## Requirements
 
@@ -421,7 +421,7 @@ memo runs four background daemons:
 |---|---|---|---|
 | `agent` (default) | 14 | ~1.4k | Standard agent work — max token economy |
 | `core` / `slim` | 34 | ~3.0k | Constrained clients (Codex, OpenCode), admin-lite |
-| `full` / `default` | 131 | ~15k | Power users, debugging |
+| `full` / `default` | 133 | ~15k | Power users, debugging |
 
 Set via `MEMO_MCP_PROFILE=full` or in each client's MCP env config.
 

--- a/src/memo/server_import_export.py
+++ b/src/memo/server_import_export.py
@@ -149,3 +149,39 @@ def register(server: FastMCP, memory: Memory) -> None:
         safe = _resolve_safe_path(output_path, "export")
         result = memory.import_export.export_to(safe, "markdown_bundle")
         return result.__dict__
+
+    @annotated_tool(server, **WRITE_IDEMPOTENT)
+    def memo_export_passport(
+        output_path: str,
+    ) -> dict[str, Any]:
+        """Export a versioned, vendor-neutral memory passport (memo.passport.v1).
+
+        Higher fidelity than JSON: a stable schema header plus the provenance /
+        verification `extra` bag, so another memo (or tool) can validate and
+        re-import the canonical record intact. See docs/PASSPORT.md.
+
+        Args:
+            output_path: Path to write the passport file (under current dir,
+                Downloads, Desktop, or Documents).
+        """
+        safe = _resolve_safe_path(output_path, "export")
+        result = memory.import_export.export_to(safe, "passport")
+        return result.__dict__
+
+    @annotated_tool(server, **WRITE)
+    def memo_import_passport(
+        input_path: str,
+    ) -> dict[str, Any]:
+        """Import a versioned memo.passport.v1 file (validated, high-fidelity).
+
+        Preserves content/title/type/tags/created and the provenance /
+        verification `extra` bag; ids and derived indexes are rebuilt by this
+        store. Rejects a malformed / wrong-schema passport before writing.
+
+        Args:
+            input_path: Path to the passport file (under current dir, Downloads,
+                Desktop, or Documents).
+        """
+        safe = _resolve_safe_path(input_path, "import")
+        result = memory.import_export.import_from(safe, "passport")
+        return result.__dict__

--- a/tests/test_cli_mcp_surface_smoke.py
+++ b/tests/test_cli_mcp_surface_smoke.py
@@ -105,7 +105,7 @@ def test_mcp_full_profile_registers_every_decorated_server_tool(
     registered = _mcp_tool_names(tmp_path, monkeypatch, "full")
 
     assert expected <= registered
-    assert len(registered) == 131
+    assert len(registered) == 133
 
 
 @pytest.mark.parametrize(
@@ -113,7 +113,7 @@ def test_mcp_full_profile_registers_every_decorated_server_tool(
     [
         ("agent", 14),
         ("core", 34),
-        ("full", 131),
+        ("full", 133),
     ],
 )
 def test_mcp_profile_tool_counts(

--- a/tests/test_server_import_export.py
+++ b/tests/test_server_import_export.py
@@ -28,8 +28,8 @@ def _make_server_and_tools():
     return server, tools
 
 
-def test_register_exposes_all_five_tools(tmp_cfg) -> None:
-    """register() must expose all five expected MCP tools."""
+def test_register_exposes_all_import_export_tools(tmp_cfg) -> None:
+    """register() must expose every expected import/export MCP tool."""
     from memo.memory import Memory
     from memo.server_import_export import register
 
@@ -42,9 +42,11 @@ def test_register_exposes_all_five_tools(tmp_cfg) -> None:
     expected = {
         "memo_import_json",
         "memo_import_csv",
+        "memo_import_passport",
         "memo_export_json",
         "memo_export_csv",
         "memo_export_markdown_bundle",
+        "memo_export_passport",
     }
     assert expected == set(tools), f"Tool mismatch: {set(tools)}"
 

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -179,6 +179,6 @@ def test_readme_surface_counts_and_top_level_command_inventory_are_exact() -> No
     documented = set(re.findall(r"`([a-z][a-z0-9-]*)`", block))
 
     assert documented == set(cli.commands)
-    assert "| `full` / `default` | 131 |" in readme
-    assert "versus **131 tools / ~15k tokens**" in readme
-    assert "default MCP surface is 14 tools, not 131" in readme
+    assert "| `full` / `default` | 133 |" in readme
+    assert "versus **133 tools / ~15k tokens**" in readme
+    assert "default MCP surface is 14 tools, not 133" in readme


### PR DESCRIPTION
Completes Plan C of the Constitutional memo program (#66): the memory passport was CLI-only; this adds the deferred MCP surface.

- `memo_export_passport` / `memo_import_passport` in `server_import_export.py`, mirroring the existing `memo_export_json/csv/markdown_bundle` + `memo_import_json/csv` tools (same path allow-list, same `WRITE`/`WRITE_IDEMPOTENT` annotations). A data op, not cognition — consistent with memo's MCP-surface policy.
- Full MCP surface **131 → 133** (agent=14 / core=34 profiles unchanged): updated the count assertions in `test_cli_mcp_surface_smoke` + `test_supply_chain`, the three README figures, and broadened the import/export registration test to the full set.

### Test plan
- [x] `test_cli_mcp_surface_smoke` (full=133) + `test_supply_chain` README counts + `test_server_import_export` — 344 passed against worktree source
- [x] mypy + ruff clean; quality gate passes (no new broad-exception/complexity budgets)
- [ ] CI (10 required checks)

With this, nothing from the three plans is left: mandates, drift guard, passport (CLI + MCP), and the gated nightly auto-sync are all on master. The "Living Docs writer" remains a deliberate YAGNI exclusion (overlaps `dream_profile`).