### PR TITLE
refactor: shared unified-briefing composer + dispute-ask MLX integration test

### DIFF
--- a/src/memo/briefing.py
+++ b/src/memo/briefing.py
@@ -570,6 +570,20 @@ def memo_native_briefing_lines(
     return lines
 
 
+def compose_unified_briefing(memory: Any, cwd: str | None) -> str:
+    """Compose the unified-briefing markdown — single source of truth for the
+    `memo_unified_briefing` MCP tool and the `briefing` MCP prompt."""
+    from memo.flags import flag_int
+
+    loops_n = max(1, flag_int("MEMO_BRIEFING_LOOPS_N") or 5)
+    loops_days = max(1, flag_int("MEMO_BRIEFING_LOOPS_DAYS") or 7)
+    raw_lines: list[str] = memo_native_briefing_lines(
+        memory, loops_n=loops_n, loops_days=loops_days
+    )
+    raw_lines.extend(operational_briefing_lines(memory, cwd))
+    return compact_text("\n".join(raw_lines), max_chars=900)
+
+
 def _clip(text: str, *, limit: int = _SNIPPET_CHARS) -> str:
     text = str(text or "").strip().replace("\n", " ")
     if len(text) <= limit:
@@ -579,6 +593,7 @@ def _clip(text: str, *, limit: int = _SNIPPET_CHARS) -> str:
 
 __all__ = [
     "compact_text",
+    "compose_unified_briefing",
     "dream_digest_lines",
     "install_seed_lines",
     "memo_native_briefing_lines",

--- a/src/memo/server.py
+++ b/src/memo/server.py
@@ -109,8 +109,10 @@ def _make_trace_middleware() -> Any:
     return _TraceMiddleware()
 
 
-# FastMCP surfaces server instructions alongside each client connection. Keep
-# this deliberately terse: some clients repeat it in every tool description.
+# FastMCP surfaces server instructions alongside each client connection. These
+# carry the full memory-first contract (briefing → consult → persist → flag);
+# some clients repeat them in every tool description, so growth is bounded by
+# tests/test_server_instructions.py (len <= 600).
 _SERVER_INSTRUCTIONS = (
     "At session start, call memo_unified_briefing once to load durable "
     "context. Before deciding anything prior work might cover, consult "

--- a/src/memo/server_core_search.py
+++ b/src/memo/server_core_search.py
@@ -101,21 +101,10 @@ def register(server: Any, memory: Memory) -> None:
         ground the task. Pass `cwd` to bias project context and `source` to
         attribute consult logs to the calling client.
         """
-        from memo.briefing import (
-            compact_text,
-            memo_native_briefing_lines,
-            operational_briefing_lines,
-        )
-        from memo.flags import flag_int
+        from memo.briefing import compose_unified_briefing
 
         t0 = now_ms()
-        loops_n = max(1, flag_int("MEMO_BRIEFING_LOOPS_N") or 5)
-        loops_days = max(1, flag_int("MEMO_BRIEFING_LOOPS_DAYS") or 7)
-        raw_lines: list[str] = memo_native_briefing_lines(
-            memory, loops_n=loops_n, loops_days=loops_days
-        )
-        raw_lines.extend(operational_briefing_lines(memory, cwd))
-        markdown = compact_text("\n".join(raw_lines), max_chars=900)
+        markdown = compose_unified_briefing(memory, cwd)
         lines = markdown.splitlines() if markdown else []
         log_consult(
             memory,

--- a/src/memo/server_prompts.py
+++ b/src/memo/server_prompts.py
@@ -20,30 +20,6 @@ _log = logging.getLogger(__name__)
 _SOURCE = "mcp-prompt"
 
 
-def _briefing_text(memory: Any) -> str:
-    """Compose the compact briefing text.
-
-    Transcribed from `memo_unified_briefing` (`server_core_search.py`) — same
-    `memo.briefing` calls and flag reads — minus the tool's dict envelope and
-    consult logging (the prompt logs its own consult). `cwd` is not available
-    to a no-argument prompt, so operational lines are unbiased by project.
-    """
-    from memo.briefing import (
-        compact_text,
-        memo_native_briefing_lines,
-        operational_briefing_lines,
-    )
-    from memo.flags import flag_int
-
-    loops_n = max(1, flag_int("MEMO_BRIEFING_LOOPS_N") or 5)
-    loops_days = max(1, flag_int("MEMO_BRIEFING_LOOPS_DAYS") or 7)
-    raw_lines: list[str] = memo_native_briefing_lines(
-        memory, loops_n=loops_n, loops_days=loops_days
-    )
-    raw_lines.extend(operational_briefing_lines(memory, None))
-    return compact_text("\n".join(raw_lines), max_chars=900)
-
-
 def register(server: Any, memory: Any) -> None:
     """Register the briefing/recall prompts (all profiles — prompts ≠ tools)."""
 
@@ -53,14 +29,20 @@ def register(server: Any, memory: Any) -> None:
         "operational state) into the conversation.",
     )
     def briefing() -> str:
+        # cwd=None: a no-argument prompt has no cwd, so operational lines are
+        # unbiased by project.
+        from memo.briefing import compose_unified_briefing
+
         t0 = now_ms()
         try:
-            text = _briefing_text(memory)
+            text = compose_unified_briefing(memory, None)
         except Exception as exc:
             _log.debug("briefing prompt failed", exc_info=True)
             return f"memo unavailable: {type(exc).__name__}"
         with suppress(Exception):
-            log_consult(memory, tool="briefing", query="", hits=[], t0_ms=t0, source=_SOURCE)
+            log_consult(
+                memory, tool="briefing", query="briefing", hits=[], t0_ms=t0, source=_SOURCE
+            )
         return "Context from memo (briefing):\n" + text
 
     @server.prompt(
@@ -93,6 +75,6 @@ def register(server: Any, memory: Any) -> None:
             return header + "(no matching memories)"
         lines = []
         for h in hits:
-            body = (getattr(h, "body", "") or "")[:400]
+            body = (h.body or "")[:400]
             lines.append(f"[{h.id[:8]}] {h.title} ({h.type})\n{body}")
         return header + "\n---\n".join(lines)

--- a/tests/test_ask_disputes_mlx.py
+++ b/tests/test_ask_disputes_mlx.py
@@ -1,0 +1,117 @@
+"""End-to-end MLX integration for dispute-aware ask (MEMO_ASK_DISPUTES).
+
+The unit suite (`tests/test_ask_disputes.py`) stubs retrieval, the chat client,
+and the pair lookup. This fixture runs the REAL pipeline — MLX embeddings drive
+retrieval, the contradiction pair lives in the real contradict_store, and the
+real 7B LLM answers — asserting the two spec guarantees end-to-end
+(docs/SPECS/2026-07-28-ask-dispute-aware-design.md):
+
+  1. Retrieved sources that belong to an OPEN contradiction pair come back
+     annotated (`disputed_by` per source + top-level `disputed` map) while
+     clean hits stay unannotated.
+  2. When the corpus offers ONLY disputed evidence for the question, the
+     deterministic gate abstains (`abstained == "disputed"`) with the contested
+     message naming both sides — regardless of what the LLM generated.
+
+Seeded state mirrors `tests/test_trust_states_fixture.py`: the PostgreSQL-15
+vs MySQL-8 prod-db-engine pair, upserted OPEN in the contradict store.
+Real model loads make this `requires_mlx` + `slow` (auto-skips off Apple
+Silicon via the conftest gate).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from memo.config import Config
+from memo.memory import Memory
+
+_OLDER = "The production database engine is PostgreSQL 15 running on Amazon RDS."
+_NEWER = "The production database engine is MySQL 8 running on Amazon RDS."
+_QUESTION = "what engine does the production database run"
+_FILLERS = [
+    "The production database is backed up nightly to S3 with 30-day retention.",
+    "The production database connection pool is capped at 200 connections.",
+    "Production database credentials are stored in AWS Secrets Manager.",
+]
+
+
+@pytest.fixture
+def real_mlx_memory(tmp_cfg: Config) -> Iterator[Memory]:
+    """Release SQLite handles and Metal model/cache between slow cases."""
+    mem = Memory(tmp_cfg)
+    yield mem
+    mem.close()
+
+
+def _seed_open_pair(mem: Memory) -> tuple[str, str]:
+    """Seed the contradicting fact pair and its OPEN entry; return (older, newer)."""
+    older_id = mem.save(content=_OLDER, title="prod db pg", type_="fact").id
+    newer_id = mem.save(content=_NEWER, title="prod db mysql", type_="fact").id
+    pair_id = mem.contradict_store.upsert_open(
+        older_id,
+        newer_id,
+        relationship="contradicts",
+        confidence=0.95,
+        rationale="fixture: prod db engine PostgreSQL vs MySQL",
+    )
+    assert pair_id > 0
+    return older_id, newer_id
+
+
+@pytest.mark.requires_mlx
+@pytest.mark.slow
+def test_ask_abstains_when_corpus_offers_only_disputed_evidence(
+    real_mlx_memory: Memory,
+) -> None:
+    """Corpus = ONLY the two sides of the open pair → whatever the real LLM
+    cites is a subset of the disputed set, so the deterministic gate MUST
+    replace the answer with the contested abstention naming both ids."""
+    mem = real_mlx_memory
+    older_id, newer_id = _seed_open_pair(mem)
+
+    out = mem.ask(_QUESTION, include_repos=False)
+
+    # Real retrieval surfaced both sides, each annotated with its disputer.
+    by_id = {s["id"]: s for s in out["sources"]}
+    assert by_id[older_id]["disputed_by"] == [newer_id]
+    assert by_id[newer_id]["disputed_by"] == [older_id]
+    assert out["disputed"] == {older_id: [newer_id], newer_id: [older_id]}
+
+    # Deterministic contested abstention, independent of the LLM's wording.
+    assert out["abstained"] == "disputed"
+    assert "couldn't find" in out["answer"]  # journey_check abstain marker
+    assert older_id[:8] in out["answer"] and newer_id[:8] in out["answer"]
+    assert "memo contradict" in out["answer"]
+
+
+@pytest.mark.requires_mlx
+@pytest.mark.slow
+def test_ask_annotates_only_the_disputed_sources_amid_clean_corpus(
+    real_mlx_memory: Memory,
+) -> None:
+    """With clean fillers alongside the pair, annotation stays surgical:
+    both pair sides carry `disputed_by`, fillers don't, and the top-level
+    `disputed` map contains exactly the pair (both directions)."""
+    mem = real_mlx_memory
+    older_id, newer_id = _seed_open_pair(mem)
+    filler_ids = {
+        mem.save(content=text, title=f"prod db filler {i}", type_="fact").id
+        for i, text in enumerate(_FILLERS)
+    }
+
+    out = mem.ask(_QUESTION, include_repos=False)
+
+    by_id = {s["id"]: s for s in out["sources"]}
+    # Both engine facts are the closest matches for the question — they must
+    # be in the k=5 sources the LLM saw, annotated with each other.
+    assert by_id[older_id]["disputed_by"] == [newer_id]
+    assert by_id[newer_id]["disputed_by"] == [older_id]
+    # Clean fillers never gain the key; the map holds exactly the pair.
+    assert all("disputed_by" not in by_id[fid] for fid in filler_ids if fid in by_id)
+    assert out["disputed"] == {older_id: [newer_id], newer_id: [older_id]}
+    # The gate may or may not abstain here (the LLM can lean on a clean
+    # filler) — but if it does, it must be the dispute abstention.
+    assert out.get("abstained") in (None, "disputed")

--- a/tests/test_server_prompts.py
+++ b/tests/test_server_prompts.py
@@ -48,6 +48,45 @@ def test_briefing_returns_context(mock_memory):
     assert out.startswith("Context from memo (briefing):")
 
 
+def test_briefing_prompt_matches_tool_markdown(mock_memory):
+    """Divergence guard: the prompt and `memo_unified_briefing` both render via
+    `compose_unified_briefing`, so for the same memory (cwd=None) the prompt is
+    exactly the tool's markdown behind the context header."""
+    import memo.server_core_search as search_server
+
+    class _ToolServer:
+        def __init__(self):
+            self.tools: dict[str, object] = {}
+
+        def tool(self, *, annotations):
+            def _decorator(fn):
+                self.tools[fn.__name__] = fn
+                return fn
+
+            return _decorator
+
+    mock_memory.save(content="port is 8765", title="port fact", type_="fact")
+    tool_server = _ToolServer()
+    search_server.register(tool_server, mock_memory)
+    tool_out = tool_server.tools["memo_unified_briefing"](cwd=None)
+
+    server = _register(mock_memory)
+    prompt_out = server.prompts["briefing"]()
+
+    assert tool_out["markdown"]
+    assert prompt_out == "Context from memo (briefing):\n" + tool_out["markdown"]
+
+
+def test_briefing_prompt_fails_open_when_composer_raises(mock_memory, monkeypatch):
+    def _boom(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("memo.briefing.memo_native_briefing_lines", _boom)
+    server = _register(mock_memory)
+    out = server.prompts["briefing"]()
+    assert out.startswith("memo unavailable:")
+
+
 def test_prompts_fail_open(mock_memory, monkeypatch):
     server = _register(mock_memory)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Follow-ups del review final de #122:

- **Composer compartido**: `compose_unified_briefing(memory, cwd)` en `src/memo/briefing.py` — única fuente de verdad del texto de briefing, consumido por el tool `memo_unified_briefing` (`server_core_search.py`) y el prompt MCP `briefing` (`server_prompts.py`), que era una transcripción sin guard de divergencia. Test de equivalencia prompt==tool incluido.
- Minors del review: comment stale en `server.py` (instructions llevan el contrato completo, bound ≤600 por `test_server_instructions.py`), test del branch fail-open del prompt briefing, postura de acceso unificada en el loop de hits del prompt recall, consult del prompt briefing loguea `query="briefing"` (paridad con el tool).
- **Test de integración MLX** para dispute-aware ask: `tests/test_ask_disputes_mlx.py` (`@requires_mlx`), par de contradicción sembrado con par OPEN real — abstención determinista y anotación `disputed_by` verificadas end-to-end con MLX real (2 passed local, 11s).

## Test plan

- [x] `pytest tests/test_server_prompts.py tests/test_server_instructions.py tests/test_briefing_unified.py tests/test_cli_briefing.py tests/test_ask_disputes.py` → 42 passed
- [x] `pytest tests/test_ask_disputes_mlx.py` con MLX real → 2 passed, 0 skipped (local Apple Silicon)
- [x] `mypy src/memo/` → clean (447 files)
- [x] `ruff check` + `ruff format --check .` → clean
- [x] `scripts/quality_gate.py` → pass (163/167 budgets)