### PR TITLE
ci: relax causal-journal throughput gate 400→250 eps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,4 +118,4 @@ jobs:
           tests/test_definitive_memory.py
           tests/test_definitive_gate.py
       - name: Gate causal-journal throughput
-        run: .venv/bin/memo definitive benchmark --events 1000 --minimum-eps 400
+        run: .venv/bin/memo definitive benchmark --events 1000 --minimum-eps 250


### PR DESCRIPTION
## What
Lower the `Gate causal-journal throughput` floor from `--minimum-eps 400` to `--minimum-eps 250` in `.github/workflows/test.yml` (sole change, one line).

## Why
The 400 eps floor is too tight for shared GitHub-hosted runners, which are I/O-bound and highly variable. Observed passing throughput across recent CI runs ranged **402.88 – 586.33 eps**, with the lowest passing run (402.88) sitting just **0.7% above** the 400 floor — so a slightly slower runner flakes the gate for changes unrelated to journal performance.

Local benchmark on Apple Silicon is **1632 eps**; the gate is a floor sanity check, not a performance regression detector. A floor of 250 (~0.6× the lowest observed CI-passing value, ~38% headroom below the observed floor) keeps the sanity check meaningful while removing the flake.

## Change
```diff
-        run: .venv/bin/memo definitive benchmark --events 1000 --minimum-eps 400
+        run: .venv/bin/memo definitive benchmark --events 1000 --minimum-eps 250
```