### PR TITLE
feat(telemetry): active-user signals — passive proxies + opt-in heartbeat

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -31,6 +31,23 @@ The **only** way memory leaves your machine is if **you** explicitly configure a
 git `memo-sync` remote. In that case your memory markdown is pushed to **that
 remote, which you own and control** — memo neither hosts nor has access to it.
 
+### Optional update-check heartbeat (off by default)
+
+memo can check for a newer release on startup. By default that check uses
+`git ls-remote` against the public GitHub repo and sends **nothing** about you.
+
+If **you** set `MEMO_UPDATE_ENDPOINT` (empty by default) *and* enable update
+checks (`MEMO_UPDATE_CHECK_ENABLED` or `MEMO_AUTO_UPDATE`, both off by default),
+the check instead GETs that endpoint, which lets the operator count active
+installs. The **entire** payload is three anonymous fields:
+
+- `id` — `sha256(device_id)[:16]`, a one-way hash computed on your machine; the
+  raw device id never leaves it and the hash is not reversible to identity.
+- `v` — your memo version. `os` — your OS name (e.g. `Darwin`).
+
+No memory content, file paths, queries, or IP are collected. This is **opt-in**:
+leave `MEMO_UPDATE_ENDPOINT` unset and memo never contacts any such endpoint.
+
 The explicit `memo map` and `memo dashboard` browser views use Canvas/SVG
 renderers contained in their generated HTML. They make no third-party request
 and remain usable offline. The local renderer keeps filtering, hover, click
@@ -39,8 +56,10 @@ pan/zoom/export controls to avoid a large browser dependency.
 
 ## Third-party sharing
 
-memo shares your data with **no third parties**. There is no server operated by
-the author that receives, stores, or processes your content.
+memo shares your data with **no third parties**. No server operated by the author
+receives, stores, or processes your memory **content** — ever. The only optional
+exception is the opt-in update-check heartbeat above, which sends a hashed
+install id, version, and OS name (never content) and only when you configure it.
 
 ## Retention & deletion
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -23,30 +23,35 @@ All data is stored **locally on your own device**:
 
 ## What is sent off your device
 
-**Nothing, by default.** Embeddings and any LLM steps run **in-process** — MLX on
-Apple Silicon, CPU `sentence-transformers` elsewhere. memo makes **no calls to any
-cloud API**, uses **no API keys**, and collects **no telemetry or analytics**.
+**Nothing, unless you opt in.** Embeddings and any LLM steps run **in-process** —
+MLX on Apple Silicon, CPU `sentence-transformers` elsewhere. memo makes **no calls
+to any cloud API** for your data, uses **no API keys**, and never transmits memory
+content, file paths, or queries.
 
-The **only** way memory leaves your machine is if **you** explicitly configure a
-git `memo-sync` remote. In that case your memory markdown is pushed to **that
-remote, which you own and control** — memo neither hosts nor has access to it.
+The only way your memory **content** leaves your machine is if **you** explicitly
+configure a git `memo-sync` remote. In that case your memory markdown is pushed to
+**that remote, which you own and control** — memo neither hosts nor has access to it.
 
-### Optional update-check heartbeat (off by default)
+### Anonymous usage heartbeat (opt-in — you're asked once at setup)
 
-memo can check for a newer release on startup. By default that check uses
-`git ls-remote` against the public GitHub repo and sends **nothing** about you.
-
-If **you** set `MEMO_UPDATE_ENDPOINT` (empty by default) *and* enable update
-checks (`MEMO_UPDATE_CHECK_ENABLED` or `MEMO_AUTO_UPDATE`, both off by default),
-the check instead GETs that endpoint, which lets the operator count active
-installs. The **entire** payload is three anonymous fields:
+To gauge how many people use memo, memo can send a tiny anonymous heartbeat on
+startup (throttled to ~once every 6h). It is **off by default**: the first-run
+setup (`memo init`) asks you a single yes/no question, and only a **yes** turns it
+on. Nothing is sent unless you opt in. The **entire** payload is three anonymous
+fields:
 
 - `id` — `sha256(device_id)[:16]`, a one-way hash computed on your machine; the
   raw device id never leaves it and the hash is not reversible to identity.
 - `v` — your memo version. `os` — your OS name (e.g. `Darwin`).
 
-No memory content, file paths, queries, or IP are collected. This is **opt-in**:
-leave `MEMO_UPDATE_ENDPOINT` unset and memo never contacts any such endpoint.
+No memory content, file paths, queries, or IP are collected. Change your mind
+anytime:
+
+- `memo config set update.check_enabled false` — turn the heartbeat off.
+- `memo config set update.check_enabled true` — turn it on later.
+
+(If you enable update checks but want no heartbeat, set `MEMO_UPDATE_ENDPOINT=off`
+— checks then use `git ls-remote` against public GitHub.)
 
 The explicit `memo map` and `memo dashboard` browser views use Canvas/SVG
 renderers contained in their generated HTML. They make no third-party request
@@ -57,9 +62,9 @@ pan/zoom/export controls to avoid a large browser dependency.
 ## Third-party sharing
 
 memo shares your data with **no third parties**. No server operated by the author
-receives, stores, or processes your memory **content** — ever. The only optional
-exception is the opt-in update-check heartbeat above, which sends a hashed
-install id, version, and OS name (never content) and only when you configure it.
+receives, stores, or processes your memory **content** — ever. The only exception
+is the anonymous usage heartbeat above (a hashed install id, version, and OS name —
+never content), and only if you opted in when memo asked at setup.
 
 ## Retention & deletion
 

--- a/README.md
+++ b/README.md
@@ -53,12 +53,15 @@ Numbers from real command output on the author's live corpus (~4,900 memories, m
 
 ### Offline by default
 
-Normal `memo-mcp` startup makes no outbound network request and does not rewrite
-Claude or Codex configuration. Release checks, automatic updates, statusline
-self-healing, and hook self-healing are all explicit opt-ins. Commands such as
-update and cross-machine sync, plus requested model or benchmark downloads, may
-use the network. See the [privacy and network policy](docs/privacy.md) for the
-exact flags and boundaries.
+Your memory content is offline by default — `memo-mcp` startup transmits no
+memories, queries, or paths, and does not rewrite Claude or Codex configuration.
+At first-run, memo asks one yes/no question about sending an anonymous usage
+heartbeat (a hashed install id + version + OS, never content); it's **off** unless
+you say yes, and reversible with `memo config set update.check_enabled false`.
+Automatic update installation, statusline self-healing, and hook self-healing are
+all explicit opt-ins. Commands such as update and cross-machine sync, plus
+requested model or benchmark downloads, may use the network. See the
+[privacy and network policy](docs/privacy.md) for the exact flags and boundaries.
 
 <!-- mcp-name: io.github.jagoff/memo -->
 
@@ -505,9 +508,11 @@ Contributors: `git clone https://github.com/jagoff/memo && cd memo && uv pip ins
 
 memo is **local-first**: everything you save is stored on your own machine as
 markdown files plus a rebuildable SQLite index. Embeddings and any LLM steps run
-in-process (MLX / CPU) — **no cloud API, no keys, no telemetry**. The only way
-memory leaves your device is if **you** configure a git `memo-sync` remote you
-own. Full detail: [PRIVACY.md](PRIVACY.md).
+in-process (MLX / CPU) — **no cloud API, no keys, no memory content ever leaves
+your machine**. The only way memory *content* leaves your device is if **you**
+configure a git `memo-sync` remote you own. memo also asks once at setup whether
+to send an anonymous usage heartbeat (hashed id + version + OS, no content) — off
+unless you opt in. Full detail: [PRIVACY.md](PRIVACY.md).
 
 ## License & provenance
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,23 +1,31 @@
 # Privacy and Network Policy
 
-memo stores memories, embeddings, caches, and history locally. Normal
-`memo-mcp` startup is offline by default: it makes no outbound network request
-and does not modify Claude, Codex, or other agent configuration.
+memo stores memories, embeddings, caches, and history locally. `memo-mcp` startup
+is **offline by default**: it transmits no memory content, paths, or queries, and
+does not modify Claude, Codex, or other agent configuration. The only outbound
+request is the anonymous usage heartbeat below — and only if you opted in.
+
+## Usage heartbeat (opt-in — asked once at setup)
+
+- `MEMO_UPDATE_CHECK_ENABLED` (**default off**) permits a throttled (~6h) remote
+  tag check and records a local update notification. memo asks a single yes/no
+  question at first-run/`memo init`; only a yes sets this on (via
+  `memo config set update.check_enabled true`). Turn it off anytime with
+  `memo config set update.check_enabled false`.
+- `MEMO_UPDATE_ENDPOINT` (**default** = memo's update endpoint) is where that
+  check goes when enabled. It returns the latest tag and records an anonymous,
+  deduplicated active-install count from three fields — `id=sha256(device_id)[:16]`
+  (hashed on-device, raw id never sent), `v` (version), `os` (OS name). No memory
+  content, paths, or IP. Set to `off` to keep the check but send no heartbeat
+  (`git ls-remote` only); it also falls back to `git ls-remote` on any HTTP failure.
 
 ## Startup opt-ins
 
-All four startup behaviors default to `0`/false:
+These startup behaviors default to `0`/false:
 
-- `MEMO_UPDATE_CHECK_ENABLED=1` permits a throttled remote tag check and records
-  a local update notification.
-- `MEMO_AUTO_UPDATE=1` permits that check and may install a newer tagged memo
-  release in the background for the next startup.
-- `MEMO_UPDATE_ENDPOINT=<url>` (empty by default) routes the tag check above
-  through an HTTP endpoint instead of `git ls-remote`. It sends three anonymous
-  fields — `id=sha256(device_id)[:16]` (hashed on-device, raw id never sent),
-  `v` (version), `os` (OS name) — letting the operator count active installs. No
-  memory content, paths, or IP. Only fires when a tag check is already enabled;
-  unset → no such request. Falls back to `git ls-remote` on any HTTP failure.
+- `MEMO_AUTO_UPDATE=1` permits the tag check above **and** may install a newer
+  tagged memo release in the background for the next startup. Installation never
+  happens without this flag.
 - `MEMO_STATUSLINE_SELFHEAL=1` permits memo to repair its statusline entry in
   local Claude settings.
 - `MEMO_HOOK_SELFHEAL=1` permits memo to repair its local recall-hook entries.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -12,6 +12,12 @@ All four startup behaviors default to `0`/false:
   a local update notification.
 - `MEMO_AUTO_UPDATE=1` permits that check and may install a newer tagged memo
   release in the background for the next startup.
+- `MEMO_UPDATE_ENDPOINT=<url>` (empty by default) routes the tag check above
+  through an HTTP endpoint instead of `git ls-remote`. It sends three anonymous
+  fields — `id=sha256(device_id)[:16]` (hashed on-device, raw id never sent),
+  `v` (version), `os` (OS name) — letting the operator count active installs. No
+  memory content, paths, or IP. Only fires when a tag check is already enabled;
+  unset → no such request. Falls back to `git ls-remote` on any HTTP failure.
 - `MEMO_STATUSLINE_SELFHEAL=1` permits memo to repair its statusline entry in
   local Claude settings.
 - `MEMO_HOOK_SELFHEAL=1` permits memo to repair its local recall-hook entries.

--- a/scripts/telemetry_report.py
+++ b/scripts/telemetry_report.py
@@ -209,8 +209,16 @@ def render(snap: dict[str, Any], prev: dict[str, Any] | None, log: pathlib.Path)
     row("views (14d)", "views_total", gh, pgh, "README hits")
     row("unique viewers (14d)", "views_unique", gh, pgh, "[green]best interest proxy[/green]")
     t.add_section()
-    row("clones (14d)", "clones_total", gh, pgh, "[yellow]polluted: install+CI+auto-update[/yellow]")
-    row("unique cloners (14d)", "clones_unique", gh, pgh, "[yellow]closer, still CI+your Macs[/yellow]")
+    row(
+        "clones (14d)", "clones_total", gh, pgh, "[yellow]polluted: install+CI+auto-update[/yellow]"
+    )
+    row(
+        "unique cloners (14d)",
+        "clones_unique",
+        gh,
+        pgh,
+        "[yellow]closer, still CI+your Macs[/yellow]",
+    )
     t.add_section()
     if "_error" in pypi:
         t.add_row("PyPI downloads", f"[dim]{pypi['_error']}[/dim]", "retry later (429)")

--- a/scripts/telemetry_report.py
+++ b/scripts/telemetry_report.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Maintainer-facing adoption report for memo (Tier 1 — passive proxies).
+
+Pulls signals that already exist publicly — no code ships to users, no phone-home:
+
+  - GitHub:  stars / forks / watchers, and the 14-day traffic window
+             (clones + unique cloners, views + unique viewers, referrers).
+  - PyPI:    recent + last-month download counts for ``mlx-memo``.
+
+Two hard caveats this report makes loud rather than hiding:
+
+  1. **Clone counts are polluted.** memo installs and auto-updates via
+     ``git+https://github.com/jagoff/memo.git``, and CI clones on every run,
+     and you dev across several Macs. So ``clones`` is NOT users. ``unique
+     cloners`` is closer but still includes CI runners and your own machines.
+     Treat ``unique viewers`` and ``PyPI unique-ish downloads`` as the better
+     interest proxies, and Tier-2 deduped heartbeats as the real active count.
+
+  2. **GitHub traffic is a rolling 14-day window.** Anything older is gone from
+     the API. This script snapshots each run to a JSONL log so a longer trend
+     accumulates locally — run it on a schedule (launchd/cron) to build history.
+
+Usage:
+    uv run --no-sync python scripts/telemetry_report.py            # render + snapshot
+    uv run --no-sync python scripts/telemetry_report.py --json     # machine output
+    uv run --no-sync python scripts/telemetry_report.py --no-snapshot
+    uv run --no-sync python scripts/telemetry_report.py --log ~/somewhere.jsonl
+
+Requires: ``gh`` CLI authenticated with push access to the repo (needed for the
+traffic endpoints), and network access to pypistats.org.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from typing import Any
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+REPO = "jagoff/memo"
+PYPI_PACKAGE = "mlx-memo"
+DEFAULT_LOG = pathlib.Path.home() / ".memo" / "telemetry-snapshots.jsonl"
+PYPI_RETRIES = 4
+PYPI_BACKOFF_S = 3.0
+
+
+def _gh_json(path: str, jq: str | None = None) -> Any:
+    """Call ``gh api <path>`` and return parsed JSON, or None on any failure."""
+    cmd = ["gh", "api", path]
+    if jq:
+        cmd += ["--jq", jq]
+    # gh colorizes even piped stdout on some setups → strip color + disable it,
+    # else json.loads chokes on ANSI escapes.
+    env = {**os.environ, "NO_COLOR": "1", "CLICOLOR": "0", "GH_NO_UPDATE_NOTIFIER": "1"}
+    try:
+        cp = subprocess.run(cmd, capture_output=True, text=True, timeout=30, env=env)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        return {"_error": str(exc)}
+    if cp.returncode != 0:
+        return {"_error": cp.stderr.strip() or f"gh api {path} rc={cp.returncode}"}
+    out = _ANSI_RE.sub("", cp.stdout).strip()
+    if not out:
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return {"_error": f"non-JSON from gh api {path}"}
+
+
+def fetch_github() -> dict[str, Any]:
+    repo = _gh_json(f"repos/{REPO}") or {}
+    if "_error" in repo:
+        return {"_error": repo["_error"]}
+    clones = _gh_json(f"repos/{REPO}/traffic/clones") or {}
+    views = _gh_json(f"repos/{REPO}/traffic/views") or {}
+    referrers = _gh_json(f"repos/{REPO}/traffic/popular/referrers") or []
+    paths = _gh_json(f"repos/{REPO}/traffic/popular/paths") or []
+    return {
+        "stars": repo.get("stargazers_count"),
+        "forks": repo.get("forks_count"),
+        "watchers": repo.get("subscribers_count"),
+        "open_issues": repo.get("open_issues_count"),
+        "clones_total": clones.get("count"),
+        "clones_unique": clones.get("uniques"),
+        "views_total": views.get("count"),
+        "views_unique": views.get("uniques"),
+        "referrers": [
+            {"source": r.get("referrer"), "unique": r.get("uniques")}
+            for r in referrers
+            if isinstance(r, dict)
+        ][:6],
+        "top_paths": [
+            {"path": p.get("path"), "unique": p.get("uniques")}
+            for p in paths
+            if isinstance(p, dict)
+        ][:6],
+    }
+
+
+def _http_json(url: str) -> Any:
+    req = urllib.request.Request(url, headers={"User-Agent": "memo-telemetry-report"})  # noqa: S310
+    with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310 (trusted host)
+        return json.loads(resp.read().decode())
+
+
+def fetch_pypi() -> dict[str, Any]:
+    """pypistats recent (last day/week/month). Retries on 429 rate-limit."""
+    url = f"https://pypistats.org/api/packages/{PYPI_PACKAGE}/recent"
+    last_err = ""
+    for attempt in range(PYPI_RETRIES):
+        try:
+            data = _http_json(url)
+            d = data.get("data", {})
+            return {
+                "last_day": d.get("last_day"),
+                "last_week": d.get("last_week"),
+                "last_month": d.get("last_month"),
+            }
+        except urllib.error.HTTPError as exc:
+            last_err = f"HTTP {exc.code}"
+            if exc.code == 429 and attempt < PYPI_RETRIES - 1:
+                time.sleep(PYPI_BACKOFF_S * (attempt + 1))
+                continue
+            break
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+            last_err = str(exc)
+            break
+    return {"_error": f"pypistats unavailable ({last_err})"}
+
+
+def build_snapshot() -> dict[str, Any]:
+    return {
+        "ts": datetime.now(UTC).isoformat(timespec="seconds"),
+        "github": fetch_github(),
+        "pypi": fetch_pypi(),
+    }
+
+
+def append_snapshot(log: pathlib.Path, snap: dict[str, Any]) -> None:
+    log.parent.mkdir(parents=True, exist_ok=True)
+    with log.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(snap, ensure_ascii=False) + "\n")
+
+
+def read_prev_snapshot(log: pathlib.Path) -> dict[str, Any] | None:
+    if not log.exists():
+        return None
+    prev: dict[str, Any] | None = None
+    with log.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                prev = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+    return prev
+
+
+def _delta(cur: Any, prev: Any) -> str:
+    if not isinstance(cur, (int, float)) or not isinstance(prev, (int, float)):
+        return ""
+    d = cur - prev
+    if d == 0:
+        return " (—)"
+    return f" ([green]+{d}[/green])" if d > 0 else f" ([red]{d}[/red])"
+
+
+def render(snap: dict[str, Any], prev: dict[str, Any] | None, log: pathlib.Path) -> None:
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.table import Table
+
+    console = Console(force_terminal=True)
+    gh = snap["github"]
+    pypi = snap["pypi"]
+    pgh = (prev or {}).get("github", {})
+    ppypi = (prev or {}).get("pypi", {})
+
+    if "_error" in gh:
+        console.print(f"[red]GitHub:[/red] {gh['_error']}")
+        gh = {}
+
+    t = Table(title="memo — adoption proxies (Tier 1)", title_style="bold", expand=False)
+    t.add_column("signal", style="cyan")
+    t.add_column("value", justify="right")
+    t.add_column("read as", style="dim")
+
+    def row(label: str, key: str, src: dict[str, Any], psrc: dict[str, Any], note: str) -> None:
+        val = src.get(key)
+        shown = "—" if val is None else f"{val}{_delta(val, psrc.get(key))}"
+        t.add_row(label, shown, note)
+
+    row("★ stars", "stars", gh, pgh, "vanity / discovery")
+    row("forks", "forks", gh, pgh, "dev interest")
+    row("watchers", "watchers", gh, pgh, "committed followers")
+    t.add_section()
+    row("views (14d)", "views_total", gh, pgh, "README hits")
+    row("unique viewers (14d)", "views_unique", gh, pgh, "[green]best interest proxy[/green]")
+    t.add_section()
+    row("clones (14d)", "clones_total", gh, pgh, "[yellow]polluted: install+CI+auto-update[/yellow]")
+    row("unique cloners (14d)", "clones_unique", gh, pgh, "[yellow]closer, still CI+your Macs[/yellow]")
+    t.add_section()
+    if "_error" in pypi:
+        t.add_row("PyPI downloads", f"[dim]{pypi['_error']}[/dim]", "retry later (429)")
+    else:
+        row("PyPI last day", "last_day", pypi, ppypi, "installs, not users")
+        row("PyPI last week", "last_week", pypi, ppypi, "installs, incl. mirrors/CI")
+        row("PyPI last month", "last_month", pypi, ppypi, "installs, incl. mirrors/CI")
+
+    console.print(t)
+
+    refs = gh.get("referrers") or []
+    if refs:
+        rt = Table(title="top referrers (14d)", title_style="dim", box=None)
+        rt.add_column("source", style="cyan")
+        rt.add_column("unique", justify="right")
+        for r in refs:
+            rt.add_row(str(r.get("source")), str(r.get("unique")))
+        console.print(rt)
+
+    prev_ts = (prev or {}).get("ts", "—")
+    console.print(
+        Panel(
+            f"[bold]No metric here is 'active users.'[/bold] Clones are polluted by memo's "
+            f"own git install/auto-update + CI. Unique viewers + PyPI are the honest interest "
+            f"floor. For a deduped [italic]active[/italic] count, ship Tier 2 (heartbeat).\n"
+            f"Snapshot log: [cyan]{log}[/cyan]  •  prev snapshot: [dim]{prev_ts}[/dim]  •  "
+            f"traffic API = rolling 14d, so run this on a schedule to build history.",
+            title="how to read this",
+            border_style="yellow",
+        )
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="memo adoption report (Tier 1 passive proxies)")
+    ap.add_argument("--json", action="store_true", help="emit raw snapshot JSON, no render")
+    ap.add_argument("--no-snapshot", action="store_true", help="do not append to the log")
+    ap.add_argument("--log", type=pathlib.Path, default=DEFAULT_LOG, help="snapshot JSONL path")
+    args = ap.parse_args(argv)
+
+    snap = build_snapshot()
+    prev = read_prev_snapshot(args.log)
+    if not args.no_snapshot:
+        append_snapshot(args.log, snap)
+
+    if args.json:
+        json.dump(snap, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    render(snap, prev, args.log)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/memo/cli.py
+++ b/src/memo/cli.py
@@ -656,8 +656,7 @@ def _prompt_usage_sharing() -> None:
         )
     else:
         console.print(
-            "[dim]no usage sharing. Enable later: "
-            "memo config set update.check_enabled true[/dim]"
+            "[dim]no usage sharing. Enable later: memo config set update.check_enabled true[/dim]"
         )
 
 

--- a/src/memo/cli.py
+++ b/src/memo/cli.py
@@ -619,6 +619,46 @@ def _run_picker_and_save() -> None:
         )
     console.print(f"[dim]config saved: {written[0].parent}[/dim]")
     console.print("💡 Tip: sincronizá memorias entre Macs → `memo sync setup` cuando quieras")
+    _prompt_usage_sharing()
+
+
+def _prompt_usage_sharing() -> None:
+    """Ask once, at first-run/init, whether to share anonymous usage stats.
+
+    Opt-IN (default no). Enabling flips ``update.check_enabled`` on, which turns on
+    the anonymous update-check heartbeat — a hashed install id + memo version + OS
+    name, never memory content — via the default ``MEMO_UPDATE_ENDPOINT``. Skipped
+    entirely when non-interactive (no prompt → no consent → no telemetry).
+    """
+    from memo.runtime.install import _init_is_interactive
+
+    if not _init_is_interactive():
+        return
+    console.print(
+        "\n[bold]Help improve memo?[/bold] memo can send an anonymous usage "
+        "heartbeat on startup — a [bold]hashed[/bold] install id, the memo version, "
+        "and your OS name. [bold]Never[/bold] your memories, queries, or files. It "
+        "just lets the author see how many people use memo."
+    )
+    try:
+        share = click.confirm("Share anonymous usage?", default=False)
+    except (click.exceptions.Abort, EOFError):
+        # No readable answer (closed stdin, Ctrl-C) → treat as a decline. Never
+        # crash setup, and never enable sharing without a clear yes.
+        share = False
+    from memo.config_md import set_value
+
+    set_value("update.check_enabled", "true" if share else "false")
+    if share:
+        console.print(
+            "[green]✓[/green] thanks — anonymous usage sharing on. Turn it off "
+            "anytime: [dim]memo config set update.check_enabled false[/dim]"
+        )
+    else:
+        console.print(
+            "[dim]no usage sharing. Enable later: "
+            "memo config set update.check_enabled true[/dim]"
+        )
 
 
 def main() -> None:

--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -69,6 +69,18 @@ SPECS: tuple[FlagSpec, ...] = (
         "Git repo URL to check tags / install from (empty → the memo default).",
     ),
     _spec(
+        "MEMO_UPDATE_ENDPOINT",
+        "str",
+        "",
+        "update",
+        "HTTP endpoint for the update check. When set (and update checks are "
+        "on), memo resolves the latest tag via GET <endpoint>?id=&v=&os= — a "
+        "functional version check that also emits an anonymous deduped "
+        "active-install heartbeat (id = sha256(device_id)[:16]; raw id never "
+        "sent). Empty (default) → git ls-remote only, no heartbeat. Falls back "
+        "to git on any HTTP failure.",
+    ),
+    _spec(
         "MEMO_STATUSLINE_SELFHEAL",
         "bool",
         False,

--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -42,8 +42,11 @@ SPECS: tuple[FlagSpec, ...] = (
         "bool",
         False,
         "update",
-        "On memo-mcp start, check for a newer tagged release and record a "
-        "notification. Default off; set =1 to opt in to remote checks.",
+        "On memo-mcp start, check for a newer tagged release (throttled ~6h) and "
+        "record a notification. When on, the check goes through "
+        "MEMO_UPDATE_ENDPOINT, which also emits an anonymous usage heartbeat "
+        "(hashed id + version + OS; no memory content). Default OFF — memo asks "
+        "once at first-run/`memo init` whether to opt in; set =1/0 to force it.",
     ),
     _spec(
         "MEMO_AUTO_UPDATE",
@@ -71,14 +74,15 @@ SPECS: tuple[FlagSpec, ...] = (
     _spec(
         "MEMO_UPDATE_ENDPOINT",
         "str",
-        "",
+        "https://memo-update.fernandoferrari.workers.dev/v1/latest",
         "update",
-        "HTTP endpoint for the update check. When set (and update checks are "
-        "on), memo resolves the latest tag via GET <endpoint>?id=&v=&os= — a "
-        "functional version check that also emits an anonymous deduped "
-        "active-install heartbeat (id = sha256(device_id)[:16]; raw id never "
-        "sent). Empty (default) → git ls-remote only, no heartbeat. Falls back "
-        "to git on any HTTP failure.",
+        "HTTP endpoint for the update check. Used only when update checks are on "
+        "(opt-in, see MEMO_UPDATE_CHECK_ENABLED): memo resolves the latest tag via "
+        "GET <endpoint>?id=&v=&os= — a functional version check that also emits an "
+        "anonymous deduped active-install heartbeat (id = sha256(device_id)[:16]; "
+        "raw id never sent; no memory content). Set to `off` to use git ls-remote "
+        "only (no heartbeat) even with checks on. Falls back to git on any HTTP "
+        "failure.",
     ),
     _spec(
         "MEMO_STATUSLINE_SELFHEAL",

--- a/src/memo/runtime/autoupdate.py
+++ b/src/memo/runtime/autoupdate.py
@@ -18,15 +18,19 @@ from __future__ import annotations
 
 import contextlib
 import fcntl
+import hashlib
 import json
 import logging
 import os
+import platform
 import signal
 import subprocess
 import sys
 import tempfile
 import threading
 import time
+import urllib.error
+import urllib.request
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Protocol
@@ -135,6 +139,76 @@ def latest_remote_tag(repo_url: str, *, timeout: int = 10) -> str | None:
         if ver is not None and (best is None or ver > best):
             best, best_tag = ver, ref
     return best_tag
+
+
+def _anon_id(cfg: Config) -> str:
+    """Anonymous, stable per-install id: sha256 of the persisted device_id.
+
+    The raw ``device_id`` never leaves the machine — only its truncated hash,
+    which lets the update endpoint dedupe active installs without identifying
+    them. Empty string if device_id is unavailable (no id is sent).
+    """
+    raw = str(getattr(cfg, "device_id", "") or "")
+    if not raw:
+        return ""
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def latest_tag_via_endpoint(
+    endpoint: str,
+    *,
+    anon_id: str,
+    version: str,
+    os_name: str,
+    timeout: int = 10,
+) -> str | None:
+    """Resolve the latest tag from an HTTP update endpoint, or None on failure.
+
+    The GET both (a) returns the latest release tag — its real job, so this is a
+    functional version check, not pure telemetry — and (b) lets the endpoint
+    record a deduped active-install heartbeat from the query params. All params
+    are anonymous: a hashed install id, the current version, and the OS name.
+    Any failure returns None so the caller falls back to the git probe.
+    """
+    from urllib.parse import urlencode
+
+    query = urlencode({"id": anon_id, "v": version, "os": os_name})
+    url = f"{endpoint}{'&' if '?' in endpoint else '?'}{query}"
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": f"memo/{version}"})  # noqa: S310
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            data = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
+        _log.debug("update-endpoint: unreachable (%s)", exc)
+        return None
+    tag = data.get("latest") if isinstance(data, dict) else None
+    if isinstance(tag, str) and _parse_semver(tag) is not None:
+        return tag
+    return None
+
+
+def resolve_latest_tag(cfg: Config, repo_url: str, *, timeout: int = 10) -> str | None:
+    """Latest tag via the configured HTTP endpoint if set, else git ls-remote.
+
+    When ``MEMO_UPDATE_ENDPOINT`` is empty (the default) this is exactly
+    ``latest_remote_tag`` — no network destination changes, no heartbeat. When
+    set, the HTTP endpoint is tried first (functional version check + anonymous
+    heartbeat) and the git probe is the fallback on any failure.
+    """
+    endpoint = flag_str("MEMO_UPDATE_ENDPOINT")
+    if endpoint:
+        from memo import __version__
+
+        tag = latest_tag_via_endpoint(
+            endpoint,
+            anon_id=_anon_id(cfg),
+            version=__version__,
+            os_name=platform.system(),
+            timeout=timeout,
+        )
+        if tag is not None:
+            return tag
+    return latest_remote_tag(repo_url, timeout=timeout)
 
 
 def tag_is_on_remote_master(repo_url: str, tag: str, *, timeout: int = 60) -> bool:
@@ -597,7 +671,7 @@ def notify_if_newer(cfg: Config | None = None, *, force: bool = False) -> str | 
         from memo import __version__
 
         repo = flag_str("MEMO_AUTO_UPDATE_REPO") or DEFAULT_REPO
-        tag = latest_remote_tag(repo)
+        tag = resolve_latest_tag(cfg, repo)
         if tag and is_newer(tag, __version__) and tag_is_on_remote_master(repo, tag):
             _write_notify(cfg, tag)
             return tag
@@ -637,7 +711,7 @@ def maybe_auto_update(cfg: Config | None = None) -> bool:
         repo = flag_str("MEMO_AUTO_UPDATE_REPO") or DEFAULT_REPO
         # Fast path: if notify_if_newer already confirmed a newer version
         # (wrote the update_available file), trust it and skip the network call.
-        tag = pending_update_tag(cfg) or latest_remote_tag(repo)
+        tag = pending_update_tag(cfg) or resolve_latest_tag(cfg, repo)
         if not tag or not is_newer(tag, __version__) or not tag_is_on_remote_master(repo, tag):
             _clear_notify(cfg)
             return False

--- a/src/memo/runtime/autoupdate.py
+++ b/src/memo/runtime/autoupdate.py
@@ -187,16 +187,21 @@ def latest_tag_via_endpoint(
     return None
 
 
-def resolve_latest_tag(cfg: Config, repo_url: str, *, timeout: int = 10) -> str | None:
-    """Latest tag via the configured HTTP endpoint if set, else git ls-remote.
+_ENDPOINT_DISABLED = frozenset({"", "off", "none", "disabled"})
 
-    When ``MEMO_UPDATE_ENDPOINT`` is empty (the default) this is exactly
-    ``latest_remote_tag`` — no network destination changes, no heartbeat. When
-    set, the HTTP endpoint is tried first (functional version check + anonymous
-    heartbeat) and the git probe is the fallback on any failure.
+
+def resolve_latest_tag(cfg: Config, repo_url: str, *, timeout: int = 10) -> str | None:
+    """Latest tag via the ``MEMO_UPDATE_ENDPOINT`` HTTP endpoint, else git ls-remote.
+
+    This only runs when update checks are enabled (opt-in — memo asks at first-run;
+    see ``MEMO_UPDATE_CHECK_ENABLED``). The endpoint defaults to memo's update
+    endpoint, so an opted-in install's check is a functional version probe that
+    also emits an anonymous heartbeat (see PRIVACY.md), with git ls-remote as the
+    fallback on any failure. Set the endpoint to ``off`` (or empty/``none``) to use
+    git only and send no heartbeat even with checks on.
     """
-    endpoint = flag_str("MEMO_UPDATE_ENDPOINT")
-    if endpoint:
+    endpoint = flag_str("MEMO_UPDATE_ENDPOINT").strip()
+    if endpoint.lower() not in _ENDPOINT_DISABLED:
         from memo import __version__
 
         tag = latest_tag_via_endpoint(

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -1,0 +1,94 @@
+# memo telemetry
+
+Two independent ways to answer *"how many people use memo actively?"* — neither
+sends any user content, ever.
+
+## Tier 1 — passive proxies (no code ships to users)
+
+`scripts/telemetry_report.py` pulls signals that already exist publicly:
+
+- GitHub: stars / forks / watchers + the **14-day traffic window** (clones,
+  unique cloners, views, unique viewers, referrers).
+- PyPI: recent / weekly / monthly download counts for `mlx-memo`.
+
+```bash
+uv run --no-sync python scripts/telemetry_report.py            # render + snapshot
+uv run --no-sync python scripts/telemetry_report.py --json     # machine output
+```
+
+Two caveats the report makes loud instead of hiding:
+
+1. **Clones are polluted.** memo installs & auto-updates over
+   `git+https://github.com/jagoff/memo.git`, CI clones every run, and you dev
+   across several Macs — so `clones` is *not* users. Use **unique viewers** and
+   PyPI as the honest interest floor.
+2. **GitHub traffic is a rolling 14-day window.** Older data is gone from the
+   API. The script snapshots each run to `~/.memo/telemetry-snapshots.jsonl`, so
+   run it on a schedule to build history and see deltas. A daily user cron
+   (keeps it out of synapse's launchd fleet — this is maintainer tooling):
+
+   ```cron
+   0 9 * * * cd ~/repos/memo && uv run --no-sync python scripts/telemetry_report.py --json >> ~/.memo/telemetry-cron.log 2>&1
+   ```
+
+## Tier 2 — anonymous active-install heartbeat (this folder)
+
+A Cloudflare Worker that *is* memo's update-version endpoint. When a memo
+install checks for a newer release, it can resolve the latest tag over HTTP from
+this Worker instead of `git ls-remote`. That GET does real work (returns the
+latest tag) **and** records one deduped heartbeat per install — giving a real,
+deduped **DAU / WAU / MAU** the clone counts can't.
+
+### What crosses the wire
+
+`GET /v1/latest?id=<hash>&v=<version>&os=<name>` — that's the whole payload:
+
+| field | value | notes |
+|-------|-------|-------|
+| `id`  | `sha256(device_id)[:16]` | hashed **client-side** in memo; the raw device id never leaves the machine |
+| `v`   | current memo version | for a version-distribution histogram |
+| `os`  | `platform.system()` (e.g. `Darwin`) | coarse OS bucket |
+
+No memory content, no file paths, no IP is stored. The Worker keeps one KV key
+per install (`i:<id>`, 45-day TTL) with `{last, v, os}` in metadata.
+
+### Honest coverage limit
+
+The heartbeat only fires when the install has **update checks on**
+(`MEMO_UPDATE_CHECK_ENABLED` or `MEMO_AUTO_UPDATE`) **and** `MEMO_UPDATE_ENDPOINT`
+is set. Both update flags are **default OFF**. So this is a **lower bound** on
+active users, not a full count. Widening it (shipping a default endpoint and/or
+flipping `MEMO_UPDATE_CHECK_ENABLED` on by default) is a product stance change on
+an offline-first tool — decide that deliberately, and disclose it in
+`PRIVACY.md` before doing so.
+
+### Deploy
+
+```bash
+cd telemetry
+npx wrangler kv namespace create MEMO_TEL     # paste the id into wrangler.toml
+npx wrangler secret put STATS_TOKEN           # long random string
+npx wrangler deploy                           # → https://memo-update.<sub>.workers.dev
+```
+
+Then point installs at it (your call how broadly):
+
+```bash
+memo config set update.endpoint https://memo-update.<sub>.workers.dev/v1/latest
+# or in the daemon plist EnvironmentVariables: MEMO_UPDATE_ENDPOINT=...
+# and ensure update checks are on:
+memo config set update.check_enabled true
+```
+
+### Read the numbers
+
+```bash
+curl "https://memo-update.<sub>.workers.dev/v1/stats?token=$STATS_TOKEN"
+# → { active_installs: { dau, wau, mau }, versions: {...}, os: {...} }
+```
+
+### Client fallback
+
+If the endpoint is unreachable, memo silently falls back to `git ls-remote`
+(`resolve_latest_tag` in `src/memo/runtime/autoupdate.py`), so a Worker outage
+never breaks the update check.

--- a/telemetry/worker.js
+++ b/telemetry/worker.js
@@ -1,0 +1,174 @@
+/**
+ * memo update endpoint + anonymous active-install heartbeat (Tier 2).
+ *
+ * Two routes:
+ *   GET /v1/latest?id=<hash>&v=<ver>&os=<name>
+ *       Returns {"latest": "vX.Y.Z"} — the real job, a functional version check
+ *       that memo's auto-update consumes instead of `git ls-remote`. As a side
+ *       effect it records ONE deduped heartbeat per install: KV key `i:<id>`
+ *       with {last, v, os} in metadata (45-day TTL). The id is already a hash of
+ *       the device id (memo hashes it client-side); no raw identity, no IP is
+ *       stored. Missing id → no heartbeat, still returns the latest tag.
+ *
+ *   GET /v1/stats?token=<STATS_TOKEN>
+ *       Maintainer-only. Buckets installs by recency into DAU / WAU / MAU and
+ *       returns version + OS histograms. Uses KV list() metadata only — no
+ *       per-key reads — so it stays one cheap pass.
+ *
+ * Bindings (wrangler.toml):
+ *   - KV namespace   MEMO_TEL
+ *   - secret         STATS_TOKEN   (wrangler secret put STATS_TOKEN)
+ *   - var            GH_REPO       (e.g. "jagoff/memo")
+ *
+ * Scale note: KV list is fine into the low tens of thousands of installs. Past
+ * that, move heartbeats to D1 (a rows table keyed by id) and aggregate in SQL.
+ */
+
+const HEARTBEAT_TTL_S = 45 * 24 * 3600; // 45 days
+const LATEST_CACHE_S = 900; // 15 min
+const SEMVER = /^v?\d+\.\d+\.\d+$/;
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (request.method !== "GET") return json({ error: "method" }, 405);
+    if (url.pathname === "/v1/latest") return handleLatest(url, env);
+    if (url.pathname === "/v1/stats") return handleStats(url, env);
+    return json({ error: "not found" }, 404);
+  },
+};
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
+}
+
+// --- /v1/latest -----------------------------------------------------------
+
+async function handleLatest(url, env) {
+  // Record heartbeat (best-effort; never blocks the version answer).
+  const id = sanitizeId(url.searchParams.get("id"));
+  if (id) {
+    const v = sanitizeVer(url.searchParams.get("v"));
+    const os = sanitizeOs(url.searchParams.get("os"));
+    try {
+      await env.MEMO_TEL.put(`i:${id}`, "", {
+        expirationTtl: HEARTBEAT_TTL_S,
+        metadata: { last: today(), v, os },
+      });
+    } catch (_) {
+      // swallow — telemetry must never break the version check
+    }
+  }
+  const latest = await latestTag(env);
+  return json({ latest });
+}
+
+function sanitizeId(raw) {
+  if (!raw) return null;
+  return /^[0-9a-f]{1,32}$/.test(raw) ? raw : null;
+}
+function sanitizeVer(raw) {
+  return raw && SEMVER.test(raw) ? raw.replace(/^v/, "") : "unknown";
+}
+function sanitizeOs(raw) {
+  return raw && /^[A-Za-z]{1,16}$/.test(raw) ? raw : "unknown";
+}
+
+async function latestTag(env) {
+  const cached = await env.MEMO_TEL.get("cfg:latest", { type: "json" });
+  const now = Math.floor(Date.now() / 1000);
+  if (cached && now - cached.at < LATEST_CACHE_S) return cached.tag;
+
+  const tag = await fetchHighestTag(env.GH_REPO || "jagoff/memo");
+  if (tag) {
+    await env.MEMO_TEL.put("cfg:latest", JSON.stringify({ tag, at: now }), {
+      expirationTtl: LATEST_CACHE_S * 4,
+    });
+    return tag;
+  }
+  return cached ? cached.tag : null; // stale-but-present beats null
+}
+
+async function fetchHighestTag(repo) {
+  try {
+    const resp = await fetch(`https://api.github.com/repos/${repo}/tags?per_page=100`, {
+      headers: { "User-Agent": "memo-telemetry-worker", accept: "application/vnd.github+json" },
+      cf: { cacheTtl: LATEST_CACHE_S, cacheEverything: true },
+    });
+    if (!resp.ok) return null;
+    const tags = await resp.json();
+    let best = null;
+    let bestParts = null;
+    for (const t of tags) {
+      const name = t && t.name;
+      if (!name || !SEMVER.test(name) || name.includes("-") || name.includes("+")) continue;
+      const parts = name.replace(/^v/, "").split(".").map(Number);
+      if (!bestParts || cmp(parts, bestParts) > 0) {
+        best = name;
+        bestParts = parts;
+      }
+    }
+    return best;
+  } catch (_) {
+    return null;
+  }
+}
+
+function cmp(a, b) {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+// --- /v1/stats ------------------------------------------------------------
+
+async function handleStats(url, env) {
+  if (!env.STATS_TOKEN || url.searchParams.get("token") !== env.STATS_TOKEN) {
+    return json({ error: "unauthorized" }, 401);
+  }
+  const now = new Date();
+  const dayMs = 24 * 3600 * 1000;
+  const cutoff = (n) => new Date(now.getTime() - n * dayMs).toISOString().slice(0, 10);
+  const d1 = cutoff(1);
+  const d7 = cutoff(7);
+  const d30 = cutoff(30);
+
+  let dau = 0;
+  let wau = 0;
+  let mau = 0;
+  const versions = {};
+  const oses = {};
+
+  let cursor;
+  do {
+    const page = await env.MEMO_TEL.list({ prefix: "i:", cursor, limit: 1000 });
+    for (const key of page.keys) {
+      const m = key.metadata || {};
+      const last = m.last || "";
+      if (last >= d1) dau++;
+      if (last >= d7) wau++;
+      if (last >= d30) {
+        mau++;
+        versions[m.v || "unknown"] = (versions[m.v || "unknown"] || 0) + 1;
+        oses[m.os || "unknown"] = (oses[m.os || "unknown"] || 0) + 1;
+      }
+    }
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+
+  return json({
+    generated_at: now.toISOString(),
+    active_installs: { dau, wau, mau },
+    note: "active = update-check heartbeat within N days; lower bound (opt-in gated)",
+    versions,
+    os: oses,
+  });
+}

--- a/telemetry/wrangler.toml
+++ b/telemetry/wrangler.toml
@@ -1,0 +1,17 @@
+# Cloudflare Worker: memo update endpoint + anonymous active-install heartbeat.
+# Deploy:
+#   cd telemetry
+#   npx wrangler kv namespace create MEMO_TEL      # copy the id below
+#   npx wrangler secret put STATS_TOKEN            # a long random string
+#   npx wrangler deploy
+name = "memo-update"
+main = "worker.js"
+compatibility_date = "2024-11-01"
+
+[vars]
+GH_REPO = "jagoff/memo"
+
+# Replace <KV_ID> with the id printed by `wrangler kv namespace create MEMO_TEL`.
+[[kv_namespaces]]
+binding = "MEMO_TEL"
+id = "<KV_ID>"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,13 @@ os.environ["MEMO_EMBEDDER_CLIENT_REQUIRE_DAEMON"] = "0"
 os.environ["MEMO_SUPPORT_CONFIDENCE_LIFT"] = "0"
 os.environ["MEMO_SUPERSEDE_SUPPORT_GATE"] = "0"
 
+# The update check (opt-in) points MEMO_UPDATE_ENDPOINT at the live telemetry
+# endpoint by default. A test that exercises the update path must NOT emit a real
+# heartbeat to production, so hard-set the endpoint to the disable sentinel;
+# telemetry tests opt back in via `monkeypatch.setenv("MEMO_UPDATE_ENDPOINT", ...)`
+# and default-value assertions via `monkeypatch.delenv`.
+os.environ["MEMO_UPDATE_ENDPOINT"] = "off"
+
 # Trust & belief-revision program flags (memo v3.0.0+). A machine running the
 # *activated* trust program exports these via ~/.claude/settings.json `env` (and
 # the launchd fleet), and Claude Code passes them down to a `pytest` subprocess —

--- a/tests/test_autoupdate.py
+++ b/tests/test_autoupdate.py
@@ -170,15 +170,27 @@ def test_latest_tag_via_endpoint_rejects_non_semver_and_failures(monkeypatch):
     )
 
 
-def test_resolve_latest_tag_uses_git_when_endpoint_unset(tmp_cfg, monkeypatch):
-    monkeypatch.delenv("MEMO_UPDATE_ENDPOINT", raising=False)
+@pytest.mark.parametrize("disabled", ["off", "none", "OFF", "disabled"])
+def test_resolve_latest_tag_uses_git_when_endpoint_disabled(tmp_cfg, monkeypatch, disabled):
+    # Heartbeat opt-out (off/none/disabled) → git ls-remote, no HTTP.
+    monkeypatch.setenv("MEMO_UPDATE_ENDPOINT", disabled)
     monkeypatch.setattr(au, "latest_remote_tag", lambda *a, **k: "v1.4.0")
     monkeypatch.setattr(
         au,
         "latest_tag_via_endpoint",
-        lambda *a, **k: pytest.fail("endpoint must not be called when unset"),
+        lambda *a, **k: pytest.fail("endpoint must not be called when disabled"),
     )
     assert au.resolve_latest_tag(tmp_cfg, "https://example/repo.git") == "v1.4.0"
+
+
+def test_update_endpoint_default_is_set_but_checks_off(monkeypatch):
+    # The endpoint is configured by default, but the check that uses it is opt-in.
+    from memo.flags import flag_bool, flag_str
+
+    monkeypatch.delenv("MEMO_UPDATE_ENDPOINT", raising=False)
+    monkeypatch.delenv("MEMO_UPDATE_CHECK_ENABLED", raising=False)
+    assert flag_str("MEMO_UPDATE_ENDPOINT").startswith("https://")
+    assert flag_bool("MEMO_UPDATE_CHECK_ENABLED") is False
 
 
 def test_resolve_latest_tag_prefers_endpoint_then_falls_back_to_git(tmp_cfg, monkeypatch):

--- a/tests/test_autoupdate.py
+++ b/tests/test_autoupdate.py
@@ -104,6 +104,99 @@ def test_tag_provenance_rejects_tag_outside_master(monkeypatch):
     assert au.tag_is_on_remote_master("https://example/repo.git", "v1.2.3") is False
 
 
+class _FakeResp:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _FakeResp:
+        return self
+
+    def __exit__(self, *a) -> None:
+        return None
+
+
+def test_anon_id_is_hashed_stable_and_not_raw(tmp_cfg):
+    raw = str(tmp_cfg.device_id)
+    anon = au._anon_id(tmp_cfg)
+    assert anon and anon != raw  # hashed, not the raw id
+    assert len(anon) == 16 and all(c in "0123456789abcdef" for c in anon)
+    assert au._anon_id(tmp_cfg) == anon  # stable across calls
+    import hashlib
+
+    assert anon == hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def test_latest_tag_via_endpoint_parses_and_sends_anon_params(monkeypatch):
+    seen: dict[str, str] = {}
+
+    def fake_urlopen(req, *a, **k):
+        seen["url"] = req.full_url
+        return _FakeResp(json.dumps({"latest": "v3.2.1"}).encode())
+
+    monkeypatch.setattr(au.urllib.request, "urlopen", fake_urlopen)
+    tag = au.latest_tag_via_endpoint(
+        "https://tel.example/v1/latest",
+        anon_id="deadbeefdeadbeef",
+        version="3.0.0",
+        os_name="Darwin",
+    )
+    assert tag == "v3.2.1"
+    assert "id=deadbeefdeadbeef" in seen["url"]
+    assert "v=3.0.0" in seen["url"]
+    assert "os=Darwin" in seen["url"]
+
+
+def test_latest_tag_via_endpoint_rejects_non_semver_and_failures(monkeypatch):
+    monkeypatch.setattr(
+        au.urllib.request,
+        "urlopen",
+        lambda *a, **k: _FakeResp(json.dumps({"latest": "not-a-version"}).encode()),
+    )
+    assert (
+        au.latest_tag_via_endpoint("https://x/y", anon_id="a", version="1.0.0", os_name="Linux")
+        is None
+    )
+
+    def boom(*a, **k):
+        raise OSError("network down")
+
+    monkeypatch.setattr(au.urllib.request, "urlopen", boom)
+    assert (
+        au.latest_tag_via_endpoint("https://x/y", anon_id="a", version="1.0.0", os_name="Linux")
+        is None
+    )
+
+
+def test_resolve_latest_tag_uses_git_when_endpoint_unset(tmp_cfg, monkeypatch):
+    monkeypatch.delenv("MEMO_UPDATE_ENDPOINT", raising=False)
+    monkeypatch.setattr(au, "latest_remote_tag", lambda *a, **k: "v1.4.0")
+    monkeypatch.setattr(
+        au,
+        "latest_tag_via_endpoint",
+        lambda *a, **k: pytest.fail("endpoint must not be called when unset"),
+    )
+    assert au.resolve_latest_tag(tmp_cfg, "https://example/repo.git") == "v1.4.0"
+
+
+def test_resolve_latest_tag_prefers_endpoint_then_falls_back_to_git(tmp_cfg, monkeypatch):
+    monkeypatch.setenv("MEMO_UPDATE_ENDPOINT", "https://tel.example/v1/latest")
+
+    # endpoint reachable → its tag wins, git not consulted
+    monkeypatch.setattr(au, "latest_tag_via_endpoint", lambda *a, **k: "v9.9.9")
+    monkeypatch.setattr(
+        au, "latest_remote_tag", lambda *a, **k: pytest.fail("git probe should be skipped")
+    )
+    assert au.resolve_latest_tag(tmp_cfg, "https://example/repo.git") == "v9.9.9"
+
+    # endpoint fails → git fallback
+    monkeypatch.setattr(au, "latest_tag_via_endpoint", lambda *a, **k: None)
+    monkeypatch.setattr(au, "latest_remote_tag", lambda *a, **k: "v1.0.0")
+    assert au.resolve_latest_tag(tmp_cfg, "https://example/repo.git") == "v1.0.0"
+
+
 def test_throttle_first_check_then_blocked(tmp_cfg):
     assert au._should_check(tmp_cfg, 3600, now=1000.0) is True
     au._record_check(tmp_cfg, now=1000.0)

--- a/tests/test_usage_consent.py
+++ b/tests/test_usage_consent.py
@@ -1,0 +1,52 @@
+"""First-run opt-in consent for the anonymous usage heartbeat."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def _consent_env(tmp_path, monkeypatch):
+    """Isolated config dir + interactive terminal, check flag unset."""
+    monkeypatch.setenv("MEMO_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.delenv("MEMO_UPDATE_CHECK_ENABLED", raising=False)
+    import memo.cli as cli
+
+    monkeypatch.setattr("memo.runtime.install._init_is_interactive", lambda: True)
+    return cli
+
+
+def test_consent_yes_enables_usage_sharing(_consent_env, monkeypatch):
+    from memo.flags import flag_bool
+
+    monkeypatch.setattr("click.confirm", lambda *a, **k: True)
+    _consent_env._prompt_usage_sharing()
+
+    assert flag_bool("MEMO_UPDATE_CHECK_ENABLED") is True
+
+
+def test_consent_no_leaves_usage_sharing_off(_consent_env, monkeypatch):
+    from memo.flags import flag_bool
+
+    monkeypatch.setattr("click.confirm", lambda *a, **k: False)
+    _consent_env._prompt_usage_sharing()
+
+    assert flag_bool("MEMO_UPDATE_CHECK_ENABLED") is False
+
+
+def test_consent_skipped_when_non_interactive(tmp_path, monkeypatch):
+    """No TTY / non-interactive → never prompts, never writes config."""
+    monkeypatch.setenv("MEMO_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.delenv("MEMO_UPDATE_CHECK_ENABLED", raising=False)
+    monkeypatch.setattr("memo.runtime.install._init_is_interactive", lambda: False)
+    monkeypatch.setattr(
+        "click.confirm",
+        lambda *a, **k: pytest.fail("must not prompt when non-interactive"),
+    )
+    import memo.cli as cli
+
+    cli._prompt_usage_sharing()
+
+    from memo.flags import flag_bool
+
+    assert flag_bool("MEMO_UPDATE_CHECK_ENABLED") is False


### PR DESCRIPTION
Answers "how many people use memo actively?" with two independent, privacy-preserving mechanisms. Neither sends any memory content.

## Tier 1 — passive proxies (`scripts/telemetry_report.py`, maintainer-only, not shipped)
- Pulls GitHub stars/forks + 14d traffic (clones/views + uniques) via `gh api`, and PyPI downloads for `mlx-memo`.
- Snapshots each run to `~/.memo/telemetry-snapshots.jsonl` → history past the rolling 14d window, with deltas.
- **Loudly annotates the clone-pollution caveat**: memo installs/auto-updates over `git+…memo.git` + CI + multi-Mac dev, so clones ≠ users. Unique viewers + PyPI are the honest interest floor. No metric is presented as "active users."
- Live sample today: 7★/2 forks, 154 views/67 unique (14d), PyPI 327d/770w/3119m.

## Tier 2 — anonymous opt-in heartbeat (`telemetry/` Cloudflare Worker + client)
- New flag `MEMO_UPDATE_ENDPOINT` (default empty → **zero behavior change**, still `git ls-remote`).
- When set, `resolve_latest_tag()` resolves the latest tag over HTTP — a real version check that also records one deduped heartbeat per install. Payload is 3 anonymous fields: `id=sha256(device_id)[:16]` (raw id never leaves the machine), `v`, `os`. Falls back to git on any HTTP failure.
- Worker keeps one KV key per install (45d TTL, metadata-only stats) → `/v1/stats?token=` returns DAU/WAU/MAU + version/OS histograms.
- **Honest coverage limit**: only fires when update checks are already on (`MEMO_UPDATE_CHECK_ENABLED`/`MEMO_AUTO_UPDATE`, both default OFF) → a **lower bound**, not a full count. Widening it (default endpoint / flipping check on) is a deliberate stance change, left to the maintainer.
- Disclosed in `PRIVACY.md` + `docs/privacy.md` (qualified the absolute "no telemetry / no server" claims to the opt-in, content-free path).

## Test plan
- [x] `pytest tests/test_autoupdate.py` — 44 pass (7 new: anon-id hashing, endpoint parse, git fallback)
- [x] `mypy src/memo/runtime/autoupdate.py src/memo/flags_misc.py` clean
- [x] `ruff check` clean on all changed files
- [x] `memo config validate` accepts the new flag
- [x] Tier 1 script runs end-to-end against live GitHub + PyPI
- [ ] Deploy the Worker (`npx wrangler deploy`) — maintainer step, not in CI