### PR TITLE
feat(graph): memo graph mindmap — offline-clean interactive HTML viz

### DIFF
--- a/src/memo/cli_graph.py
+++ b/src/memo/cli_graph.py
@@ -188,6 +188,61 @@ def graph_explore(entity: str, max_neighbors: int, max_memories: int, as_json: b
         console.print("[dim]Nothing around this entity.[/dim]")
 
 
+@graph_group.command(name="mindmap")
+@click.argument("entity", required=False)
+@click.option("--depth", type=int, default=2, show_default=True, help="Neighborhood hops.")
+@click.option("--node-cap", type=int, default=300, show_default=True, help="Max nodes rendered.")
+@click.option("-o", "--out", "out_path", type=click.Path(), default=None, help="Output HTML path.")
+@click.option("--open/--no-open", "open_browser", default=True, help="Open in a browser.")
+def graph_mindmap(
+    entity: str | None, depth: int, node_cap: int, out_path: str | None, open_browser: bool
+) -> None:
+    """Render a graph neighborhood as a self-contained interactive HTML mindmap.
+
+    Offline-clean (no CDN), pan/zoom/fold. Defaults to the highest-degree
+    entity when none is given.
+
+    Example: memo graph mindmap mlx --depth 2
+    """
+    import tempfile
+    import webbrowser
+
+    from memo.atomic_io import atomic_write_text
+    from memo.graph_mindmap import build_mindmap_tree, mindmap_filename, render_mindmap_html
+
+    cfg = Config.from_env()
+    mem = _get_memory(cfg)
+    export = mem.navigator.export_json()
+    nodes = export["nodes"]
+    edges = export["edges"]
+    if not nodes:
+        console.print("[yellow]Graph is empty — nothing to render.[/yellow]")
+        return
+
+    ids = {n["id"] for n in nodes}
+    if entity is None:
+        degree: dict[str, int] = {}
+        for edge in edges:
+            degree[edge["source"]] = degree.get(edge["source"], 0) + 1
+            degree[edge["target"]] = degree.get(edge["target"], 0) + 1
+        center = max(ids, key=lambda i: (degree.get(i, 0), i))
+    else:
+        center = entity
+        if center not in ids:
+            console.print(f"[yellow]Entity '{center}' is not in the graph.[/yellow]")
+            return
+
+    tree = build_mindmap_tree(nodes, edges, center=center, depth=depth, node_cap=node_cap)
+    document = render_mindmap_html(tree, title=f"memo graph — {center}")
+
+    dest = Path(out_path) if out_path else Path(tempfile.gettempdir()) / mindmap_filename(center)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(dest, document, mode=0o600)
+    console.print(f"[green]Wrote[/green] {dest}")
+    if open_browser:
+        webbrowser.open(dest.as_uri())
+
+
 @graph_group.command(name="communities")
 @click.option("--min-size", type=int, default=2, help="Minimum community size (default: 2)")
 @click.option("--json", "as_json", is_flag=True, help="Output raw JSON")

--- a/src/memo/graph_mindmap.py
+++ b/src/memo/graph_mindmap.py
@@ -1,0 +1,241 @@
+"""Render a graph neighborhood as a self-contained interactive HTML mindmap.
+
+Viz output only — no MCP tool, no cognition verb (respects the
+no-cognition-on-MCP invariant). Consumes existing `GraphNavigator` exports;
+adds no graph computation.
+
+The generated HTML mirrors memo's Health-Dashboard security pattern
+(`web_build.py` + `html_security.py`): inlined CSS/JS, CSP-nonce, no external
+`<script src>`/CDN. The renderer is a small memo-owned vanilla-SVG tree drawer
+(pan/zoom/fold) — no vendored third-party JS — so the offline invariant holds
+by construction under `default-src 'none'; script-src 'nonce-...'`.
+"""
+
+from __future__ import annotations
+
+import html
+from collections import deque
+from typing import Any
+
+from memo.html_security import content_security_policy, html_safe_json, new_csp_nonce
+
+MindmapNode = dict[str, Any]
+
+DEFAULT_NODE_CAP = 300
+
+
+def build_mindmap_tree(
+    nodes: list[dict[str, Any]],
+    edges: list[dict[str, Any]],
+    center: str,
+    depth: int,
+    node_cap: int = DEFAULT_NODE_CAP,
+) -> MindmapNode:
+    """Convert a graph subgraph into a nested markmap ``{content, children}`` tree.
+
+    Breadth-first from ``center`` out to ``depth`` hops, each node placed under
+    its first-visited parent (so cycles never recurse and each entity appears
+    once). Total node count is capped at ``node_cap`` to keep the HTML small.
+    """
+    label = {n["id"]: n.get("label", n["id"]) for n in nodes}
+    adj: dict[str, list[str]] = {}
+    for edge in edges:
+        src, dst = edge["source"], edge["target"]
+        adj.setdefault(src, []).append(dst)
+        adj.setdefault(dst, []).append(src)
+    # Deterministic neighbor order → stable output for golden/diff tests.
+    for name in adj:
+        adj[name] = sorted(set(adj[name]))
+
+    root: MindmapNode = {"content": label.get(center, center), "children": []}
+    node_of: dict[str, MindmapNode] = {center: root}
+    used = {center}
+    frontier: deque[str] = deque([center])
+
+    for _ in range(max(depth, 0)):
+        nxt: deque[str] = deque()
+        for name in frontier:
+            for neighbor in adj.get(name, []):
+                if neighbor in used or len(used) >= node_cap:
+                    continue
+                used.add(neighbor)
+                child: MindmapNode = {"content": label.get(neighbor, neighbor), "children": []}
+                node_of[name]["children"].append(child)
+                node_of[neighbor] = child
+                nxt.append(neighbor)
+            if len(used) >= node_cap:
+                break
+        if len(used) >= node_cap:
+            break
+        frontier = nxt
+
+    return root
+
+
+def mindmap_filename(center: str) -> str:
+    """Filesystem-safe basename for a default output path (no slashes/spaces)."""
+    safe = "".join(c if c.isalnum() or c in "-_" else "-" for c in center).strip("-")
+    return f"memo-mindmap-{safe or 'graph'}.html"
+
+
+def render_mindmap_html(tree: MindmapNode, title: str = "memo graph") -> str:
+    """Render a complete, self-contained, offline-clean interactive HTML document."""
+    nonce = new_csp_nonce()
+    csp = content_security_policy(nonce, allow_local_fetch=False)
+    data = html_safe_json(tree, ensure_ascii=False)
+    return (
+        _TEMPLATE.replace("__CSP_POLICY__", csp)
+        .replace("__TITLE__", html.escape(title))
+        .replace("__CSP_NONCE__", nonce)
+        .replace("__DATA_JSON__", data)
+        .replace("__MINDMAP_JS__", _MINDMAP_JS)
+    )
+
+
+# ── inlined renderer (memo-owned vanilla SVG; no third-party JS) ────────────
+
+_MINDMAP_JS = r"""
+(function () {
+  "use strict";
+  var NS = "http://www.w3.org/2000/svg";
+  var COL = 210, ROW = 26;
+  var svg = document.getElementById("mm");
+  var gRoot = document.createElementNS(NS, "g");
+  svg.appendChild(gRoot);
+
+  var root = JSON.parse(document.getElementById("payload").textContent);
+  (function prep(n) {
+    n._collapsed = false;
+    (n.children || []).forEach(prep);
+  })(root);
+
+  var tx = 0, ty = 0, scale = 1, fitted = false;
+  function applyTransform() {
+    gRoot.setAttribute("transform", "translate(" + tx + "," + ty + ") scale(" + scale + ")");
+  }
+
+  function layout() {
+    var placed = [], links = [], y = 0;
+    (function walk(n, depth) {
+      var x = depth * COL, myY;
+      var kids = n._collapsed ? [] : (n.children || []);
+      if (kids.length === 0) {
+        myY = y * ROW; y += 1;
+      } else {
+        var cys = kids.map(function (k) { return walk(k, depth + 1); });
+        myY = (cys[0] + cys[cys.length - 1]) / 2;
+        kids.forEach(function (k, i) { links.push([x, myY, x + COL, cys[i]]); });
+      }
+      placed.push({ n: n, x: x, y: myY });
+      return myY;
+    })(root, 0);
+    return { placed: placed, links: links };
+  }
+
+  function render() {
+    while (gRoot.firstChild) gRoot.removeChild(gRoot.firstChild);
+    var lay = layout();
+    lay.links.forEach(function (l) {
+      var mx = (l[0] + l[2]) / 2;
+      var p = document.createElementNS(NS, "path");
+      p.setAttribute("class", "edge");
+      p.setAttribute("d", "M" + l[0] + "," + l[1] + " C" + mx + "," + l[1] +
+        " " + mx + "," + l[3] + " " + l[2] + "," + l[3]);
+      gRoot.appendChild(p);
+    });
+    lay.placed.forEach(function (item) {
+      var g = document.createElementNS(NS, "g");
+      g.setAttribute("transform", "translate(" + item.x + "," + item.y + ")");
+      var hasKids = (item.n.children || []).length > 0;
+      if (hasKids) {
+        var c = document.createElementNS(NS, "circle");
+        c.setAttribute("class", "knob" + (item.n._collapsed ? " collapsed" : ""));
+        c.setAttribute("cx", "-7"); c.setAttribute("cy", "0"); c.setAttribute("r", "4");
+        c.addEventListener("mousedown", function (e) { e.stopPropagation(); });
+        c.addEventListener("click", function (e) {
+          e.stopPropagation();
+          item.n._collapsed = !item.n._collapsed;
+          render();
+        });
+        g.appendChild(c);
+      }
+      var t = document.createElementNS(NS, "text");
+      t.setAttribute("class", "label"); t.setAttribute("x", "2"); t.setAttribute("y", "4");
+      t.textContent = item.n.content;
+      g.appendChild(t);
+      gRoot.appendChild(g);
+    });
+    if (!fitted) { autofit(); fitted = true; }
+  }
+
+  function autofit() {
+    var b = gRoot.getBBox();
+    var W = svg.clientWidth || 800, H = svg.clientHeight || 600, pad = 48;
+    if (b.width === 0 || b.height === 0) { applyTransform(); return; }
+    scale = Math.min((W - pad) / b.width, (H - pad) / b.height, 1.4);
+    tx = pad / 2 - b.x * scale;
+    ty = H / 2 - (b.y + b.height / 2) * scale;
+    applyTransform();
+  }
+
+  svg.addEventListener("wheel", function (e) {
+    e.preventDefault();
+    var r = svg.getBoundingClientRect();
+    var mx = e.clientX - r.left, my = e.clientY - r.top;
+    var f = e.deltaY < 0 ? 1.1 : 0.9;
+    tx = mx - (mx - tx) * f; ty = my - (my - ty) * f; scale *= f;
+    applyTransform();
+  }, { passive: false });
+
+  var dragging = false, lx = 0, ly = 0;
+  svg.addEventListener("mousedown", function (e) { dragging = true; lx = e.clientX; ly = e.clientY; });
+  window.addEventListener("mousemove", function (e) {
+    if (!dragging) return;
+    tx += e.clientX - lx; ty += e.clientY - ly; lx = e.clientX; ly = e.clientY;
+    applyTransform();
+  });
+  window.addEventListener("mouseup", function () { dragging = false; });
+  window.addEventListener("resize", function () { fitted = false; render(); });
+
+  render();
+})();
+"""
+
+_TEMPLATE = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="referrer" content="no-referrer" />
+<meta http-equiv="Content-Security-Policy" content="__CSP_POLICY__" />
+<title>__TITLE__</title>
+<style>
+  :root {
+    --bg: #0a0e16; --panel: #131a28; --border: #243049;
+    --fg: #eef3fb; --fg-mute: #93a1b8; --edge: #3a4a6b; --knob: #5b9dff;
+  }
+  html, body { margin: 0; height: 100%; background: var(--bg); color: var(--fg);
+    font: 14px/1.4 system-ui, -apple-system, sans-serif; overflow: hidden; }
+  header { position: fixed; top: 0; left: 0; right: 0; padding: 8px 14px;
+    background: linear-gradient(var(--panel), rgba(19,26,40,0)); pointer-events: none;
+    display: flex; gap: 12px; align-items: baseline; z-index: 2; }
+  header h1 { margin: 0; font-size: 14px; font-weight: 600; }
+  header .hint { color: var(--fg-mute); font-size: 12px; }
+  #mm { width: 100vw; height: 100vh; display: block; cursor: grab; }
+  #mm:active { cursor: grabbing; }
+  .edge { fill: none; stroke: var(--edge); stroke-width: 1.4; }
+  .label { fill: var(--fg); font-size: 13px; }
+  .knob { fill: var(--bg); stroke: var(--knob); stroke-width: 1.6; cursor: pointer; }
+  .knob.collapsed { fill: var(--knob); }
+</style>
+</head>
+<body>
+<header>
+  <h1>__TITLE__</h1>
+  <span class="hint">drag to pan · scroll to zoom · click a node's dot to fold</span>
+</header>
+<svg id="mm"></svg>
+<script id="payload" type="application/json" nonce="__CSP_NONCE__">__DATA_JSON__</script>
+<script nonce="__CSP_NONCE__">__MINDMAP_JS__</script>
+</body>
+</html>"""

--- a/tests/test_graph_mindmap.py
+++ b/tests/test_graph_mindmap.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from memo.cli import cli
+from memo.graph_mindmap import build_mindmap_tree, render_mindmap_html
+
+
+def _env(tmp_cfg) -> dict[str, str]:
+    return {
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_DATA_DIR": str(tmp_cfg.data_dir),
+        "MEMO_STATE_DIR": str(tmp_cfg.state_dir),
+        "MEMO_VAULT_PATH": str(tmp_cfg.vault_path),
+        "MEMO_AUTO_PROJECT_TAG": "0",
+    }
+
+
+# ── tree builder ──────────────────────────────────────────────────────────
+
+
+def test_tree_centers_and_nests_neighbors() -> None:
+    nodes = [
+        {"id": "memo", "label": "memo"},
+        {"id": "sqlite", "label": "sqlite"},
+        {"id": "mlx", "label": "mlx"},
+    ]
+    edges = [
+        {"source": "memo", "target": "sqlite"},
+        {"source": "memo", "target": "mlx"},
+    ]
+    tree = build_mindmap_tree(nodes, edges, center="memo", depth=1)
+    assert tree["content"] == "memo"
+    labels = {c["content"] for c in tree["children"]}
+    assert labels == {"sqlite", "mlx"}
+
+
+def test_tree_respects_node_cap() -> None:
+    nodes = [{"id": f"n{i}", "label": f"n{i}"} for i in range(500)]
+    edges = [{"source": "n0", "target": f"n{i}"} for i in range(1, 500)]
+    tree = build_mindmap_tree(nodes, edges, center="n0", depth=1, node_cap=10)
+    assert len(tree["children"]) <= 9  # center + at most node_cap-1 children
+
+
+def test_tree_depth_two_nests_grandchildren() -> None:
+    nodes = [{"id": x, "label": x} for x in ("a", "b", "c")]
+    edges = [{"source": "a", "target": "b"}, {"source": "b", "target": "c"}]
+    tree = build_mindmap_tree(nodes, edges, center="a", depth=2)
+    b = tree["children"][0]
+    assert b["content"] == "b"
+    assert b["children"][0]["content"] == "c"
+
+
+def test_tree_depth_one_does_not_descend() -> None:
+    nodes = [{"id": x, "label": x} for x in ("a", "b", "c")]
+    edges = [{"source": "a", "target": "b"}, {"source": "b", "target": "c"}]
+    tree = build_mindmap_tree(nodes, edges, center="a", depth=1)
+    b = tree["children"][0]
+    assert b["children"] == []  # c is 2 hops away, excluded at depth=1
+
+
+def test_tree_no_cycles_when_graph_has_cycle() -> None:
+    nodes = [{"id": x, "label": x} for x in ("a", "b", "c")]
+    edges = [
+        {"source": "a", "target": "b"},
+        {"source": "b", "target": "c"},
+        {"source": "c", "target": "a"},
+    ]
+    tree = build_mindmap_tree(nodes, edges, center="a", depth=5)
+    # every node visited at most once — no infinite recursion, bounded size
+    seen: list[str] = []
+
+    def walk(n: dict) -> None:
+        seen.append(n["content"])
+        for c in n["children"]:
+            walk(c)
+
+    walk(tree)
+    assert sorted(seen) == ["a", "b", "c"]
+
+
+# ── HTML renderer ─────────────────────────────────────────────────────────
+
+
+def test_html_is_offline_clean_and_embeds_tree() -> None:
+    tree = build_mindmap_tree(
+        [{"id": "memo", "label": "memo"}, {"id": "x", "label": "x"}],
+        [{"source": "memo", "target": "x"}],
+        center="memo",
+        depth=1,
+    )
+    html = render_mindmap_html(tree, title="t")
+    assert html.lstrip().lower().startswith("<!doctype html>")
+    # offline-clean: no external resources
+    assert 'src="http' not in html and 'href="http' not in html
+    assert "cdn" not in html.lower()
+    # tree embedded as JSON payload
+    assert '"content"' in html
+    assert '"memo"' in html
+    # CSP present + nonce'd inline scripts
+    assert "content-security-policy" in html.lower()
+    assert "nonce=" in html
+
+
+def test_html_escapes_title_and_payload() -> None:
+    tree = build_mindmap_tree(
+        [{"id": "</script>", "label": "</script>"}], [], center="</script>", depth=1
+    )
+    html = render_mindmap_html(tree, title="<b>x</b>")
+    # The JSON payload data must not carry a literal </script> that would break
+    # out of its <script type="application/json"> node.
+    after_open = html.split('type="application/json"', 1)[1]
+    data = after_open.split(">", 1)[1].split("</script>", 1)[0]
+    assert "</script>" not in data
+    assert "\\u003c/script" in data  # the entity name survived, escaped
+
+
+# ── CLI subcommand ────────────────────────────────────────────────────────
+
+
+def _stub_mem(nodes, edges):
+    class _Nav:
+        def export_json(self, include_memories: bool = False):
+            return {"nodes": nodes, "edges": edges}
+
+    class _Mem:
+        navigator = _Nav()
+
+    return _Mem()
+
+
+def test_mindmap_cli_writes_html(tmp_path, tmp_cfg, monkeypatch) -> None:
+    mem = _stub_mem(
+        [{"id": "memo", "label": "memo"}, {"id": "x", "label": "x"}],
+        [{"source": "memo", "target": "x"}],
+    )
+    monkeypatch.setattr("memo.cli_graph._get_memory", lambda _cfg: mem)
+    out = tmp_path / "mm.html"
+    result = CliRunner().invoke(
+        cli,
+        ["graph", "mindmap", "memo", "--depth", "1", "--out", str(out), "--no-open"],
+        env=_env(tmp_cfg),
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    assert out.read_text(encoding="utf-8").lstrip().lower().startswith("<!doctype html>")
+
+
+def test_mindmap_cli_empty_graph_is_graceful(tmp_path, tmp_cfg, monkeypatch) -> None:
+    monkeypatch.setattr("memo.cli_graph._get_memory", lambda _cfg: _stub_mem([], []))
+    out = tmp_path / "mm.html"
+    result = CliRunner().invoke(
+        cli,
+        ["graph", "mindmap", "--out", str(out), "--no-open"],
+        env=_env(tmp_cfg),
+    )
+    assert result.exit_code == 0, result.output
+    assert not out.exists()
+    assert "empty" in result.output.lower()
+
+
+def test_mindmap_cli_defaults_to_top_degree_entity(tmp_path, tmp_cfg, monkeypatch) -> None:
+    # hub has degree 3, others degree 1 → hub is the default center
+    nodes = [{"id": x, "label": x} for x in ("hub", "a", "b", "c")]
+    edges = [
+        {"source": "hub", "target": "a"},
+        {"source": "hub", "target": "b"},
+        {"source": "hub", "target": "c"},
+    ]
+    monkeypatch.setattr("memo.cli_graph._get_memory", lambda _cfg: _stub_mem(nodes, edges))
+    out = tmp_path / "mm.html"
+    result = CliRunner().invoke(
+        cli,
+        ["graph", "mindmap", "--out", str(out), "--no-open"],
+        env=_env(tmp_cfg),
+    )
+    assert result.exit_code == 0, result.output
+    html = out.read_text(encoding="utf-8")
+    payload = json.loads(
+        html.split('type="application/json"', 1)[1].split(">", 1)[1].split("</script>", 1)[0]
+    )
+    assert payload["content"] == "hub"


### PR DESCRIPTION
## What

Adds `memo graph mindmap [ENTITY]` — renders a graph neighborhood as a **self-contained, offline-clean interactive HTML mindmap** (pan / zoom / fold). Implements Spec 4 of the competitive-review batch (`docs/superpowers/specs/2026-07-22-graph-mindmap-viz-design.md`).

## How

- **`src/memo/graph_mindmap.py`**
  - `build_mindmap_tree(nodes, edges, center, depth, node_cap)` — BFS over the existing `GraphNavigator.export_json()` subgraph → nested `{content, children}` tree. Depth-bounded, node-capped (default 300), cycle-safe (each entity placed once under its first-visited parent).
  - `render_mindmap_html(tree, title)` — mirrors the Health-Dashboard security pattern (`web_build.py` + `html_security.py`): inlined CSS/JS, CSP-nonce (`content_security_policy(nonce, allow_local_fetch=False)`), `html_safe_json` payload, no external `<script src>` / CDN.
  - The renderer is a **small memo-owned vanilla-SVG drawer** (~130 lines inline JS: pan/zoom/fold via `addEventListener`, no inline `onclick`) — **no vendored third-party JS**. The offline invariant holds by construction under `default-src 'none'; script-src 'nonce-...'`, and the wheel gains no d3/markmap bloat.
- **`src/memo/cli_graph.py`** — `memo graph mindmap [ENTITY] [--depth N] [--node-cap N] [-o PATH] [--open/--no-open]`. Defaults the center to the highest-degree entity; empty graph is a graceful no-op. Writes via `atomic_write_text(mode=0o600)`.

## Invariants

- **Viz output only** — no MCP tool, no cognition verb (respects the no-cognition-on-MCP invariant).
- **Offline** — no CDN, no external fetch. Grep-asserted in tests.
- No new graph computation; consumes existing navigator exports.

## Test plan

- [x] `tests/test_graph_mindmap.py` (10, TDD): builder centers/nests, node-cap, depth bound, cycle-safety; renderer offline-clean + payload/title escaping; CLI writes HTML, empty-graph no-op, top-degree default.
- [x] ruff check + `ruff format --check` + mypy clean on changed files.
- [x] `scripts/quality_gate.py` ratchet: passes (new file within budgets).
- [x] diff-cover changed-lines: **94%** (≥90 gate).
- [x] Inline renderer JS `node --check` OK.
- [x] End-to-end against the live graph: 120-node cap respected, offline-clean, CSP present, center=top-degree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)