### PR TITLE
fix: bound PEM regex quantifier to resolve py/polynomial-redos (2 HIGH)

### DIFF
--- a/src/memo/redact.py
+++ b/src/memo/redact.py
@@ -48,7 +48,7 @@ _TOKEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
 )
 
 _PEM_RE = re.compile(
-    r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+    r"-----BEGIN [A-Z ]{0,40}PRIVATE KEY-----.*?-----END [A-Z ]{0,40}PRIVATE KEY-----",
     re.DOTALL,
 )
 

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 import pytest
 
 from memo.errors import ValidationError
@@ -53,6 +55,30 @@ def test_pem_requires_joined_text_not_per_line():
     per_line = [f for line in pem.splitlines() for f in scan_secrets(line)]
     assert per_line == []  # per-line: invisible
     assert ("private-key", "****[private-key]") in scan_secrets(pem)  # joined: caught
+
+
+@pytest.mark.parametrize("label", ["RSA ", "EC ", "ENCRYPTED ", "OPENSSH ", ""])
+def test_redacts_private_key_block_across_label_forms(label):
+    """Every real PEM key-type label ("RSA ", "EC ", "ENCRYPTED ", "OPENSSH ",
+    plain) stays redacted under the bounded ``[A-Z ]{0,40}`` quantifier."""
+    pem = f"-----BEGIN {label}PRIVATE KEY-----\nabc\ndef\n-----END {label}PRIVATE KEY-----"
+    res = redact_secrets(f"key:\n{pem}\nend")
+    assert f"BEGIN {label}PRIVATE KEY" not in res.text
+    assert "****[private-key]" in res.text
+    assert "private-key" in res.found
+
+
+def test_pem_near_miss_without_close_marker_is_linear_and_unmatched():
+    # Pathological shape for the former unbounded ``[A-Z ]*``: a BEGIN marker
+    # followed by 10k uppercase chars that never complete ``PRIVATE KEY-----``.
+    # The bounded ``{0,40}`` quantifier makes matching linear — it returns
+    # promptly and leaves the fragment untouched (guards py/polynomial-redos).
+    fragment = "-----BEGIN " + "A" * 10_000
+    start = time.perf_counter()
+    res = redact_secrets(fragment)
+    assert time.perf_counter() - start < 1.0
+    assert res.text == fragment
+    assert res.found == ()
 
 
 def test_clean_text_untouched():


### PR DESCRIPTION
## Vulnerability

`src/memo/redact.py`'s `_PEM_RE` used an **unbounded** `[A-Z ]*` for the key-type label in *both* the BEGIN and END markers:

```python
r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----"
```

On input like `-----BEGIN ` followed by many uppercase/space characters that never complete `PRIVATE KEY-----`, those quantifiers cause **polynomial backtracking**. CodeQL flags this as `py/polynomial-redos` (2 HIGH alerts) at the usage sites:
- `redact.py:118` — `_PEM_RE.search`
- `redact.py:120` — `_PEM_RE.sub`

(`redact.py:146` `_PEM_RE.finditer` shares the same regex.)

## Fix

Bound **both** quantifiers `[A-Z ]*` → `[A-Z ]{0,40}`:

```python
r"-----BEGIN [A-Z ]{0,40}PRIVATE KEY-----.*?-----END [A-Z ]{0,40}PRIVATE KEY-----"
```

Every real PEM key-type label — `"RSA "`, `"EC "`, `"ENCRYPTED "`, `"OPENSSH "`, `"DSA "`, plain (`""`) — is well under 40 chars, so the pattern still matches **every real PEM header** while the repetition becomes bounded (linear, no catastrophic backtracking). No other behavior change. This mirrors the repo's prior ReDoS fixes.

## Tests

- `test_redacts_private_key_block_across_label_forms` — parametrized over RSA / EC / ENCRYPTED / OPENSSH / plain labels; each still redacts to `****[private-key]` with `private-key` in the found kinds.
- `test_pem_near_miss_without_close_marker_is_linear_and_unmatched` — a malicious near-miss (`-----BEGIN ` + 10k `A`s, no close marker) returns promptly and leaves the fragment untouched (guards the ReDoS).

Full local gate run (isolated worktree off `origin/master`, only these two files changed): ruff check + format, mypy, `scripts/quality_gate.py` (exit 0), and `pytest tests/test_redact.py` (25 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)