### PR TITLE
chore(homebrew): sync formula to v4.4.5 PyPI sdist

### DIFF
--- a/docs/homebrew/mlx-memo.rb
+++ b/docs/homebrew/mlx-memo.rb
@@ -21,8 +21,8 @@ class MlxMemo < Formula
 
   desc "Local MCP memory for AI agents — MLX-native, sqlite-vec, markdown vault"
   homepage "https://github.com/jagoff/memo"
-  url "https://files.pythonhosted.org/packages/12/93/c71e1bb08c530b4571bc35d2a22c0f0b2a7370f6cad00c92094631205815/mlx_memo-4.4.4.tar.gz"
-  sha256 "a3593f0866858becb655b0c6e9ef9d5f5994e1401fb36b9d82bad1deb1d60b8c"
+  url "https://files.pythonhosted.org/packages/11/64/df66583b54443017100f36f7da33dba7f26566d31dce817b7b3fa1ddc97e/mlx_memo-4.4.5.tar.gz"
+  sha256 "91e54865e276fd503566d0091b6a580e5e5db5144a0c23af574e5999a624594f"
   license "MIT"
 
   depends_on arch: :arm64


### PR DESCRIPTION
Post-publish formula sync (pattern of #114): exact PyPI sdist URL + sha256 for mlx-memo 4.4.5, from the PyPI JSON API. Clears the two `memo release check` formula-drift warnings.