### PR TITLE
fix: publish daemon stats before responses

### DIFF
--- a/src/memo/recall_socket.py
+++ b/src/memo/recall_socket.py
@@ -80,6 +80,7 @@ def _read_pid(state_dir: Path) -> int | None:
 class _RecallHandler(socketserver.StreamRequestHandler):
     server: _RecallServer  # type: ignore[assignment]
     timeout = 5.0
+    _stats_recorded = False
 
     def _write_response(self, result: str, *, debug: bool) -> bool:
         try:
@@ -91,6 +92,28 @@ class _RecallHandler(socketserver.StreamRequestHandler):
                     f"# recall-daemon: client disconnected before response: {exc}", file=sys.stderr
                 )
             return False
+
+    def _record_stats_once(self, *, started_at: float, op: str, error: bool) -> None:
+        if self._stats_recorded:
+            return
+        self._stats_recorded = True
+        stats = getattr(self.server, "_stats", None)
+        if stats is not None:
+            latency_ms = (time.time() - started_at) * 1000.0
+            stats.record(op, latency_ms, error=error)
+
+    def _write_tracked_response(
+        self,
+        result: str,
+        *,
+        debug: bool,
+        started_at: float,
+        op: str,
+        error: bool,
+    ) -> bool:
+        """Publish request metrics before its response becomes observable."""
+        self._record_stats_once(started_at=started_at, op=op, error=error)
+        return self._write_response(result, debug=debug)
 
     def _embed_query(self, req: dict[str, Any]) -> str:
         text = str(req.get("text") or "")
@@ -236,43 +259,36 @@ class _RecallHandler(socketserver.StreamRequestHandler):
         debug = flag_bool("MEMO_RECALL_DEBUG")
         op = "parse"
         error = False
-        stats_recorded = False
-
-        def record_stats() -> None:
-            """Publish request metrics before its response becomes observable."""
-            nonlocal stats_recorded
-            if stats_recorded:
-                return
-            stats_recorded = True
-            stats = getattr(self.server, "_stats", None)
-            if stats is not None:
-                latency_ms = (time.time() - t0) * 1000.0
-                stats.record(op, latency_ms, error=error)
-
-        def respond(result: str) -> bool:
-            record_stats()
-            return self._write_response(result, debug=debug)
+        self._stats_recorded = False
 
         try:
             try:
                 line = self.rfile.readline(_MAX_LINE_BYTES)
                 if not line:
-                    respond("{}")
+                    self._write_tracked_response(
+                        "{}", debug=debug, started_at=t0, op=op, error=error
+                    )
                     return
                 if len(line) >= _MAX_LINE_BYTES and not line.endswith(b"\n"):
                     error = True
-                    respond("{}")
+                    self._write_tracked_response(
+                        "{}", debug=debug, started_at=t0, op=op, error=error
+                    )
                     return
                 req = json.loads(line.decode("utf-8", errors="replace").strip())
             except (json.JSONDecodeError, UnicodeDecodeError, ValueError, OSError) as exc:
                 error = True
                 print(f"# recall-daemon: parse error: {type(exc).__name__}: {exc}", file=sys.stderr)
-                respond("{}")
+                self._write_tracked_response(
+                    "{}", debug=debug, started_at=t0, op=op, error=error
+                )
                 return
 
             if not isinstance(req, dict):
                 error = True
-                respond("{}")
+                self._write_tracked_response(
+                    "{}", debug=debug, started_at=t0, op=op, error=error
+                )
                 return
 
             op = str(req.get("op") or "recall").strip()
@@ -289,7 +305,9 @@ class _RecallHandler(socketserver.StreamRequestHandler):
                     _we = getattr(self.server, "_warm_event", None)
                     if _we is not None and not _we.is_set():
                         _log_lock_contention("recall_warming", 0.0, "warmup")
-                        respond(BUSY_RESPONSE)
+                        self._write_tracked_response(
+                            BUSY_RESPONSE, debug=debug, started_at=t0, op=op, error=error
+                        )
                         return
                     prompt = (req.get("prompt") or "").strip()
                     cwd = req.get("cwd") or None
@@ -298,7 +316,9 @@ class _RecallHandler(socketserver.StreamRequestHandler):
                     _turn = int(_turn) if isinstance(_turn, (int, float)) else None
                     _client = req.get("client") or None
                     if not prompt:
-                        respond("{}")
+                        self._write_tracked_response(
+                            "{}", debug=debug, started_at=t0, op=op, error=error
+                        )
                         return
                     from memo.flags import flag_int
 
@@ -323,7 +343,9 @@ class _RecallHandler(socketserver.StreamRequestHandler):
                                 f"# recall-daemon: lock busy >{timeout_s:.1f}s, bailing busy",
                                 file=sys.stderr,
                             )
-                        respond(BUSY_RESPONSE)
+                        self._write_tracked_response(
+                            BUSY_RESPONSE, debug=debug, started_at=t0, op=op, error=error
+                        )
                         return
                     if wait_ms > _LOCK_WAIT_LOG_MS:
                         _log_lock_contention("recall_lock_wait", wait_ms, held_by)
@@ -395,11 +417,13 @@ class _RecallHandler(socketserver.StreamRequestHandler):
                 )
                 result = json.dumps({"error": f"{type(exc).__name__}: {exc}"})
 
-            delivered = respond(result)
+            delivered = self._write_tracked_response(
+                result, debug=debug, started_at=t0, op=op, error=error
+            )
             if delivered and log_fn is not None:
                 log_fn()
         finally:
-            record_stats()
+            self._record_stats_once(started_at=t0, op=op, error=error)
 
 
 # Lock acquisition order (to avoid deadlocks):

--- a/src/memo/recall_socket.py
+++ b/src/memo/recall_socket.py
@@ -236,26 +236,43 @@ class _RecallHandler(socketserver.StreamRequestHandler):
         debug = flag_bool("MEMO_RECALL_DEBUG")
         op = "parse"
         error = False
+        stats_recorded = False
+
+        def record_stats() -> None:
+            """Publish request metrics before its response becomes observable."""
+            nonlocal stats_recorded
+            if stats_recorded:
+                return
+            stats_recorded = True
+            stats = getattr(self.server, "_stats", None)
+            if stats is not None:
+                latency_ms = (time.time() - t0) * 1000.0
+                stats.record(op, latency_ms, error=error)
+
+        def respond(result: str) -> bool:
+            record_stats()
+            return self._write_response(result, debug=debug)
+
         try:
             try:
                 line = self.rfile.readline(_MAX_LINE_BYTES)
                 if not line:
-                    self._write_response("{}", debug=debug)
+                    respond("{}")
                     return
                 if len(line) >= _MAX_LINE_BYTES and not line.endswith(b"\n"):
                     error = True
-                    self._write_response("{}", debug=debug)
+                    respond("{}")
                     return
                 req = json.loads(line.decode("utf-8", errors="replace").strip())
             except (json.JSONDecodeError, UnicodeDecodeError, ValueError, OSError) as exc:
                 error = True
                 print(f"# recall-daemon: parse error: {type(exc).__name__}: {exc}", file=sys.stderr)
-                self._write_response("{}", debug=debug)
+                respond("{}")
                 return
 
             if not isinstance(req, dict):
                 error = True
-                self._write_response("{}", debug=debug)
+                respond("{}")
                 return
 
             op = str(req.get("op") or "recall").strip()
@@ -272,7 +289,7 @@ class _RecallHandler(socketserver.StreamRequestHandler):
                     _we = getattr(self.server, "_warm_event", None)
                     if _we is not None and not _we.is_set():
                         _log_lock_contention("recall_warming", 0.0, "warmup")
-                        self._write_response(BUSY_RESPONSE, debug=debug)
+                        respond(BUSY_RESPONSE)
                         return
                     prompt = (req.get("prompt") or "").strip()
                     cwd = req.get("cwd") or None
@@ -281,7 +298,7 @@ class _RecallHandler(socketserver.StreamRequestHandler):
                     _turn = int(_turn) if isinstance(_turn, (int, float)) else None
                     _client = req.get("client") or None
                     if not prompt:
-                        self._write_response("{}", debug=debug)
+                        respond("{}")
                         return
                     from memo.flags import flag_int
 
@@ -306,7 +323,7 @@ class _RecallHandler(socketserver.StreamRequestHandler):
                                 f"# recall-daemon: lock busy >{timeout_s:.1f}s, bailing busy",
                                 file=sys.stderr,
                             )
-                        self._write_response(BUSY_RESPONSE, debug=debug)
+                        respond(BUSY_RESPONSE)
                         return
                     if wait_ms > _LOCK_WAIT_LOG_MS:
                         _log_lock_contention("recall_lock_wait", wait_ms, held_by)
@@ -378,14 +395,11 @@ class _RecallHandler(socketserver.StreamRequestHandler):
                 )
                 result = json.dumps({"error": f"{type(exc).__name__}: {exc}"})
 
-            delivered = self._write_response(result, debug=debug)
+            delivered = respond(result)
             if delivered and log_fn is not None:
                 log_fn()
         finally:
-            latency_ms = (time.time() - t0) * 1000.0
-            stats = getattr(self.server, "_stats", None)
-            if stats is not None:
-                stats.record(op, latency_ms, error=error)
+            record_stats()
 
 
 # Lock acquisition order (to avoid deadlocks):

--- a/src/memo/recall_socket.py
+++ b/src/memo/recall_socket.py
@@ -279,16 +279,12 @@ class _RecallHandler(socketserver.StreamRequestHandler):
             except (json.JSONDecodeError, UnicodeDecodeError, ValueError, OSError) as exc:
                 error = True
                 print(f"# recall-daemon: parse error: {type(exc).__name__}: {exc}", file=sys.stderr)
-                self._write_tracked_response(
-                    "{}", debug=debug, started_at=t0, op=op, error=error
-                )
+                self._write_tracked_response("{}", debug=debug, started_at=t0, op=op, error=error)
                 return
 
             if not isinstance(req, dict):
                 error = True
-                self._write_tracked_response(
-                    "{}", debug=debug, started_at=t0, op=op, error=error
-                )
+                self._write_tracked_response("{}", debug=debug, started_at=t0, op=op, error=error)
                 return
 
             op = str(req.get("op") or "recall").strip()

--- a/tests/test_embedder_client.py
+++ b/tests/test_embedder_client.py
@@ -73,7 +73,7 @@ def _send_raw(state_dir: Path, payload: dict[str, Any], timeout: float = 2.0) ->
 
 
 @pytest.fixture
-def daemon() -> Iterator[Path]:
+def daemon_server() -> Iterator[tuple[Path, _RecallServer]]:
     """Spin up a real `_RecallServer` thread on a tmp Unix socket.
 
     macOS limits AF_UNIX paths to ~104 chars, well shorter than the
@@ -92,12 +92,17 @@ def daemon() -> Iterator[Path]:
     while time.time() < deadline and not sock_path.exists():
         time.sleep(0.01)
     try:
-        yield state_dir
+        yield state_dir, server
     finally:
         server.shutdown()
         server.server_close()
         thread.join(timeout=2.0)
         shutil.rmtree(state_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def daemon(daemon_server: tuple[Path, _RecallServer]) -> Path:
+    return daemon_server[0]
 
 
 @pytest.fixture(autouse=True)
@@ -328,6 +333,44 @@ def test_stats_counts_errors(daemon: Path):
     snap = _send_raw(daemon, {"op": "stats"})
     assert snap["ops"]["warp_drive"]["count"] == 1
     assert snap["ops"]["warp_drive"]["errors"] == 1
+
+
+@pytest.mark.concurrency
+@pytest.mark.resource_hygiene
+def test_response_is_not_visible_before_request_stats(
+    daemon_server: tuple[Path, _RecallServer], monkeypatch: pytest.MonkeyPatch
+):
+    state_dir, server = daemon_server
+    record_entered = threading.Event()
+    release_record = threading.Event()
+    original_record = server._stats.record
+
+    def blocking_record(op: str, latency_ms: float, *, error: bool = False) -> None:
+        record_entered.set()
+        assert release_record.wait(timeout=2.0)
+        original_record(op, latency_ms, error=error)
+
+    monkeypatch.setattr(server._stats, "record", blocking_record)
+
+    sock_path = _socket_path(state_dir)
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+        sock.settimeout(2.0)
+        sock.connect(str(sock_path))
+        sock.sendall(b'{"op":"warp_drive"}\n')
+        assert record_entered.wait(timeout=2.0)
+        try:
+            sock.settimeout(0.05)
+            with pytest.raises(socket.timeout):
+                sock.recv(1)
+        finally:
+            release_record.set()
+
+        sock.settimeout(2.0)
+        response = b""
+        while b"\n" not in response:
+            response += sock.recv(65536)
+
+    assert "unknown op" in json.loads(response)["error"]
 
 
 def test_client_stats_via_socket(daemon: Path):

--- a/tests/test_embedder_client.py
+++ b/tests/test_embedder_client.py
@@ -21,6 +21,7 @@ from typing import Any
 import pytest
 
 import memo.embedder_client as embedder_client
+from memo.embed_protocol import MAX_LINE_BYTES
 from memo.recall_server import (
     _RecallServer,
     _socket_path,
@@ -300,6 +301,37 @@ def test_send_request_helper_round_trips(daemon: Path):
     raw = connect_and_send(daemon, {"op": "ping"}, timeout=2.0)
     assert raw is not None
     assert json.loads(raw)["ok"] is True
+
+
+@pytest.mark.parametrize(
+    ("wire", "expected_errors"),
+    [
+        pytest.param(b"", 0, id="eof"),
+        pytest.param(b"x" * MAX_LINE_BYTES, 1, id="oversized"),
+        pytest.param(b"{\n", 1, id="invalid-json"),
+        pytest.param(b"[]\n", 1, id="non-object-json"),
+    ],
+)
+def test_invalid_frames_are_answered_and_accounted(
+    daemon_server: tuple[Path, _RecallServer], wire: bytes, expected_errors: int
+):
+    state_dir, server = daemon_server
+    before = server._stats.snapshot()["ops"].get("parse", {"count": 0, "errors": 0})
+
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+        sock.settimeout(2.0)
+        sock.connect(str(_socket_path(state_dir)))
+        if wire:
+            sock.sendall(wire)
+        sock.shutdown(socket.SHUT_WR)
+        response = b""
+        while b"\n" not in response:
+            response += sock.recv(65536)
+
+    assert json.loads(response) == {}
+    after = server._stats.snapshot()["ops"]["parse"]
+    assert after["count"] == before["count"] + 1
+    assert after["errors"] == before["errors"] + expected_errors
 
 
 # -- stats + status -------------------------------------------------------


### PR DESCRIPTION
## Summary
- record every recall-daemon request before its response becomes observable
- preserve exactly-once stats recording across normal and early-return paths
- add a deterministic socket-ordering regression in the concurrency/resource-hygiene lanes

## Root cause
The threaded socket handler wrote its response before the finally block called stats.record(). An immediate stats request could therefore run on another handler thread and miss the request that had already completed from the client perspective.

## Verification
- ruff: all checks passed
- mypy: 417 source files clean
- focused daemon tests: 35 passed
- deterministic regression + original failure repeated: 100 passed
- strict resource repeats: 40 passed
- full non-slow suite: 5097 passed, 29 skipped, 75.69% coverage
- recall pre-push gate: 280 searches, passed