### PR TITLE
fix(constitution): standing rules must be directives, not recalled task-logs

### DIFF
--- a/src/memo/constitution.py
+++ b/src/memo/constitution.py
@@ -158,20 +158,74 @@ def resync_rules_in_repo(
     return out
 
 
-# --- rule source (delegates to the shared motor) -----------------------------
+# --- rule source (graduated motor + directive-shape filter) ------------------
+
+# Types that are directive by nature — the "how to work" tier.
+_RULE_TYPES = frozenset({"feedback", "preference"})
+
+# Strong directive / prohibition markers (en + es). A `decision` memory only
+# counts as a standing rule when its text carries one — this is what separates
+# "never `git add -A`" (a rule) from "bump version 2.10.0" (a recalled task log).
+_DIRECTIVE_MARKERS = (
+    "never",
+    "always",
+    "must",
+    "should",
+    "don't",
+    "do not",
+    "dont",
+    "avoid",
+    "prefer",
+    "ensure",
+    "forbid",
+    "prohib",
+    "nunca",
+    "siempre",
+    "evitá",
+    "evita",
+    "debe",
+    "preferí",
+    "no uses",
+)
+
+
+def _looks_like_rule(text: str) -> bool:
+    low = text.lower()
+    return any(marker in low for marker in _DIRECTIVE_MARKERS)
+
+
+def _is_rule_memory(mtype: str, text: str) -> bool:
+    """A standing rule is a directive, not an episodic task log.
+
+    ``feedback`` / ``preference`` memories are directive by nature; a
+    ``decision`` qualifies only when its text is imperatively shaped. Every
+    other type (note / fact / bug / synthesis / manual / reference) is
+    knowledge or a log — never an enforceable rule.
+    """
+    if mtype in _RULE_TYPES:
+        return True
+    if mtype == "decision":
+        return _looks_like_rule(text)
+    return False
 
 
 def gather_rules(mem: Any, cfg: Any, *, k: int = 3, min_used: float = 0.5) -> list[tuple[str, str]]:
     """Load-bearing standing rules as ``(memory_id, text)`` pairs.
 
-    Thin delegate to ``dream_profile._gather_rules`` — the same graduation
-    (cited in >= ``k`` distinct sessions) and retire-on-contradiction logic
-    that feeds the profile's Standing-rules block, so the mandate surface and
-    the profile surface can never disagree about what the standing rules are.
+    Candidates come from ``dream_profile._gather_rules`` (graduated by use +
+    retire-on-contradiction), then filtered to memories that are actually
+    *directives* — feedback/preference, or an imperatively-shaped decision. This
+    keeps recalled task-logs ("pushed to master", "bump version 2.10.0") out of
+    the mandate/drift surfaces, where only enforceable conventions belong.
     """
     from memo.dream_profile import _gather_rules
 
-    return _gather_rules(mem, cfg, k=k, min_used=min_used)
+    rules: list[tuple[str, str]] = []
+    for rid, text in _gather_rules(mem, cfg, k=k, min_used=min_used):
+        rec = mem.get(rid)
+        if rec is not None and _is_rule_memory(rec.type, text):
+            rules.append((rid, text))
+    return rules
 
 
 # --- opted-in repo registry + nightly auto-sync ------------------------------

--- a/tests/test_constitution.py
+++ b/tests/test_constitution.py
@@ -168,20 +168,44 @@ def test_resync_no_opted_in_files_returns_empty(tmp_path: Path) -> None:
     assert resync_rules_in_repo([R1], cwd=tmp_path) == []
 
 
-# --- gather_rules delegates to the shared motor ------------------------------
+# --- gather_rules: graduated motor + directive-shape filter ------------------
 
 
-def test_gather_rules_delegates_to_dream_profile_motor(monkeypatch) -> None:
+def test_looks_like_rule_detects_directives_not_task_logs() -> None:
+    assert ct._looks_like_rule("Never use `git add -A`")
+    assert ct._looks_like_rule("preferí httpx sobre requests")
+    assert not ct._looks_like_rule("bump version 2.10.0")
+    assert not ct._looks_like_rule("pushed to master confirmed")
+
+
+def test_is_rule_memory_by_type_and_shape() -> None:
+    assert ct._is_rule_memory("feedback", "commit without asking")  # directive by type
+    assert ct._is_rule_memory("preference", "delta for diffs")  # directive by type
+    assert ct._is_rule_memory("decision", "Never `git add -A`")  # shaped decision
+    assert not ct._is_rule_memory("decision", "bump version 2.10.0")  # log-shaped decision
+    assert not ct._is_rule_memory("note", "checked pr status")  # episodic type
+
+
+def test_gather_rules_filters_task_logs_and_passes_knobs(monkeypatch) -> None:
     called: dict[str, object] = {}
+    R_PREF = ("f00d0001aa", "delta para diffs")
+    R_LOG = ("10900002bb", "pusheado a master confirmado")
 
     def fake_gather(mem, cfg, *, k, min_used):
-        called["k"] = k
-        called["min_used"] = min_used
-        return [R1, R2]
+        called["k"], called["min_used"] = k, min_used
+        return [R1, R2, R_PREF, R_LOG]  # R1 directive decision, R2 declarative decision
 
+    types = {
+        "abcd1234ef": "decision",  # R1 "Never git add -A" → kept (directive)
+        "beef5678aa": "decision",  # R2 "int8 … default" → dropped (no marker)
+        "f00d0001aa": "preference",  # kept by type
+        "10900002bb": "note",  # task-log type → dropped
+    }
+    fake_mem = SimpleNamespace(get=lambda rid: SimpleNamespace(id=rid, type=types.get(rid)))
     monkeypatch.setattr("memo.dream_profile._gather_rules", fake_gather)
-    out = ct.gather_rules(object(), object(), k=4, min_used=0.6)
-    assert out == [R1, R2]
+
+    ids = [rid for rid, _ in ct.gather_rules(fake_mem, object(), k=4, min_used=0.6)]
+    assert ids == ["abcd1234ef", "f00d0001aa"]
     assert called == {"k": 4, "min_used": 0.6}
 
 
@@ -257,7 +281,9 @@ def test_mandate_sync_pass_refreshes_registered_repos(monkeypatch, tmp_path: Pat
     ct.register_repo(state, tmp_path / "gone")
 
     cfg = SimpleNamespace(state_dir=state)
-    res = ct.run_mandate_sync_pass(cfg, object())
+    # gather_rules filters by memory type → mem.get must return rule-typed records
+    fake_mem = SimpleNamespace(get=lambda rid: SimpleNamespace(id=rid, type="decision"))
+    res = ct.run_mandate_sync_pass(cfg, fake_mem)
 
     assert res["status"] == "done"
     assert len(res["synced"]) == 1  # only the live repo
@@ -268,5 +294,6 @@ def test_mandate_sync_pass_refreshes_registered_repos(monkeypatch, tmp_path: Pat
 
 def test_mandate_sync_pass_noop_when_no_repos(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("memo.dream_profile._gather_rules", lambda mem, cfg, *, k, min_used: [R1])
-    res = ct.run_mandate_sync_pass(SimpleNamespace(state_dir=tmp_path / "state"), object())
+    fake_mem = SimpleNamespace(get=lambda rid: SimpleNamespace(id=rid, type="decision"))
+    res = ct.run_mandate_sync_pass(SimpleNamespace(state_dir=tmp_path / "state"), fake_mem)
     assert res["status"] == "noop" and res["synced"] == []


### PR DESCRIPTION
Follow-up to the Constitutional memo program (#66/#67). Dogfooding revealed that `gather_rules` (feeding `memo mandate --dynamic` and `memo drift`) mined "cited in ≥ k sessions" memories verbatim — so a store dominated by session logs surfaced task-log titles ("bump version 2.10.0", "pushed to master confirmed") as "rules". That's noise for surfaces where only enforceable conventions belong.

**Fix:** graduated candidates are now filtered to memories that are actually *directives*:
- `feedback` / `preference` — directive by type;
- `decision` — only when imperatively shaped (never/always/must/avoid/prefer/nunca/… — reuses the drift prohibition intuition);
- everything else (note/fact/bug/synthesis, log-shaped decisions) is dropped.

On the maintainer's live store this yields **0 rules instead of 13 garbage** — precision over recall, which is correct for an enforced surface. `dream_profile` is untouched (candidates still come from its motor; the filter is constitution-local).

### Test plan
- [x] `test_constitution` — new `_looks_like_rule` / `_is_rule_memory` / filter tests; auto-sync tests updated for the `mem.get` filter pass. 44 passed (+ drift).
- [x] mypy + ruff clean; quality gate passes
- [x] live check: `gather_rules` on real store → 0 (was 13 task-logs)
- [ ] CI