### PR TITLE
fix: bm25 fallback was fully gated by the vec-cosine min_sim floor

### DIFF
--- a/eval/quality_baseline.json
+++ b/eval/quality_baseline.json
@@ -279,7 +279,7 @@
     "src/memo/quality.py::classify_quality": 14,
     "src/memo/quality_compact.py::preview_quality_compaction": 15,
     "src/memo/recall_logic.py::_recall_logic": 54,
-    "src/memo/recall_logic.py::rank_hits": 16,
+    "src/memo/recall_logic.py::rank_hits": 17,
     "src/memo/recall_logic.py::render_recall_context": 25,
     "src/memo/recall_socket.py::handle": 20,
     "src/memo/repo_index.py::embed": 11,

--- a/src/memo/recall_logic.py
+++ b/src/memo/recall_logic.py
@@ -974,9 +974,17 @@ def rank_hits(
             _explain_stage(explain, raw, "altitude")
 
     def _passes(h: Any) -> bool:
-        gate = vec_cosine(h) if (knobs.mode == "hybrid" and vec_cosine is not None) else h.score
-        if gate is not None and gate < knobs.min_sim:
-            return False
+        # bm25-mode `h.score` is on the BM25 relevance scale, NOT cosine — applying
+        # the cosine-calibrated `min_sim` floor (0.5 fresh default) to it is a
+        # category error that gates out genuine matches (e.g. a cold-start
+        # vec->bm25 downgrade, where a hit's bm25 ~0.156 fails the floor its vec
+        # cosine ~0.87 would pass). Skip the cosine floor in bm25 mode; bm25 hits
+        # are already relevance-ranked and any match scores > 0. vec/hybrid keep
+        # the floor unchanged.
+        if knobs.mode != "bm25":
+            gate = vec_cosine(h) if (knobs.mode == "hybrid" and vec_cosine is not None) else h.score
+            if gate is not None and gate < knobs.min_sim:
+                return False
         return not (knobs.min_body_chars > 0 and len((h.body or "").strip()) < knobs.min_body_chars)
 
     if explain is None:

--- a/tests/test_bm25_floor.py
+++ b/tests/test_bm25_floor.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from memo.recall_logic import RankKnobs, rank_hits
+
+
+@dataclass
+class _Hit:
+    id: str
+    score: float | None
+    title: str = ""
+    body: str = ""
+    type: str = "note"
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+def _mk(id: str, score: float | None, **kw: Any) -> _Hit:
+    """Build a hit with content unique per id, so dedup_hits only collapses
+    genuine duplicates (same id), not distinct memories sharing a default body."""
+    kw.setdefault("title", f"title {id}")
+    kw.setdefault("body", f"distinct body for memory {id}, long enough to pass the gate")
+    return _Hit(id=id, score=score, **kw)
+
+
+def test_bm25_mode_does_not_gate_hit_below_cosine_floor() -> None:
+    # A bm25-scale score (0.156) is below the cosine-calibrated min_sim (0.5),
+    # but bm25 hits are already relevance-ranked — they must NOT be gated out
+    # (the cold-start vec->bm25 downgrade returned nothing before this fix).
+    hits = [_mk("a", 0.156)]
+    out = rank_hits(hits, RankKnobs(min_sim=0.5, mode="bm25", min_body_chars=0))
+    assert [h.id for h in out] == ["a"]
+
+
+def test_vec_mode_still_gates_same_low_score() -> None:
+    # The SAME 0.156 score is a genuine cosine similarity in vec mode and stays
+    # gated; a 0.87 cosine passes. Proves the fix is scoped to bm25 mode only.
+    hits = [_mk("low", 0.156), _mk("high", 0.87)]
+    out = rank_hits(hits, RankKnobs(min_sim=0.5, mode="vec", min_body_chars=0))
+    assert [h.id for h in out] == ["high"]
+
+
+def test_bm25_mode_still_applies_min_body_chars_gate() -> None:
+    # The body-length gate is orthogonal to the cosine floor and must still
+    # apply in bm25 mode.
+    hits = [
+        _mk("short", 0.156, body="tiny"),
+        _mk("long", 0.156, body="a body that is comfortably longer than the min_body_chars gate"),
+    ]
+    out = rank_hits(hits, RankKnobs(min_sim=0.5, mode="bm25", min_body_chars=40))
+    assert [h.id for h in out] == ["long"]  # short body dropped, low score kept


### PR DESCRIPTION
## The bug

`rank_hits`'s inner `_passes` gate applied the cosine-calibrated `min_sim` floor (0.5 fresh default) to **bm25-mode** hits. But in bm25 mode `h.score` is on the **BM25 relevance scale** — values in `(0, 1)`, roughly `1 - 1/(1 + bm)` — **not** cosine similarity.

Applying a 0.5 cosine floor to those scores is a category error: it rejects essentially every bm25 hit (e.g. a genuine match with bm25 ~0.156 fails the 0.5 floor, even though its vec cosine ~0.87 would have passed). The practical consequence is that **bm25 fallback returned nothing** — the cold-start `vec -> bm25` downgrade, and any daemon-down / vec-unavailable bm25 recall, silently produced an empty result.

## The fix

One guard in `src/memo/recall_logic.py` (`rank_hits._passes`): **skip the cosine floor when `knobs.mode == "bm25"`**. bm25 hits are already relevance-ranked and any match scores `> 0`, so no cosine floor applies. **vec and hybrid keep the floor unchanged**, and the `min_body_chars` gate still applies in every mode.

## Evidence it's safe (vec/hybrid untouched)

`memo eval recall --labels eval/regression_labels.json --k 5 --force` was run against the live index **before and after** the change. The vec/hybrid grid is byte-identical:

| config | prec@k (before → after) | noise@k |
|---|---|---|
| A vec/0.60/keep | 0.708 → 0.708 | 0.0 |
| B vec/0.72/excl | 0.649 → 0.649 | 0.0 |
| C hyb/0.40/excl | 0.719 → 0.719 | 0.0 |
| D hyb/0.40/ctx  | 0.649 → 0.649 | 0.0 |

The eval harness has no bm25 config, and the guard is a pure no-op for vec/hybrid, so the numbers are identical by construction and confirmed empirically.

## Test

New `tests/test_bm25_floor.py` (deterministic, no MLX — hits constructed directly, exercised through `rank_hits`):
- bm25 mode surfaces a 0.156 hit that is below the 0.5 floor (not gated).
- vec mode still gates the same 0.156 hit and passes a 0.87 hit.
- `min_body_chars` gate still applies in bm25 mode.

## Note

The one-branch guard bumps `rank_hits` C901 complexity 16 → 17; `eval/quality_baseline.json` is updated by that single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)