### PR TITLE
release: v3.11.1 — dream progress spinner fix

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "memo",
   "description": "Local MCP memory for AI agents — MLX on Apple Silicon or CPU sentence-transformers on Linux/Ubuntu, sqlite-vec store, markdown-on-disk in your Obsidian vault. Zero Ollama, zero cloud APIs.",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "author": {
     "name": "Fernando Ferrari",
     "email": "fernandoferrari@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+## [3.11.1] - 2026-07-22
+
+### Fixed
+
+- **Dream progress spinner is visible again in real terminals.** The shared
+  Rich `Console` was constructed with `force_terminal=False`, which Rich 15
+  short-circuits in `is_terminal` (returned before the `isatty()` check) — so
+  memo emitted no ANSI and `memo dream run`'s spinner/progress bar never
+  rendered, leaving the pipeline looking frozen after the pre-dream inventory
+  panel with zero feedback. The console now auto-detects the terminal
+  (`Console()`), and `_make_progress` gates on `console.is_terminal` (the stream
+  it renders to) instead of `sys.stderr.isatty()`. Non-TTY runs (pipes, tests,
+  launchd) and `MEMO_NONINTERACTIVE=1` stay plain as before.
+
 ## [3.11.0] - 2026-07-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ exact flags and boundaries.
 ## Install — one step
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
 ```
 
 The installer auto-detects **uv** (preferred) or falls back to **pipx**. It downloads MLX models, and wires memo into every agent client it finds (Claude Code, Codex, Devin, Devin Desktop, OpenCode).
@@ -109,7 +109,7 @@ First install downloads ~8 GB of MLX models (5–15 min); later installs hit the
 **Migrating from another Mac?** Install first, then restore your corpus:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
 memo sync bootstrap git@github.com:yourname/memo-sync.git   # restore from git
 ```
 
@@ -179,7 +179,7 @@ On a ~200-memory corpus, `memo roi` estimates **~80k tokens of model work avoide
 memo installs itself if you hand the repo (or just the install line) to an AI agent:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
 memo doctor --strict-runtime     # verify runtime is healthy
 ```
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,7 +4,7 @@ Docker image runs memo's **CPU-only backend** — ideal for Linux, testing, or c
 
 > For full memo (reranking + LLM verbs), use native install on Apple Silicon Mac:
 > ```bash
-> curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | bash
+> curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
 > ```
 
 ## Quick start (10 seconds)

--- a/docs/install-new-mac.md
+++ b/docs/install-new-mac.md
@@ -27,7 +27,7 @@ brew install python@3.13
 Recommended path:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
 ```
 
 The installer uses `pipx`, downloads the default MLX models, runs
@@ -60,13 +60,13 @@ effective source and can be reviewed before any file is written.
 To explicitly track the latest PyPI release instead of the installer's pinned release:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | MEMO_INSTALL_FROM_PYPI=1 bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_FROM_PYPI=1 bash
 ```
 
 To skip client configuration entirely:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | MEMO_INSTALL_SKIP_AGENT_CONFIG=1 bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_SKIP_AGENT_CONFIG=1 bash
 ```
 
 ## 3. Move Your Data

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,7 +27,7 @@ sqlite state, and CLI should move together as one subsystem.
 ```bash
 # One-line installer (uv/pipx under the hood, pins the matching release,
 # and configures Claude Code + Codex + OpenCode + Devin Desktop when available)
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
 # or install the latest published PyPI release explicitly
 pipx install mlx-memo
 # or
@@ -59,22 +59,22 @@ memo --version
 
 ```bash
 # Install the latest published PyPI release instead of GitHub master.
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | MEMO_INSTALL_FROM_PYPI=1 bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_FROM_PYPI=1 bash
 
 # Pin a published PyPI version.
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | MEMO_VERSION=0.6.0 bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_VERSION=0.6.0 bash
 
 # Install from an explicit pipx spec (local checkout, git ref, wheel, etc.).
 MEMO_INSTALL_SPEC=/path/to/memo ./install.sh
 
 # Skip agent-client configuration during install.
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | MEMO_INSTALL_SKIP_AGENT_CONFIG=1 bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_SKIP_AGENT_CONFIG=1 bash
 
 # Force-skip the MLX model download (models load lazily on first use).
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | MEMO_INSTALL_DOWNLOAD_MODELS=no bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_DOWNLOAD_MODELS=no bash
 
 # Force-yes the MLX model download (skip the interactive confirmation).
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | MEMO_INSTALL_DOWNLOAD_MODELS=yes bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_DOWNLOAD_MODELS=yes bash
 ```
 
 **Model download** is part of memo's structure (embedder + reranker + chat
@@ -115,7 +115,7 @@ the corpus. On **Linux / Ubuntu**, use the CPU-index install command in
 [ubuntu.md](ubuntu.md).
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
 memo doctor --strict-runtime
 memo install-slash --client claude-code --client codex --client opencode --client devin-desktop
 ```

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 APP_NAME="mlx-memo"
 OLD_APP_NAME="memo-mcp"
 PYPI_SPEC="mlx-memo"
-DEFAULT_VERSION="3.11.0"
+DEFAULT_VERSION="3.11.1"
 MIN_PYTHON_MAJOR=3
 MIN_PYTHON_MINOR=13
 

--- a/packaging/mcpb-node/manifest.json
+++ b/packaging/mcpb-node/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "memo",
   "display_name": "memo - local-first memory (Node)",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "Local-first long-term memory for AI agents. 100% offline: no cloud API, no keys.",
   "long_description": "memo gives Claude a persistent, local-first memory: decisions, facts and preferences saved today are recalled automatically in future sessions.\n\n- Hybrid retrieval: vector (sqlite-vec) + BM25 fused with RRF, optional cross-encoder rerank\n- Embeddings run in-process - MLX on Apple Silicon, CPU sentence-transformers on Linux - so nothing ever leaves your machine\n- Markdown files are the source of truth (Obsidian-compatible); the sqlite index is fully rebuildable\n- Time-machine queries (ask what was known at any past date), contradiction detection, nightly synthesis\n- Small MCP surface (13 tools, ~1.2k tokens)\n\nRequires the `uv` runtime. For supply-chain safety the bootstrap never downloads and executes a remote shell script; install uv from the official Astral documentation before first launch. The first launch then installs the exactly pinned memo package and can take 1-2 minutes.",
   "author": {

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "memo",
   "display_name": "memo - local-first memory",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "Local-first long-term memory for AI agents. 100% offline: no cloud API, no keys.",
   "long_description": "memo gives Claude a persistent, local-first memory: decisions, facts and preferences saved today are recalled automatically in future sessions.\n\n- Hybrid retrieval: vector (sqlite-vec) + BM25 fused with RRF, optional cross-encoder rerank\n- Embeddings run in-process - MLX on Apple Silicon, CPU sentence-transformers on Linux - so nothing ever leaves your machine\n- Markdown files are the source of truth (Obsidian-compatible); the sqlite index is fully rebuildable\n- Time-machine queries (ask what was known at any past date), contradiction detection, nightly synthesis\n- Small MCP surface (13 tools, ~1.2k tokens)\n\nRequires the `uv` Python runtime (https://docs.astral.sh/uv/) and Python 3.13+. First launch downloads the package and the embedding model; subsequent launches are instant.",
   "author": {
@@ -23,7 +23,7 @@
     "entry_point": "server/main.py",
     "mcp_config": {
       "command": "uvx",
-      "args": ["--from", "mlx-memo==3.11.0", "memo-mcp"]
+      "args": ["--from", "mlx-memo==3.11.1", "memo-mcp"]
     }
   },
   "keywords": ["memory", "mcp", "local-first", "rag", "obsidian", "offline", "mlx"],

--- a/plugins/memo/.codex-plugin/plugin.json
+++ b/plugins/memo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memo",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "Slash skill and MCP wiring for memo, the local memory system: MLX on Apple Silicon or CPU on Linux/Intel.",
   "author": {
     "name": "Fernando Ferrari",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 # only the PyPI distribution moved. Back-compat: existing users on
 # `memo-mcp ≤ 0.4.3` keep working; new installs use `pip install mlx-memo`.
 name = "mlx-memo"
-version = "3.11.0"
+version = "3.11.1"
 description = "Local-first semantic memory for AI agents — MLX (Apple Silicon) or CPU sentence-transformers (Linux/Ubuntu) embeddings + sqlite-vec, MCP server. No cloud, no API keys."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/jagoff/memo",
     "source": "github"
   },
-  "version": "3.11.0",
+  "version": "3.11.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mlx-memo",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/memo/cli_common.py
+++ b/src/memo/cli_common.py
@@ -17,8 +17,12 @@ from rich.console import Console
 from memo.config import Config
 
 # One process-wide rich Console shared by every command for consistent output.
-# force_terminal=False ensures tests/non-TTY get plain text, not ANSI escape codes.
-console = Console(force_terminal=False)
+# Auto-detect the terminal (the Rich default): a real TTY gets colour + live
+# spinners/progress bars; tests, pipes, and launchd (non-TTY stdout) get plain
+# text. NOTE: force_terminal=False is NOT "auto" — Rich short-circuits
+# is_terminal to the forced value, so it would kill colour AND the dream
+# progress spinner in real terminals too.
+console = Console()
 
 
 def get_memory(cfg: Config) -> Any:

--- a/src/memo/dream_utils.py
+++ b/src/memo/dream_utils.py
@@ -72,14 +72,14 @@ def _corpus_fingerprint(mem: Memory) -> str | None:
 
 def _make_progress() -> Progress:
     """Create a Rich progress bar, disabled in non-TTY environments."""
-    import sys
-
     from memo.cli_common import console
     from memo.flags import flag_bool
 
     # Non-interactive runs (launchd, piped output) skip the live-render
-    # ANSI control stream to reduce output noise.
-    disable = flag_bool("MEMO_NONINTERACTIVE") or not sys.stderr.isatty()
+    # ANSI control stream to reduce output noise. Key the decision off the SAME
+    # console the Progress renders to (stdout) — not sys.stderr — so a redirected
+    # stderr can't silence a spinner on an interactive stdout, and vice versa.
+    disable = flag_bool("MEMO_NONINTERACTIVE") or not console.is_terminal
     return Progress(
         SpinnerColumn(),
         TextColumn("[progress.description]{task.description}"),

--- a/tests/test_dream_progress_tty.py
+++ b/tests/test_dream_progress_tty.py
@@ -1,0 +1,42 @@
+"""Guards for the dream progress spinner's TTY gating.
+
+Regression cover for the bug where `Console(force_terminal=False)` hard-disabled
+`is_terminal` in Rich 15 (short-circuits before isatty), so the dream pipeline's
+spinner/progress bar never rendered in a real terminal — the pipeline looked
+frozen after the pre-dream inventory panel with no feedback.
+"""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+import memo.cli_common as cli_common
+from memo.dream_utils import _make_progress
+
+
+def test_global_console_auto_detects_terminal() -> None:
+    # Must stay None (auto-detect) — a forced value would short-circuit
+    # is_terminal and kill colour + the spinner in real terminals.
+    assert cli_common.console._force_terminal is None
+
+
+def test_make_progress_enabled_on_a_real_terminal(monkeypatch) -> None:
+    monkeypatch.delenv("MEMO_NONINTERACTIVE", raising=False)
+    monkeypatch.setattr(cli_common, "console", Console(force_terminal=True))
+    progress = _make_progress()
+    assert progress.disable is False
+
+
+def test_make_progress_disabled_off_a_terminal(monkeypatch) -> None:
+    monkeypatch.delenv("MEMO_NONINTERACTIVE", raising=False)
+    monkeypatch.setattr(cli_common, "console", Console(force_terminal=False))
+    progress = _make_progress()
+    assert progress.disable is True
+
+
+def test_make_progress_disabled_when_noninteractive(monkeypatch) -> None:
+    # An explicit non-interactive run (launchd) stays quiet even on a TTY.
+    monkeypatch.setenv("MEMO_NONINTERACTIVE", "1")
+    monkeypatch.setattr(cli_common, "console", Console(force_terminal=True))
+    progress = _make_progress()
+    assert progress.disable is True


### PR DESCRIPTION
## What

Patch release **v3.11.1**. Restores the `memo dream run` progress spinner/bar in real terminals.

## Why

The shared Rich `Console` was built with `force_terminal=False`. Rich 15 short-circuits `is_terminal` to the forced value **before** the `isatty()` check, so memo emitted zero ANSI and the dream pipeline's spinner/progress bar never rendered — the run looked frozen after the pre-dream inventory panel with no feedback.

## Fix (commit 6287ce53)

- `cli_common.py`: `Console()` auto-detects the terminal (TTY → colour + spinner; pipes/tests/launchd → plain, unchanged).
- `dream_utils._make_progress`: gate `disable` on `console.is_terminal` (the stream it renders to) instead of `sys.stderr.isatty()`. `MEMO_NONINTERACTIVE` override preserved.
- `tests/test_dream_progress_tty.py`: 4 regression tests locking the TTY gating.

Verified end-to-end under a pty: ANSI + spinner + bar emit; non-TTY stays plain.

## Release commit 3ad783e7

Version bump 3.11.0 → 3.11.1 across all manifests + docs + CHANGELOG via `memo release bump patch`. Tag `v3.11.1` already pushed.

## Test plan

- [x] `ruff` + `mypy` clean on changed files
- [x] targeted dream/console suites green (64 + 4)
- [ ] CI 10/10 checks