### PR TITLE
docs: move Install section directly after What is memo?

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,43 @@
 Normal local operation needs no Ollama, Qdrant, cloud API, or API key. Optional
 federation uses a local signing key that you control.
 
+## Install — one step
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v4.4.0/install.sh | bash
+```
+
+The installer auto-detects **uv** (preferred) or falls back to **pipx**. It downloads MLX models, and wires memo into every agent client it finds (Claude Code, Codex, Devin, Devin Desktop, OpenCode).
+
+Prefer a manual install? Any of these expose the same two binaries — `memo` (CLI) and `memo-mcp` (MCP server):
+
+```bash
+uv tool install mlx-memo          # recommended
+pipx install mlx-memo
+brew tap jagoff/memo && brew install mlx-memo
+```
+
+> Keep memo **isolated as its own tool** (uv tool / pipx / Homebrew). Don't vendor it inside another project's `.venv`. `memo doctor --strict-runtime` verifies the install.
+
+**On Linux, or just want to try it without installing anything?** Run the Docker
+image (CPU backend on Linux — search/recall/save; the reranker + `ask`/
+`synthesize`/`dream` verbs are Apple-Silicon-only):
+
+```bash
+docker run --rm ghcr.io/jagoff/memo:latest memo doctor
+```
+
+Details in **[docs/docker.md](docs/docker.md)**.
+
+First install downloads ~8 GB of MLX models (5–15 min); later installs hit the HuggingFace cache. Full installer knobs and "move to a new Mac" steps: **[docs/reference.md › Install](docs/reference.md#install-detail)**.
+
+**Migrating from another Mac?** Install first, then restore your corpus:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v4.4.0/install.sh | bash
+memo sync bootstrap git@github.com:yourname/memo-sync.git   # restore from git
+```
+
 ### Memo 4: one independent memory runtime
 
 Memo owns the full memory loop: durable Markdown records, retrieval, causal
@@ -102,43 +139,6 @@ sync, plus requested model or benchmark downloads, may use the network. See the
 <img src="docs/demo.gif" alt="memo in a terminal: save a fact once, then a later session recalls it automatically." width="760" />
 
 </div>
-
-## Install — one step
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v4.4.0/install.sh | bash
-```
-
-The installer auto-detects **uv** (preferred) or falls back to **pipx**. It downloads MLX models, and wires memo into every agent client it finds (Claude Code, Codex, Devin, Devin Desktop, OpenCode).
-
-Prefer a manual install? Any of these expose the same two binaries — `memo` (CLI) and `memo-mcp` (MCP server):
-
-```bash
-uv tool install mlx-memo          # recommended
-pipx install mlx-memo
-brew tap jagoff/memo && brew install mlx-memo
-```
-
-> Keep memo **isolated as its own tool** (uv tool / pipx / Homebrew). Don't vendor it inside another project's `.venv`. `memo doctor --strict-runtime` verifies the install.
-
-**On Linux, or just want to try it without installing anything?** Run the Docker
-image (CPU backend on Linux — search/recall/save; the reranker + `ask`/
-`synthesize`/`dream` verbs are Apple-Silicon-only):
-
-```bash
-docker run --rm ghcr.io/jagoff/memo:latest memo doctor
-```
-
-Details in **[docs/docker.md](docs/docker.md)**.
-
-First install downloads ~8 GB of MLX models (5–15 min); later installs hit the HuggingFace cache. Full installer knobs and "move to a new Mac" steps: **[docs/reference.md › Install](docs/reference.md#install-detail)**.
-
-**Migrating from another Mac?** Install first, then restore your corpus:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/jagoff/memo/v4.4.0/install.sh | bash
-memo sync bootstrap git@github.com:yourname/memo-sync.git   # restore from git
-```
 
 ## What makes memo different
 


### PR DESCRIPTION
Reorders README so `## Install — one step` follows the `## What is memo?` intro, moving the three detail subsections (Memo 4 / Measured results / Local-first) below it.

Docs-only; no retrieval/code changes.

Note: the three moved sections stay `###`, so they now nest under Install in the TOC — can flatten to `##` if preferred.