### PR TITLE
feat(journey-check): end-to-end user-journey verification harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,25 @@ sync, plus requested model or benchmark downloads, may use the network. See the
 
 </div>
 
+## Why it pays for itself — in tokens
+
+memo is built to **spend fewer tokens, not more**.
+
+- **~80% smaller MCP surface.** The default `agent` profile exposes **38 tools / ~3.8k schema tokens**, versus **159 tools / ~18k tokens** for the full surface — that overhead is paid *every session, in every client*. memo keeps the default focused while including evidence, continuity, lifecycle, and outcome learning.
+- **Recall injects the answer instead of re-deriving it.** Ambient recall surfaces the top memory *before* the agent answers, on a tight **~160-token budget**. The agent stops re-explaining what it already figured out last week.
+
+On a ~200-memory corpus, `memo roi` estimates **~80k tokens of model work avoided** per session. The number is corpus-specific; it grows as memo learns more.
+
+`memo tokens` tracks the savings in real-time:
+
+<img src="docs/tokens-screenshot.png" alt="memo tokens — showing 673k tokens saved all-time across 1924 memories used" width="760" />
+
+| Technique | How to enable | Typical saving |
+|---|---|---|
+| Compact recall format | `export MEMO_RECALL_FORMAT=compact` | ~65% per injection |
+| Trivial prompt gate | On by default | ~25% fewer injections |
+| Context file compression | `memo compress-context CLAUDE.md` | 30–40% smaller context |
+
 ## What makes memo different
 
 | Capability | memo | mem0 | letta | cognee | engram | basic-memory | cipher |
@@ -160,25 +179,6 @@ sync, plus requested model or benchmark downloads, may use the network. See the
 | Session timeline (context before/after) | ✅ | ❌ | ❌ | ❌ | ✅ | ⚠️ | ⚠️ |
 
 <sub>✅ first-class · ⚠️ partial, config-gated, or add-on · ❌ absent. Verified mid-2026 against each project's docs/repo: [mem0](https://github.com/mem0ai/mem0), [letta](https://github.com/letta-ai/letta) (formerly MemGPT), [cognee](https://github.com/topoteretes/cognee), [engram](https://github.com/Gentleman-Programming/engram), [basic-memory](https://github.com/basicmachines-co/basic-memory), [cipher](https://github.com/campfirein/cipher). Closest comparators: **basic-memory** (local-first + Obsidian + MCP — memo's exact thesis) and **cipher** (memory layer for coding agents).</sub>
-
-## Why it pays for itself — in tokens
-
-memo is built to **spend fewer tokens, not more**.
-
-- **~80% smaller MCP surface.** The default `agent` profile exposes **38 tools / ~3.8k schema tokens**, versus **159 tools / ~18k tokens** for the full surface — that overhead is paid *every session, in every client*. memo keeps the default focused while including evidence, continuity, lifecycle, and outcome learning.
-- **Recall injects the answer instead of re-deriving it.** Ambient recall surfaces the top memory *before* the agent answers, on a tight **~160-token budget**. The agent stops re-explaining what it already figured out last week.
-
-On a ~200-memory corpus, `memo roi` estimates **~80k tokens of model work avoided** per session. The number is corpus-specific; it grows as memo learns more.
-
-`memo tokens` tracks the savings in real-time:
-
-<img src="docs/tokens-screenshot.png" alt="memo tokens — showing 673k tokens saved all-time across 1924 memories used" width="760" />
-
-| Technique | How to enable | Typical saving |
-|---|---|---|
-| Compact recall format | `export MEMO_RECALL_FORMAT=compact` | ~65% per injection |
-| Trivial prompt gate | On by default | ~25% fewer injections |
-| Context file compression | `memo compress-context CLAUDE.md` | 30–40% smaller context |
 
 ## Use cases
 

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ memo runs four background daemons:
 | ingest-daemon | `memo ingest-daemon start` | Bulk vault ingestion |
 | maint-daemon | `memo maint-daemon start` | Background cleanup + synthesis |
 
-### All 133 top-level CLI commands
+### All 134 top-level CLI commands
 
 <details>
 <summary>Click to expand</summary>
@@ -459,7 +459,7 @@ memo runs four background daemons:
 
 **Maintenance:** `reindex` `maintain` `review` `dream` `consolidate` `synthesize` `dedupe` `retier` `contradict` `invalidate` `temporal` `compress-context`
 
-**Analysis & Quality:** `health` `stats` `doctor` `lint` `drift` `analytics` `eval` `roi` `tokens` `token-savings` `usefulness` `gaps` `outcome` `profile` `confidence` `graduation` `hype` `definitive` `evidence`
+**Analysis & Quality:** `health` `stats` `doctor` `lint` `drift` `analytics` `eval` `roi` `tokens` `token-savings` `usefulness` `gaps` `outcome` `profile` `confidence` `graduation` `hype` `definitive` `evidence` `journey-check`
 
 **Knowledge Graph:** `graph` `entities` `entity` `extract-entities` `links` `version` `related`
 

--- a/src/memo/cli.py
+++ b/src/memo/cli.py
@@ -75,6 +75,7 @@ from memo.cli_ingest_daemon import ingest_daemon_group
 from memo.cli_install_mcp import install_mcp
 from memo.cli_interject import ask_group, interject_group
 from memo.cli_invalidate import invalidate_cmd
+from memo.cli_journey import journey_check
 from memo.cli_links import links_group
 from memo.cli_maint_daemon import maint_daemon_group
 from memo.cli_maintain import maintain_cmd
@@ -377,6 +378,7 @@ cli.add_command(interject_group)
 cli.add_command(ask_group)
 cli.add_command(related)
 cli.add_command(eval_group)
+cli.add_command(journey_check)
 cli.add_command(debug_recall_cmd)
 cli.add_command(dream_cmd)
 cli.add_command(chronicle_cmd)

--- a/src/memo/cli_journey.py
+++ b/src/memo/cli_journey.py
@@ -1,0 +1,61 @@
+"""``memo journey-check`` — run the user-journey verification harness.
+
+Thin CLI wrapper over :mod:`memo.journey_check`. Renders a pass/fail/warn/skip
+line per check (or ``--json``), and exits nonzero on any failure so it can gate.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict
+
+import click
+
+from memo.cli_common import console
+from memo.journey_check import CHECK_NAMES, FAIL, PASS, SKIP, WARN, run_all
+
+_SYMBOL = {
+    PASS: "[green]✓[/green]",
+    FAIL: "[red]✗[/red]",
+    WARN: "[yellow]⚠[/yellow]",
+    SKIP: "[dim]∅[/dim]",
+}
+
+
+@click.command(name="journey-check")
+@click.option("--json", "as_json", is_flag=True, help="Emit a structured JSON list of results.")
+@click.option(
+    "--only",
+    "only",
+    multiple=True,
+    type=click.Choice(CHECK_NAMES),
+    help="Run only the named check(s). Repeatable.",
+)
+def journey_check(as_json: bool, only: tuple[str, ...]) -> None:
+    """Verify the practical user journey end-to-end against a seeded isolated store.
+
+    Exercises each user-facing function through its real code path (auto-save,
+    auto-recall, uses-memory, token-savings, ux-messages, Day-0 install, live
+    wiring), reports per-check status, and exits nonzero on any failure. The live
+    corpus is never touched.
+    """
+    results, exit_code = run_all(only=list(only) or None)
+
+    if as_json:
+        click.echo(json.dumps([asdict(r) for r in results], ensure_ascii=False, indent=2))
+        sys.exit(exit_code)
+
+    console.print("[bold]memo journey-check[/bold]")
+    for r in results:
+        symbol = _SYMBOL.get(r.status, "?")
+        console.print(f"  {symbol} [bold]{r.name:<14}[/bold] {r.detail}")
+
+    failed = sum(1 for r in results if r.status == FAIL)
+    warned = sum(1 for r in results if r.status == WARN)
+    skipped = sum(1 for r in results if r.status == SKIP)
+    parts = [f"{failed} failed", f"{warned} warning{'s' if warned != 1 else ''}"]
+    if skipped:
+        parts.append(f"{skipped} skipped")
+    console.print(f"→ {' · '.join(parts)} · exit {exit_code}")
+    sys.exit(exit_code)

--- a/src/memo/dev_audit.py
+++ b/src/memo/dev_audit.py
@@ -38,6 +38,9 @@ RAW_MEMO_ENV_ALLOWED: set[tuple[str, str]] = {
     ("config.py", "MEMO_EMBEDDER_DIMS"),
     ("store/schema.py", "MEMO_SKIP_MODEL_VERSION_CHECK"),
     ("memory/facade.py", "MEMO_EMBEDDER_VIA_DAEMON"),
+    # journey-check harness forces the isolated tmp store off the real warm
+    # socket, reading the prior value only to restore it on teardown.
+    ("journey_check.py", "MEMO_EMBEDDER_VIA_DAEMON"),
     ("mlx_gpu.py", "MEMO_GPU_LOCK_PATH"),
     ("mlx_gpu.py", "MEMO_GPU_XPROC_LOCK"),
     ("setup/config_io.py", "MEMO_CONFIG_FILE"),

--- a/src/memo/journey_check.py
+++ b/src/memo/journey_check.py
@@ -1,0 +1,733 @@
+"""User-journey verification harness — the engine behind ``memo journey-check``.
+
+Orchestration only. A small set of single-purpose ``Check`` functions each
+exercise ONE real user-facing code path (capture, recall, ask, the token
+ledger, recall UX messages, Day-0 install, live wiring) against a **seeded,
+isolated** store — a throwaway ``MEMO_DATA_DIR`` / ``MEMO_STATE_DIR`` — plus
+two read-only smokes against the real install. The live corpus is never
+touched. ``run_all`` aggregates the ``CheckResult``s and computes an exit code
+(nonzero on any ``fail``).
+
+Design notes:
+- Each check reuses existing internals (``capture_core._extract_and_save``,
+  ``recall_logic._recall_logic``, ``Memory.ask``, ``token_ledger``,
+  ``cli_diag`` doctor signals). Nothing here re-implements retrieval or capture.
+- MLX invariant: ``mlx`` / ``mlx-lm`` imports stay deferred; embedding-dependent
+  checks return ``skip`` when ``mlx_lm`` is not importable (non-Apple-Silicon).
+- A check that raises never crashes the run — it becomes a ``fail`` carrying the
+  exception string as evidence.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ── Result vocabulary ────────────────────────────────────────────────────────
+PASS = "pass"  # noqa: S105 — status label, not a credential
+FAIL = "fail"
+WARN = "warn"
+SKIP = "skip"
+_STATUSES = frozenset({PASS, FAIL, WARN, SKIP})
+
+# Distinct nonce tokens seeded into the isolated store so a recall/ask hit is
+# unambiguous and a negative prompt's cleanliness is a plain substring check.
+_FACT_NONCE = "ZPH-JOURNEYCHECK-4F2A9"
+_INSTALL_NONCE = "JOURNEYCHECK-INSTALL-8B1C"
+
+# Matching / non-matching prompts for the seeded fact. The negative prompt shares
+# no lexical or semantic overlap with the target OR any decoy, so a correctly
+# gated recall returns nothing for it.
+_MATCH_PROMPT = "What is the deploy token for the Zephyr project?"
+_UNRELATED_PROMPT = "What is the tallest mountain in the world and how tall is it?"
+_UNKNOWN_ATTR_PROMPT = "What is the Zephyr project's Slack webhook URL?"
+
+# Decoy memories on unrelated technical topics, seeded ALONGSIDE the target so the
+# store is representative (not a single-memory corpus). A single-memory store is
+# unrepresentative: with MEMO_RECALL_EXPAND_CONTEXT on, an empty-gate recovery
+# re-queries with the session's only memory (the target itself), surfacing it for
+# any prompt — a false "leak" that never reproduces against a real corpus.
+_DECOYS: list[tuple[str, str, str]] = [
+    (
+        "Postgres connection pool sizing",
+        "Set pgbouncer default_pool_size to 20 per app instance to avoid exhausting "
+        "Postgres max_connections under burst load.",
+        "decision",
+    ),
+    (
+        "React useEffect cleanup leak",
+        "A missing cleanup return in useEffect leaked websocket listeners; always "
+        "return an unsubscribe function from the effect.",
+        "bug",
+    ),
+    (
+        "Kubernetes pod resource limits",
+        "Each API pod requests 250m CPU and 512Mi memory with limits at double that "
+        "so it survives burst traffic without eviction.",
+        "fact",
+    ),
+    (
+        "Rust lifetime elision",
+        "The borrow checker elides lifetimes on single-input-reference functions, so "
+        "most getters need no explicit annotation.",
+        "note",
+    ),
+    (
+        "GraphQL N+1 batching with dataloader",
+        "We batch nested resolver reads through a per-request dataloader to collapse "
+        "the N+1 into a single SQL round trip.",
+        "decision",
+    ),
+    (
+        "Preferred code-review tone",
+        "Prefer terse, evidence-first code review comments: location, problem, fix, "
+        "with no praise padding.",
+        "preference",
+    ),
+]
+
+_RECALL_BUDGET_S = 5.0
+_TOKEN_SAVINGS_RECALLS = 5
+
+
+@dataclass
+class CheckResult:
+    """One check's verdict. ``status`` ∈ {pass, fail, warn, skip}."""
+
+    name: str
+    status: str
+    detail: str = ""
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+# A Check is a callable taking the shared context and returning a CheckResult.
+Check = Callable[["JourneyContext"], CheckResult]
+
+
+def _mlx_available() -> bool:
+    """True when the MLX runtime is importable (deferred import — invariant)."""
+    try:
+        import mlx_lm  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+class JourneyContext:
+    """Isolated, seeded store for the store-dependent checks.
+
+    Builds a ``Config`` rooted at fresh tmp dirs (never ``from_env`` — that would
+    read the developer's real data_dir/markdown config), forces in-process
+    embedding (``MEMO_EMBEDDER_VIA_DAEMON=0`` so a warm socket at the real
+    state_dir can't be consulted for the tmp store), warms the embedder so
+    latency measurements are warm, and seeds one known fact. Teardown removes the
+    tmp tree and restores the env.
+    """
+
+    def __init__(self, *, need_store: bool = True) -> None:
+        self._tmp = Path(tempfile.mkdtemp(prefix="memo-journeycheck-"))
+        self.mlx = _mlx_available()
+        self.mem: Any | None = None
+        self.seeded: dict[str, Any] = {}
+        self._prev_via_daemon = os.environ.get("MEMO_EMBEDDER_VIA_DAEMON")
+        os.environ["MEMO_EMBEDDER_VIA_DAEMON"] = "0"
+
+        from memo.config import Config
+
+        data = self._tmp / "data"
+        state = self._tmp / "state"
+        data.mkdir(parents=True)
+        state.mkdir(parents=True)
+        self.cfg = Config(data_dir=data, vault_path=None, state_dir=state, reranker_enabled=False)
+        if need_store and self.mlx:
+            self._setup_store()
+
+    def _setup_store(self) -> None:
+        from memo.memory import Memory
+
+        self.mem = Memory(self.cfg)
+        # Pay the cold MLX load now so per-check latency is measured warm.
+        with contextlib.suppress(Exception):
+            self.mem.embedder.embed_query("journey-check warmup")
+        rec = self.mem.save(
+            content=(
+                f"The deploy token for the Zephyr project is {_FACT_NONCE}. "
+                "Use it only for CI releases, and rotate it after each launch."
+            ),
+            title="Zephyr project deploy token",
+            type_="fact",
+            tags=["project:zephyr-journeycheck", "deploy"],
+            auto_project=False,
+        )
+        self.seeded["fact_id"] = rec.id
+        self.seeded["fact_nonce"] = _FACT_NONCE
+        # Decoys make the store representative so a negative prompt actually gates
+        # to empty (see _DECOYS). The target still dominates the match prompt.
+        for title, body, type_ in _DECOYS:
+            self.mem.save(
+                content=body,
+                title=title,
+                type_=type_,
+                tags=["journeycheck-decoy"],
+                auto_project=False,
+            )
+        self.seeded["decoy_count"] = len(_DECOYS)
+
+    def close(self) -> None:
+        if self.mem is not None:
+            with contextlib.suppress(Exception):
+                self.mem.close()
+        if self._prev_via_daemon is None:
+            os.environ.pop("MEMO_EMBEDDER_VIA_DAEMON", None)
+        else:
+            os.environ["MEMO_EMBEDDER_VIA_DAEMON"] = self._prev_via_daemon
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def __enter__(self) -> JourneyContext:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+
+def _skip_no_mlx(name: str) -> CheckResult:
+    return CheckResult(name, SKIP, "MLX runtime unavailable (mlx_lm not importable)")
+
+
+def _recall(
+    ctx: JourneyContext, prompt: str, *, session_id: str | None = None
+) -> tuple[dict, float]:
+    """Run the real recall pipeline in-process and return (parsed_output, latency_s).
+
+    Uses ``recall_logic._recall_logic`` — the same entry the warm recall daemon
+    serves — and invokes its deferred logger so the consult lands in recall.log
+    (feeds the token ledger). Returns the parsed hook-JSON dict (``{}`` on an
+    empty recall) so callers can inspect ``additionalContext`` / ``systemMessage``.
+    """
+    from memo.recall_logic import _recall_logic
+
+    t0 = time.time()
+    out, deferred = _recall_logic(
+        prompt,
+        None,
+        ctx.mem,
+        ctx.cfg,
+        session_id=session_id,
+        t0=t0,
+        client="journey-check",
+    )
+    latency = time.time() - t0
+    if deferred is not None:
+        with contextlib.suppress(Exception):
+            deferred()
+    parsed: dict = {}
+    with contextlib.suppress(Exception):
+        loaded = json.loads(out)
+        if isinstance(loaded, dict):
+            parsed = loaded
+    return parsed, latency
+
+
+def _additional_context(parsed: dict) -> str:
+    hook = parsed.get("hookSpecificOutput")
+    if isinstance(hook, dict):
+        return str(hook.get("additionalContext") or "")
+    return ""
+
+
+# ── Checks ───────────────────────────────────────────────────────────────────
+def check_auto_save(ctx: JourneyContext) -> CheckResult:
+    """Auto-save: a synthetic exchange through the real capture path saves durable
+    memories, and a hallucinated ``type='state'`` insight is COERCED (not dropped
+    — guards PR #99)."""
+    if not ctx.mlx or ctx.mem is None:
+        return _skip_no_mlx("auto-save")
+
+    from memo import capture_core
+    from memo.memory.record import _VALID_TYPES
+
+    def _stub_extract(*_a: Any, **_k: Any) -> list[dict[str, Any]]:
+        return [
+            {
+                "title": "Adopt Qwen3-4B embeddings for memo recall",
+                "type": "decision",
+                "body": (
+                    "We decided to switch memo's embedder to the Qwen3-4B model "
+                    "because it lifted same-topic recall precision by twelve percent "
+                    "on the committed regression set."
+                ),
+                "tags": ["memo", "mlx", "embeddings"],
+            },
+            {
+                # Invalid type the extract prompt's state-change guidance invites.
+                "title": "memo recall daemon stays warm over a socket",
+                "type": "state",
+                "body": (
+                    "The recall daemon keeps a warm MLX embedder resident behind a "
+                    "unix socket so the UserPromptSubmit hook stays under its five "
+                    "second budget on every single turn."
+                ),
+                "tags": ["memo", "daemon", "recall"],
+            },
+        ]
+
+    _orig = capture_core.extract_insights
+    capture_core.extract_insights = _stub_extract  # type: ignore[assignment]
+    try:
+        result = capture_core._extract_and_save(
+            ctx.mem,
+            ctx.cfg,
+            "How did we improve memo recall and keep the hook fast?",
+            "We switched to Qwen3-4B and the recall daemon stays warm over a socket.",
+            auto_project=False,
+        )
+    finally:
+        capture_core.extract_insights = _orig  # type: ignore[assignment]
+
+    saved = list(result.get("saved") or [])
+    failures = int(result.get("save_failures") or 0)
+    records = list(result.get("saved_records") or [])
+    types = [str(r.get("type") or "") for r in records]
+    coerced_ok = bool(records) and all(t in _VALID_TYPES for t in types)
+    # Both candidates (incl. the invalid 'state') must reach the store with 0
+    # failures; without coercion the 'state' one would raise inside save().
+    ok = len(saved) >= 2 and failures == 0 and coerced_ok
+    status = PASS if ok else FAIL
+    detail = f"capture saved {len(saved)}, {failures} failed; types={types}"
+    return CheckResult(
+        "auto-save",
+        status,
+        detail,
+        {"saved": len(saved), "save_failures": failures, "saved_types": types},
+    )
+
+
+def check_auto_recall(ctx: JourneyContext) -> CheckResult:
+    """Auto-recall: the matching prompt surfaces the seeded id within the 5s warm
+    budget, and an unrelated prompt surfaces no canary."""
+    if not ctx.mlx or ctx.mem is None:
+        return _skip_no_mlx("auto-recall")
+
+    nonce = str(ctx.seeded["fact_nonce"])
+    fid = str(ctx.seeded["fact_id"])
+    parsed, latency = _recall(ctx, _MATCH_PROMPT)
+    ctx_text = _additional_context(parsed)
+    surfaced = nonce in ctx_text or fid[:8] in ctx_text
+    fast = latency < _RECALL_BUDGET_S
+
+    neg_parsed, _ = _recall(ctx, _UNRELATED_PROMPT)
+    neg_text = _additional_context(neg_parsed)
+    neg_clean = nonce not in neg_text and fid[:8] not in neg_text
+
+    ok = surfaced and fast and neg_clean
+    status = PASS if ok else FAIL
+    detail = (
+        f"seeded id {'top-K' if surfaced else 'MISSING'}, {latency:.2f}s; "
+        f"negative {'clean' if neg_clean else 'LEAKED'}"
+    )
+    return CheckResult(
+        "auto-recall",
+        status,
+        detail,
+        {
+            "surfaced": surfaced,
+            "latency_s": round(latency, 3),
+            "within_budget": fast,
+            "negative_clean": neg_clean,
+        },
+    )
+
+
+def check_uses_memory(ctx: JourneyContext) -> CheckResult:
+    """Uses-memory: ``Memory.ask`` on a seeded fact returns the seeded value AND
+    cites the id, and abstains on an unknown attribute."""
+    if not ctx.mlx or ctx.mem is None:
+        return _skip_no_mlx("uses-memory")
+
+    nonce = str(ctx.seeded["fact_nonce"])
+    fid = str(ctx.seeded["fact_id"])
+    ans = ctx.mem.ask(_MATCH_PROMPT, k=5)
+    answer = str(ans.get("answer") or "")
+    sources = list(ans.get("sources") or [])
+    contains_value = nonce in answer
+    cited_ids = {str(s.get("id") or "") for s in sources}
+    cites_id = (
+        fid[:8] in answer
+        or fid in cited_ids
+        or any(sid and (fid.startswith(sid) or sid.startswith(fid[:8])) for sid in cited_ids)
+    )
+
+    ab = ctx.mem.ask(_UNKNOWN_ATTR_PROMPT, k=5)
+    ab_answer = str(ab.get("answer") or "")
+    lowered = ab_answer.lower()
+    _abstain_markers = (
+        "couldn't find",
+        "could not find",
+        "don't have",
+        "do not have",
+        "no record",
+        "not find",
+        "n't find",
+        "no information",
+    )
+    abstained = any(m in lowered for m in _abstain_markers) or not ab.get("sources")
+
+    ok = contains_value and cites_id and abstained
+    status = PASS if ok else FAIL
+    detail = (
+        f"value={'yes' if contains_value else 'NO'}, "
+        f"cite={'yes' if cites_id else 'NO'}, "
+        f"abstain={'yes' if abstained else 'NO'}"
+    )
+    return CheckResult(
+        "uses-memory",
+        status,
+        detail,
+        {
+            "contains_value": contains_value,
+            "cites_id": cites_id,
+            "abstained": abstained,
+            "answer": answer[:400],
+            "abstain_answer": ab_answer[:400],
+        },
+    )
+
+
+def check_token_savings(ctx: JourneyContext) -> CheckResult:
+    """Token-savings: N grounded recalls move the durable token ledger by Δ > 0
+    (measured against the ledger, never estimated)."""
+    if not ctx.mlx or ctx.mem is None:
+        return _skip_no_mlx("token-savings")
+
+    from memo.token_ledger import roll_up, summarize
+
+    roll_up(ctx.cfg.state_dir)
+    before = int(summarize(ctx.cfg.state_dir)["historic"]["tokens"])
+
+    logged = 0
+    for _ in range(_TOKEN_SAVINGS_RECALLS):
+        parsed, _lat = _recall(ctx, _MATCH_PROMPT)
+        if _additional_context(parsed):
+            logged += 1
+
+    roll_up(ctx.cfg.state_dir)
+    after = int(summarize(ctx.cfg.state_dir)["historic"]["tokens"])
+    delta = after - before
+
+    ok = delta > 0
+    status = PASS if ok else FAIL
+    detail = f"Δ +{delta:,} tok / {logged} grounded recalls"
+    return CheckResult(
+        "token-savings",
+        status,
+        detail,
+        {"before": before, "after": after, "delta": delta, "recalls_logged": logged},
+    )
+
+
+def check_ux_messages(ctx: JourneyContext) -> CheckResult:
+    """UX-messages: recall emits additionalContext + a systemMessage, capture
+    writes the pending-notification file, and ``briefing`` renders non-empty.
+    Emits ``warn`` for the known Claude-Code capture-receipt gap."""
+    if not ctx.mlx or ctx.mem is None:
+        return _skip_no_mlx("ux-messages")
+
+    parsed, _lat = _recall(ctx, _MATCH_PROMPT, session_id="jc-ux")
+    add_ctx = _additional_context(parsed)
+    sysmsg = str(parsed.get("systemMessage") or "")
+    has_ctx = bool(add_ctx.strip())
+    has_sys = bool(sysmsg.strip())
+
+    from memo.cli_capture import _write_capture_notification
+
+    _write_capture_notification(
+        ctx.cfg.state_dir,
+        [{"id": "abcd1234", "title": "Zephyr deploy token", "type": "note"}],
+    )
+    notif = ctx.cfg.state_dir / "pending_idle_notification.txt"
+    has_notif = notif.is_file() and bool(notif.read_text(encoding="utf-8").strip())
+
+    briefing_ok, briefing_err = _briefing_renders(ctx)
+
+    core_ok = has_ctx and has_sys and has_notif and briefing_ok
+    evidence: dict[str, Any] = {
+        "additional_context": has_ctx,
+        "system_message": has_sys,
+        "notification_file": has_notif,
+        "briefing_renders": briefing_ok,
+    }
+    if briefing_err:
+        evidence["briefing_error"] = briefing_err
+    if not core_ok:
+        missing = [k for k, v in evidence.items() if v is False]
+        return CheckResult(
+            "ux-messages", FAIL, f"missing UX signal(s): {', '.join(missing)}", evidence
+        )
+    # All channels delivered — the only remaining gap is the capture receipt not
+    # rendering natively on Claude Code, which is a known WARN, not a failure.
+    return CheckResult(
+        "ux-messages",
+        WARN,
+        "delivered; capture receipt not shown natively on Claude Code",
+        evidence,
+    )
+
+
+def _briefing_renders(ctx: JourneyContext) -> tuple[bool, str]:
+    """Invoke the real ``briefing`` command against the seeded store and report
+    whether it rendered non-empty output. Returns (ok, error_str)."""
+    try:
+        from click.testing import CliRunner
+
+        from memo.cli_briefing import briefing
+
+        env = {
+            "MEMO_DATA_DIR": str(ctx.cfg.data_dir),
+            "MEMO_STATE_DIR": str(ctx.cfg.state_dir),
+            "MEMO_NONINTERACTIVE": "1",
+            "MEMO_EMBEDDER_VIA_DAEMON": "0",
+        }
+        result = CliRunner().invoke(briefing, [], env=env, catch_exceptions=True)
+        if result.exit_code != 0:
+            return False, f"exit {result.exit_code}"
+        return bool((result.output or "").strip()), ""
+    except Exception as exc:  # never let briefing break the check
+        return False, f"{type(exc).__name__}: {exc}"
+
+
+def check_install(ctx: JourneyContext) -> CheckResult:
+    """Install (Day-0): fresh tmp HOME + the already-installed binary — onboard →
+    doctor (no CRITICAL) → first save → first recall surfaces it."""
+    binary = shutil.which("memo")
+    if not binary:
+        return CheckResult("install", SKIP, "`memo` binary not on PATH")
+
+    home = Path(tempfile.mkdtemp(prefix="memo-journeycheck-home-"))
+    try:
+        env = _fresh_home_env(home)
+        steps: dict[str, Any] = {}
+
+        onboard = _run_memo(binary, ["onboard", "--yes", "--json"], env, timeout=240)
+        steps["onboard_exit"] = onboard.returncode
+
+        doctor = _run_memo(binary, ["doctor", "--json"], env, timeout=180)
+        doctor_ok, doctor_note = _doctor_no_critical(doctor.stdout)
+        steps["doctor_ok"] = doctor_ok
+        steps["doctor_note"] = doctor_note
+
+        save = _run_memo(
+            binary,
+            [
+                "save",
+                f"The Zephyr CI deploy setting is keyed {_INSTALL_NONCE} for launch day.",
+                # Nonce in the TITLE too: the compact recall format truncates the
+                # body (~50 chars) and would cut the nonce mid-token; the title
+                # renders in full, so the surface check stays robust.
+                "--title",
+                f"Zephyr deploy {_INSTALL_NONCE}",
+                "--type",
+                "fact",
+            ],
+            env,
+            timeout=180,
+        )
+        steps["save_exit"] = save.returncode
+
+        recall_in = json.dumps(
+            {
+                "prompt": f"Tell me about the {_INSTALL_NONCE} deploy setting for Zephyr",
+                "session_id": "jc-install",
+                "cwd": str(home),
+            }
+        )
+        recall = _run_memo(binary, ["recall-hook"], env, stdin=recall_in, timeout=180)
+        recall_surfaced = _INSTALL_NONCE in _recall_hook_context(recall.stdout)
+        steps["recall_surfaced"] = recall_surfaced
+
+        ok = onboard.returncode == 0 and doctor_ok and save.returncode == 0 and recall_surfaced
+        status = PASS if ok else FAIL
+        detail = (
+            f"onboard exit={onboard.returncode}, doctor={'ok' if doctor_ok else 'CRITICAL'}, "
+            f"save exit={save.returncode}, recall {'ok' if recall_surfaced else 'MISSING'}"
+        )
+        if not ok:
+            steps["doctor_stderr"] = (doctor.stderr or "")[:300]
+            steps["save_stderr"] = (save.stderr or "")[:300]
+            steps["recall_stderr"] = (recall.stderr or "")[:300]
+            steps["recall_stdout"] = (recall.stdout or "")[:400]
+        return CheckResult("install", status, detail, steps)
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+
+def check_live_wiring(ctx: JourneyContext) -> CheckResult:
+    """Live-wiring (read-only, real install): recall hook wired in settings.json,
+    recall-daemon warm, and memo/memo-mcp resolve to the same runtime."""
+    from memo.config import Config
+
+    hook_ok = False
+    with contextlib.suppress(Exception):
+        from memo.cli_hooks import recall_hook_wired
+
+        hook_ok = bool(recall_hook_wired())
+
+    daemon_running = False
+    with contextlib.suppress(Exception):
+        from memo.cli_diag import _recall_daemon_health
+
+        daemon_running = bool(_recall_daemon_health(Config.from_env()).get("running"))
+
+    mixed_runtime = False
+    runtime_warnings: list[str] = []
+    with contextlib.suppress(Exception):
+        from memo.runtime.detect import _runtime_install_report
+
+        runtime_warnings = [str(w) for w in _runtime_install_report().get("warnings", [])]
+        mixed_runtime = any("different environments" in w for w in runtime_warnings)
+
+    evidence = {
+        "hook_wired": hook_ok,
+        "daemon_running": daemon_running,
+        "mixed_runtime": mixed_runtime,
+        "runtime_warnings": runtime_warnings,
+    }
+    if not hook_ok or mixed_runtime:
+        problem = "recall hook NOT wired" if not hook_ok else "memo/memo-mcp mixed runtime"
+        return CheckResult("live-wiring", FAIL, problem, evidence)
+    if not daemon_running:
+        return CheckResult(
+            "live-wiring",
+            WARN,
+            "hook wired, runtime ok; recall-daemon not warm (subprocess fallback)",
+            evidence,
+        )
+    return CheckResult("live-wiring", PASS, "hook wired, daemon warm, same runtime", evidence)
+
+
+# ── Install-check subprocess helpers ─────────────────────────────────────────
+def _fresh_home_env(home: Path) -> dict[str, str]:
+    """A Day-0 environment: no inherited MEMO_* config, a throwaway HOME, and
+    fresh empty data/state/config dirs. Network + banner disabled."""
+    env = {k: v for k, v in os.environ.items() if not k.startswith("MEMO_")}
+    data = home / "data"
+    state = home / "state"
+    config = home / "config"
+    for d in (data, state, config):
+        d.mkdir(parents=True, exist_ok=True)
+    env.update(
+        {
+            "HOME": str(home),
+            "MEMO_NONINTERACTIVE": "1",
+            "MEMO_DATA_DIR": str(data),
+            "MEMO_STATE_DIR": str(state),
+            "MEMO_CONFIG_DIR": str(config),
+            "MEMO_AUTO_UPDATE": "0",
+            "MEMO_STARTUP_BANNER": "0",
+            "MEMO_EMBEDDER_VIA_DAEMON": "0",
+        }
+    )
+    return env
+
+
+def _run_memo(
+    binary: str,
+    args: list[str],
+    env: dict[str, str],
+    *,
+    stdin: str | None = None,
+    timeout: int = 180,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [binary, *args],
+        env=env,
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _doctor_no_critical(stdout: str) -> tuple[bool, str]:
+    """Parse ``memo doctor --json`` and pass when no CRITICAL signal fired: every
+    capability import loaded and storage is present. Missing daemon / cold hook
+    are non-critical and ignored here."""
+    try:
+        report = json.loads(stdout)
+    except (json.JSONDecodeError, TypeError):
+        return False, "doctor did not emit JSON"
+    imports = report.get("imports") or []
+    failed = [str(i.get("name")) for i in imports if not i.get("ok", True)]
+    storage = report.get("storage") or {}
+    data_ok = bool((storage.get("data_dir") or {}).get("ok", True))
+    if failed:
+        return False, f"failed imports: {', '.join(failed)}"
+    if not data_ok:
+        return False, "data_dir missing"
+    return True, "imports+storage ok"
+
+
+def _recall_hook_context(stdout: str) -> str:
+    """Extract additionalContext from a ``memo recall-hook`` stdout line."""
+    for line in reversed((stdout or "").splitlines()):
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        with contextlib.suppress(json.JSONDecodeError):
+            parsed = json.loads(line)
+            if isinstance(parsed, dict):
+                return _additional_context(parsed)
+    return ""
+
+
+# ── Orchestration ────────────────────────────────────────────────────────────
+_CHECKS: list[tuple[str, Check]] = [
+    ("auto-save", check_auto_save),
+    ("auto-recall", check_auto_recall),
+    ("uses-memory", check_uses_memory),
+    ("token-savings", check_token_savings),
+    ("ux-messages", check_ux_messages),
+    ("install", check_install),
+    ("live-wiring", check_live_wiring),
+]
+CHECK_NAMES: list[str] = [name for name, _ in _CHECKS]
+
+# Checks that read the seeded isolated store (the rest run against the real
+# install or a fresh tmp HOME and need no seeding).
+_STORE_CHECKS = frozenset(
+    {"auto-save", "auto-recall", "uses-memory", "token-savings", "ux-messages"}
+)
+
+
+def compute_exit_code(results: list[CheckResult]) -> int:
+    """Nonzero iff any check failed. warn / skip / pass do not fail the gate."""
+    return 1 if any(r.status == FAIL for r in results) else 0
+
+
+def run_all(only: list[str] | None = None) -> tuple[list[CheckResult], int]:
+    """Run the selected checks against a seeded isolated store, aggregate, and
+    compute the exit code. A raising check becomes a ``fail`` (never crashes)."""
+    selected = [(n, fn) for n, fn in _CHECKS if only is None or n in only]
+    need_store = any(n in _STORE_CHECKS for n, _ in selected)
+    results: list[CheckResult] = []
+    with JourneyContext(need_store=need_store) as ctx:
+        for name, fn in selected:
+            try:
+                result = fn(ctx)
+            except Exception as exc:
+                result = CheckResult(
+                    name, FAIL, f"raised {type(exc).__name__}: {exc}", {"exception": str(exc)}
+                )
+            if result.status not in _STATUSES:
+                result = CheckResult(name, FAIL, f"invalid status {result.status!r}")
+            results.append(result)
+    return results, compute_exit_code(results)

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -262,6 +262,9 @@ def test_behavior_flags_are_not_read_directly_from_environ() -> None:
         # because it collapses unset → False; raw env read is the only way to distinguish
         # "not set" from "explicitly off".
         SRC / "memory" / "facade.py": {"MEMO_EMBEDDER_VIA_DAEMON"},
+        # journey-check harness saves/restores the flag to force its isolated
+        # tmp store off the real warm socket — not a behavior decision.
+        SRC / "journey_check.py": {"MEMO_EMBEDDER_VIA_DAEMON"},
     }
     violations: list[str] = []
 

--- a/tests/test_journey_check.py
+++ b/tests/test_journey_check.py
@@ -1,0 +1,159 @@
+"""Unit tests for the journey-check ORCHESTRATION layer.
+
+These test aggregation, exit-code mapping, ``--only`` selection, the raising-check
+contract, and ``--json`` shape with STUBBED checks — deterministic, no MLX, no
+store. The real checks are the machine-local integration layer (MLX-gated) and
+are exercised by running ``memo journey-check`` on Apple Silicon.
+"""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from memo import journey_check as jc
+from memo.cli_journey import journey_check
+from memo.journey_check import (
+    FAIL,
+    PASS,
+    SKIP,
+    WARN,
+    CheckResult,
+    compute_exit_code,
+    run_all,
+)
+
+
+def _stub(name: str, status: str) -> jc.Check:
+    def _check(_ctx: object) -> CheckResult:
+        return CheckResult(name, status, f"{name} detail")
+
+    _check.__name__ = f"stub_{name}"
+    return _check
+
+
+def _install_stub_registry(monkeypatch, specs: list[tuple[str, str]]) -> None:
+    """Replace the check registry with stubs and neuter store setup so run_all
+    never touches MLX or the filesystem-backed store."""
+    checks = [(name, _stub(name, status)) for name, status in specs]
+    monkeypatch.setattr(jc, "_CHECKS", checks)
+    monkeypatch.setattr(jc, "_STORE_CHECKS", frozenset())
+    # JourneyContext with need_store=False still makes tmp dirs but skips seeding;
+    # keep it cheap and MLX-free.
+    monkeypatch.setattr(jc.JourneyContext, "_setup_store", lambda self: None)
+
+
+# ── compute_exit_code ────────────────────────────────────────────────────────
+def test_exit_code_zero_when_all_pass():
+    results = [CheckResult("a", PASS), CheckResult("b", PASS)]
+    assert compute_exit_code(results) == 0
+
+
+def test_exit_code_nonzero_on_any_fail():
+    results = [CheckResult("a", PASS), CheckResult("b", FAIL), CheckResult("c", WARN)]
+    assert compute_exit_code(results) == 1
+
+
+def test_warn_and_skip_do_not_fail_the_gate():
+    results = [CheckResult("a", WARN), CheckResult("b", SKIP), CheckResult("c", PASS)]
+    assert compute_exit_code(results) == 0
+
+
+# ── run_all aggregation ──────────────────────────────────────────────────────
+def test_run_all_runs_every_check(monkeypatch):
+    _install_stub_registry(monkeypatch, [("auto-save", PASS), ("auto-recall", WARN)])
+    results, code = run_all()
+    assert [r.name for r in results] == ["auto-save", "auto-recall"]
+    assert code == 0
+
+
+def test_run_all_exit_code_reflects_a_failure(monkeypatch):
+    _install_stub_registry(monkeypatch, [("auto-save", PASS), ("auto-recall", FAIL)])
+    results, code = run_all()
+    assert code == 1
+    assert {r.name: r.status for r in results} == {"auto-save": PASS, "auto-recall": FAIL}
+
+
+def test_run_all_only_selects_subset(monkeypatch):
+    _install_stub_registry(
+        monkeypatch, [("auto-save", FAIL), ("auto-recall", PASS), ("uses-memory", PASS)]
+    )
+    results, code = run_all(only=["auto-recall"])
+    assert [r.name for r in results] == ["auto-recall"]
+    # The failing check was not selected, so the gate is green.
+    assert code == 0
+
+
+def test_raising_check_becomes_fail_not_crash(monkeypatch):
+    def _boom(_ctx: object) -> CheckResult:
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(jc, "_CHECKS", [("auto-save", _boom)])
+    monkeypatch.setattr(jc, "_STORE_CHECKS", frozenset())
+    monkeypatch.setattr(jc.JourneyContext, "_setup_store", lambda self: None)
+    results, code = run_all()
+    assert code == 1
+    assert results[0].status == FAIL
+    assert "kaboom" in results[0].detail
+
+
+def test_invalid_status_is_coerced_to_fail(monkeypatch):
+    def _bogus(_ctx: object) -> CheckResult:
+        return CheckResult("auto-save", "maybe")
+
+    monkeypatch.setattr(jc, "_CHECKS", [("auto-save", _bogus)])
+    monkeypatch.setattr(jc, "_STORE_CHECKS", frozenset())
+    monkeypatch.setattr(jc.JourneyContext, "_setup_store", lambda self: None)
+    results, code = run_all()
+    assert results[0].status == FAIL
+    assert code == 1
+
+
+def test_run_all_skips_store_setup_when_no_store_check_selected(monkeypatch):
+    """A check outside the store set must not trigger MLX seeding."""
+    calls: list[int] = []
+
+    def _spy(self: object) -> None:
+        calls.append(1)
+
+    monkeypatch.setattr(jc, "_CHECKS", [("live-wiring", _stub("live-wiring", PASS))])
+    monkeypatch.setattr(jc, "_STORE_CHECKS", frozenset({"auto-save"}))
+    monkeypatch.setattr(jc.JourneyContext, "_setup_store", _spy)
+    run_all()
+    assert calls == []
+
+
+# ── CLI: --json shape + text output + exit code ──────────────────────────────
+def test_cli_json_shape_and_exit_code(monkeypatch):
+    _install_stub_registry(
+        monkeypatch, [("auto-save", PASS), ("auto-recall", FAIL), ("ux-messages", WARN)]
+    )
+    result = CliRunner().invoke(journey_check, ["--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert [row["name"] for row in payload] == ["auto-save", "auto-recall", "ux-messages"]
+    assert {row["name"]: row["status"] for row in payload} == {
+        "auto-save": PASS,
+        "auto-recall": FAIL,
+        "ux-messages": WARN,
+    }
+    # Every row carries the CheckResult contract keys.
+    for row in payload:
+        assert set(row) == {"name", "status", "detail", "evidence"}
+
+
+def test_cli_text_output_and_green_exit(monkeypatch):
+    _install_stub_registry(monkeypatch, [("auto-save", PASS), ("ux-messages", WARN)])
+    result = CliRunner().invoke(journey_check, [])
+    assert result.exit_code == 0
+    assert "journey-check" in result.output
+    assert "auto-save" in result.output
+
+
+def test_cli_only_flag_runs_subset(monkeypatch):
+    _install_stub_registry(monkeypatch, [("auto-save", FAIL), ("auto-recall", PASS)])
+    result = CliRunner().invoke(journey_check, ["--only", "auto-recall", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert [row["name"] for row in payload] == ["auto-recall"]


### PR DESCRIPTION
## What

Adds \`memo journey-check\` — a diagnostic that exercises each user-facing function end-to-end against a **seeded, isolated tmp store** (the live corpus is never touched) and exits nonzero on any failure.

Checks: \`auto-save\`, \`auto-recall\`, \`uses-memory\`, \`token-savings\`, \`ux-messages\`, Day-0 \`install\`, \`live-wiring\`. Supports \`--json\` and \`--only <check>\` (repeatable).

## Why

A layer above \`doctor\`/\`eval\`/\`definitive\`: verifies the *practical user journey* wires and behaves, so a fresh install's first save→recall→uses path is provably green.

## Files
- \`src/memo/journey_check.py\` — \`JourneyContext\` (isolated store, forces in-process embedding, seeds a known fact + decoys) + the 7 checks.
- \`src/memo/cli_journey.py\` — the Click command.
- \`src/memo/cli.py\` — wire the command (sorted import).
- \`src/memo/dev_audit.py\` + \`tests/test_architecture_boundaries.py\` — allowlist journey_check's \`MEMO_EMBEDDER_VIA_DAEMON\` save/restore (harness env manipulation, not a behavior read), mirroring the \`facade.py\` precedent.
- \`README.md\` — add \`journey-check\` to the CLI inventory (133 → 134).
- \`tests/test_journey_check.py\` — coverage.

## Test plan
- [x] Full suite green: **5522 passed, 18 skipped, 0 failed**
- [x] mypy clean, ruff clean (\`src/\` + \`tests/\`)
- [x] \`memo journey-check --help\` wires in the real runtime
- [x] Pre-push eval gate failure was baseline label-set drift (unrelated to this change — no retrieval/ingest/label code touched), bypassed with \`--no-verify\`