### PR TITLE
fix: resolve py/polynomial-redos in redact.py (<private>-span stripping)

### DIFF
--- a/src/memo/redact.py
+++ b/src/memo/redact.py
@@ -56,8 +56,10 @@ _ENTROPY_CANDIDATE_RE = re.compile(r"\b[A-Za-z0-9+/_=-]{32,}\b")
 _HEX_RE = re.compile(r"^[0-9a-fA-F]+$")
 _ENTROPY_MIN_BITS = 4.2
 
-_PRIVATE_SPAN_RE = re.compile(r"<private>.*?</private>", re.DOTALL | re.IGNORECASE)
-_PRIVATE_OPEN_RE = re.compile(r"<private>.*\Z", re.DOTALL | re.IGNORECASE)
+# Fixed-width literal markers only (no ``.*`` — linear, ReDoS-free). Span
+# logic lives in ``strip_private_spans`` as a linear scan over these matches.
+_PRIVATE_MARK_OPEN_RE = re.compile(r"<private>", re.IGNORECASE)
+_PRIVATE_MARK_CLOSE_RE = re.compile(r"</private>", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -155,11 +157,24 @@ def strip_private_spans(text: str) -> str:
     """Drop ``<private>…</private>`` spans; an unclosed ``<private>`` drops
     everything to end-of-text (fail-closed: better to lose a capture than
     leak private content into a persisted memory)."""
-    if not text or "<private>" not in text.lower():
+    if not text or _PRIVATE_MARK_OPEN_RE.search(text) is None:
         return text
-    out = _PRIVATE_SPAN_RE.sub("", text)
-    out = _PRIVATE_OPEN_RE.sub("", out)
-    return out.strip()
+    # Linear scan (indices into the original string — no lowercased copy, so
+    # no Unicode length-drift): keep text before each ``<private>``, skip to
+    # the next ``</private>``; an unclosed open drops everything to EOT.
+    parts: list[str] = []
+    i = 0
+    while True:
+        m_open = _PRIVATE_MARK_OPEN_RE.search(text, i)
+        if m_open is None:
+            parts.append(text[i:])
+            break
+        parts.append(text[i : m_open.start()])
+        m_close = _PRIVATE_MARK_CLOSE_RE.search(text, m_open.end())
+        if m_close is None:
+            break
+        i = m_close.end()
+    return "".join(parts).strip()
 
 
 def sanitize_persisted_text(text: str, *, entropy: bool = False) -> RedactionResult:

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -92,6 +92,19 @@ def test_strip_private_spans_multiline_and_unclosed_drops_to_end():
     assert out == "public"
 
 
+def test_strip_private_spans_multiple_spans_removed():
+    out = strip_private_spans("a<private>x</private>b<private>y</private>c")
+    assert out == "abc"
+
+
+def test_strip_private_spans_many_unclosed_markers_is_linear():
+    # Pathological shape for the former ``<private>.*?</private>`` regex: many
+    # opens, no close. Linear scan drops from the first open to EOT and returns
+    # promptly (guards the py/polynomial-redos fix).
+    text = "keep " + "<private>" * 50_000 + "tail-no-close"
+    assert strip_private_spans(text) == "keep"
+
+
 def test_privacy_flags_registered_with_defaults(monkeypatch):
     from memo.flags import flag_bool
 


### PR DESCRIPTION
CodeQL `py/polynomial-redos` flagged `_PRIVATE_SPAN_RE` (`<private>.*?</private>`) and `_PRIVATE_OPEN_RE` (`<private>.*\\Z`): the ambiguous `.*`/`.*?` over uncontrolled text backtracks polynomially on many `<private>` markers with no close.

**Fix (systemic, matches the prior reference-link ReDoS fix):** replace the two ambiguous regexes with fixed-width literal marker regexes (`<private>` / `</private>`, linear, ReDoS-free) and do the span logic as a linear scan over original-string indices (no lowercased copy → no Unicode length-drift). Fail-closed behavior on unclosed `<private>` (drop to EOT) is preserved.

Regression test: 50k unclosed markers strips in ~0.1s (was polynomial). Existing `test_redact.py` / `test_capture.py` behavior unchanged (62 passed, mypy + ruff clean).