### PR TITLE
chore(homebrew): sync formula to v4.4.6 PyPI sdist

### DIFF
--- a/docs/homebrew/mlx-memo.rb
+++ b/docs/homebrew/mlx-memo.rb
@@ -21,8 +21,8 @@ class MlxMemo < Formula
 
   desc "Local MCP memory for AI agents — MLX-native, sqlite-vec, markdown vault"
   homepage "https://github.com/jagoff/memo"
-  url "https://files.pythonhosted.org/packages/11/64/df66583b54443017100f36f7da33dba7f26566d31dce817b7b3fa1ddc97e/mlx_memo-4.4.5.tar.gz"
-  sha256 "91e54865e276fd503566d0091b6a580e5e5db5144a0c23af574e5999a624594f"
+  url "https://files.pythonhosted.org/packages/cb/6e/8893d48435413d75f3e6e7fef3b556bb7823aa8d05a83a132dfd1bccb635/mlx_memo-4.4.6.tar.gz"
+  sha256 "58ab92aba5e80e0e42ea1412a69189b91a76053f7fec41c21b168a6a937cae38"
   license "MIT"
 
   depends_on arch: :arm64


### PR DESCRIPTION
Post-publish formula sync: exact PyPI sdist URL + sha256 for mlx-memo 4.4.6 (from the PyPI JSON API). Clears the release-check formula-drift warnings.