### PR TITLE
fix: backup list/restore crash on legacy 'memoria_count' metadata

### DIFF
--- a/src/memo/sync.py
+++ b/src/memo/sync.py
@@ -17,7 +17,7 @@ import shutil
 import sqlite3
 import stat
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -56,6 +56,21 @@ class BackupMetadata:
     compressed_size: int
     original_size: int
     name: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BackupMetadata:
+        """Build from on-disk JSON, tolerating legacy keys and extra fields.
+
+        Older backups stored the memory count under the Spanish key
+        ``memoria_count``; alias it so those backups stay listable and
+        restorable. Unknown keys are dropped rather than raising, keeping
+        reads forward-compatible with newer metadata schemas.
+        """
+        payload = dict(data)
+        if "memoria_count" in payload and "memory_count" not in payload:
+            payload["memory_count"] = payload.pop("memoria_count")
+        known = {f.name for f in fields(cls)}
+        return cls(**{key: value for key, value in payload.items() if key in known})
 
 
 class BackupManager:
@@ -468,7 +483,7 @@ class BackupManager:
 
     def _read_directory_metadata(self, backup_path: Path) -> BackupMetadata:
         data = json.loads((backup_path / "metadata.json").read_text(encoding="utf-8"))
-        meta = BackupMetadata(**data)
+        meta = BackupMetadata.from_dict(data)
         meta.name = backup_path.name
         return meta
 
@@ -488,7 +503,7 @@ class BackupManager:
                         if extracted:
                             data = json.loads(extracted.read().decode("utf-8"))
                             data["compressed_size"] = archive.stat().st_size
-                            meta = BackupMetadata(**data)
+                            meta = BackupMetadata.from_dict(data)
                             meta.name = archive.name.removesuffix(".tar.gz")
                             return meta
         except Exception:  # noqa: S110
@@ -585,7 +600,9 @@ class BackupManager:
         if not metadata_path.is_file() or metadata_path.is_symlink():
             raise ValueError("Backup metadata is missing or unsafe")
         try:
-            metadata = BackupMetadata(**json.loads(metadata_path.read_text(encoding="utf-8")))
+            metadata = BackupMetadata.from_dict(
+                json.loads(metadata_path.read_text(encoding="utf-8"))
+            )
         except (json.JSONDecodeError, TypeError) as exc:
             raise ValueError(f"Backup metadata is invalid: {exc}") from exc
         restore_plan: list[tuple[Path, Path, bool]] = []

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -420,6 +420,47 @@ def test_backup_manager_list_ignores_hidden_scratch_directories(backup_manager):
     assert backup_manager.list_backups() == []
 
 
+def test_backup_metadata_from_dict_aliases_legacy_key_and_drops_unknowns():
+    # Older backups wrote the count under the Spanish key `memoria_count`, and
+    # future backups may add fields this version does not know about. Reading
+    # either must not raise (regression: `backup list` crashed with TypeError).
+    meta = BackupMetadata.from_dict(
+        {
+            "timestamp": "2026-06-23T22:49:36+00:00",
+            "memoria_count": 1740,
+            "checksum": "abc",
+            "compressed_size": 10,
+            "original_size": 20,
+            "future_field": "ignored",
+        }
+    )
+    assert meta.memory_count == 1740
+    assert meta.checksum == "abc"
+
+
+def test_backup_manager_list_reads_legacy_memoria_count_directory(backup_manager):
+    legacy = backup_manager.backup_dir / "backup_2026-06-23T22-49-36.557354+00-00"
+    legacy.mkdir()
+    (legacy / "metadata.json").write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-06-23T22:49:36.557354+00:00",
+                "memoria_count": 1740,
+                "checksum": "8dedf15f",
+                "compressed_size": 1069669816,
+                "original_size": 1069669816,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    backups = backup_manager.list_backups()
+
+    surfaced = [b for b in backups if b.name == legacy.name]
+    assert len(surfaced) == 1
+    assert surfaced[0].memory_count == 1740
+
+
 def test_backup_manager_restores_valid_compressed_archive(backup_manager):
     original = backup_manager.memory_dir / "compressed.md"
     original.write_text("compressed backup body", encoding="utf-8")


### PR DESCRIPTION
## Problem

`memo backup list` crashes hard whenever any pre-rename backup is present:

```
TypeError: BackupMetadata.__init__() got an unexpected keyword argument 'memoria_count'. Did you mean 'memory_count'?
```

Older backups wrote the memory count under the Spanish key `memoria_count`. The dataclass field was later renamed to `memory_count`, but the three metadata readers still call `BackupMetadata(**data)`, which rejects the legacy key. A single legacy directory backup breaks `backup list` for the whole store; `backup restore` of an old backup likewise fails with a misleading "Backup metadata is invalid".

Real example on disk (`~/.local/share/memo/backups/backup_2026-06-23T22-49-36.../metadata.json`):
```json
{ "timestamp": "...", "memoria_count": 1740, "checksum": "...", ... }
```

## Fix

- Add `BackupMetadata.from_dict()` — aliases `memoria_count → memory_count` and drops unknown keys (so newer metadata schemas are also read forward-compatibly).
- Route all three read sites through it: `_read_directory_metadata`, `_read_archive_metadata` (tar), and the restore path.

## Verification

- `memo backup list` against the real store now lists all 10 backups (incl. the legacy `memoria_count` one), no crash.
- Regression tests: `BackupMetadata.from_dict` legacy-key alias + unknown-field drop, and `list_backups()` surfacing a legacy directory backup with `memory_count == 1740`.
- `pytest tests/test_sync.py -k backup` → 39 passed; `mypy` + `ruff` clean.

Found while exercising the entire memo CLI surface (304 commands) against a live store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)