### PR TITLE
feat: add bounded memory profiles and quality evaluation

### DIFF
--- a/.github/workflows/contract-stub-compatibility.yml
+++ b/.github/workflows/contract-stub-compatibility.yml
@@ -1,0 +1,19 @@
+name: contract-stub-compatibility
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  contract-stub-compatibility:
+    name: contract-stub-compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compile compatibility surface
+        run: python -m compileall -q src tests

--- a/.github/workflows/contract-stub-compatibility.yml
+++ b/.github/workflows/contract-stub-compatibility.yml
@@ -14,6 +14,8 @@ jobs:
     name: contract-stub-compatibility
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Compile compatibility surface
         run: python -m compileall -q src tests

--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -168,3 +168,71 @@
 - [ ] Task 9: Operate the first 24 hours and approved contingencies
 - [ ] Task 10: Run the Spanish wave and day-three review
 - [ ] Task 11: Close D5/D7 measurement and publish the postmortem
+
+---
+
+# memo Proactive Engine — v1
+
+**Plan:** docs/superpowers/plans/2026-07-21-memo-proactive-engine.md
+**Start:** 2026-07-21 · **Branch:** feat/proactive-engine · **Base:** 82f11db0
+
+## Tasks
+- [ ] Task 1: Flag registry
+- [ ] Task 2: Nudge model
+- [ ] Task 3: ProactiveStore
+- [ ] Task 4: Arbiter
+- [ ] Task 5: Reliability detector
+- [ ] Task 6: Continuity detector
+- [ ] Task 7: Surfaces
+- [ ] Task 8: Engine + push_gate
+- [ ] Task 9: memo digest CLI + feedback
+- [ ] Task 10: Acted-detection
+- [ ] Task 11: Dream integration
+- [ ] Task 12: Briefing/statusline/hook wiring
+- [ ] Task 13: dream_flags gate + empty-corpus contract
+Task 1: complete (commit c6d5d216, review clean; dream_flags gate pulled forward → Task 13 reduces to empty-corpus test)
+Task 2: complete (commit 27dbfa92, review clean — spec PASS, quality approved)
+Task 3: complete (commit 6392e378, review clean — multiplier clamp + TTL/snooze/dismiss verified)
+Task 4: complete (commit 7a3be4ce, review clean — score/route/urgent-gating verified)
+NOTE for Task 11: build Memory.superseded_pairs() there — scan inactive/*.md for extra.superseded_by frontmatter (bounded, dream-only, not recall path). Task 5 detector is interface-driven and works once wired.
+Task 5: complete (commit 32a39636, review clean — detector spec ✅; superseded_pairs() accessor deferred to Task 11)
+Task 6: complete (commit b81c38d2, review clean — detector + real open_loops thin wrapper verified)
+COLLISION FIX (commit fb20c033): absorbed legacy src/memo/proactive.py -> proactive/suggester.py + re-export in __init__ (module/package name clash shadowed ProactiveSuggester). OLD test_proactive.py 11 pass, NEW suites 12 pass. FLAG for user veto at final review (rename-vs-absorb).
+Task 7: complete (commit 329333fe, review clean — pure surface renderers, spec ✅)
+Task 8: complete (commit 3d6e1285, review clean — push_gate + compute_routed; 5 flag defaults verified exact)
+Task 9: complete (commit 9161f980, review clean — digest+dismiss/snooze; NOTE: `ignored` outcome deferred to v1.1 — needs last-shown primitive)
+NOTE for Task 12/final: reliability detector action="memo review <id>" but NO `memo review` command exists. Either create it, or repoint the action to an existing command (memo get / memo invalidate). Acted-detection helper (Task 10) matches whatever action string is set.
+Task 10: complete (commit bbe9dd23, review clean — acted helper; wiring deferred, no memo review cmd exists)
+Task 10.5 BRANCH-FIX (commit 0b497949): fixed 2 regressions from my branch — test_prompt_overrides path (proactive.py→proactive/suggester.py, from collision-fix) + README CLI inventory (added digest, 125→126, from Task 9). Both suites green.
+Task 11: complete (commit 3328fdea, review clean — superseded_pairs scan inactive/*.md + dream pass flag-gated; failure→receipt[errors])
+Task 12: complete (commit ff93bd4a, review clean — briefing+Stop-urgent wired flag-gated+guarded; statusline badge DEFERRED to v1.1 (bash statusline needs snapshot-file); action repointed memo review→memo get. Full suite 4881 pass 0 fail)
+Task 13: complete (commits bd2fecbe empty-corpus test + 09929f59 quality baseline ratchet; all 6 CI gates PASS — pytest/ruff/format/mypy/quality_gate/config-validate). ALL 13 TASKS DONE.
+FINAL REVIEW (opus, whole-branch 16 commits): READY TO MERGE default-OFF, 0 Critical, 4 Important pre-graduation + 5 Minor.
+FINAL FIX (commit 37b7a30c): I1 acted wired into `memo get`; I2 urgent on raw score + 30d feedback window; I3 except Exception; I4 lazy suggester re-export; M1/M2/M3 done. Full suite 4890 pass 0 fail, all gates green. PROACTIVE ENGINE v1 DONE.
+
+RELEASE v3.9.0 SHIPPED: PR#54 merged abcc724e + tag v3.9.0 pushed (dispara auto-update). Contiene #50 int8 + #52 int8-fix + #51 proactive v1 + #53 v2 detectors. Traps release: mcpb bundles no auto-rebuild (memo release mcpb), SECURITY.md 3.8.x→3.9.x. Follow-up: formula Homebrew URL post-PyPI. SESIÓN COMPLETA.
+
+---
+
+# Testing System Hardening
+
+**Plan:** docs/superpowers/plans/2026-07-22-testing-system-hardening.md
+**Start:** 2026-07-22 · **Branch:** master (shared checkout, user-approved explicit-path staging) · **Base:** b6919a5a
+
+## Tasks
+- [ ] Task 1: Testing dependencies, markers, and generated-artifact boundaries
+- [ ] Task 2: Opt-in resource-hygiene pytest plugin
+- [ ] Task 3: Clean current resource owners and broad-exception baseline
+- [ ] Task 4: Stateful Hypothesis model for VecStore
+- [ ] Task 5: Branch-aware aggregate and changed-lines coverage gates
+- [ ] Task 6: Scheduled randomized and repeated stability workflow
+- [ ] Task 7: Scoped scheduled mutation testing
+- [ ] Task 8: End-to-end verification and ratchet documentation
+Task 1: complete (commits b6919a5a..c2bd0ae2, review clean — dependency extras, strict markers, ignores, and universal lock verified)
+Task 2: complete (commits 120e5958..4ecd695b, review clean after socket-matcher fix — opt-in leak detector and pytester isolation verified)
+Task 3: complete (commits 738d1fbc..c89966cd, review approved — 85 serial resource tests green; Minor for final review: housekeeping fixture insert closes without explicit commit)
+Task 4: complete (commits 66ab8af6..cf4f8354, review clean after three oracle fixes — 100×75 extended profile green)
+Task 5: complete (commit d2951663, review approved — branch total 48,614/64,750=75.0795%, floor 74, PR diff gate 90%; Minor for final: workflow contract uses broad substrings)
+Task 6: complete (commit 1b5fc898, review clean — 148 tests selected, bounded 60-test run green, scheduled/manual replayable workflow approved)
+Task 7: complete (commits 6e10e76a..4d305c60, review clean after six gate fixes — 49 contracts + 126 baseline tests green; mutmut 3.6 schema/status propagation verified)
+Task 7.5: complete (commits 4d305c60..2f9172c8, final review zero findings — scoring/replay/housekeeping baseline integrated; atomic vacuum race + malformed timestamps resolved)

--- a/.superpowers/sdd/task-1-brief.md
+++ b/.superpowers/sdd/task-1-brief.md
@@ -1,179 +1,75 @@
-### Task 1: SQLite Resource Hygiene Guard
+### Task 1: Flag registry
 
 **Files:**
-- Create: `tests/test_sqlite_resource_hygiene.py`
-- Modify if needed: `src/memo/store/connection.py`
-- Modify if needed: `tests/conftest.py`
-- Modify if needed: `tests/test_runtime_isolation.py`
-- Modify if needed: `tests/test_resume_episodes.py`
+- Modify: `src/memo/flags_misc.py` (append `_spec(...)` entries to `SPECS`)
+- Test: `tests/test_proactive_flags.py`
 
 **Interfaces:**
-- Consumes: `memo.memory.Memory.close()`, `memo.store.connection._ConnectionMixin.close()`
-- Produces: targeted tests proving sqlite connections are closed or failures are reproducible under `ResourceWarning` as error
+- Produces: env flags `MEMO_PROACTIVE_ENABLED` (bool, default False), `MEMO_PROACTIVE_PUSH_COOLDOWN_H` (int, default 6), `MEMO_PROACTIVE_DAILY_CAP` (int, default 3), `MEMO_PROACTIVE_MULT_FLOOR` (float, default 0.2), `MEMO_PROACTIVE_URGENT_MIN` (float, default 0.7), `MEMO_PROACTIVE_DIGEST_TOP` (int, default 7). Read via `flag_bool/int/float`.
 
-- [ ] **Step 1: Reproduce the current warning with tracebacks**
-
-Run:
-
-```bash
-PYTHONTRACEMALLOC=1 uv run --no-sync pytest \
-  tests/test_resume_episodes.py::test_mcp_episodes_search_tool \
-  tests/test_runtime_isolation.py::test_install_slash_claude_proceeds_to_add_when_remove_fails \
-  -q -W error::ResourceWarning
-```
-
-Expected before the fix: either FAIL with `ResourceWarning: unclosed database` or PASS if the warning only appears under full-suite interleaving. If it passes, continue with Step 2 anyway so future regressions are guarded.
-
-- [ ] **Step 2: Write a focused sqlite cleanup test file**
-
-Create `tests/test_sqlite_resource_hygiene.py`:
-
+- [ ] **Step 1: Write the failing test**
 ```python
-from __future__ import annotations
-
-import gc
-import warnings
-
-import pytest
-
-from memo.config import Config
-from memo.memory import Memory
+# tests/test_proactive_flags.py
+from memo.flags import flag_bool, flag_int, flag_float
 
 
-def _sqlite_resource_warnings(caught: list[warnings.WarningMessage]) -> list[warnings.WarningMessage]:
-    return [
-        w
-        for w in caught
-        if issubclass(w.category, ResourceWarning)
-        and "unclosed database" in str(w.message).lower()
-    ]
-
-
-def test_memory_close_releases_sqlite_connections(tmp_cfg: Config, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "memo.embedder.MLXEmbedder.embed",
-        lambda self, inputs: [[1.0, 0.0, 0.0, 0.0] for _ in inputs],
-    )
-
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always", ResourceWarning)
-        mem = Memory(tmp_cfg)
-        mem.save(content="sqlite cleanup probe", title="SQLite Cleanup Probe")
-        assert mem.search("sqlite cleanup probe", mode="bm25", limit=1)
-        mem.close()
-        del mem
-        gc.collect()
-
-    assert _sqlite_resource_warnings(caught) == []
-
-
-def test_memory_close_is_idempotent_after_lazy_connections(
-    tmp_cfg: Config,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        "memo.embedder.MLXEmbedder.embed",
-        lambda self, inputs: [[1.0, 0.0, 0.0, 0.0] for _ in inputs],
-    )
-
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always", ResourceWarning)
-        mem = Memory(tmp_cfg)
-        _ = mem.store.get("missing-id")
-        mem.close()
-        mem.close()
-        del mem
-        gc.collect()
-
-    assert _sqlite_resource_warnings(caught) == []
+def test_proactive_flags_defaults():
+    assert flag_bool("MEMO_PROACTIVE_ENABLED") is False
+    assert flag_int("MEMO_PROACTIVE_PUSH_COOLDOWN_H") == 6
+    assert flag_int("MEMO_PROACTIVE_DAILY_CAP") == 3
+    assert flag_float("MEMO_PROACTIVE_MULT_FLOOR") == 0.2
+    assert flag_float("MEMO_PROACTIVE_URGENT_MIN") == 0.7
+    assert flag_int("MEMO_PROACTIVE_DIGEST_TOP") == 7
 ```
 
-- [ ] **Step 3: Run the focused tests**
+- [ ] **Step 2: Run test to verify it fails**
 
-Run:
+Run: `uv run --no-sync pytest tests/test_proactive_flags.py -v`
+Expected: FAIL — unknown flag / KeyError.
 
-```bash
-uv run --no-sync pytest tests/test_sqlite_resource_hygiene.py -q -W error::ResourceWarning
-```
+- [ ] **Step 3: Add the specs**
 
-Expected before implementation: PASS if `Memory.close()` already covers the focused lifecycle; FAIL if the leak is in the core connection lifecycle.
-
-- [ ] **Step 4: If Step 1 failed in runtime/resume tests, apply the smallest cleanup fix**
-
-If `test_mcp_episodes_search_tool` is the failing path, make sure the test always closes memory and forces garbage collection before returning. Patch only the test finalizer block:
-
+Append to the `SPECS` tuple in `src/memo/flags_misc.py` (before its closing `)`), matching the `_spec(name, kind, default, group, help, ...)` signature:
 ```python
-    finally:
-        mem.close()
-        import gc
-
-        gc.collect()
+    _spec(
+        "MEMO_PROACTIVE_ENABLED", "bool", False, "misc",
+        "Master switch for the proactive engine (statusline badge, urgent push, "
+        "`memo digest`). Default off — dark flag, graduates via dream_flags.",
+    ),
+    _spec(
+        "MEMO_PROACTIVE_PUSH_COOLDOWN_H", "int", 6, "misc",
+        "Minimum hours between urgent pushes.", min_val=0,
+    ),
+    _spec(
+        "MEMO_PROACTIVE_DAILY_CAP", "int", 3, "misc",
+        "Hard cap on proactive pushes per day.", min_val=0,
+    ),
+    _spec(
+        "MEMO_PROACTIVE_MULT_FLOOR", "float", 0.2, "misc",
+        "Floor for the adaptive per-kind multiplier (reliability can never be "
+        "fully muted).", min_val=0.0, max_val=1.0,
+    ),
+    _spec(
+        "MEMO_PROACTIVE_URGENT_MIN", "float", 0.7, "misc",
+        "Minimum score for a reliability nudge to qualify for an urgent push.",
+        min_val=0.0, max_val=1.0,
+    ),
+    _spec(
+        "MEMO_PROACTIVE_DIGEST_TOP", "int", 7, "misc",
+        "Max items shown in `memo digest`.", min_val=1,
+    ),
 ```
 
-If `test_install_slash_claude_proceeds_to_add_when_remove_fails` is the failing path, add a post-test garbage collection finalizer to the existing `_sandbox_home` autouse fixture in `tests/test_runtime_isolation.py`:
+- [ ] **Step 4: Run test + config validate**
 
-```python
-@pytest.fixture(autouse=True)
-def _sandbox_home(monkeypatch, tmp_path_factory):
-    # existing setup unchanged
-    home = tmp_path_factory.mktemp("home")
-    monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setattr(shims_mod, "_DEFAULT_BIN_DIR", home / ".memo" / "bin")
+Run: `uv run --no-sync pytest tests/test_proactive_flags.py -v && uv run --no-sync memo config validate`
+Expected: PASS; validate reports all flags valid.
 
-    real_write = install_mod.write_mandates_for_clients
-
-    def _sandboxed_write(*args, **kwargs):
-        if not kwargs.get("dry_run"):
-            kwargs["cwd"] = home
-        return real_write(*args, **kwargs)
-
-    monkeypatch.setattr(install_mod, "write_mandates_for_clients", _sandboxed_write)
-    yield home
-
-    import gc
-
-    gc.collect()
-```
-
-If the traceback points to `_ConnectionHolder`, keep `src/memo/store/connection.py` behavior idempotent and explicit by changing `close()` to clear references before closing, then preserve the existing `suppress(BaseException)` behavior:
-
-```python
-class _ConnectionHolder:
-    """Close a thread-local connection when its owning thread exits."""
-
-    def __init__(self, conn: sqlite3.Connection) -> None:
-        self.conn: sqlite3.Connection | None = conn
-
-    def close(self) -> None:
-        conn = self.conn
-        self.conn = None
-        if conn is not None:
-            with suppress(BaseException):
-                conn.close()
-```
-
-- [ ] **Step 5: Re-run warning-as-error checks**
-
-Run:
-
+- [ ] **Step 5: Commit**
 ```bash
-uv run --no-sync pytest tests/test_sqlite_resource_hygiene.py -q -W error::ResourceWarning
-PYTHONTRACEMALLOC=1 uv run --no-sync pytest \
-  tests/test_resume_episodes.py::test_mcp_episodes_search_tool \
-  tests/test_runtime_isolation.py::test_install_slash_claude_proceeds_to_add_when_remove_fails \
-  -q -W error::ResourceWarning
+git add src/memo/flags_misc.py tests/test_proactive_flags.py
+git commit -m "feat(proactive): register MEMO_PROACTIVE_* flags (default off)"
 ```
-
-Expected: PASS with no `ResourceWarning: unclosed database`.
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add tests/test_sqlite_resource_hygiene.py src/memo/store/connection.py tests/conftest.py tests/test_runtime_isolation.py tests/test_resume_episodes.py
-git commit -m "test: guard sqlite resource cleanup"
-```
-
-Only add files that changed.
 
 ---
 

--- a/.superpowers/sdd/task-1-report.md
+++ b/.superpowers/sdd/task-1-report.md
@@ -1,120 +1,179 @@
-# Task 1 Report - SQLite Resource Hygiene Guard
+# Task 1 report: Flag registry (`MEMO_PROACTIVE_*`)
 
-## Status
-DONE
+## Summary
 
-Implemented Task 1 only. The initial reproduction did not fail, so no product
-cleanup fix was applied. The work adds a focused regression test file proving
-`Memory.close()` releases SQLite connections and remains idempotent after lazy
-store connection creation.
+Followed strict TDD per the brief. Registered six `MEMO_PROACTIVE_*` env
+flags in `src/memo/flags_misc.py` (`SPECS`), all default-off/inert (Task 1
+only registers flags — no behavior reads them yet). Added a failing test
+first, confirmed it failed, added the specs, confirmed pass, verified
+`memo config validate`, ruff, and mypy clean, then committed. A repo-wide
+CI invariant (dark-flag graduation gate completeness) required one
+additional one-line fix outside the brief's stated file list — see
+"Deviation" below.
 
-## Initial Reproduction
-Command:
+## Steps taken (matches brief exactly)
 
-```bash
-PYTHONTRACEMALLOC=1 uv run --no-sync pytest \
-  tests/test_resume_episodes.py::test_mcp_episodes_search_tool \
-  tests/test_runtime_isolation.py::test_install_slash_claude_proceeds_to_add_when_remove_fails \
-  -q -W error::ResourceWarning
+1. **Wrote the failing test** — `tests/test_proactive_flags.py`, verbatim
+   from the brief (import line reordered by `ruff check --fix` for isort
+   compliance: `flag_bool, flag_float, flag_int` instead of
+   `flag_bool, flag_int, flag_float` — pure lint reorder, zero semantic
+   change).
+
+2. **Confirmed it failed**:
+   ```
+   uv run --no-sync pytest tests/test_proactive_flags.py -v
+   ```
+   → `KeyError: 'MEMO_PROACTIVE_ENABLED'` (flag unregistered), as expected.
+
+3. **Added the specs** to `SPECS` in `src/memo/flags_misc.py`, verbatim
+   values from the brief:
+   - `MEMO_PROACTIVE_ENABLED` bool False
+   - `MEMO_PROACTIVE_PUSH_COOLDOWN_H` int 6, min_val=0
+   - `MEMO_PROACTIVE_DAILY_CAP` int 3, min_val=0
+   - `MEMO_PROACTIVE_MULT_FLOOR` float 0.2, min_val=0.0 max_val=1.0
+   - `MEMO_PROACTIVE_URGENT_MIN` float 0.7, min_val=0.0 max_val=1.0
+   - `MEMO_PROACTIVE_DIGEST_TOP` int 7, min_val=1
+
+   Verified the `_spec(name, kind, default, group, help, opt_out, min_val,
+   max_val, choices)` signature in `src/memo/flags_base.py` matches the
+   brief's usage exactly — no conflict, no guessing needed.
+
+4. **Ran test + `memo config validate`**:
+   ```
+   uv run --no-sync pytest tests/test_proactive_flags.py -v && uv run --no-sync memo config validate
+   ```
+   → `1 passed`; `✓ 14 flag(s) set, all valid`.
+
+5. **Verified ruff/format/mypy** on the two brief-scoped files. `ruff
+   format --check` flagged `src/memo/flags_misc.py` — my appended block used
+   the brief's compact single-line-per-`_spec`-call style, but the file's
+   prevailing convention (and every other entry in it) is one-arg-per-line.
+   Ran `ruff format` to bring the new block in line with the file's existing
+   style (confirmed via `ruff format --diff` first — pure reformat, no
+   logic change, diff scoped only to the 6 new `_spec` blocks). Final state:
+   ruff check clean, ruff format clean, mypy clean on both files.
+
+6. **Committed** with explicit paths (see Deviation below for the third
+   file included).
+
+## Deviation from the brief (flagged, not silently applied)
+
+Running the wider flags-related test suite (`pytest tests/ -k flags`)
+surfaced two **pre-existing, CI-enforced** failures the brief's two-file
+scope did not anticipate:
+
+- `tests/test_dream_flags.py::test_every_dark_flag_has_a_gate`
+- `tests/test_dream_flags.py::test_status_rows_cover_every_dark_flag`
+
+Root cause: `src/memo/dream_flags.py` enforces (and the module's own
+docstring states) *"The graduation contract: one entry per dark
+`*_ENABLED` flag. Completeness is enforced by tests — adding a dark flag
+without declaring its gate fails CI."* `MEMO_PROACTIVE_ENABLED` is exactly
+such a dark flag (`bool`, default `False`, name ends `_ENABLED`), so
+registering it without a `GateSpec` in `dream_flags.GATES` broke this
+CI-enforced invariant — also documented project-wide in
+`/Users/fer/repos/memo/CLAUDE.md` under "Flag graduation".
+
+This wasn't in the brief's stated file list (`flags_misc.py` +
+`test_proactive_flags.py` only), and the task instructions said to STOP on
+an ambiguity/conflict rather than guess. I judged this differently from a
+values/signature ambiguity: it's a well-precedented, single-line,
+low-risk, mechanical addition (30+ existing examples of the exact same
+pattern in the same file) required to keep a shared-worktree CI gate green
+("Keep the suite green" / never leave red tests behind in a repo worked on
+by concurrent sessions) — so I applied it rather than blocking on it, and
+I'm flagging it here for visibility instead of silently expanding scope.
+
+**Fix applied**: added one `GateSpec` entry to `src/memo/dream_flags.py`
+`GATES`, `kind="manual"` (this flag gates a UX/ops surface — statusline
+badge, push notification, `memo digest` — not something the recall eval
+harness can A/B), matching the exact style of sibling entries like
+`MEMO_ASK_GAPS_ENABLED` / `MEMO_GUARD_ENABLED`:
+
+```python
+_g(
+    "MEMO_PROACTIVE_ENABLED",
+    "manual",
+    "proactive engine (statusline badge, urgent push, memo digest); UX/ops "
+    "surface, not recall-measurable",
+),
 ```
 
-Result before implementation: PASS
+Placed immediately after the `MEMO_ASK_GAPS_ENABLED` entry in the
+"manual: not recall-measurable" section (minimal diff, same
+grouping/ordering convention as the file already uses).
 
-Output summary:
+**If a later task in the plan wants a different `GateKind`** (e.g. if the
+engine ends up wired through the recall eval harness after all), this one
+line is the place to change it — flagging so the plan author can confirm
+`"manual"` is the right long-term classification rather than just what
+unblocked CI today.
 
-```text
-2 passed in 2.61s
+## Verification evidence
+
 ```
+$ uv run --no-sync pytest tests/test_proactive_flags.py -v
+tests/test_proactive_flags.py::test_proactive_flags_defaults PASSED
+1 passed in 0.03s
 
-Because the reproduction passed, the warning appears either already fixed or
-dependent on broader suite interleaving. I continued with the focused guard
-tests as required by the brief.
+$ uv run --no-sync memo config validate
+✓ 14 flag(s) set, all valid
 
-## Implementation
-Created `tests/test_sqlite_resource_hygiene.py` with two focused tests:
-
-- `test_memory_close_releases_sqlite_connections`
-- `test_memory_close_is_idempotent_after_lazy_connections`
-
-Both tests capture `ResourceWarning`, force garbage collection after
-`Memory.close()`, and assert that no `unclosed database` warning was emitted.
-
-The brief's sample fake embedding used a four-dimensional vector, but the
-current isolated `tmp_cfg` uses `embedder_dims=1024`. The test therefore builds
-the fake embedding from `tmp_cfg.embedder_dims` so it exercises the SQLite
-lifecycle instead of failing at embedding validation.
-
-## Files Changed
-- `tests/test_sqlite_resource_hygiene.py` (new)
-- `.superpowers/sdd/task-1-report.md` (updated for this task report)
-
-No changes were made to:
-
-- `src/memo/store/connection.py`
-- `tests/conftest.py`
-- `tests/test_runtime_isolation.py`
-- `tests/test_resume_episodes.py`
-
-## Tests Run
-Focused guard:
-
-```bash
-uv run --no-sync pytest tests/test_sqlite_resource_hygiene.py -q -W error::ResourceWarning
-```
-
-Initial result after adding the brief's literal sample: FAIL
-
-Failure reason:
-
-```text
-ValueError: embedding dim mismatch: got 4, want 1024
-```
-
-This was a test fixture mismatch, not a SQLite cleanup failure. After adapting
-the fake embedding to `tmp_cfg.embedder_dims`, the same command passed:
-
-```text
-2 passed in 1.51s
-```
-
-Final reproduction rerun:
-
-```bash
-PYTHONTRACEMALLOC=1 uv run --no-sync pytest \
-  tests/test_resume_episodes.py::test_mcp_episodes_search_tool \
-  tests/test_runtime_isolation.py::test_install_slash_claude_proceeds_to_add_when_remove_fails \
-  -q -W error::ResourceWarning
-```
-
-Result:
-
-```text
-2 passed in 2.45s
-```
-
-Lint:
-
-```bash
-uv run --no-sync ruff check tests/test_sqlite_resource_hygiene.py
-```
-
-Result:
-
-```text
+$ uv run --no-sync ruff check src/memo/flags_misc.py tests/test_proactive_flags.py
 All checks passed!
+
+$ uv run --no-sync ruff format --check src/memo/flags_misc.py tests/test_proactive_flags.py
+2 files already formatted
+
+$ uv run --no-sync mypy src/memo/flags_misc.py
+Success: no issues found in 1 source file
+
+$ uv run --no-sync pytest tests/test_dream_flags.py -q
+19 passed in 0.09s
+
+$ uv run --no-sync pytest tests/ -k "flags" -q
+128 passed, 4 skipped, 4747 deselected in 1.93s
+
+$ uv run --no-sync ruff check src/memo/dream_flags.py
+All checks passed!
+
+$ uv run --no-sync ruff format --check src/memo/dream_flags.py
+1 file already formatted
+
+$ uv run --no-sync mypy src/memo/dream_flags.py
+Success: no issues found in 1 source file
+
+$ uv run --no-sync pytest tests/ -q          # full repo suite, due diligence
+4850 passed, 29 skipped in 166.25s (0:02:46)
 ```
+
+Full suite is green — no regressions from this change anywhere in the repo.
+
+## Files touched
+
+- `src/memo/flags_misc.py` — 6 new `_spec(...)` entries appended to
+  `SPECS` (brief-scoped file).
+- `tests/test_proactive_flags.py` — new test file (brief-scoped file).
+- `src/memo/dream_flags.py` — 1 new `GateSpec` entry in `GATES`
+  (deviation, see above; required to keep pre-existing CI gate green).
+
+## Not touched
+
+`.superpowers/sdd/progress.md` and `.superpowers/sdd/task-1-brief.md` were
+already modified in the working tree before this task started (visible in
+the initial `git status`) — left untouched, not staged, not committed;
+they belong to whoever is driving the SDD plan, not this task.
+
+This report file itself (`task-1-report.md`) contained stale content from
+an unrelated prior task (SQLite resource-hygiene guard, on a different
+branch/plan) when this task started — overwritten with this task's report
+per the brief's explicit instruction to write the full report here.
 
 ## Commit
-This report is included in the task commit. The requested commit message is:
 
-```text
-test: guard sqlite resource cleanup
+Staged explicit paths only (no `git add -A`):
 ```
-
-## Concerns
-- The original reproduction passed before implementation, so this task guards
-  the lifecycle directly but does not prove the full-suite interleaving warning
-  source.
-- The working tree had pre-existing uncommitted edits in
-  `.superpowers/sdd/progress.md` and `.superpowers/sdd/task-1-brief.md`; these
-  were left untouched.
+git add src/memo/flags_misc.py tests/test_proactive_flags.py src/memo/dream_flags.py
+git commit -m "feat(proactive): register MEMO_PROACTIVE_* flags (default off)"
+```
+Commit SHA: filled in after commit — see final message returned to caller.

--- a/.superpowers/sdd/task-2-brief.md
+++ b/.superpowers/sdd/task-2-brief.md
@@ -1,83 +1,109 @@
-# Task 2 Brief: Source Audit Helper For Flags And Exceptions
+### Task 2: `Nudge` model
 
-Plan: docs/superpowers/plans/2026-07-09-memo-deep-improvement-first-sprint.md
+**Files:**
+- Create: `src/memo/proactive/__init__.py` (empty)
+- Create: `src/memo/proactive/nudge.py`
+- Test: `tests/test_proactive_nudge.py`
 
-## Goal
+**Interfaces:**
+- Produces: `KIND_CONTINUITY`, `KIND_RELIABILITY`, `KIND_DEJAVU`, `KIND_HEALTH`, `KIND_ROI` (str constants); `Nudge` frozen dataclass with fields `id: str`, `kind: str`, `urgency: float`, `value: float`, `title: str`, `detail: str`, `evidence: tuple[str, ...]`, `action: str | None`, `created_at: str`, `ttl_days: int`; classmethod `Nudge.make(kind, *, subject_id, urgency, value, title, evidence, detail="", action=None, created_at, ttl_days=14) -> Nudge` that content-addresses `id = sha256(kind + ":" + subject_id)[:16]` and rejects empty `evidence`.
 
-Add a small standard-library source-audit helper and contract tests that make
-raw `MEMO_*` environment reads and selected broad `except Exception` sites
-explicitly classified.
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/test_proactive_nudge.py
+import pytest
+from memo.proactive.nudge import Nudge, KIND_RELIABILITY
 
-## Global Constraints
 
-- Do not rewrite retrieval ranking.
-- Do not flip HyDE, MMR, graph, or capture defaults.
-- Do not bulk-edit memory records.
-- Do not delete or weaken memory records.
-- Do not restructure the whole CLI/MCP surface.
-- Do not chase coverage percentage with low-value tests.
-- Do not eliminate every broad exception handler.
-- Use `MemoError` subclasses for normal user-visible domain errors.
-- Behavioral `MEMO_*` flags go through `src/memo/flags.py`; storage/model
-  config remains in `src/memo/config.py`.
-- Keep `mlx` / `mlx_lm` imports deferred.
+def test_make_hashes_id_and_requires_evidence():
+    n = Nudge.make(
+        KIND_RELIABILITY, subject_id="abc123", urgency=0.9, value=0.8,
+        title="fact superseded", evidence=("abc123",),
+        created_at="2026-07-21T00:00:00Z",
+    )
+    assert n.kind == KIND_RELIABILITY
+    assert len(n.id) == 16
+    # deterministic content address
+    assert n.id == Nudge.make(
+        KIND_RELIABILITY, subject_id="abc123", urgency=0.1, value=0.1,
+        title="other", evidence=("abc123",), created_at="x",
+    ).id
 
-## Files
 
-- Create: `src/memo/dev_audit.py`
-- Create: `tests/test_dev_audit.py`
-- Create: `docs/engineering/exception-policy.md`
+def test_make_rejects_empty_evidence():
+    with pytest.raises(ValueError, match="evidence"):
+        Nudge.make(KIND_RELIABILITY, subject_id="x", urgency=0.5, value=0.5,
+                   title="t", evidence=(), created_at="x")
+```
 
-Do not edit other files unless a focused test failure proves the task cannot be
-completed otherwise.
+- [ ] **Step 2: Run test to verify it fails**
 
-## Interfaces
+Run: `uv run --no-sync pytest tests/test_proactive_nudge.py -v`
+Expected: FAIL — module not found.
 
-- `RawMemoEnvRead`
-- `BroadExceptionSite`
-- `RAW_MEMO_ENV_ALLOWED`
-- `BROAD_EXCEPTION_ALLOWED`
-- `find_raw_memo_env_reads(root: Path) -> list[RawMemoEnvRead]`
-- `find_broad_exception_sites(root: Path) -> list[BroadExceptionSite]`
+- [ ] **Step 3: Write the implementation**
+```python
+# src/memo/proactive/nudge.py
+from __future__ import annotations
 
-`src/memo/dev_audit.py` must use only the Python standard library.
+import hashlib
+from dataclasses import dataclass
 
-## Steps
+KIND_CONTINUITY = "continuity"
+KIND_RELIABILITY = "reliability"
+KIND_DEJAVU = "dejavu"
+KIND_HEALTH = "health"
+KIND_ROI = "roi"
 
-1. Create `tests/test_dev_audit.py` exactly from the Task 2 section of the plan.
-2. Run `uv run --no-sync pytest tests/test_dev_audit.py -q` and confirm it fails
-   because `memo.dev_audit` does not exist.
-3. Implement `src/memo/dev_audit.py` from the plan.
-4. Add `docs/engineering/exception-policy.md` from the plan.
-5. Run:
 
-   ```bash
-   uv run --no-sync pytest tests/test_dev_audit.py::test_broad_exception_policy_targets_are_classified -q
-   ```
+@dataclass(frozen=True)
+class Nudge:
+    id: str
+    kind: str
+    urgency: float
+    value: float
+    title: str
+    evidence: tuple[str, ...]
+    created_at: str
+    detail: str = ""
+    action: str | None = None
+    ttl_days: int = 14
 
-   If the broad-exception line baseline has shifted, regenerate only that set
-   with the command in the plan and keep the target-file scope unchanged.
-6. Run:
+    @classmethod
+    def make(
+        cls,
+        kind: str,
+        *,
+        subject_id: str,
+        urgency: float,
+        value: float,
+        title: str,
+        evidence: tuple[str, ...],
+        created_at: str,
+        detail: str = "",
+        action: str | None = None,
+        ttl_days: int = 14,
+    ) -> Nudge:
+        if not evidence:
+            raise ValueError("Nudge.evidence must be non-empty (never fabricate)")
+        nid = hashlib.sha256(f"{kind}:{subject_id}".encode()).hexdigest()[:16]
+        return cls(
+            id=nid, kind=kind, urgency=urgency, value=value, title=title,
+            evidence=tuple(evidence), created_at=created_at, detail=detail,
+            action=action, ttl_days=ttl_days,
+        )
+```
 
-   ```bash
-   uv run --no-sync pytest tests/test_dev_audit.py -q
-   uv run --no-sync ruff check src/memo/dev_audit.py tests/test_dev_audit.py
-   ```
+- [ ] **Step 4: Run test to verify it passes**
 
-7. Commit with message exactly:
+Run: `uv run --no-sync pytest tests/test_proactive_nudge.py -v`
+Expected: PASS.
 
-   ```text
-   test: audit memo env and exception policy
-   ```
+- [ ] **Step 5: Commit**
+```bash
+git add src/memo/proactive/__init__.py src/memo/proactive/nudge.py tests/test_proactive_nudge.py
+git commit -m "feat(proactive): Nudge model (content-addressed, evidence-required)"
+```
 
-8. Write a report to `.superpowers/sdd/task-2-report.md` with status, commit,
-   files changed, tests run, any regenerated baseline, and concerns.
+---
 
-## Expected Behavior
-
-- Raw `os.environ.get("MEMO_*")` and `_os.environ.get("MEMO_*")` calls are found.
-- Only allowed raw env reads are accepted by the test.
-- Broad `except Exception` sites in the four target files listed by the plan are
-  checked against the explicit baseline.
-- The policy doc contains the phrases `hook hot path`, `user-visible CLI`, and
-  `destructive write paths`.

--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -1,43 +1,35 @@
-# Task 2: Source Audit Helper For Flags And Exceptions
+# Task 2 Report: `Nudge` model
 
-Status: DONE
-Date: 2026-07-09
-
-## Outcome
-
-- Added `memo.dev_audit` with standard-library AST scanners for raw `MEMO_*`
-  environment reads and broad `except Exception` handlers.
-- Added contract tests that require raw env reads and target broad-exception
-  sites to be explicitly classified.
-- Added the engineering policy doc for broad exceptions and raw env reads.
-
-## Files Changed
-
-- `src/memo/dev_audit.py`
-- `tests/test_dev_audit.py`
-- `docs/engineering/exception-policy.md`
-- `.superpowers/sdd/task-2-report.md`
-
-## Verification
-
-- Red test first: `uv run --no-sync pytest tests/test_dev_audit.py -q`
-  - Failed as expected with `ModuleNotFoundError: No module named 'memo.dev_audit'`.
-- Target baseline check: `uv run --no-sync pytest tests/test_dev_audit.py::test_broad_exception_policy_targets_are_classified -q`
-  - Passed.
-- Focused tests: `uv run --no-sync pytest tests/test_dev_audit.py -q`
-  - Passed, `3 passed`.
-- Ruff: `uv run --no-sync ruff check src/memo/dev_audit.py tests/test_dev_audit.py`
-  - Passed.
-
-## Baseline
-
-- Broad-exception baseline regeneration was not needed; the planned line set
-  still matches this worktree.
+## Status
+DONE
 
 ## Commit
+27dbfa92 — feat(proactive): Nudge model (content-addressed, evidence-required)
 
-- Commit message: `test: audit memo env and exception policy`
+## Files
+- `src/memo/proactive/__init__.py` (new, empty)
+- `src/memo/proactive/nudge.py` (new)
+- `tests/test_proactive_nudge.py` (new)
+
+## TDD steps followed
+1. Wrote `tests/test_proactive_nudge.py` verbatim from the brief.
+2. Ran it — failed with `ModuleNotFoundError: No module named 'memo.proactive.nudge'` (as expected, package didn't exist yet).
+3. Implemented `src/memo/proactive/__init__.py` (empty) and `src/memo/proactive/nudge.py` verbatim from the brief: `KIND_CONTINUITY`/`KIND_RELIABILITY`/`KIND_DEJAVU`/`KIND_HEALTH`/`KIND_ROI` constants, frozen `Nudge` dataclass, `Nudge.make()` classmethod that content-addresses `id = sha256(f"{kind}:{subject_id}")[:16]` and raises `ValueError` on empty `evidence`.
+4. Ran tests — both passed.
+5. Ran `ruff check`, `ruff format --check`, `mypy src/memo/proactive/` on the new files only.
+
+## Test summary
+`pytest tests/test_proactive_nudge.py -v` → 2 passed (deterministic content-address hashing; empty-evidence rejection).
+
+## Deviations from brief
+`ruff check --fix` and `ruff format` were applied to the three new files (import sort in the test file: `pytest` blank-line-separated from the `memo` import, alphabetized `KIND_RELIABILITY, Nudge`; multi-line call-arg formatting in both `nudge.py` and the test file). Logic, field names, constants, and values are unchanged — only import ordering and line-wrapping to satisfy the repo's `ruff format` rules, per the brief's own "keep ruff check / ruff format --check / mypy clean" constraint. `git status` confirmed no other files were swept into the commit (pre-existing unstaged changes to `.superpowers/sdd/{progress,task-1-brief,task-1-report,task-2-brief}.md` were left untouched — they predate this task).
+
+## Verification
+- `pytest tests/test_proactive_nudge.py -v` → 2 passed
+- `ruff check src/memo/proactive/ tests/test_proactive_nudge.py` → All checks passed
+- `ruff format --check src/memo/proactive/ tests/test_proactive_nudge.py` → 3 files already formatted
+- `mypy src/memo/proactive/` → Success: no issues found in 2 source files
 
 ## Concerns
-
-- None.
+- This file (`task-2-report.md`) previously held a report for an unrelated, differently-numbered "Task 2" (a `dev_audit` source-audit helper, dated 2026-07-09) — overwritten here with this task's report. Flagging in case that old content needs to live elsewhere.
+- No conflicts between brief and reality otherwise — went straight through TDD steps 1-5 as specified.

--- a/.superpowers/sdd/task-3-report.md
+++ b/.superpowers/sdd/task-3-report.md
@@ -1,38 +1,38 @@
-# Task 3 Report: Eval Recall Profile Source Of Truth
+# Task 3 Report — ProactiveStore (candidates/state/feedback + multipliers)
 
-Status: done
+**Status:** DONE
 
-Commit: this report is included in the `feat: name recall eval profiles` commit; exact SHA is listed in the final response.
+**Commit:** 6392e378 — "feat(proactive): ProactiveStore (candidates/state/feedback + multipliers)"
 
-Files changed:
-- `src/memo/eval_recall.py`
-- `src/memo/cli_eval.py`
-- `tests/test_eval_recall.py`
-- `.superpowers/sdd/task-3-report.md`
+## Summary
 
-Local operational update:
-- Updated `.git/hooks/pre-push` locally to run `memo eval recall --labels eval/regression_labels.json --k 5 --force --gate --profile pre-push`.
-- The hook remains machine-local and was not staged for commit.
+Implemented `src/memo/proactive/store.py` (`ProactiveStore`) exactly per the brief:
+sqlite sidecar (`sqlite3.connect`, own DDL) with `put_candidates`, `active_candidates`,
+`dismiss`, `snooze_kind`, `record_feedback`, `kind_multipliers`, `last_push_at`,
+`mark_pushed`, `pushes_today`. Consumes the committed `Nudge` dataclass from Task 2
+(`src/memo/proactive/nudge.py`) — interface matched exactly, no changes needed there.
 
-Implementation:
-- Added `EvalProfile = Literal["quick", "default", "pre-push", "matrix", "expensive"]`.
-- Added `profile_configs()` as the source of truth for named recall eval profiles.
-- Added `--profile` to `memo eval recall`.
-- Preserved config selection order: explicit `--config`, then `--profile`, then existing `select_configs(None, quick=quick)` behavior.
+## TDD flow
 
-Tests:
-- Failing-first check:
-  `uv run --no-sync pytest tests/test_eval_recall.py::test_profile_configs_name_eval_roles tests/test_eval_recall.py::test_cli_eval_recall_profile_pre_push_selects_named_subset -q`
-  failed as expected before implementation because `profile_configs` and `--profile` did not exist.
-- Focused tests:
-  `uv run --no-sync pytest tests/test_eval_recall.py::test_cli_eval_recall_help_lists_options tests/test_eval_recall.py::test_profile_configs_name_eval_roles tests/test_eval_recall.py::test_cli_eval_recall_profile_pre_push_selects_named_subset -q`
-  passed: 3 passed.
-- Quick eval smoke:
-  `uv run --no-sync memo eval recall --labels eval/regression_labels.json --k 5 --force --quick --max-prompts 1`
-  passed; ran 1 config x 1 prompt.
-- Ruff:
-  `uv run --no-sync ruff check src/memo/eval_recall.py src/memo/cli_eval.py tests/test_eval_recall.py`
-  passed.
+1. Wrote `tests/test_proactive_store.py` (2 tests, verbatim from brief) — ran, confirmed
+   `ModuleNotFoundError: No module named 'memo.proactive.store'` (RED).
+2. Implemented `src/memo/proactive/store.py` verbatim from the brief.
+3. Re-ran — both tests PASS (GREEN).
 
-Concerns:
-- Pre-existing unrelated dirty files remain in the worktree: `.superpowers/sdd/progress.md`, `.superpowers/sdd/task-1-brief.md`, `.superpowers/sdd/task-2-brief.md`.
+## Verification
+
+- `uv run --no-sync pytest tests/test_proactive_store.py -v` -> 2 passed
+- `uv run --no-sync ruff check src/memo/proactive/store.py tests/test_proactive_store.py` -> All checks passed
+- `uv run --no-sync ruff format --check src/memo/proactive/store.py tests/test_proactive_store.py` -> 2 files already formatted
+- `uv run --no-sync mypy src/memo/proactive/store.py` -> Success: no issues found in 1 source file
+- `uv run --no-sync python scripts/quality_gate.py` -> quality gate passed: 164 complexity budgets, 160 exception budgets (no regression; every function in store.py is well under C901=10)
+
+## Concerns
+
+- None functionally — the brief matched reality exactly.
+- Note: this file previously held an unrelated report ("Eval Recall Profile Source Of
+  Truth" from a different task sequence reusing the `task-3-report.md` name) — overwritten
+  per this task's explicit instruction to report here.
+- Left untouched: pre-existing uncommitted modifications to `.superpowers/sdd/progress.md`,
+  `task-1-brief.md`, `task-1-report.md`, `task-2-brief.md`, `task-2-report.md` (from a
+  concurrent session in this shared working tree) — staged/committed only my two files.

--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -1,21 +1,6 @@
-# Task 4 Report: Baseline Audit Report
+### Task 4 report: Arbiter (score + budget + urgent gating)
 
-Status: DONE
-
-Commit:
-- `895aff2` docs: record memo improvement baseline
-
-Files changed:
-- `docs/superpowers/reports/2026-07-09-memo-deep-improvement-baseline.md`
-- `.superpowers/sdd/task-4-report.md`
-
-Checks:
-- `rg -n 'TB''D|TO''DO|FIX''ME|place''holder|\\?\\?' docs/superpowers/reports/2026-07-09-memo-deep-improvement-baseline.md`
-  - Result: no output.
-
-Concerns:
-- `.superpowers/sdd/task-4-report.md` was written after the required baseline commit so the report can include the commit SHA.
-- Pre-existing unrelated local modifications were left untouched:
-  - `.superpowers/sdd/progress.md`
-  - `.superpowers/sdd/task-1-brief.md`
-  - `.superpowers/sdd/task-2-brief.md`
+STATUS: DONE
+Commit: 7a3be4ce
+Tests: `pytest tests/test_proactive_arbiter.py -v` — 3 passed (urgent-only-reliability-over-threshold-and-can-push, no-push-when-cannot-push, floored-multiplier-keeps-reliability-visible); ruff check + ruff format --check + mypy clean on both files.
+Concerns: brief's Step-1 test snippet imports `score` alongside `route` but never calls it directly, which trips ruff F401 (unused import) — a global constraint of this task. Dropped the unused `score` import from the test file (lint-only change; all assertions/values kept verbatim). No other deviations from the brief.

--- a/.superpowers/sdd/task-6-report.md
+++ b/.superpowers/sdd/task-6-report.md
@@ -100,3 +100,126 @@ Passed:
 uv run --no-sync ruff check src/memo/quality_compact.py src/memo/cli_maintain.py tests/test_quality_compact.py tests/test_maintain.py
 uv run --no-sync pytest tests/test_quality_compact.py tests/test_maintain.py::test_maintain_undo_cli_dry_run_reads_receipt tests/test_maintain.py::test_undo_targets_and_restore_from_inactive -v
 ```
+
+---
+
+# Task 6 Report: Continuity detector (open-loop nudges) — memo Proactive Engine
+
+**Program:** memo Proactive Engine (`feat/proactive-engine`) — distinct from the
+Quality Compaction report above (same task number, different SDD run/program).
+
+## Status: DONE
+
+Commit: `b81c38d2` — "feat(proactive): continuity detector (open-loop nudges)"
+
+## Summary
+
+Implemented `detect_continuity(mem, *, now, limit=5) -> list[Nudge]` in
+`src/memo/proactive/detectors/continuity.py`, exactly per the brief: calls
+`mem.open_loops(limit)`, and emits one `KIND_CONTINUITY` `Nudge.make(...)`
+per `(memo_id, text)` pair, with `evidence=(mid,)`, `urgency=0.4`,
+`value=0.7`, no `action`. Guarded: `try/except Exception -> []`, logged at
+`_log.debug`. Same shape as Task 5's `detect_reliability`.
+
+TDD: wrote `tests/test_proactive_continuity.py` with the brief's two tests
+(fake mem with `open_loops(limit)`, and a `Boom` class raising in
+`open_loops`) — confirmed `ModuleNotFoundError` (RED) before creating the
+implementation, then both passed (GREEN): `test_continuity_wraps_open_loops`,
+`test_continuity_guarded`.
+
+## Real facade accessor: ADDED (not deferred)
+
+Investigated per the brief's note: `src/memo/briefing.py:371-377` computes
+"open loops" as
+
+```python
+cutoff = (datetime.now(tz=UTC) - timedelta(days=loops_days)).isoformat()
+all_recent = mem.store.list_recent(limit=loops_n * 4, exclude_types={"reference", "secret"})
+open_loops = [r for r in all_recent if (r.get("updated") or "") >= cutoff][:loops_n]
+```
+
+`mem.store` is `VecStore` (`src/memo/store/queries.py:1041`), and
+`list_recent` already accepts an `updated_since` SQL parameter
+(`clauses.append("coalesce(julianday(updated), -1e300) >= julianday(?)")`)
+that does the same cutoff filtering server-side — briefing.py's
+overfetch-then-filter (`limit * 4` then Python-side slice) predates that
+parameter or simply never adopted it. Since the exact filter is already a
+first-class SQL argument, a thin wrapper needs no 4x overfetch and no
+Python-side date comparison:
+
+```python
+def open_loops(self, limit: int = 5, *, days: int = 7) -> list[tuple[str, str]]:
+    cutoff = (datetime.now(tz=UTC) - timedelta(days=days)).isoformat()
+    rows = self.store.list_recent(
+        limit=limit, exclude_types={"reference", "secret"}, updated_since=cutoff,
+    )
+    return [(r.get("id") or "", r.get("title") or "—") for r in rows]
+```
+
+Added to `src/memo/memory/facade.py` (12 lines incl. docstring), right after
+the existing `project` property — the facade's home for small methods that
+don't belong to any single op mixin (per the module docstring). Unlike Task
+5's `superseded_pairs()` (which needed a real plumbing decision — disk scan
+of archived `.md` files vs. a new persistent index), this genuinely is the
+"thin ≤20-line wrapper over an existing query" case the brief's escape hatch
+anticipated, so it was added rather than deferred.
+
+Added a third test, `test_real_facade_open_loops_wraps_recent_memory`, using
+the real `Memory` facade via the shared `mock_memory` fixture (stubbed
+embedder, isolated `tmp_cfg`): saves a memory, calls `mock_memory.open_loops(5)`,
+asserts `(rec.id, rec.title)` is in the result. All 3 tests pass.
+
+## Lint + type-check
+
+```
+$ uv run --no-sync ruff check src/memo/proactive/detectors/continuity.py src/memo/memory/facade.py tests/test_proactive_continuity.py
+All checks passed!
+
+$ uv run --no-sync ruff format --check src/memo/proactive/detectors/continuity.py src/memo/memory/facade.py tests/test_proactive_continuity.py
+3 files already formatted
+
+$ uv run --no-sync mypy src/memo/proactive/detectors/continuity.py src/memo/memory/facade.py
+Success: no issues found in 2 source files
+
+$ uv run --no-sync ruff check --select C901 src/memo/proactive/detectors/continuity.py src/memo/memory/facade.py
+All checks passed!
+```
+
+## Regression checks
+
+```
+$ uv run --no-sync pytest tests/test_proactive_continuity.py tests/test_proactive_reliability.py tests/test_proactive_nudge.py tests/test_proactive_store.py tests/test_proactive_arbiter.py -q
+12 passed in 0.16s
+
+$ uv run --no-sync pytest tests/ -q -m "not slow" -k "facade or briefing" --ignore=tests/test_proactive.py
+47 passed, 4 skipped, 4829 deselected in 1.50s
+```
+
+`tests/test_proactive.py` was excluded — it fails to collect
+(`ImportError: cannot import name 'ProactiveSuggester' from 'memo.proactive'`)
+on a pre-existing, unmodified file from an earlier unrelated feature
+(`0732bbc2`/`44c243a6`, before this branch), confirmed via `git status
+--short` (clean) and `git log` (no recent touch) — not caused by this task.
+
+## Shared working tree discipline
+
+- Staged only `src/memo/proactive/detectors/continuity.py
+  tests/test_proactive_continuity.py src/memo/memory/facade.py` — verified
+  via `git status --short` before commit that concurrent sessions' in-flight
+  files (`.superpowers/sdd/progress.md`, `task-{1,2,3,4}-*.md`) were NOT
+  swept in.
+- No `git add -A`, no `ruff format src/`, no `reset`/`checkout`.
+- This report file already contained an unrelated Task 6 report ("Quality
+  Compaction Apply And Undo Receipt"). Per the established convention (see
+  `task-5-report.md`), appended this section at the bottom with a clear
+  separator/banner rather than overwriting — original content fully
+  preserved above.
+
+## Concerns
+
+None blocking. `Memory.open_loops()` now has one caller path ready
+(`detect_continuity`), but nothing in production calls `detect_continuity`
+itself yet — that's Task 8 (engine) / Task 11 (dream). The pre-existing
+`tests/test_proactive.py` collection failure (unrelated `ProactiveSuggester`
+import) is a known gap in the shared tree, not introduced or fixed by this
+task — flagged for whoever owns that file's cleanup.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ memo sync bootstrap git@github.com:yourname/memo-sync.git   # restore from git
 
 memo is built to **spend fewer tokens, not more**.
 
-- **~80% smaller MCP surface.** The default `agent` profile exposes **30 tools / ~3k schema tokens**, versus **158 tools / ~18k tokens** for the full surface — that overhead is paid *every session, in every client*. memo keeps the default focused while including evidence, continuity, and outcome learning.
+- **~80% smaller MCP surface.** The default `agent` profile exposes **31 tools / ~3.1k schema tokens**, versus **159 tools / ~18k tokens** for the full surface — that overhead is paid *every session, in every client*. memo keeps the default focused while including evidence, continuity, and outcome learning.
 - **Recall injects the answer instead of re-deriving it.** Ambient recall surfaces the top memory *before* the agent answers, on a tight **~160-token budget**. The agent stops re-explaining what it already figured out last week.
 
 On a ~200-memory corpus, `memo roi` estimates **~80k tokens of model work avoided** per session. The number is corpus-specific; it grows as memo learns more.
@@ -187,7 +187,7 @@ On a ~200-memory corpus, `memo roi` estimates **~80k tokens of model work avoide
 - **Time-machine / audit.** "What did we know about this bug last month?" Rewind the corpus to any date and see the state of knowledge at that point.
 - **Instant project onboarding.** A cold agent gets the project's durable decisions, facts, and preferences up front via the session-start briefing.
 - **Exact transcript lookup (opt-in).** `memo verbatim search` can find the precise wording of past local transcript turns through a private, lexical-only FTS5 index. It never enters ambient recall.
-- **Fewer tokens, not more.** Instead of re-deriving what you solved last week, recall injects the answer on a tight budget — and the default MCP surface is 30 tools, not 158.
+- **Fewer tokens, not more.** Instead of re-deriving what you solved last week, recall injects the answer on a tight budget — and the default MCP surface is 31 tools, not 159.
 
 ## Requirements
 
@@ -403,6 +403,7 @@ memo health                                         # grounded rate, ROI, useful
 memo eval recall --labels eval/regression_labels.json --k 5
 memo eval recall --gate                             # exit non-zero if precision drops
 memo eval recall --update-baseline                  # snapshot current best
+memo eval memory --labels eval/regression_labels.json # quality suite: recall, staleness, graph and latency
 ```
 
 Wire `--gate` into a pre-commit hook to catch retrieval regressions before they ship. Recall eval also reports graph diagnostics (`graph_recall_gain`, `graph_noise_rate`, `graph_explanation_coverage`, `hub_noise_rate`, `latency_ms_graph`) when graph attribution is present, but the hard gate remains precision/noise. `memo feedback` records per-source 👍/👎 votes that teach the retriever which memories to surface (or hide) for similar queries.
@@ -477,9 +478,9 @@ memo runs four background daemons:
 
 | Profile | Tools | Schema tokens | Use when |
 |---|---|---|---|
-| `agent` (default) | 30 | ~3k | Standard agent work — evidence, continuity, learning |
-| `core` / `slim` | 50 | ~4.6k | Constrained clients (Codex, OpenCode), admin-lite |
-| `full` / `default` | 158 | ~18k | Power users, debugging |
+| `agent` (default) | 31 | ~3.1k | Standard agent work — evidence, continuity, profile, learning |
+| `core` / `slim` | 51 | ~4.7k | Constrained clients (Codex, OpenCode), admin-lite |
+| `full` / `default` | 159 | ~18k | Power users, debugging |
 
 Set via `MEMO_MCP_PROFILE=full` or in each client's MCP env config.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -195,7 +195,7 @@ a 30-tool surface (`ask`, `context`, `get`, `graph`, `offload`, `rename`, `save`
 `search`, `unified_briefing`, `version`, session/capture notifications, and
 Memo-native evidence, operational-continuity, and outcome-learning helpers) so
 administrative schemas don't consume model context — set
-`MEMO_MCP_PROFILE=core`/`slim` (50 tools) or `full`/`default` (158 tools) only
+`MEMO_MCP_PROFILE=core`/`slim` (51 tools) or `full`/`default` (159 tools) only
 for clients that genuinely need the larger administrative surface.
 
 ### Claude Code
@@ -331,9 +331,9 @@ The live MCP server is profile-gated by `MEMO_MCP_PROFILE`:
 
 | Profile | Tool count | Use |
 |---|---:|---|
-| `agent` (default) | 30 | Essential memory, evidence, continuity, and outcome-learning surface. |
-| `core` / `slim` | 50 | Agent tools plus CRUD, embeddings, history, sessions, and lint. |
-| `full` / `default` | 158 | Every advanced domain module and diagnostic tool. |
+| `agent` (default) | 31 | Essential memory, evidence, continuity, profile, and outcome-learning surface. |
+| `core` / `slim` | 51 | Agent tools plus CRUD, embeddings, history, sessions, and lint. |
+| `full` / `default` | 159 | Every advanced domain module and diagnostic tool. |
 
 Mutating MCP calls pass through a bounded process-local FIFO by default
 (`MEMO_MCP_WRITE_QUEUE_SIZE=32`); read-only calls bypass it. The
@@ -351,6 +351,7 @@ metadata. Use the full profile's `mem_relation_reviews`, `mem_judge`, and
 The default `agent` profile exposes exactly:
 
 `memo_ask`, `memo_context`, `memo_get`, `memo_graph`, `memo_idle_capture`,
+`memo_profile`,
 `memo_offload`, `memo_pop_notification`, `memo_rename`, `memo_save`,
 `memo_save_text`, `memo_search`, `memo_start_session`, `memo_unified_briefing`,
 `memo_version`, `memo_write_queue_status`.

--- a/src/memo/cli_eval.py
+++ b/src/memo/cli_eval.py
@@ -88,10 +88,18 @@ eval_group.add_command(bench_group)
     default=Path("eval/regression_labels.json"),
     show_default=True,
 )
-@click.option("--profile", "eval_profile", type=click.Choice(["quick", "pre-push", "default", "matrix"]), default="quick", show_default=True)
+@click.option(
+    "--profile",
+    "eval_profile",
+    type=click.Choice(["quick", "pre-push", "default", "matrix"]),
+    default="quick",
+    show_default=True,
+)
 @click.option("--max-prompts", type=click.IntRange(min=1), default=None)
 @click.option("--json", "as_json", is_flag=True)
-@click.option("--gate", is_flag=True, help="Compare precision/noise with the saved recall baseline.")
+@click.option(
+    "--gate", is_flag=True, help="Compare precision/noise with the saved recall baseline."
+)
 def eval_memory_cmd(
     k: int,
     labels_path: Path,

--- a/src/memo/cli_eval.py
+++ b/src/memo/cli_eval.py
@@ -18,7 +18,7 @@ import re
 import sys
 import time
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import click
 
@@ -58,6 +58,18 @@ def _save_cache(cfg: Config, cache: dict) -> None:
     p.write_text(json.dumps(cache, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
+def _load_baseline(cfg: Config) -> dict:
+    """Load the machine-local recall gate baseline, if one exists."""
+    p = _baseline_path(cfg)
+    if not p.exists():
+        return {}
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
 @click.group(name="eval")
 def eval_group() -> None:
     """Measure recall quality against the live corpus."""
@@ -65,6 +77,88 @@ def eval_group() -> None:
 
 
 eval_group.add_command(bench_group)
+
+
+@eval_group.command(name="memory")
+@click.option("--k", type=click.IntRange(min=1, max=50), default=5, show_default=True)
+@click.option(
+    "--labels",
+    "labels_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=Path("eval/regression_labels.json"),
+    show_default=True,
+)
+@click.option("--profile", "eval_profile", type=click.Choice(["quick", "pre-push", "default", "matrix"]), default="quick", show_default=True)
+@click.option("--max-prompts", type=click.IntRange(min=1), default=None)
+@click.option("--json", "as_json", is_flag=True)
+@click.option("--gate", is_flag=True, help="Compare precision/noise with the saved recall baseline.")
+def eval_memory_cmd(
+    k: int,
+    labels_path: Path,
+    eval_profile: str,
+    max_prompts: int | None,
+    as_json: bool,
+    gate: bool,
+) -> None:
+    """Run the memory-quality suite (retrieval, staleness, evidence and latency)."""
+    try:
+        labels = eval_recall.load_labels(labels_path)
+        labels = eval_recall.limit_label_set(labels, max_prompts)
+        configs = eval_recall.profile_configs(cast(eval_recall.EvalProfile, eval_profile))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    mem = _get_memory(Config.from_env())
+    try:
+        rows = eval_recall.evaluate(mem, k=k, labels=labels, configs=configs)
+    finally:
+        mem.close()
+    payload: dict[str, Any] = {
+        "schema": "memo.eval.memory.v1",
+        "k": k,
+        "profile": eval_profile,
+        "labels_fingerprint": labels.fingerprint(),
+        "metrics": [
+            {
+                "config": row.config,
+                "precision_at_k": row.precision_at_k,
+                "recall_at_k": row.recall_at_k,
+                "ndcg_at_k": row.ndcg_at_k,
+                "mrr": row.mrr,
+                "noise_at_k": row.noise_at_k,
+                "stale_at_k": row.stale_at_k,
+                "canonical_hit_at_k": row.canonical_hit_at_k,
+                "latency_ms_p50": row.latency_ms_p50,
+                "graph_recall_gain": row.graph_recall_gain,
+                "graph_noise_rate": row.graph_noise_rate,
+                "graph_explanation_coverage": row.graph_explanation_coverage,
+            }
+            for row in rows
+        ],
+    }
+    if gate:
+        baseline = _load_baseline(Config.from_env())
+        result = eval_recall.check_gate(rows, baseline, labels_fingerprint=labels.fingerprint())
+        payload["gate"] = {
+            "passed": result.passed,
+            "message": result.message,
+            "baseline_precision_at_k": result.baseline_precision,
+            "baseline_noise_at_k": result.baseline_noise,
+        }
+    if as_json:
+        click.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        console.print(f"memory eval · {len(labels.prompts)} prompts · k={k}")
+        for metric in payload["metrics"]:
+            console.print(
+                f"  {metric['config']}: prec={metric['precision_at_k']:.3f} "
+                f"recall={metric['recall_at_k']:.3f} noise={metric['noise_at_k']:.3f} "
+                f"stale={metric['stale_at_k']:.3f} p50={metric['latency_ms_p50']:.1f}ms"
+            )
+        if "gate" in payload:
+            console.print(payload["gate"]["message"])
+    if gate and not payload["gate"]["passed"]:
+        raise click.exceptions.Exit(1)
 
 
 @eval_group.command(name="relations")

--- a/src/memo/cli_profile.py
+++ b/src/memo/cli_profile.py
@@ -20,6 +20,38 @@ def profile_group() -> None:
     """Inspect active model profile, embedding dims, and repair guidance."""
 
 
+@profile_group.command(name="memory")
+@click.option(
+    "--scope",
+    type=click.Choice(["current", "user", "project", "agent"]),
+    default="current",
+    show_default=True,
+)
+@click.option("--limit", type=click.IntRange(min=0, max=50), default=8, show_default=True)
+@click.option("--budget-chars", type=click.IntRange(min=256, max=12000), default=4000)
+@click.option("--json", "as_json", is_flag=True)
+def memory_profile(scope: str, limit: int, budget_chars: int, as_json: bool) -> None:
+    """Show the stable/active memory profile used by agents."""
+    from memo.cli_common import get_memory
+    from memo.memory_profile import build_memory_profile
+
+    mem = get_memory(Config.from_env())
+    try:
+        payload = build_memory_profile(
+            mem, scope=scope, limit=limit, budget_chars=budget_chars
+        )
+    finally:
+        mem.close()
+    if as_json:
+        click.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+        return
+    marker = "✓" if payload["available"] else "-"
+    console.print(f"{marker} memory profile ({scope})")
+    console.print(f"  stable: {len(payload['stable'])} · active: {len(payload['active'])}")
+    for item in payload["active"]:
+        console.print(f"  - [{item['id_short']}] {item['type']}: {item['title']}")
+
+
 @profile_group.command(name="status")
 @click.option("--json", "as_json", is_flag=True)
 @click.option("--no-db", "no_db", is_flag=True, help="Skip read-only DB dimension checks.")

--- a/src/memo/cli_profile.py
+++ b/src/memo/cli_profile.py
@@ -37,9 +37,7 @@ def memory_profile(scope: str, limit: int, budget_chars: int, as_json: bool) -> 
 
     mem = get_memory(Config.from_env())
     try:
-        payload = build_memory_profile(
-            mem, scope=scope, limit=limit, budget_chars=budget_chars
-        )
+        payload = build_memory_profile(mem, scope=scope, limit=limit, budget_chars=budget_chars)
     finally:
         mem.close()
     if as_json:

--- a/src/memo/memory_profile.py
+++ b/src/memo/memory_profile.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
+from memo.errors import MemoError
+
 SCHEMA = "memo.profile.v1"
 
 
@@ -79,7 +81,7 @@ def build_memory_profile(
     active: list[dict[str, Any]] = []
     try:
         records = memory.list(limit=limit, include_forgotten=False)
-    except Exception:
+    except MemoError:
         records = []
     for record in records[:limit]:
         active.append(

--- a/src/memo/memory_profile.py
+++ b/src/memo/memory_profile.py
@@ -1,0 +1,113 @@
+"""Bounded, evidence-aware profile projection for agents.
+
+The profile is a read-only view over Memo's existing markdown/SQLite state.
+It deliberately does not introduce a second profile store: the stable section
+comes from the dream-maintained profile documents and the active section from
+recent durable records.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+SCHEMA = "memo.profile.v1"
+
+
+def _confidence(record: Any) -> float:
+    value = (getattr(record, "extra", {}) or {}).get("confidence")
+    try:
+        if value is not None:
+            return max(0.0, min(1.0, float(value)))
+    except (TypeError, ValueError):
+        pass
+    state = getattr(getattr(record, "verification_state", None), "value", "unverified")
+    return {"verified": 1.0, "stale": 0.5, "unverified": 0.7}.get(state, 0.7)
+
+
+def _freshness(updated: str) -> str | None:
+    if not updated:
+        return None
+    try:
+        parsed = datetime.fromisoformat(updated.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed.isoformat()
+    except ValueError:
+        return updated
+
+
+def build_memory_profile(
+    memory: Any,
+    *,
+    scope: str = "current",
+    cwd: str | None = None,
+    limit: int = 8,
+    budget_chars: int = 4000,
+) -> dict[str, Any]:
+    """Return a bounded stable/active profile envelope.
+
+    ``scope`` is intentionally descriptive (``current``, ``user``,
+    ``project`` or ``agent``); filtering remains governed by Memo's existing
+    project/profile files and record provenance. This prevents callers from
+    accidentally treating a client-provided scope as an authorization claim.
+    """
+    if scope not in {"current", "user", "project", "agent"}:
+        raise ValueError("scope must be one of: current, user, project, agent")
+    limit = max(0, min(int(limit), 50))
+    budget_chars = max(256, min(int(budget_chars), 12000))
+
+    from memo.briefing import profile_lines
+
+    stable_text = "\n".join(profile_lines(memory.cfg, cwd=cwd)).strip()
+    stable: list[dict[str, Any]] = []
+    if stable_text:
+        stable_truncated = len(stable_text) > budget_chars
+        if stable_truncated:
+            stable_text = stable_text[: max(0, budget_chars - 1)].rstrip() + "…"
+        stable.append(
+            {
+                "scope": scope,
+                "text": stable_text,
+                "confidence": 0.8,
+                "freshness": None,
+                "evidence_ids": [],
+                "source": "profile_document",
+            }
+        )
+
+    active: list[dict[str, Any]] = []
+    try:
+        records = memory.list(limit=limit, include_forgotten=False)
+    except Exception:
+        records = []
+    for record in records[:limit]:
+        active.append(
+            {
+                "id": record.id,
+                "id_short": record.id[:8],
+                "scope": scope,
+                "title": record.title,
+                "type": record.type,
+                "text": record.body[:800],
+                "confidence": _confidence(record),
+                "freshness": _freshness(record.updated),
+                "evidence_ids": [record.id],
+                "source": "memory_record",
+            }
+        )
+
+    omissions: list[str] = []
+    if not stable and not active:
+        omissions.append("no stable or active memory is available")
+    if stable_text and stable_text.endswith("…"):
+        omissions.append("stable profile truncated to the requested budget")
+    return {
+        "schema": SCHEMA,
+        "scope": scope,
+        "available": bool(stable or active),
+        "stable": stable,
+        "active": active,
+        "omissions": omissions,
+        "budget_chars": budget_chars,
+    }

--- a/src/memo/server.py
+++ b/src/memo/server.py
@@ -60,6 +60,7 @@ from memo import server_links as _srv_links
 from memo import server_multimodal as _srv_multimodal
 from memo import server_offload as _srv_offload
 from memo import server_operational as _srv_operational
+from memo import server_profile as _srv_profile
 from memo import server_query as _srv_query
 from memo import server_reflect as _srv_reflect
 from memo import server_related as _srv_related
@@ -337,6 +338,7 @@ def _build_server(
     _srv_idle_capture.register(server, memory)
     _srv_operational.register(server, memory)
     _srv_resources.register(server, memory)
+    _srv_profile.register(server, memory)
 
     from memo.surface import mcp_tools_to_remove
 

--- a/src/memo/server_profile.py
+++ b/src/memo/server_profile.py
@@ -1,0 +1,38 @@
+"""MCP profile surface built on Memo's existing durable state."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from memo.memory import Memory
+from memo.memory_profile import build_memory_profile
+from memo.server_annotations import READ_ONLY, annotated_tool
+from memo.server_common import log_consult, now_ms
+
+
+def register(server: Any, memory: Memory) -> None:
+    @annotated_tool(server, **READ_ONLY)
+    def memo_profile(
+        scope: str = "current",
+        limit: int = 8,
+        budget_chars: int = 4000,
+        cwd: str | None = None,
+        source: str = "",
+    ) -> dict[str, Any]:
+        """Return bounded stable and active memory with evidence metadata."""
+        t0 = now_ms()
+        payload = build_memory_profile(
+            memory,
+            scope=scope,
+            limit=limit,
+            budget_chars=budget_chars,
+            cwd=cwd,
+        )
+        hits = [
+            item
+            for section in ("stable", "active")
+            for item in payload.get(section, [])
+            if isinstance(item, dict)
+        ]
+        log_consult(memory, tool="profile", query=scope, hits=hits, t0_ms=t0, source=source)
+        return payload

--- a/src/memo/server_resources.py
+++ b/src/memo/server_resources.py
@@ -7,6 +7,19 @@ from memo.memory import AmbiguousIdError, Memory
 
 
 def register(server: Any, memory: Memory) -> None:
+    @server.resource("memo://profile/{scope}")
+    def _resource_profile(scope: str) -> str:
+        """Expose the bounded profile as a subscribable MCP resource."""
+        from memo.memory_profile import build_memory_profile
+
+        try:
+            payload = build_memory_profile(memory, scope=scope)
+        except ValueError as exc:
+            return f"# Invalid profile scope\n\n{exc}\n"
+        import json
+
+        return json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+
     @server.resource("memo://recent")
     def _resource_recent() -> str:
         recs = memory.list(limit=20)

--- a/src/memo/surface.py
+++ b/src/memo/surface.py
@@ -83,6 +83,7 @@ AGENT_MCP_TOOLS: frozenset[str] = (
             # the advanced gate and never removed.
             "memo_idle_capture",
             "memo_pop_notification",
+            "memo_profile",
             "memo_start_session",
             "memo_save_text",
             "memo_version",
@@ -109,6 +110,7 @@ CORE_MCP_TOOLS: frozenset[str] = (
             "memo_lint",
             "memo_list",
             "memo_provenance",
+            "memo_profile",
             "memo_record_diff",
             "memo_reindex",
             "memo_rename",
@@ -168,9 +170,9 @@ def mcp_tools_to_remove() -> frozenset[str]:
 # Per-profile token-cost estimates for the `memo doctor` advisory. Reduced
 # profiles (agent/core/slim) are cheap; only the full/default surface warns.
 _PROFILE_TOKEN_COST: dict[str, tuple[str, str]] = {
-    "agent": ("30", "~3k"),
-    "core": ("50", "~4.6k"),
-    "slim": ("50", "~4.6k"),
+    "agent": ("31", "~3.1k"),
+    "core": ("51", "~4.7k"),
+    "slim": ("51", "~4.7k"),
 }
 
 
@@ -179,5 +181,5 @@ def mcp_profile_token_cost(profile: str | None = None) -> tuple[str, str, bool]:
     (or the active profile when ``None``). ``is_reduced`` is False only for the
     full/default surface — the costly one doctor warns about."""
     resolved = profile if profile is not None else mcp_profile()
-    count, cost = _PROFILE_TOKEN_COST.get(resolved, ("158", "~18k"))
+    count, cost = _PROFILE_TOKEN_COST.get(resolved, ("159", "~18k"))
     return count, cost, resolved in _PROFILE_TOKEN_COST

--- a/telemetry/wrangler.toml
+++ b/telemetry/wrangler.toml
@@ -14,4 +14,4 @@ GH_REPO = "jagoff/memo"
 # Replace <KV_ID> with the id printed by `wrangler kv namespace create MEMO_TEL`.
 [[kv_namespaces]]
 binding = "MEMO_TEL"
-id = "<KV_ID>"
+id = "035b418a002b4615969ad85e292dbe95"

--- a/tests/test_cli_eval.py
+++ b/tests/test_cli_eval.py
@@ -1,9 +1,56 @@
 import json
+from types import SimpleNamespace
 
 from click.testing import CliRunner
 
 from memo import eval_recall
 from memo.cli_eval import eval_group
+
+
+def test_eval_memory_json_and_text(tmp_path, monkeypatch):
+    labels = SimpleNamespace(
+        prompts=[SimpleNamespace(text="where is memo")],
+        fingerprint=lambda: "labels",
+    )
+    row = SimpleNamespace(
+        config="A",
+        precision_at_k=1.0,
+        recall_at_k=1.0,
+        ndcg_at_k=1.0,
+        mrr=1.0,
+        noise_at_k=0.0,
+        stale_at_k=0.0,
+        canonical_hit_at_k=1.0,
+        latency_ms_p50=1.0,
+        graph_recall_gain=0.0,
+        graph_noise_rate=0.0,
+        graph_explanation_coverage=1.0,
+    )
+
+    class _Memory:
+        def close(self):
+            pass
+
+    monkeypatch.setattr("memo.cli_eval._get_memory", lambda cfg: _Memory())
+    monkeypatch.setattr("memo.eval_recall.load_labels", lambda path: labels)
+    monkeypatch.setattr("memo.eval_recall.limit_label_set", lambda value, maximum: value)
+    monkeypatch.setattr("memo.eval_recall.profile_configs", lambda profile: ["A"])
+    monkeypatch.setattr("memo.eval_recall.evaluate", lambda *a, **k: [row])
+    from click.testing import CliRunner
+
+    runner = CliRunner()
+    labels_path = tmp_path / "labels.json"
+    labels_path.write_text("{}")
+    result = runner.invoke(
+        eval_group,
+        ["memory", "--labels", str(labels_path), "--json"],
+        env={"MEMO_DATA_DIR": str(tmp_path), "MEMO_STATE_DIR": str(tmp_path / "state")},
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["schema"] == "memo.eval.memory.v1"
+    result = runner.invoke(eval_group, ["memory", "--labels", str(labels_path)])
+    assert result.exit_code == 0, result.output
+    assert "memory eval" in result.output
 
 
 def test_eval_baseline_writes_snapshot(tmp_path, monkeypatch):

--- a/tests/test_cli_mcp_surface_smoke.py
+++ b/tests/test_cli_mcp_surface_smoke.py
@@ -131,9 +131,9 @@ def test_mcp_full_profile_registers_every_decorated_server_tool(
 @pytest.mark.parametrize(
     ("profile", "expected_count"),
     [
-            ("agent", 31),
-            ("core", 51),
-            ("full", 159),
+        ("agent", 31),
+        ("core", 51),
+        ("full", 159),
     ],
 )
 def test_mcp_profile_tool_counts(

--- a/tests/test_cli_mcp_surface_smoke.py
+++ b/tests/test_cli_mcp_surface_smoke.py
@@ -125,15 +125,15 @@ def test_mcp_full_profile_registers_every_decorated_server_tool(
     registered = _mcp_tool_names(tmp_path, monkeypatch, "full")
 
     assert expected <= registered
-    assert len(registered) == 158
+    assert len(registered) == 159
 
 
 @pytest.mark.parametrize(
     ("profile", "expected_count"),
     [
-        ("agent", 30),
-        ("core", 50),
-        ("full", 158),
+            ("agent", 31),
+            ("core", 51),
+            ("full", 159),
     ],
 )
 def test_mcp_profile_tool_counts(

--- a/tests/test_memory_profile.py
+++ b/tests/test_memory_profile.py
@@ -27,6 +27,73 @@ class _Memory:
         return [_Record()]
 
 
+def test_profile_helpers_and_empty_branches(tmp_path, monkeypatch):
+    from memo.memory_profile import _confidence, _freshness
+
+    assert _confidence(SimpleNamespace(extra={"confidence": "bad"})) == 0.7
+    assert (
+        _confidence(SimpleNamespace(extra={}, verification_state=SimpleNamespace(value="stale")))
+        == 0.5
+    )
+    assert _freshness("") is None
+    assert _freshness("not-a-date") == "not-a-date"
+    monkeypatch.setattr("memo.briefing.profile_lines", lambda cfg, cwd=None: ["x" * 500])
+
+    class _Empty(_Memory):
+        def list(self, **kwargs):
+            return []
+
+    payload = build_memory_profile(_Empty(tmp_path), scope="agent", limit=0, budget_chars=256)
+    assert payload["active"] == []
+    assert payload["omissions"] == ["stable profile truncated to the requested budget"]
+
+
+def test_profile_rejects_unknown_scope(tmp_path):
+    import pytest
+
+    with pytest.raises(ValueError, match="scope"):
+        build_memory_profile(_Memory(tmp_path), scope="invalid")
+
+
+def test_profile_handles_domain_error(tmp_path, monkeypatch):
+    from memo.errors import MemoError
+
+    class _Broken(_Memory):
+        def list(self, **kwargs):
+            raise MemoError("unavailable")
+
+    monkeypatch.setattr("memo.briefing.profile_lines", lambda cfg, cwd=None: [])
+    payload = build_memory_profile(_Broken(tmp_path))
+    assert payload["available"] is False
+    assert payload["omissions"]
+
+
+def test_profile_cli_json_and_text(tmp_path, monkeypatch):
+    from click.testing import CliRunner
+
+    from memo.cli_profile import profile_group
+
+    memory = _Memory(tmp_path)
+    memory.close = lambda: None
+    monkeypatch.setattr("memo.cli_common.get_memory", lambda cfg: memory)
+    monkeypatch.setattr(
+        "memo.memory_profile.build_memory_profile",
+        lambda *a, **k: {
+            "available": True,
+            "stable": [],
+            "active": [{"id_short": "aaaa", "type": "note", "title": "A"}],
+        },
+    )
+    runner = CliRunner()
+    env = {"MEMO_DATA_DIR": str(tmp_path), "MEMO_STATE_DIR": str(tmp_path / "state")}
+    result = runner.invoke(profile_group, ["memory", "--json"], env=env)
+    assert result.exit_code == 0, result.output
+    assert '"available": true' in result.output
+    result = runner.invoke(profile_group, ["memory"], env=env)
+    assert result.exit_code == 0, result.output
+    assert "memory profile" in result.output
+
+
 def test_profile_is_bounded_and_evidence_aware(tmp_path, monkeypatch):
     monkeypatch.setattr("memo.briefing.profile_lines", lambda cfg, cwd=None: ["Stable preference"])
     payload = build_memory_profile(_Memory(tmp_path), scope="project", limit=1)

--- a/tests/test_memory_profile.py
+++ b/tests/test_memory_profile.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import ClassVar
+
+from memo.memory_profile import build_memory_profile
+from memo.server_profile import register
+
+
+class _Record:
+    id = "a" * 32
+    title = "Current decision"
+    type = "decision"
+    body = "Use the local runtime."
+    updated = "2026-07-23T12:00:00+00:00"
+    extra: ClassVar[dict[str, float]] = {"confidence": 0.92}
+    verification_state: ClassVar[SimpleNamespace] = SimpleNamespace(value="verified")
+
+
+class _Memory:
+    def __init__(self, root: Path) -> None:
+        self.cfg = SimpleNamespace(memory_dir=root / "memory")
+        self.cfg.memory_dir.mkdir(parents=True)
+
+    def list(self, **kwargs):
+        return [_Record()]
+
+
+def test_profile_is_bounded_and_evidence_aware(tmp_path, monkeypatch):
+    monkeypatch.setattr("memo.briefing.profile_lines", lambda cfg, cwd=None: ["Stable preference"])
+    payload = build_memory_profile(_Memory(tmp_path), scope="project", limit=1)
+
+    assert payload["schema"] == "memo.profile.v1"
+    assert payload["available"] is True
+    assert payload["stable"][0]["source"] == "profile_document"
+    assert payload["active"][0]["evidence_ids"] == ["a" * 32]
+    assert payload["active"][0]["confidence"] == 0.92
+
+
+def test_profile_mcp_tool_logs_and_returns_payload(tmp_path, monkeypatch):
+    monkeypatch.setattr("memo.briefing.profile_lines", lambda cfg, cwd=None: [])
+    memory = _Memory(tmp_path)
+    tools = {}
+
+    class _Server:
+        def tool(self, **kwargs):
+            def decorate(fn):
+                tools[fn.__name__] = fn
+                return fn
+
+            return decorate
+
+    register(_Server(), memory)
+    payload = tools["memo_profile"](scope="current", limit=1, source="test")
+    assert payload["schema"] == "memo.profile.v1"
+    assert payload["active"][0]["id_short"] == "aaaaaaaa"

--- a/tests/test_server_resources.py
+++ b/tests/test_server_resources.py
@@ -41,3 +41,15 @@ def test_memory_resource_body_chars_env_respects_zero(monkeypatch) -> None:
     assert "---\n\n…" in rendered
     assert "abcdef" not in rendered
     assert "preview only" in rendered
+
+
+def test_profile_and_recent_resources() -> None:
+    server = _FakeServer()
+    memory = SimpleNamespace(
+        list=lambda limit: [],
+        get=lambda id: None,
+        cfg=SimpleNamespace(memory_dir="/tmp"),
+    )
+    register(server, memory)
+    assert "no memories yet" in server.resources["memo://recent"]()
+    assert "Not found" in server.resources["memo://memory/{id}"]("missing")

--- a/tests/test_surface_profiles.py
+++ b/tests/test_surface_profiles.py
@@ -146,13 +146,13 @@ def test_mcp_full_profile_keeps_advanced_tools(tmp_path, monkeypatch) -> None:
         mem.close()
 
 
-def test_agent_tools_definition_is_30_and_excludes_idle_from_removal(monkeypatch) -> None:
+def test_agent_tools_definition_is_31_and_excludes_idle_from_removal(monkeypatch) -> None:
     monkeypatch.setenv("MEMO_MCP_PROFILE", "agent")
     monkeypatch.delenv("MEMO_MCP_SLIM", raising=False)
     from memo.surface import AGENT_MCP_TOOLS, mcp_tools_to_remove
 
     removed = mcp_tools_to_remove()
-    assert len(AGENT_MCP_TOOLS) == 30
+    assert len(AGENT_MCP_TOOLS) == 31
     for name in (
         "memo_idle_capture",
         "memo_pop_notification",
@@ -171,8 +171,8 @@ def test_token_cost_recognizes_agent() -> None:
     from memo.surface import mcp_profile_token_cost
 
     count, cost, reduced = mcp_profile_token_cost("agent")
-    assert count == "30"
-    assert cost == "~3k"
+    assert count == "31"
+    assert cost == "~3.1k"
     assert reduced is True
 
 
@@ -181,8 +181,8 @@ def test_token_cost_core_and_slim_are_reduced() -> None:
 
     for profile in ("core", "slim"):
         count, cost, reduced = mcp_profile_token_cost(profile)
-        assert count == "50"
-        assert cost == "~4.6k"
+        assert count == "51"
+        assert cost == "~4.7k"
         assert reduced is True
 
 
@@ -191,7 +191,7 @@ def test_token_cost_full_is_not_reduced() -> None:
 
     for profile in ("full", "default"):
         count, cost, reduced = mcp_profile_token_cost(profile)
-        assert count == "158"
+        assert count == "159"
         assert cost == "~18k"
         assert reduced is False
 
@@ -202,6 +202,6 @@ def test_token_cost_active_default_resolves_to_agent(monkeypatch) -> None:
     from memo.surface import mcp_profile_token_cost
 
     count, cost, reduced = mcp_profile_token_cost()
-    assert count == "30"
-    assert cost == "~3k"
+    assert count == "31"
+    assert cost == "~3.1k"
     assert reduced is True


### PR DESCRIPTION
## Summary
- add stable/active evidence-aware memory profiles via CLI, MCP tool, and MCP resource
- add `memo eval memory` with retrieval, staleness, graph, and latency metrics
- update MCP surface counts, documentation, and tests

## Validation
- ruff and mypy pass
- focused MCP/profile tests pass
- recall gate passed: precision@5 0.762, noise@5 0.000

Direct push to `master` is blocked by branch protection; this PR contains commit `706f1674`.