### PR TITLE
release: v3.11.2 — dream progress feedback (spinner + valid measures)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "memo",
   "description": "Local MCP memory for AI agents — MLX on Apple Silicon or CPU sentence-transformers on Linux/Ubuntu, sqlite-vec store, markdown-on-disk in your Obsidian vault. Zero Ollama, zero cloud APIs.",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "author": {
     "name": "Fernando Ferrari",
     "email": "fernandoferrari@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "memo",
   "description": "Local MCP memory for AI agents — MLX on Apple Silicon or CPU sentence-transformers on Linux/Ubuntu, sqlite-vec store, markdown-on-disk in your Obsidian vault. Zero Ollama, zero cloud APIs.",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "author": {
     "name": "Fernando Ferrari",
     "email": "fernandoferrari@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+## [3.11.2] - 2026-07-22
+
+### Fixed
+
+- **`memo dream run` no longer shows a meaningless `0/?` bar on the status
+  line.** The pipeline runs two Rich tasks in one Progress: a determinate
+  `overall` task (the N/14 bar) and a rolling `step` status line with
+  `total=None`. The stock `BarColumn` + `MofNCompleteColumn` rendered a
+  full/pulsing bar and a `0/?` counter for the indeterminate step (e.g.
+  `recall self-tuner... 0/?`). Both columns now blank out when `task.total is
+  None`, so the step shows only spinner + description + elapsed while the
+  overall bar keeps its real N/14 measure.
+
 ## [3.11.1] - 2026-07-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+## [3.11.1] - 2026-07-22
+
+### Fixed
+
+- **Dream progress spinner is visible again in real terminals.** The shared
+  Rich `Console` was constructed with `force_terminal=False`, which Rich 15
+  short-circuits in `is_terminal` (returned before the `isatty()` check) — so
+  memo emitted no ANSI and `memo dream run`'s spinner/progress bar never
+  rendered, leaving the pipeline looking frozen after the pre-dream inventory
+  panel with zero feedback. The console now auto-detects the terminal
+  (`Console()`), and `_make_progress` gates on `console.is_terminal` (the stream
+  it renders to) instead of `sys.stderr.isatty()`. Non-TTY runs (pipes, tests,
+  launchd) and `MEMO_NONINTERACTIVE=1` stay plain as before.
+
 ## [3.11.0] - 2026-07-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ exact flags and boundaries.
 ## Install — one step
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.2/install.sh | bash
 ```
 
 The installer auto-detects **uv** (preferred) or falls back to **pipx**. It downloads MLX models, and wires memo into every agent client it finds (Claude Code, Codex, Devin, Devin Desktop, OpenCode).
@@ -109,7 +109,7 @@ First install downloads ~8 GB of MLX models (5–15 min); later installs hit the
 **Migrating from another Mac?** Install first, then restore your corpus:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.2/install.sh | bash
 memo sync bootstrap git@github.com:yourname/memo-sync.git   # restore from git
 ```
 
@@ -179,7 +179,7 @@ On a ~200-memory corpus, `memo roi` estimates **~80k tokens of model work avoide
 memo installs itself if you hand the repo (or just the install line) to an AI agent:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.2/install.sh | bash
 memo doctor --strict-runtime     # verify runtime is healthy
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ exact flags and boundaries.
 ## Install — one step
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
 ```
 
 The installer auto-detects **uv** (preferred) or falls back to **pipx**. It downloads MLX models, and wires memo into every agent client it finds (Claude Code, Codex, Devin, Devin Desktop, OpenCode).
@@ -109,7 +109,7 @@ First install downloads ~8 GB of MLX models (5–15 min); later installs hit the
 **Migrating from another Mac?** Install first, then restore your corpus:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
 memo sync bootstrap git@github.com:yourname/memo-sync.git   # restore from git
 ```
 
@@ -179,7 +179,7 @@ On a ~200-memory corpus, `memo roi` estimates **~80k tokens of model work avoide
 memo installs itself if you hand the repo (or just the install line) to an AI agent:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
 memo doctor --strict-runtime     # verify runtime is healthy
 ```
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,7 +4,7 @@ Docker image runs memo's **CPU-only backend** — ideal for Linux, testing, or c
 
 > For full memo (reranking + LLM verbs), use native install on Apple Silicon Mac:
 > ```bash
-> curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
+> curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.2/install.sh | bash
 > ```
 
 ## Quick start (10 seconds)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,7 +4,7 @@ Docker image runs memo's **CPU-only backend** — ideal for Linux, testing, or c
 
 > For full memo (reranking + LLM verbs), use native install on Apple Silicon Mac:
 > ```bash
-> curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | bash
+> curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
 > ```
 
 ## Quick start (10 seconds)

--- a/docs/install-new-mac.md
+++ b/docs/install-new-mac.md
@@ -27,7 +27,7 @@ brew install python@3.13
 Recommended path:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.2/install.sh | bash
 ```
 
 The installer uses `pipx`, downloads the default MLX models, runs
@@ -60,13 +60,13 @@ effective source and can be reviewed before any file is written.
 To explicitly track the latest PyPI release instead of the installer's pinned release:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_FROM_PYPI=1 bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.2/install.sh | MEMO_INSTALL_FROM_PYPI=1 bash
 ```
 
 To skip client configuration entirely:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_SKIP_AGENT_CONFIG=1 bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.2/install.sh | MEMO_INSTALL_SKIP_AGENT_CONFIG=1 bash
 ```
 
 ## 3. Move Your Data

--- a/docs/install-new-mac.md
+++ b/docs/install-new-mac.md
@@ -27,7 +27,7 @@ brew install python@3.13
 Recommended path:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
 ```
 
 The installer uses `pipx`, downloads the default MLX models, runs
@@ -60,13 +60,13 @@ effective source and can be reviewed before any file is written.
 To explicitly track the latest PyPI release instead of the installer's pinned release:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | MEMO_INSTALL_FROM_PYPI=1 bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_FROM_PYPI=1 bash
 ```
 
 To skip client configuration entirely:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | MEMO_INSTALL_SKIP_AGENT_CONFIG=1 bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_SKIP_AGENT_CONFIG=1 bash
 ```
 
 ## 3. Move Your Data

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,7 +27,7 @@ sqlite state, and CLI should move together as one subsystem.
 ```bash
 # One-line installer (uv/pipx under the hood, pins the matching release,
 # and configures Claude Code + Codex + OpenCode + Devin Desktop when available)
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
 # or install the latest published PyPI release explicitly
 pipx install mlx-memo
 # or
@@ -59,22 +59,22 @@ memo --version
 
 ```bash
 # Install the latest published PyPI release instead of GitHub master.
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | MEMO_INSTALL_FROM_PYPI=1 bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_FROM_PYPI=1 bash
 
 # Pin a published PyPI version.
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | MEMO_VERSION=0.6.0 bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_VERSION=0.6.0 bash
 
 # Install from an explicit pipx spec (local checkout, git ref, wheel, etc.).
 MEMO_INSTALL_SPEC=/path/to/memo ./install.sh
 
 # Skip agent-client configuration during install.
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | MEMO_INSTALL_SKIP_AGENT_CONFIG=1 bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_SKIP_AGENT_CONFIG=1 bash
 
 # Force-skip the MLX model download (models load lazily on first use).
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | MEMO_INSTALL_DOWNLOAD_MODELS=no bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_DOWNLOAD_MODELS=no bash
 
 # Force-yes the MLX model download (skip the interactive confirmation).
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | MEMO_INSTALL_DOWNLOAD_MODELS=yes bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_DOWNLOAD_MODELS=yes bash
 ```
 
 **Model download** is part of memo's structure (embedder + reranker + chat
@@ -115,7 +115,7 @@ the corpus. On **Linux / Ubuntu**, use the CPU-index install command in
 [ubuntu.md](ubuntu.md).
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
 memo doctor --strict-runtime
 memo install-slash --client claude-code --client codex --client opencode --client devin-desktop
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,7 +27,7 @@ sqlite state, and CLI should move together as one subsystem.
 ```bash
 # One-line installer (uv/pipx under the hood, pins the matching release,
 # and configures Claude Code + Codex + OpenCode + Devin Desktop when available)
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.2/install.sh | bash
 # or install the latest published PyPI release explicitly
 pipx install mlx-memo
 # or
@@ -59,22 +59,22 @@ memo --version
 
 ```bash
 # Install the latest published PyPI release instead of GitHub master.
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_FROM_PYPI=1 bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.2/install.sh | MEMO_INSTALL_FROM_PYPI=1 bash
 
 # Pin a published PyPI version.
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_VERSION=0.6.0 bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.2/install.sh | MEMO_VERSION=0.6.0 bash
 
 # Install from an explicit pipx spec (local checkout, git ref, wheel, etc.).
 MEMO_INSTALL_SPEC=/path/to/memo ./install.sh
 
 # Skip agent-client configuration during install.
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_SKIP_AGENT_CONFIG=1 bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.2/install.sh | MEMO_INSTALL_SKIP_AGENT_CONFIG=1 bash
 
 # Force-skip the MLX model download (models load lazily on first use).
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_DOWNLOAD_MODELS=no bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.2/install.sh | MEMO_INSTALL_DOWNLOAD_MODELS=no bash
 
 # Force-yes the MLX model download (skip the interactive confirmation).
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | MEMO_INSTALL_DOWNLOAD_MODELS=yes bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.2/install.sh | MEMO_INSTALL_DOWNLOAD_MODELS=yes bash
 ```
 
 **Model download** is part of memo's structure (embedder + reranker + chat
@@ -115,7 +115,7 @@ the corpus. On **Linux / Ubuntu**, use the CPU-index install command in
 [ubuntu.md](ubuntu.md).
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.1/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v3.11.2/install.sh | bash
 memo doctor --strict-runtime
 memo install-slash --client claude-code --client codex --client opencode --client devin-desktop
 ```

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 APP_NAME="mlx-memo"
 OLD_APP_NAME="memo-mcp"
 PYPI_SPEC="mlx-memo"
-DEFAULT_VERSION="3.11.0"
+DEFAULT_VERSION="3.11.1"
 MIN_PYTHON_MAJOR=3
 MIN_PYTHON_MINOR=13
 

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 APP_NAME="mlx-memo"
 OLD_APP_NAME="memo-mcp"
 PYPI_SPEC="mlx-memo"
-DEFAULT_VERSION="3.11.1"
+DEFAULT_VERSION="3.11.2"
 MIN_PYTHON_MAJOR=3
 MIN_PYTHON_MINOR=13
 

--- a/packaging/mcpb-node/manifest.json
+++ b/packaging/mcpb-node/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "memo",
   "display_name": "memo - local-first memory (Node)",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "description": "Local-first long-term memory for AI agents. 100% offline: no cloud API, no keys.",
   "long_description": "memo gives Claude a persistent, local-first memory: decisions, facts and preferences saved today are recalled automatically in future sessions.\n\n- Hybrid retrieval: vector (sqlite-vec) + BM25 fused with RRF, optional cross-encoder rerank\n- Embeddings run in-process - MLX on Apple Silicon, CPU sentence-transformers on Linux - so nothing ever leaves your machine\n- Markdown files are the source of truth (Obsidian-compatible); the sqlite index is fully rebuildable\n- Time-machine queries (ask what was known at any past date), contradiction detection, nightly synthesis\n- Small MCP surface (13 tools, ~1.2k tokens)\n\nRequires the `uv` runtime. For supply-chain safety the bootstrap never downloads and executes a remote shell script; install uv from the official Astral documentation before first launch. The first launch then installs the exactly pinned memo package and can take 1-2 minutes.",
   "author": {

--- a/packaging/mcpb-node/manifest.json
+++ b/packaging/mcpb-node/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "memo",
   "display_name": "memo - local-first memory (Node)",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "Local-first long-term memory for AI agents. 100% offline: no cloud API, no keys.",
   "long_description": "memo gives Claude a persistent, local-first memory: decisions, facts and preferences saved today are recalled automatically in future sessions.\n\n- Hybrid retrieval: vector (sqlite-vec) + BM25 fused with RRF, optional cross-encoder rerank\n- Embeddings run in-process - MLX on Apple Silicon, CPU sentence-transformers on Linux - so nothing ever leaves your machine\n- Markdown files are the source of truth (Obsidian-compatible); the sqlite index is fully rebuildable\n- Time-machine queries (ask what was known at any past date), contradiction detection, nightly synthesis\n- Small MCP surface (13 tools, ~1.2k tokens)\n\nRequires the `uv` runtime. For supply-chain safety the bootstrap never downloads and executes a remote shell script; install uv from the official Astral documentation before first launch. The first launch then installs the exactly pinned memo package and can take 1-2 minutes.",
   "author": {

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "memo",
   "display_name": "memo - local-first memory",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "description": "Local-first long-term memory for AI agents. 100% offline: no cloud API, no keys.",
   "long_description": "memo gives Claude a persistent, local-first memory: decisions, facts and preferences saved today are recalled automatically in future sessions.\n\n- Hybrid retrieval: vector (sqlite-vec) + BM25 fused with RRF, optional cross-encoder rerank\n- Embeddings run in-process - MLX on Apple Silicon, CPU sentence-transformers on Linux - so nothing ever leaves your machine\n- Markdown files are the source of truth (Obsidian-compatible); the sqlite index is fully rebuildable\n- Time-machine queries (ask what was known at any past date), contradiction detection, nightly synthesis\n- Small MCP surface (13 tools, ~1.2k tokens)\n\nRequires the `uv` Python runtime (https://docs.astral.sh/uv/) and Python 3.13+. First launch downloads the package and the embedding model; subsequent launches are instant.",
   "author": {
@@ -23,7 +23,7 @@
     "entry_point": "server/main.py",
     "mcp_config": {
       "command": "uvx",
-      "args": ["--from", "mlx-memo==3.11.1", "memo-mcp"]
+      "args": ["--from", "mlx-memo==3.11.2", "memo-mcp"]
     }
   },
   "keywords": ["memory", "mcp", "local-first", "rag", "obsidian", "offline", "mlx"],

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "memo",
   "display_name": "memo - local-first memory",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "Local-first long-term memory for AI agents. 100% offline: no cloud API, no keys.",
   "long_description": "memo gives Claude a persistent, local-first memory: decisions, facts and preferences saved today are recalled automatically in future sessions.\n\n- Hybrid retrieval: vector (sqlite-vec) + BM25 fused with RRF, optional cross-encoder rerank\n- Embeddings run in-process - MLX on Apple Silicon, CPU sentence-transformers on Linux - so nothing ever leaves your machine\n- Markdown files are the source of truth (Obsidian-compatible); the sqlite index is fully rebuildable\n- Time-machine queries (ask what was known at any past date), contradiction detection, nightly synthesis\n- Small MCP surface (13 tools, ~1.2k tokens)\n\nRequires the `uv` Python runtime (https://docs.astral.sh/uv/) and Python 3.13+. First launch downloads the package and the embedding model; subsequent launches are instant.",
   "author": {
@@ -23,7 +23,7 @@
     "entry_point": "server/main.py",
     "mcp_config": {
       "command": "uvx",
-      "args": ["--from", "mlx-memo==3.11.0", "memo-mcp"]
+      "args": ["--from", "mlx-memo==3.11.1", "memo-mcp"]
     }
   },
   "keywords": ["memory", "mcp", "local-first", "rag", "obsidian", "offline", "mlx"],

--- a/plugins/memo/.codex-plugin/plugin.json
+++ b/plugins/memo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memo",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "Slash skill and MCP wiring for memo, the local memory system: MLX on Apple Silicon or CPU on Linux/Intel.",
   "author": {
     "name": "Fernando Ferrari",

--- a/plugins/memo/.codex-plugin/plugin.json
+++ b/plugins/memo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memo",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "description": "Slash skill and MCP wiring for memo, the local memory system: MLX on Apple Silicon or CPU on Linux/Intel.",
   "author": {
     "name": "Fernando Ferrari",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 # only the PyPI distribution moved. Back-compat: existing users on
 # `memo-mcp ≤ 0.4.3` keep working; new installs use `pip install mlx-memo`.
 name = "mlx-memo"
-version = "3.11.1"
+version = "3.11.2"
 description = "Local-first semantic memory for AI agents — MLX (Apple Silicon) or CPU sentence-transformers (Linux/Ubuntu) embeddings + sqlite-vec, MCP server. No cloud, no API keys."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 # only the PyPI distribution moved. Back-compat: existing users on
 # `memo-mcp ≤ 0.4.3` keep working; new installs use `pip install mlx-memo`.
 name = "mlx-memo"
-version = "3.11.0"
+version = "3.11.1"
 description = "Local-first semantic memory for AI agents — MLX (Apple Silicon) or CPU sentence-transformers (Linux/Ubuntu) embeddings + sqlite-vec, MCP server. No cloud, no API keys."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/jagoff/memo",
     "source": "github"
   },
-  "version": "3.11.0",
+  "version": "3.11.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mlx-memo",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/jagoff/memo",
     "source": "github"
   },
-  "version": "3.11.1",
+  "version": "3.11.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mlx-memo",
-      "version": "3.11.1",
+      "version": "3.11.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/memo/cli_common.py
+++ b/src/memo/cli_common.py
@@ -17,8 +17,12 @@ from rich.console import Console
 from memo.config import Config
 
 # One process-wide rich Console shared by every command for consistent output.
-# force_terminal=False ensures tests/non-TTY get plain text, not ANSI escape codes.
-console = Console(force_terminal=False)
+# Auto-detect the terminal (the Rich default): a real TTY gets colour + live
+# spinners/progress bars; tests, pipes, and launchd (non-TTY stdout) get plain
+# text. NOTE: force_terminal=False is NOT "auto" — Rich short-circuits
+# is_terminal to the forced value, so it would kill colour AND the dream
+# progress spinner in real terminals too.
+console = Console()
 
 
 def get_memory(cfg: Config) -> Any:

--- a/src/memo/dream_utils.py
+++ b/src/memo/dream_utils.py
@@ -72,14 +72,14 @@ def _corpus_fingerprint(mem: Memory) -> str | None:
 
 def _make_progress() -> Progress:
     """Create a Rich progress bar, disabled in non-TTY environments."""
-    import sys
-
     from memo.cli_common import console
     from memo.flags import flag_bool
 
     # Non-interactive runs (launchd, piped output) skip the live-render
-    # ANSI control stream to reduce output noise.
-    disable = flag_bool("MEMO_NONINTERACTIVE") or not sys.stderr.isatty()
+    # ANSI control stream to reduce output noise. Key the decision off the SAME
+    # console the Progress renders to (stdout) — not sys.stderr — so a redirected
+    # stderr can't silence a spinner on an interactive stdout, and vice versa.
+    disable = flag_bool("MEMO_NONINTERACTIVE") or not console.is_terminal
     return Progress(
         SpinnerColumn(),
         TextColumn("[progress.description]{task.description}"),

--- a/src/memo/dream_utils.py
+++ b/src/memo/dream_utils.py
@@ -20,9 +20,11 @@ from rich.progress import (
     MofNCompleteColumn,
     Progress,
     SpinnerColumn,
+    Task,
     TextColumn,
     TimeElapsedColumn,
 )
+from rich.text import Text
 
 if TYPE_CHECKING:
     from memo.config import Config
@@ -70,6 +72,34 @@ def _corpus_fingerprint(mem: Memory) -> str | None:
         return None
 
 
+class _DeterminateBarColumn(BarColumn):
+    """A bar that stays blank for indeterminate tasks (``total is None``).
+
+    The dream pipeline runs two tasks in one Progress: an ``overall`` task with a
+    real ``total`` (the N-of-14 pipeline bar) and a rolling ``step`` status line
+    with ``total=None``. The stock BarColumn renders a full/pulsing bar for the
+    indeterminate step — a bar with no valid measure — so blank it out there.
+    """
+
+    def render(self, task: Task) -> Any:
+        if task.total is None:
+            return Text("")
+        return super().render(task)
+
+
+class _DeterminateMofNColumn(MofNCompleteColumn):
+    """A completed/total counter that stays blank for indeterminate tasks.
+
+    Avoids the meaningless ``0/?`` the stock column prints for the rolling
+    status ``step`` task (``total=None``).
+    """
+
+    def render(self, task: Task) -> Text:
+        if task.total is None:
+            return Text("")
+        return super().render(task)
+
+
 def _make_progress() -> Progress:
     """Create a Rich progress bar, disabled in non-TTY environments."""
     from memo.cli_common import console
@@ -83,8 +113,8 @@ def _make_progress() -> Progress:
     return Progress(
         SpinnerColumn(),
         TextColumn("[progress.description]{task.description}"),
-        BarColumn(bar_width=24),
-        MofNCompleteColumn(),
+        _DeterminateBarColumn(bar_width=24),
+        _DeterminateMofNColumn(),
         TimeElapsedColumn(),
         console=console,
         transient=False,

--- a/tests/test_dream_progress_tty.py
+++ b/tests/test_dream_progress_tty.py
@@ -40,3 +40,28 @@ def test_make_progress_disabled_when_noninteractive(monkeypatch) -> None:
     monkeypatch.setattr(cli_common, "console", Console(force_terminal=True))
     progress = _make_progress()
     assert progress.disable is True
+
+
+def _render_tasks(progress) -> str:
+    cap = Console(record=True, width=90)
+    cap.print(progress.make_tasks_table(progress.tasks))
+    return cap.export_text()
+
+
+def test_indeterminate_step_has_no_bar_or_counter(monkeypatch) -> None:
+    # The rolling status line (total=None) must not render a full/pulsing bar or
+    # a meaningless "0/?" counter — only the determinate pipeline task does.
+    monkeypatch.delenv("MEMO_NONINTERACTIVE", raising=False)
+    monkeypatch.setattr(cli_common, "console", Console(force_terminal=True))
+    progress = _make_progress()
+    overall = progress.add_task("pipeline", total=14)
+    progress.update(overall, completed=3)
+    progress.add_task("recall self-tuner...", total=None)
+
+    text = _render_tasks(progress)
+    step_line = next(ln for ln in text.splitlines() if "recall self-tuner" in ln)
+    over_line = next(ln for ln in text.splitlines() if "pipeline" in ln)
+
+    assert "/?" not in step_line
+    assert not any(ch in step_line for ch in "━╸╺▰▱█")
+    assert "3/14" in over_line

--- a/tests/test_dream_progress_tty.py
+++ b/tests/test_dream_progress_tty.py
@@ -1,0 +1,42 @@
+"""Guards for the dream progress spinner's TTY gating.
+
+Regression cover for the bug where `Console(force_terminal=False)` hard-disabled
+`is_terminal` in Rich 15 (short-circuits before isatty), so the dream pipeline's
+spinner/progress bar never rendered in a real terminal — the pipeline looked
+frozen after the pre-dream inventory panel with no feedback.
+"""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+import memo.cli_common as cli_common
+from memo.dream_utils import _make_progress
+
+
+def test_global_console_auto_detects_terminal() -> None:
+    # Must stay None (auto-detect) — a forced value would short-circuit
+    # is_terminal and kill colour + the spinner in real terminals.
+    assert cli_common.console._force_terminal is None
+
+
+def test_make_progress_enabled_on_a_real_terminal(monkeypatch) -> None:
+    monkeypatch.delenv("MEMO_NONINTERACTIVE", raising=False)
+    monkeypatch.setattr(cli_common, "console", Console(force_terminal=True))
+    progress = _make_progress()
+    assert progress.disable is False
+
+
+def test_make_progress_disabled_off_a_terminal(monkeypatch) -> None:
+    monkeypatch.delenv("MEMO_NONINTERACTIVE", raising=False)
+    monkeypatch.setattr(cli_common, "console", Console(force_terminal=False))
+    progress = _make_progress()
+    assert progress.disable is True
+
+
+def test_make_progress_disabled_when_noninteractive(monkeypatch) -> None:
+    # An explicit non-interactive run (launchd) stays quiet even on a TTY.
+    monkeypatch.setenv("MEMO_NONINTERACTIVE", "1")
+    monkeypatch.setattr(cli_common, "console", Console(force_terminal=True))
+    progress = _make_progress()
+    assert progress.disable is True


### PR DESCRIPTION
## What

Patch release **v3.11.2**. Supersedes #74 — bundles both `memo dream run` progress fixes into one PR onto master.

Contains, on top of #73:
1. `6287ce53` fix(dream): restore progress spinner in real terminals (v3.11.1)
2. `8b16fc70` fix(dream): blank bar + counter for the indeterminate status line (v3.11.2)

## Why

`memo dream run` gave no usable progress feedback:
- **No spinner:** the shared Rich `Console` used `force_terminal=False`, which Rich 15 short-circuits in `is_terminal` before the `isatty()` check → zero ANSI, the spinner/bar never rendered. The run looked frozen after the pre-dream inventory panel.
- **Bogus measure:** the rolling `step` status line (`total=None`) rendered a full/pulsing bar and a meaningless `0/?` counter (e.g. `recall self-tuner... 0/?`).

## Fixes

- `cli_common.py`: `Console()` auto-detects the terminal (TTY → colour + spinner; pipes/tests/launchd → plain).
- `dream_utils._make_progress`: gate `disable` on `console.is_terminal`; add `_DeterminateBarColumn` / `_DeterminateMofNColumn` that blank out for `total is None`, so the status line is spinner + description + elapsed and only the `overall` task shows the real N/14 bar.
- `tests/test_dream_progress_tty.py`: 5 regression tests (TTY gating + indeterminate-column blanking).

## Test plan

- [x] `ruff` + `mypy` clean on changed files
- [x] dream/console suites green (41)
- [x] verified end-to-end under a pty: ANSI + spinner + real bar emit; status line shows no `0/?`; non-TTY stays plain
- [ ] CI 10/10 checks

Tags `v3.11.1` and `v3.11.2` already pushed; both become ancestors of master when this merges.