### PR TITLE
docs: close v4.4.4 audit residuals (no behavior change)

### DIFF
--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -726,12 +726,16 @@ SPECS: tuple[FlagSpec, ...] = (
         "int",
         600,
         "capture",
-        "Minimum seconds between incremental in-session captures (`memo "
-        "capture-tick`, wired as an async per-prompt hook). Mines NEW turns "
-        "since a per-session watermark into durable memories so a long/crashed "
-        "session's insight reaches .md mid-session instead of only at Stop. "
-        "Self-throttled per session off the capture watermark; a cheap no-op "
-        "when not due. 0 disables the throttle (capture every prompt).",
+        "Minimum seconds between incremental captures for a non-forced `memo "
+        "capture-tick` (the throttle lives in `incremental_tick_due`). Mines NEW "
+        "turns since a per-session watermark into durable memories so a "
+        "long/crashed session's insight reaches .md mid-session instead of only "
+        "at Stop. A cheap no-op when not due; 0 disables the throttle. SCOPE: "
+        "this flag governs `capture-tick` only, and `--force` bypasses it — the "
+        "PreCompact hook calls `capture-tick --force`, and the UserPromptSubmit "
+        "incremental path (`memo session idle-maintenance --mode capture`) has "
+        "its own quiet-window throttle (MEMO_SESSION_IDLE_CAPTURE_SECS). Neither "
+        "live hook consults this value; it applies to a manual `capture-tick`.",
         min_val=0,
     ),
     _spec(

--- a/src/memo/memory/write_ops.py
+++ b/src/memo/memory/write_ops.py
@@ -457,6 +457,12 @@ class _WriteOpsMixin(_MemoryBase):
         # are correctness invariants, independent of the optional early capture
         # and ingest passes. Do this before any LLM, freeze check, hashing,
         # embedding, history, receipt, or log can observe caller-controlled text.
+        #
+        # ORDERING IS INTENTIONAL — sanitize runs on the FULL content, and the
+        # max_content_chars truncation happens LATER (see below). Do NOT reorder
+        # to truncate-first "to save work": a secret straddling the cut would be
+        # split, leaving an unredacted fragment on disk. The redaction regex is
+        # already linear, so scanning the full length is cheap (see redact.py).
         from memo.redact import sanitize_memory_input
 
         sanitized = sanitize_memory_input(

--- a/src/memo/sync_embed_cache.py
+++ b/src/memo/sync_embed_cache.py
@@ -40,6 +40,18 @@ Design:
   together and the guard stays truthful.
 - Import validates every vector (finite, ~unit norm) — a poisoned or corrupt
   shard row is skipped, never stored.
+
+Trust boundary (accepted residual, not a gap): import validates vector SHAPE
+only — it does not cryptographically bind a shard row's content-hash key to its
+vector value, so a peer with WRITE access to the shared sync git remote could
+substitute a shape-valid vector and shift where a memory lands in embedding
+space. That is the SAME trust boundary as the `.md` files themselves: an
+attacker who can write the sync repo already controls memory content directly
+(and more visibly). An HMAC would need a per-fleet secret shared out-of-band
+across the user's machines — a setup decision, not a code fix, and it adds no
+protection against the only attacker in scope. Operators who want the smaller
+trust boundary set `MEMO_SYNC_EMBED_CACHE=0` to skip cache import entirely and
+re-embed locally (derived data — correctness is unaffected).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Resolves the three findings the round-3 audit deliberately left as documented residuals, so none reads as an unexplained loose end. **No runtime behavior change.**

- **Embed-cache trust boundary** (was M13): `sync_embed_cache.py` docstring now states plainly that import does shape-only validation — the same trust boundary as the `.md` files (an attacker who can write the private sync remote already controls memory content). An HMAC would need an out-of-band per-fleet key and adds nothing against the only in-scope attacker. Points at the existing `MEMO_SYNC_EMBED_CACHE=0` opt-out for anyone wanting the smaller boundary.
- **`MEMO_CAPTURE_INTERVAL_S` scope**: flag doc corrected — it throttles a non-forced `capture-tick` only; the PreCompact hook runs `--force` and the per-prompt path uses `MEMO_SESSION_IDLE_CAPTURE_SECS`, so neither live hook consults it.
- **Redact ordering** (was H10): `write_ops` comment records that sanitize-before-truncate is intentional (truncate-first could split a secret across the cut), guarding against a future reorder.

## Test plan
- [x] ruff + mypy clean
- [x] `memo config validate` — all flags valid
- [x] flags + sync_embed_cache + redact tests — 70 passed