### PR TITLE
fix(deps): cap incompatible mlx-vlm releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,14 @@ updates:
         dependency-type: "production"
       python-development:
         dependency-type: "development"
-    # Keep Dependabot from widening the ML compatibility cap and manufacturing
-    # an invalid resolution. transformers 5.13 breaks the current mlx-lm
-    # tokenizer path.
+    # Keep Dependabot from widening ML compatibility caps and manufacturing an
+    # invalid resolution. transformers 5.13 breaks the current mlx-lm tokenizer
+    # path; mlx-vlm 0.6.5+ requires transformers 5.14+.
     ignore:
       - dependency-name: "transformers"
         versions: [">=5.13"]
+      - dependency-name: "mlx-vlm"
+        versions: [">=0.6.5"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,9 @@ tantivy = [
 # mlx-whisper audio transcription. Apple Silicon only, ingest-time only.
 # Install: pip install "mlx-memo[multimodal]"
 multimodal = [
-    "mlx-vlm>=0.1.12; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    # mlx-vlm >=0.6.5 requires transformers >=5.14, which conflicts with the
+    # core MLX runtime cap above. Lift both caps together.
+    "mlx-vlm>=0.1.12,<0.6.5; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "mlx-whisper>=0.4.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
 ]
 # Shared trinity schemas (memo + memflow + synapse). Optional: enables

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -39,7 +39,7 @@ def test_dependabot_covers_every_shipped_dependency_surface() -> None:
     assert all(entry["schedule"]["interval"] == "weekly" for entry in updates)
 
 
-def test_dependabot_respects_mlx_cap_without_blocking_supported_pytest() -> None:
+def test_dependabot_respects_mlx_caps_without_blocking_supported_pytest() -> None:
     config = yaml.safe_load((ROOT / ".github" / "dependabot.yml").read_text(encoding="utf-8"))
     project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
 
@@ -49,9 +49,14 @@ def test_dependabot_respects_mlx_cap_without_blocking_supported_pytest() -> None
     }
 
     assert ">=5.13" in ignored_versions["transformers"]
+    assert ">=0.6.5" in ignored_versions["mlx-vlm"]
     assert "pytest" not in ignored_versions
     assert any(
         dependency.startswith("transformers<5.13;") for dependency in project["dependencies"]
+    )
+    assert any(
+        dependency.startswith("mlx-vlm>=0.1.12,<0.6.5;")
+        for dependency in project["optional-dependencies"]["multimodal"]
     )
     assert "pytest>=9.0.3,<10" in project["optional-dependencies"]["dev"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1474,7 +1474,7 @@ requires-dist = [
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.158,<7" },
     { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.18,<1" },
     { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.18" },
-    { name = "mlx-vlm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'multimodal'", specifier = ">=0.1.12" },
+    { name = "mlx-vlm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'multimodal'", specifier = ">=0.1.12,<0.6.5" },
     { name = "mlx-whisper", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'multimodal'", specifier = ">=0.4.1" },
     { name = "mutmut", marker = "extra == 'test-mutation'", specifier = ">=3,<4" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },


### PR DESCRIPTION
Follow-up to #69.

The post-merge Dependabot refresh attempted mlx-vlm 0.6.5/0.6.6, whose metadata requires transformers >=5.14, while memo intentionally caps transformers <5.13 for mlx-lm compatibility. That made the update job unresolvable.

This change:
- caps the multimodal extra at mlx-vlm <0.6.5 (0.6.4 is the latest compatible release);
- mirrors that boundary in Dependabot;
- adds a supply-chain contract so both caps move together;
- refreshes uv.lock without changing resolved versions.

Verified locally: uv lock (199 packages), forced mlx-vlm upgrade remains 0.6.4, 16 focused contracts, Ruff, quality gate, pip-audit with zero known vulnerabilities, independent review Ready: YES.

Failed refresh: https://github.com/jagoff/memo/actions/runs/29916131704