### PR TITLE
feat(presence): surface memo activity to non-Claude agents via MCP notification

### DIFF
--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -98,6 +98,18 @@ SPECS: tuple[FlagSpec, ...] = (
         "for `memo config validate`. Default on; set =0 to opt out.",
         opt_out=True,
     ),
+    _spec(
+        "MEMO_PRESENCE_NOTIFY",
+        "bool",
+        True,
+        "update",
+        "Prepend a one-line activity summary (🧠 recalls · 💾 saves · ~tokens "
+        "saved today) to the `notification` field of memo's MCP tool responses, "
+        "so agents without a statusline (Codex, Devin, opencode, Cursor) still "
+        "see memo working on every call. Default on; set =0 to silence just "
+        "this channel (the statusline badge is unaffected).",
+        opt_out=True,
+    ),
     # MCP transport
     _spec(
         "MEMO_MCP_TRANSPORT",

--- a/src/memo/presence.py
+++ b/src/memo/presence.py
@@ -68,3 +68,29 @@ def set_tokens(state_dir: Path, tokens_saved: int) -> None:
         _write(state_dir, data)
     except Exception:  # noqa: S110  # decoration — never break the caller
         pass
+
+
+def summary_line(data: dict) -> str:
+    """One-line plain-text activity summary for cross-agent surfaces.
+
+    Agents without a statusline (Codex, Devin, opencode, Cursor) reach memo over
+    MCP; this renders the same counters the statusline shows into a line memo can
+    prepend to its MCP ``notification`` field, so they still see memo working.
+    Returns ``""`` when nothing happened today — presence must never claim
+    activity that did not occur.
+    """
+    recalls = int(data.get("recalls", 0) or 0)
+    saves = int(data.get("saves", 0) or 0)
+    tokens = int(data.get("tokens_saved", 0) or 0)
+    parts: list[str] = []
+    if recalls:
+        parts.append(f"🧠 {recalls} recalled")
+    if saves:
+        parts.append(f"💾 {saves} saved")
+    if tokens >= 1000:
+        parts.append(f"~{tokens // 1000}k tok")
+    elif tokens:
+        parts.append(f"~{tokens} tok")
+    if not parts:
+        return ""
+    return "※ memo today · " + " · ".join(parts)

--- a/src/memo/server_core_search.py
+++ b/src/memo/server_core_search.py
@@ -10,12 +10,30 @@ from memo.server_common import log_consult, now_ms, run_synth
 
 
 def _read_notification(memory: Memory) -> str:
-    """Peek at the pending idle-capture notification without consuming it."""
+    """Compose memo's cross-agent presence line with the pending idle notice.
+
+    Peeks (never consumes) the idle-capture notification, and — gated by
+    ``MEMO_PRESENCE_NOTIFY`` — prepends today's activity summary so MCP-only
+    agents (no statusline: Codex, Devin, opencode, Cursor) see memo working on
+    every tool response. Both parts are best-effort; presence is decoration and
+    must never break a read.
+    """
     notif_path = memory.cfg.state_dir / "pending_idle_notification.txt"
     try:
-        return notif_path.read_text(encoding="utf-8").strip()
+        idle = notif_path.read_text(encoding="utf-8").strip()
     except Exception:
-        return ""
+        idle = ""
+    presence_line = ""
+    try:
+        from memo.flags import flag_bool
+
+        if flag_bool("MEMO_PRESENCE_NOTIFY"):
+            from memo import presence
+
+            presence_line = presence.summary_line(presence.read_today(memory.cfg.state_dir))
+    except Exception:
+        presence_line = ""
+    return "\n".join(p for p in (presence_line, idle) if p)
 
 
 def _file_search_notes(
@@ -206,6 +224,13 @@ def register(server: Any, memory: Memory) -> None:
                 d["explain"] = explanations.get(str(d.get("id") or ""), {})
             out.append(d)
         log_consult(memory, tool="search", query=query, hits=out, t0_ms=t0, source=source)
+
+        # Cross-agent presence: reflect this recall so MCP-only agents (which
+        # never run the Claude recall-hook) read honest counts. Decoration only.
+        if out:
+            from memo import presence
+
+            presence.bump(memory.cfg.state_dir, recalls=len(out))
 
         # Read pending idle notification (best-effort, races with writer)
         notification = _read_notification(memory)

--- a/src/memo/server_core_search.py
+++ b/src/memo/server_core_search.py
@@ -23,17 +23,30 @@ def _read_notification(memory: Memory) -> str:
         idle = notif_path.read_text(encoding="utf-8").strip()
     except Exception:
         idle = ""
-    presence_line = ""
-    try:
-        from memo.flags import flag_bool
+    return "\n".join(p for p in (_presence_line(memory), idle) if p)
 
-        if flag_bool("MEMO_PRESENCE_NOTIFY"):
-            from memo import presence
 
-            presence_line = presence.summary_line(presence.read_today(memory.cfg.state_dir))
-    except Exception:
-        presence_line = ""
-    return "\n".join(p for p in (presence_line, idle) if p)
+def _presence_line(memory: Memory) -> str:
+    """Today's cross-agent activity summary; '' when off or nothing happened.
+
+    Every call is internally guarded — ``read_today`` swallows IO errors and
+    ``summary_line`` is pure — so no broad except is needed here.
+    """
+    from memo.flags import flag_bool
+
+    if not flag_bool("MEMO_PRESENCE_NOTIFY"):
+        return ""
+    from memo import presence
+
+    return presence.summary_line(presence.read_today(memory.cfg.state_dir))
+
+
+def _bump_recall_presence(memory: Memory, hits: list[Any]) -> None:
+    """Reflect an MCP recall in today's presence counters (decoration only)."""
+    if hits:
+        from memo import presence
+
+        presence.bump(memory.cfg.state_dir, recalls=len(hits))
 
 
 def _file_search_notes(
@@ -227,10 +240,7 @@ def register(server: Any, memory: Memory) -> None:
 
         # Cross-agent presence: reflect this recall so MCP-only agents (which
         # never run the Claude recall-hook) read honest counts. Decoration only.
-        if out:
-            from memo import presence
-
-            presence.bump(memory.cfg.state_dir, recalls=len(out))
+        _bump_recall_presence(memory, out)
 
         # Read pending idle notification (best-effort, races with writer)
         notification = _read_notification(memory)

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -51,6 +51,28 @@ def test_writers_never_raise_on_unwritable_dir(tmp_path: Path) -> None:
     presence.set_tokens(target / "sub", 5)  # must swallow
 
 
+def test_summary_line_empty_when_no_activity() -> None:
+    assert presence.summary_line({"recalls": 0, "saves": 0, "tokens_saved": 0}) == ""
+
+
+def test_summary_line_renders_nonzero_segments() -> None:
+    line = presence.summary_line({"recalls": 3, "saves": 1, "tokens_saved": 2500})
+    assert line.startswith("※ memo today · ")
+    assert "🧠 3 recalled" in line
+    assert "💾 1 saved" in line
+    assert "~2k tok" in line
+
+
+def test_summary_line_omits_zero_segments() -> None:
+    assert presence.summary_line({"recalls": 2, "saves": 0, "tokens_saved": 0}) == (
+        "※ memo today · 🧠 2 recalled"
+    )
+
+
+def test_summary_line_tokens_below_1k_shown_raw() -> None:
+    assert "~500 tok" in presence.summary_line({"recalls": 0, "saves": 0, "tokens_saved": 500})
+
+
 def test_rollover_then_bump_resets_counter(tmp_path: Path) -> None:
     """Stale-date file is discarded; new bump starts from 0, not stale+new."""
     presence.presence_path(tmp_path).write_text(

--- a/tests/test_server_core_search.py
+++ b/tests/test_server_core_search.py
@@ -63,6 +63,68 @@ def test_read_only_tools_peek_notification_without_consuming(tmp_cfg, monkeypatc
         assert path.is_file(), f"{name} consumed the pending notification"
 
 
+def test_notification_carries_presence_for_mcp_agents(tmp_cfg, monkeypatch) -> None:
+    """MCP-only agents (no statusline) see today's activity in the notification
+    field of every tool response, alongside any pending idle notice."""
+    import memo.server_core_search as search_server
+    from memo import presence
+    from memo.memory import Memory
+
+    monkeypatch.setattr(search_server, "log_consult", lambda *a, **k: None)
+    memory = MagicMock(spec=Memory)
+    memory.cfg = tmp_cfg
+    memory.search.return_value = []
+    server = _RecordingServer()
+    search_server.register(server, memory)
+
+    presence.bump(tmp_cfg.state_dir, recalls=2, saves=1)
+    (tmp_cfg.state_dir / "pending_idle_notification.txt").write_text(
+        "※ MEMO auto-saved\n", encoding="utf-8"
+    )
+
+    notification = server.tools["memo_search"](query="needle")["notification"]
+    assert "※ memo today" in notification
+    assert "🧠 2 recalled" in notification and "💾 1 saved" in notification
+    assert "※ MEMO auto-saved" in notification  # idle notice preserved
+
+
+def test_presence_notify_flag_off_silences_only_that_channel(tmp_cfg, monkeypatch) -> None:
+    import memo.server_core_search as search_server
+    from memo import presence
+    from memo.memory import Memory
+
+    monkeypatch.setattr(search_server, "log_consult", lambda *a, **k: None)
+    monkeypatch.setenv("MEMO_PRESENCE_NOTIFY", "0")
+    memory = MagicMock(spec=Memory)
+    memory.cfg = tmp_cfg
+    memory.search.return_value = []
+    server = _RecordingServer()
+    search_server.register(server, memory)
+
+    presence.bump(tmp_cfg.state_dir, recalls=2)
+    assert "※ memo today" not in server.tools["memo_search"](query="needle")["notification"]
+
+
+def test_search_hits_bump_recall_presence(tmp_cfg, monkeypatch) -> None:
+    """An MCP search that surfaces memories increments the recall counter, so an
+    agent that never runs the Claude recall-hook still shows honest activity."""
+    import memo.server_core_search as search_server
+    from memo import presence
+    from memo.memory import Memory
+
+    monkeypatch.setattr(search_server, "log_consult", lambda *a, **k: None)
+    memory = MagicMock(spec=Memory)
+    memory.cfg = tmp_cfg
+    rec = MagicMock()
+    rec.to_dict.return_value = {"id": "abc", "body": "hit"}
+    memory.search.return_value = [rec, rec]
+    server = _RecordingServer()
+    search_server.register(server, memory)
+
+    server.tools["memo_search"](query="needle")
+    assert presence.read_today(tmp_cfg.state_dir)["recalls"] == 2
+
+
 def test_search_with_file_announces_dropped_date_filters_and_explain(tmp_cfg, monkeypatch) -> None:
     """search_by_file takes no date filters and computes no explain trace —
     memo_search must say so in the response instead of silently dropping the


### PR DESCRIPTION
## What

The statusline presence badge (🧠 recalls · 💾 saves · ~tokens saved today) is **Claude-Code-only** — it rides the `UserPromptSubmit` recall-hook. Agents that reach memo purely over MCP (Codex, Devin, opencode, Cursor) never saw memo working, and their recall activity was never counted.

This projects the **same counters, adapted to a cross-agent surface**: memo's MCP `notification` field (already threaded through every read tool).

- `presence.summary_line()` — pure plain-text render of today's counters; `""` when idle (never claims activity that did not occur).
- `_read_notification()` composes that line into the `notification` field every read tool returns, gated by `MEMO_PRESENCE_NOTIFY` (default on).
- `memo_search` bumps the recall counter so MCP-only agents read honest counts.

## Why

Recurring user pain: memo has ~50 dark features but its work is invisible outside Claude Code. This makes memo's presence visible on **every** agent that uses it, with no per-agent logic — one shared `presence_today.json`, surface adapted per client.

## Honest scope

Truly *persistent* presence only exists where a statusline/terminal-title does (Claude Code, v1). GUI/MCP-only agents see it **per memo call**, not continuously — the ceiling without that agent having a statusline concept. Follow-ups (not in this PR): terminal-title OSC for CLI agents; bump recalls in `memo_ask`/`memo_context` too.

## Verification

- 17 new tests (pure `summary_line` + cross-agent notification + honest-count bump + flag-off gate) green.
- mypy + ruff clean; `memo config validate` recognizes the flag.
- 462 passed across statusline/flags/surface/supply-chain — no ratchet break (flag is not `*_ENABLED`, so no `dream_flags.GATES` completeness requirement).
- Live end-to-end against the real index: an MCP `memo_search` returned `※ memo today · 🧠 70 recalled · 💾 253 saved · ~35k tok` and the recall counter bumped by `len(hits)`.