### PR TITLE
feat: code_intel — graph-powered proactivity (round 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ memo runs four background daemons:
 | ingest-daemon | `memo ingest-daemon start` | Bulk vault ingestion |
 | maint-daemon | `memo maint-daemon start` | Background cleanup + synthesis |
 
-### All 135 top-level CLI commands
+### All 137 top-level CLI commands
 
 <details>
 <summary>Click to expand</summary>
@@ -473,7 +473,7 @@ memo runs four background daemons:
 
 **Daemons:** `recall-daemon` `ingest-daemon` `maint-daemon` `embed-daemon` `idle-daemon`
 
-**Other:** `backend-native` `collaborative` `feedback` `query` `mandate` `drift` `sleep-cycle` `operational` `ocr-image` `provenance` `secret` `verbatim` `mcp-command` `codex-badge` `debug-recall` `http-api` `mine-git` `token-gate` `fix` `undo` `code-facts`
+**Other:** `backend-native` `collaborative` `feedback` `query` `mandate` `drift` `sleep-cycle` `operational` `ocr-image` `provenance` `secret` `verbatim` `mcp-command` `codex-badge` `debug-recall` `http-api` `mine-git` `token-gate` `fix` `undo` `code-facts` `code-nudge` `code-health`
 
 </details>
 

--- a/src/memo/ask_gaps.py
+++ b/src/memo/ask_gaps.py
@@ -11,11 +11,18 @@ already failed to answer from real usage; asking it back is honest.
 Report-only: shadow-logs what it WOULD ask regardless of the enable flag; a
 human flips MEMO_ASK_GAPS_ENABLED after reviewing ``memo ask-gaps shadow``.
 Deduped per session (a session asks at most one NEW gap and never repeats one).
+
+Also home to the code-hub gap surface (``MEMO_GAPS_CODE_HUBS``, default ON):
+top codegraph call-magnets no memory documents, via :func:`code_hub_gaps` —
+the briefing carries at most ONE such line, read from the nightly dream
+receipt (zero graph queries at SessionStart); the full live list is for the
+CLI and the nightly code-drift pass.
 """
 
 from __future__ import annotations
 
 import json as _json
+import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -131,24 +138,107 @@ def _read_receipt_gaps(state_dir: Path) -> list[dict[str, Any]]:
         return []
 
 
+# --- code-hub gaps (MEMO_GAPS_CODE_HUBS) ------------------------------------------
+
+_HUB_TOP = 10
+# Same base query `memo code-facts` mines call hubs with: in-degree of `calls`
+# edges over src/ nodes only.
+_HUB_QUERY = (
+    "SELECT t.name, t.file_path, COUNT(*) AS n "
+    "FROM edges e JOIN nodes t ON e.target = t.id "
+    "WHERE e.kind = 'calls' AND t.file_path LIKE 'src/%' "
+    "GROUP BY t.id ORDER BY n DESC, t.qualified_name LIMIT ?"
+)
+
+
+def code_hub_gaps(mem: Any, top: int = _HUB_TOP) -> list[str]:
+    """Knowledge gaps on code hubs: top call-magnets no memory documents.
+
+    The top-``top`` codegraph nodes by incoming ``calls`` edges (src/ only)
+    that no non-reference memory cites, one ``hub sin memoria: …`` line each.
+    Gated by ``MEMO_GAPS_CODE_HUBS``; on-demand graph query only (never the
+    recall hook, never SessionStart). Fail-open: flag off / no index → [].
+    """
+    from memo import code_intel
+    from memo.flags import flag_bool
+
+    if not flag_bool("MEMO_GAPS_CODE_HUBS"):
+        return []
+    opened = code_intel.open_graph()
+    if opened is None:
+        return []
+    graph, _db_repo_id = opened
+    try:
+        return _hub_gap_lines(mem.store._conn, graph, top=top)
+    finally:
+        graph.close()
+
+
+def _hub_gap_lines(store_conn: Any, graph: Any, *, top: int) -> list[str]:
+    """The ``hub sin memoria`` lines over an OPEN graph connection — shared by
+    :func:`code_hub_gaps` and the nightly code-drift pass (which persists them
+    to the receipt for the briefing). A failed hub query degrades to no lines."""
+    from memo import code_intel
+
+    try:
+        rows = graph.execute(_HUB_QUERY, (int(top),)).fetchall()
+    except sqlite3.Error:
+        return []
+    lines: list[str] = []
+    for name, file_path, callers in rows:
+        symbol = str(name or "")
+        if not symbol:
+            continue
+        if code_intel.memories_citing(store_conn, symbols={symbol}, limit=1):
+            continue
+        lines.append(f"hub sin memoria: {symbol} ({callers} callers) — {file_path}")
+    return lines
+
+
+def _hub_briefing_lines(cfg: Any) -> list[str]:
+    """At most ONE hub line for the briefing, read from the nightly dream
+    receipt (``code_drift.hub_gaps``, written by the code-drift pass).
+
+    SessionStart's budget is ZERO graph queries: no index open, no git, no
+    store scan — one small json read. The live query belongs to
+    :func:`code_hub_gaps` (on-demand) and the nightly pass. No receipt /
+    corrupt receipt / flag off → []."""
+    from memo.flags import flag_bool
+
+    if not flag_bool("MEMO_GAPS_CODE_HUBS"):
+        return []
+    try:
+        data = _json.loads(
+            (Path(cfg.state_dir) / "dream" / "last.json").read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError):
+        return []
+    section = data.get("code_drift") if isinstance(data, dict) else None
+    gaps = section.get("hub_gaps") if isinstance(section, dict) else None
+    if not isinstance(gaps, list):
+        return []
+    return [g for g in gaps if isinstance(g, str) and g][:1]
+
+
 def briefing_lines(cfg: Any, *, session_id: str) -> list[str]:
-    """SessionStart render: at most one NEW high-value gap as a question. Never
-    raises, never fabricates. Shadow-logs whether or not it renders."""
+    """SessionStart render: at most one NEW high-value gap as a question plus
+    at most one undocumented code hub. Never raises, never fabricates.
+    Shadow-logs whether or not the question renders."""
+    lines: list[str] = []
     try:
         from memo.flags import flag_bool
 
         gaps = _read_receipt_gaps(cfg.state_dir)
         gap = pick_gap(gaps)
-        if gap is None:
-            return []
-        key = _gap_key(gap)
-        if already_asked(cfg.state_dir, session_id, key):
-            return []
-        render = flag_bool("MEMO_ASK_GAPS_ENABLED")
-        log_shadow(cfg.state_dir, shadow_record(gap, rendered=render))
-        if not render:
-            return []
-        note_asked(cfg.state_dir, session_id, key)
-        return [phrase_question(gap), ""]
+        if gap is not None:
+            key = _gap_key(gap)
+            if not already_asked(cfg.state_dir, session_id, key):
+                render = flag_bool("MEMO_ASK_GAPS_ENABLED")
+                log_shadow(cfg.state_dir, shadow_record(gap, rendered=render))
+                if render:
+                    note_asked(cfg.state_dir, session_id, key)
+                    lines.extend([phrase_question(gap), ""])
+        lines.extend(_hub_briefing_lines(cfg))
     except Exception:
-        return []
+        return lines
+    return lines

--- a/src/memo/briefing.py
+++ b/src/memo/briefing.py
@@ -309,6 +309,47 @@ def dream_digest_lines(state_dir: Path, *, max_age_h: float = 24.0) -> list[str]
         return []
 
 
+def code_drift_lines(cfg: Any) -> list[str]:
+    """'⚠ code-drift' — one line when last night's drift pass found stale refs.
+
+    Reads the ``code_drift`` key of the dream receipt
+    (``cfg.state_dir/dream/last.json``, written by ``_run_code_drift``) — zero
+    graph queries at SessionStart. Gated by ``MEMO_BRIEFING_CODE_DRIFT``
+    (default on; the flag is checked here so a disabled flag never opens the
+    receipt). Empty list on anything else — receipt missing/corrupt, pass
+    disabled/aborted, or nothing drifted.
+    """
+    import contextlib
+    import json as _json
+
+    from memo.flags import flag_bool
+
+    if not flag_bool("MEMO_BRIEFING_CODE_DRIFT"):
+        return []
+    with contextlib.suppress(Exception):
+        last = Path(cfg.state_dir) / "dream" / "last.json"
+        with last.open(encoding="utf-8") as fh:
+            data = _json.load(fh)
+        drift = data.get("code_drift")
+        if not isinstance(drift, dict) or drift.get("status") != "ok":
+            return []
+
+        def _count(key: str) -> int:
+            v = drift.get(key)
+            return len(v) if isinstance(v, list) else 0
+
+        outdated = _count("outdated")
+        partial = _count("partial")
+        repaired = _count("repaired")
+        if outdated or partial or repaired:
+            return [
+                f"⚠ code-drift: {outdated} memorias archivadas, {partial} parciales, "
+                f"{repaired} reparadas anoche — 'memo dream status'",
+                "",
+            ]
+    return []
+
+
 def proactive_lines(mem: Any, *, max_lines: int = 3) -> list[str]:
     """Compact proactive-engine digest — reliability/continuity/etc nudges.
 
@@ -475,6 +516,12 @@ def memo_native_briefing_lines(
     if flag_bool("MEMO_NEGATIVE_RECALL_ENABLED"):
         with contextlib.suppress(Exception):
             lines.extend(negative_recall_lines(mem))
+
+    # ── Code drift: last night's drift-pass outcome (receipt read, zero graph queries) ─
+    # MEMO_BRIEFING_CODE_DRIFT is checked inside the helper so a disabled flag
+    # never opens the receipt, here or in any other caller.
+    with contextlib.suppress(Exception):
+        lines.extend(code_drift_lines(mem.cfg))
 
     # Judged relation truth only; pending candidates belong to review surfaces.
     with contextlib.suppress(Exception):

--- a/src/memo/cli.py
+++ b/src/memo/cli.py
@@ -37,6 +37,7 @@ from memo.cli_capture import capture_stop, capture_tick, episodes_group, resume
 from memo.cli_chat import chat_group
 from memo.cli_chronicle import chronicle_cmd
 from memo.cli_code_facts import code_facts_cmd
+from memo.cli_code_intel import code_health_cmd, code_nudge_cmd
 from memo.cli_collaborative import collaborative_group
 from memo.cli_common import console
 from memo.cli_compress_context import compress_context_cmd
@@ -384,6 +385,8 @@ cli.add_command(debug_recall_cmd)
 cli.add_command(dream_cmd)
 cli.add_command(chronicle_cmd)
 cli.add_command(code_facts_cmd)
+cli.add_command(code_nudge_cmd)
+cli.add_command(code_health_cmd)
 cli.add_command(maintain_cmd)
 cli.add_command(invalidate_cmd)
 cli.add_command(synthesize_cmd)

--- a/src/memo/cli_code_facts.py
+++ b/src/memo/cli_code_facts.py
@@ -29,8 +29,6 @@ from memo.cli_common import get_memory as _get_memory
 from memo.code_traceability import codegraph_repo_id, codegraph_uri
 from memo.config import Config
 
-CODE_FACT_TAGS = ("project:memo", "codegraph-derived")
-
 # Cross-package dependency pairs reported (top 10 by edge count).
 _DEP_PAIR_LIMIT = 10
 # Representative symbols attached as code_refs on aggregate facts.
@@ -213,6 +211,40 @@ def _existing_hashes(mem: Any) -> set[str]:
     return hashes
 
 
+def _mining_target(
+    db_override: Path | None, project: Path | None
+) -> tuple[Path, str, tuple[str, ...]]:
+    """Resolve (db, repo_id, tags) for one mining run; --project switches all three.
+
+    Same DB default as the loader: explicit --db > project-aware discovery
+    (nearest .codegraph/codegraph.db above --project when given, else above
+    cwd) > memo's own checkout. --project never falls through to the env
+    override — mining the wrong repo under a project:<basename> tag is worse
+    than failing.
+
+    The project tag always derives from the mined repo (--project basename,
+    else the resolved DB's repo root ``<root>/.codegraph/codegraph.db``) —
+    never a hardcoded name: a run whose cwd discovery lands in ANOTHER indexed
+    repo must tag that repo, or recall's project boost surfaces its facts
+    under the wrong project.
+    """
+    from memo import codegraph_loader
+
+    if project is not None and db_override is None:
+        discovered = codegraph_loader._discover_db(start=project)
+        db = discovered if discovered is not None else project / ".codegraph" / "codegraph.db"
+    else:
+        db = codegraph_loader._resolve_db(db_override)
+    if not db.is_file():
+        raise click.ClickException(f"codegraph index not found at {db}")
+
+    if project is not None:
+        tags = (f"project:{project.resolve().name}", "codegraph-derived")
+        return db, codegraph_repo_id(project), tags
+    repo_root = db.resolve().parent.parent
+    return db, codegraph_repo_id(repo_root), (f"project:{repo_root.name}", "codegraph-derived")
+
+
 @click.command(name="code-facts")
 @click.option(
     "--apply",
@@ -227,27 +259,32 @@ def _existing_hashes(mem: Any) -> set[str]:
     default=None,
     help="Codegraph DB path (default: the loader's .codegraph/codegraph.db).",
 )
+@click.option(
+    "--project",
+    "project",
+    type=click.Path(path_type=Path, exists=True, file_okay=False),
+    default=None,
+    help="Mine another indexed repo: discover its .codegraph DB from this path "
+    "and tag the facts project:<basename>.",
+)
 @click.option("--top", default=10, show_default=True, help="Max facts per category.")
 @click.option("--json", "as_json", is_flag=True, help="Output raw JSON.")
-def code_facts_cmd(apply_: bool, db_override: Path | None, top: int, as_json: bool) -> None:
+def code_facts_cmd(
+    apply_: bool, db_override: Path | None, project: Path | None, top: int, as_json: bool
+) -> None:
     """Mine architectural facts from the codegraph index into memories.
 
     Read-only over the codegraph DB: call hubs (most-called symbols), the
     API/CLI surface, and cross-package dependencies. Dry-run by default —
     pass --apply to save each fact as a `type=fact` memory. Re-runs skip
-    facts whose provenance hash is already saved.
+    facts whose provenance hash is already saved. --project PATH mines any
+    other indexed repo: the DB is discovered from that path and the facts
+    are tagged `project:<basename>`, with refs minted under that repo's
+    codegraph:// repo id.
 
     Example: memo code-facts --top 5 --apply
     """
-    from memo import codegraph_loader
-
-    # Same DB default as the loader: explicit --db > project-aware discovery
-    # (nearest .codegraph/codegraph.db above cwd) > memo's own checkout.
-    db = codegraph_loader._resolve_db(db_override)
-    if not db.is_file():
-        raise click.ClickException(f"codegraph index not found at {db}")
-
-    repo_id = codegraph_repo_id(db.parent.parent)
+    db, repo_id, tags = _mining_target(db_override, project)
     conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     try:
@@ -273,7 +310,7 @@ def code_facts_cmd(apply_: bool, db_override: Path | None, top: int, as_json: bo
                 content=fact.text,
                 title=fact.text[:80],
                 type_="fact",
-                tags=list(CODE_FACT_TAGS),
+                tags=list(tags),
                 extra={
                     "code_refs": fact.code_refs,
                     "provenance_hash": phash,

--- a/src/memo/cli_code_intel.py
+++ b/src/memo/cli_code_intel.py
@@ -1,0 +1,316 @@
+"""`memo code-nudge` + `memo code-health` — graph↔memory awareness commands.
+
+Thin consumers of the :mod:`memo.code_intel` engine (read-only, fail-open,
+repo_id-gated — the invariants live there, not here):
+
+- ``code-nudge`` surfaces the memories whose ``code_refs`` cite the files a
+  commit touched. Silent (exit 0, no output) whenever there is nothing to
+  say — it runs from the post-commit hook and must never dirty a clean
+  commit. Pure SQL against the store; budget <300 ms, no MLX.
+- ``code-health`` joins the codegraph index with the memory corpus: the last
+  nightly drift receipt, dead knowledge (memories citing symbols nobody
+  calls), and the top call hubs no memory documents. A missing index
+  degrades to a notice, exit 0.
+
+Registered onto the root group in cli.py via ``cli.add_command``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+from typing import Any
+
+import click
+from rich.panel import Panel
+
+from memo.cli_common import console
+from memo.cli_common import get_memory as _get_memory
+from memo.config import Config
+
+# Nudge output cap: enough to be useful after a commit, short enough to stay
+# out of the way in a terminal that just printed the commit summary.
+_NUDGE_CAP = 3
+_GIT_TIMEOUT_S = 2.0
+# Hubs reported by code-health (same top-N spirit as cli_code_facts hubs).
+_HUB_LIMIT = 10
+# Receipt list keys summarized as counts ("repaired" lands with auto-repair).
+_DRIFT_LIST_KEYS = ("outdated", "partial", "repaired")
+
+
+def _changed_files(rev: str) -> list[str]:
+    """Files touched by ``rev`` per ``git diff-tree``; [] on any git failure."""
+    try:
+        proc = subprocess.run(
+            ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", rev],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if proc.returncode != 0:
+        return []
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+@click.command(name="code-nudge")
+@click.option(
+    "--commit",
+    "rev",
+    default="HEAD",
+    show_default=True,
+    help="Commit whose touched files are matched against memories.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output raw JSON.")
+def code_nudge_cmd(rev: str, as_json: bool) -> None:
+    """Surface memories citing the files a commit touched.
+
+    Reads the commit's file list from git and prints up to 3 memories whose
+    code_refs cite them — one `🧠 [id] title` line each. Silent (exit 0, no
+    output) when nothing matches or git fails, so the post-commit hook never
+    dirties a clean commit. Pure SQL — no MLX, no graph queries.
+
+    Example: memo code-nudge --commit HEAD~1
+    """
+    from memo import code_intel
+
+    files = _changed_files(rev)
+    if not files:
+        return
+    mem = _get_memory(Config.from_env())
+    hits = code_intel.memories_citing(mem.store._conn, paths=files, limit=_NUDGE_CAP)
+    if not hits:
+        return
+    if as_json:
+        payload = [{"id": hit["id"], "title": hit["title"]} for hit in hits]
+        click.echo(json.dumps(payload, ensure_ascii=False))
+        return
+    for hit in hits:
+        click.echo(f"🧠 [{hit['id'][:8]}] {hit['title']}")
+
+
+def _drift_summary(cfg: Config) -> dict[str, Any]:
+    """code_drift section of the last dream receipt, as counts; fail-open."""
+    path = cfg.state_dir / "dream" / "last.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        section = data.get("code_drift") if isinstance(data, dict) else None
+        if not isinstance(section, dict):
+            return {"status": "no-receipt"}
+        summary: dict[str, Any] = {
+            "status": str(section.get("status") or "unknown"),
+            "scanned": int(section.get("scanned") or 0),
+        }
+        for key in _DRIFT_LIST_KEYS:
+            value = section.get(key)
+            summary[key] = len(value) if isinstance(value, list) else 0
+        return summary
+    except (OSError, ValueError, TypeError):
+        return {"status": "no-receipt"}
+
+
+def _cited_memories(store_conn: Any) -> list[dict[str, Any]]:
+    """Non-reference memories carrying code_refs, with their raw ref dicts."""
+    try:
+        rows = store_conn.execute(
+            "SELECT id, title, extra_json FROM meta WHERE type != 'reference' "
+            "AND json_extract(extra_json, '$.code_refs') IS NOT NULL"
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            extra = json.loads(row["extra_json"] or "{}")
+        except json.JSONDecodeError:
+            continue
+        refs = extra.get("code_refs")
+        if not isinstance(refs, list):
+            continue
+        out.append(
+            {
+                "id": str(row["id"]),
+                "title": str(row["title"] or ""),
+                "refs": [ref for ref in refs if isinstance(ref, dict)],
+            }
+        )
+    return out
+
+
+def _ref_symbols(refs: list[dict[str, Any]], db_repo_id: str) -> set[str]:
+    """Symbols those refs cite, minus file refs and other repos' refs.
+
+    The repo claim uses the engine's :func:`code_intel.ref_repo_claim` (field,
+    else ``codegraph://`` uri host) — the same gate ``ref_status`` applies, so
+    refs minted by ``memo code-facts --project`` (uri claim only, no field)
+    are never judged against the wrong DB.
+    """
+    from memo import code_intel
+
+    symbols: set[str] = set()
+    for ref in refs:
+        if str(ref.get("kind") or "").strip().lower() == "file":
+            continue
+        repo = code_intel.ref_repo_claim(ref)
+        if repo and repo != db_repo_id:
+            continue
+        symbol = str(ref.get("label") or "").strip()
+        if symbol:
+            symbols.add(symbol)
+    return symbols
+
+
+def _dead_knowledge(
+    graph: sqlite3.Connection, db_repo_id: str, cited: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Memories citing symbols that exist in the graph with zero callers.
+
+    A symbol absent from the graph is drift (the nightly pass's business),
+    not dead knowledge — only symbols present with 0 incoming ``calls``
+    edges count.
+    """
+    all_symbols = sorted({s for memory in cited for s in _ref_symbols(memory["refs"], db_repo_id)})
+    if not all_symbols:
+        return []
+    marks = ", ".join("?" * len(all_symbols))
+    try:
+        rows = graph.execute(
+            "SELECT n.name, COUNT(e.source) FROM nodes n "  # noqa: S608 — placeholders only
+            "LEFT JOIN edges e ON e.target = n.id AND e.kind = 'calls' "
+            f"WHERE n.kind != 'file' AND n.name IN ({marks}) GROUP BY n.name",
+            all_symbols,
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    callers = {str(row[0]): int(row[1]) for row in rows}
+    out: list[dict[str, Any]] = []
+    for memory in cited:
+        dead = sorted(s for s in _ref_symbols(memory["refs"], db_repo_id) if callers.get(s) == 0)
+        if dead:
+            out.append({"id": memory["id"], "title": memory["title"], "symbols": dead})
+    return out
+
+
+def _hubs_without_memory(graph: sqlite3.Connection, store_conn: Any) -> list[dict[str, Any]]:
+    """Top src/ call hubs (by incoming ``calls`` edges) that no memory cites."""
+    from memo import code_intel
+
+    try:
+        rows = graph.execute(
+            "SELECT t.name, t.qualified_name, t.file_path, COUNT(*) AS n "
+            "FROM edges e JOIN nodes t ON e.target = t.id "
+            "WHERE e.kind = 'calls' AND t.file_path LIKE 'src/%' "
+            "GROUP BY t.id ORDER BY n DESC, t.qualified_name LIMIT ?",
+            (_HUB_LIMIT,),
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    out: list[dict[str, Any]] = []
+    for name, qualified, file_path, n in rows:
+        symbol = str(name or "")
+        if not symbol or code_intel.memories_citing(store_conn, symbols={symbol}, limit=1):
+            continue
+        out.append(
+            {
+                "name": symbol,
+                "qualified_name": str(qualified or symbol),
+                "file_path": str(file_path or ""),
+                "callers": int(n),
+            }
+        )
+    return out
+
+
+def _live_counts(
+    graph: sqlite3.Connection, db_repo_id: str, cited: list[dict[str, Any]]
+) -> dict[str, int]:
+    """Live re-verification of every cited ref via ``code_intel.ref_status``."""
+    from memo import code_intel
+
+    counts = {"vigente": 0, "desaparecido": 0, "no_verificable": 0}
+    for memory in cited:
+        for ref in memory["refs"]:
+            status = code_intel.ref_status(graph, ref, db_repo_id)
+            counts["no_verificable" if status is None else status] += 1
+    return counts
+
+
+def _render_health(report: dict[str, Any]) -> None:
+    drift = report["drift"]
+    if drift.get("status") == "no-receipt":
+        console.print("[dim]drift: sin receipt nocturno — corré `memo dream run`[/dim]")
+    else:
+        console.print(
+            f"drift: {drift['status']} — {drift['scanned']} scanned, "
+            f"{drift['outdated']} outdated, {drift['partial']} partial, "
+            f"{drift['repaired']} repaired"
+        )
+    live = drift.get("live")
+    if live:
+        console.print(
+            f"live: {live['vigente']} vigentes, {live['desaparecido']} desaparecidos, "
+            f"{live['no_verificable']} no verificables"
+        )
+    dead = report["dead_knowledge"]
+    if dead:
+        console.print(f"[yellow]dead knowledge ({len(dead)}):[/yellow]")
+        for entry in dead:
+            symbols = ", ".join(entry["symbols"])
+            console.print(f"  [{entry['id'][:8]}] {entry['title']} — 0 callers: {symbols}")
+    else:
+        console.print("[dim]dead knowledge: none[/dim]")
+    hubs = report["hubs_sin_memoria"]
+    if hubs:
+        console.print(f"[yellow]hubs sin memoria ({len(hubs)}):[/yellow]")
+        for hub in hubs:
+            console.print(f"  {hub['name']} ({hub['callers']} callers) — {hub['file_path']}")
+    else:
+        console.print("[dim]hubs sin memoria: none[/dim]")
+
+
+@click.command(name="code-health")
+@click.option("--live", is_flag=True, help="Re-verify every code ref against the live index.")
+@click.option("--json", "as_json", is_flag=True, help="Output raw JSON.")
+def code_health_cmd(live: bool, as_json: bool) -> None:
+    """Health report joining the codegraph index with the memory corpus.
+
+    Three sections: the last nightly drift receipt (memo dream run), dead
+    knowledge (memories citing symbols nobody calls), and the top call hubs
+    no memory documents. --live re-verifies every code ref against the live
+    index. Read-only over codegraph.db; a missing index degrades to a
+    notice, exit 0.
+
+    Example: memo code-health --live --json
+    """
+    from memo import code_intel
+
+    cfg = Config.from_env()
+    report: dict[str, Any] = {
+        "drift": _drift_summary(cfg),
+        "dead_knowledge": [],
+        "hubs_sin_memoria": [],
+    }
+    opened = code_intel.open_graph()
+    if opened is None:
+        if as_json:
+            click.echo(json.dumps(report, ensure_ascii=False, indent=2))
+        else:
+            console.print(Panel("codegraph index no disponible", border_style="yellow"))
+        return
+    graph, db_repo_id = opened
+    mem = _get_memory(cfg)
+    try:
+        cited = _cited_memories(mem.store._conn)
+        if live:
+            report["drift"]["live"] = _live_counts(graph, db_repo_id, cited)
+        report["dead_knowledge"] = _dead_knowledge(graph, db_repo_id, cited)
+        report["hubs_sin_memoria"] = _hubs_without_memory(graph, mem.store._conn)
+    finally:
+        graph.close()
+    if as_json:
+        click.echo(json.dumps(report, ensure_ascii=False, indent=2))
+        return
+    _render_health(report)

--- a/src/memo/cli_dream_passes.py
+++ b/src/memo/cli_dream_passes.py
@@ -9,6 +9,7 @@ read-only pre-mutation inventory. All are imported (and re-exported) by
 
 from __future__ import annotations
 
+import difflib
 import json
 import logging as _logging
 import sqlite3
@@ -1066,36 +1067,167 @@ def _code_ref_exists(
 ) -> bool | None:
     """Check one code_ref against the codegraph nodes table (one query per ref).
 
-    Returns True/False when the ref is verifiable (has a file_path and belongs
-    to the repo this DB indexes), None when it is not — an unverifiable ref
-    must never count as drift (mirror code_traceability's "never invent
-    misses"). Each ref carries the repo_id it was minted against
-    (``codegraph://<repo_id>/…``); a ref from ANOTHER repo (synapse/memflow/…)
-    legitimately has no node in this DB, so it is unverifiable here — never
-    dead. File-kind refs carry no symbol, so they are judged on file_path
-    existence alone; symbol refs additionally require a node whose name or
-    qualified_name matches.
+    Thin adapter over :func:`memo.code_intel.ref_status` — the single home of
+    the verification semantics (recall's ``_code_ref_status`` delegates there
+    too). Returns True/False when the ref is verifiable (has a file_path and
+    belongs to the repo this DB indexes), None when it is not — an
+    unverifiable ref must never count as drift (mirror code_traceability's
+    "never invent misses"). A ref minted against ANOTHER repo
+    (``codegraph://<repo_id>/…``) legitimately has no node in this DB, so it
+    is unverifiable here — never dead.
     """
-    ref_repo_id = str(ref.get("repo_id") or "").strip()
-    if ref_repo_id and ref_repo_id != db_repo_id:
-        return None
+    from memo import code_intel
+
+    status = code_intel.ref_status(graph, ref, db_repo_id)
+    return None if status is None else status == "vigente"
+
+
+# Rename candidates below this difflib ratio are not plausible renames: a
+# deleted symbol's surviving siblings must never be mistaken for its new name.
+_RENAME_SIMILARITY_FLOOR = 0.6
+# Containment ("save" in "old_save") is only rename evidence on real words —
+# 1-2 char names contain trivially.
+_RENAME_CONTAINMENT_MIN_LEN = 3
+
+
+def _plausible_rename(old: str, new: str) -> bool:
+    """True when ``new`` plausibly renames ``old`` (containment or edit similarity)."""
+    a, b = old.lower(), new.lower()
+    if not a or not b:
+        return False
+    if min(len(a), len(b)) >= _RENAME_CONTAINMENT_MIN_LEN and (a in b or b in a):
+        return True
+    return difflib.SequenceMatcher(None, a, b).ratio() >= _RENAME_SIMILARITY_FLOOR
+
+
+def _repair_candidate(graph: sqlite3.Connection, ref: dict[str, Any]) -> dict[str, Any] | None:
+    """Unique rename/move candidate node for one dead code ref, or None.
+
+    Rename: a node of the same kind in the same file whose ``qualified_name``
+    keeps the dead ref's namespace (only the final segment changed) AND whose
+    name is a :func:`_plausible_rename` of the dead symbol — without the
+    similarity guard, a DELETED symbol whose file keeps exactly one sibling of
+    the same kind would be silently re-pointed at that unrelated symbol. Move:
+    a node with the same name and kind in another file. Repair is only safe
+    with EXACTLY one distinct candidate across both probes — 0 or >1 keeps
+    today's archive flow. Fail-open: any sqlite error means no candidate.
+    """
     file_path = str(ref.get("file_path") or "").strip()
-    if not file_path:
-        return None
-    kind = str(ref.get("kind") or "").strip().lower()
+    kind = str(ref.get("kind") or "").strip()
     label = str(ref.get("label") or "").strip()
     qualified = str(ref.get("qualified_name") or "").strip()
-    symbol = label or qualified
-    if kind == "file" or not symbol:
-        row = graph.execute(
-            "SELECT 1 FROM nodes WHERE file_path = ? LIMIT 1", (file_path,)
-        ).fetchone()
-    else:
-        row = graph.execute(
-            "SELECT 1 FROM nodes WHERE file_path = ? AND (name = ? OR qualified_name = ?) LIMIT 1",
-            (file_path, symbol, qualified or symbol),
-        ).fetchone()
-    return row is not None
+    symbol = label or qualified.rsplit(".", 1)[-1]
+    if not file_path or not kind or not symbol:
+        return None
+    columns = "id, name, qualified_name, file_path, start_line, end_line"
+    rename_sql = f"SELECT {columns} FROM nodes WHERE file_path = ? AND kind = ? AND name != ?"  # noqa: S608 — static columns, placeholders only
+    rename_params: list[Any] = [file_path, kind, symbol]
+    if "." in qualified:
+        rename_sql += " AND qualified_name = ? || '.' || name"
+        rename_params.append(qualified.rsplit(".", 1)[0])
+    move_sql = f"SELECT {columns} FROM nodes WHERE name = ? AND kind = ? AND file_path != ?"  # noqa: S608 — static columns, placeholders only
+    try:
+        rows = [
+            row
+            for row in graph.execute(rename_sql, rename_params).fetchall()
+            if _plausible_rename(symbol, str(row[1] or ""))
+        ]
+        rows += graph.execute(move_sql, (symbol, kind, file_path)).fetchall()
+    except sqlite3.Error:
+        return None
+    unique = {str(row[0]): row for row in rows}
+    if len(unique) != 1:
+        return None
+    (row,) = unique.values()
+    return {
+        "id": str(row[0]),
+        "name": str(row[1] or ""),
+        "qualified_name": str(row[2] or row[1] or ""),
+        "file_path": str(row[3] or ""),
+        "start_line": int(row[4]) if row[4] is not None else None,
+        "end_line": int(row[5]) if row[5] is not None else None,
+    }
+
+
+def _repair_dead_refs(
+    mem: Memory,
+    graph: sqlite3.Connection,
+    mid: str,
+    extra: dict[str, Any],
+    db_repo_id: str,
+    *,
+    dry_run: bool,
+    result: dict[str, Any],
+) -> bool:
+    """Try to re-point a fully-drifted memory's dead refs; True skips archive.
+
+    Every dead ref with a unique :func:`_repair_candidate` is updated in
+    place (uri regenerated, file_path/lines/qualified_name re-pointed) and
+    the old ref is preserved in ``extra.code_refs_history``; the memory is
+    then NOT archived tonight — the repaired refs re-verify on the next
+    pass. Receipt entries land in ``result["repaired"]`` ({id, from, to});
+    a dry-run records them without writing. Returns False when nothing is
+    repairable, so the caller archives as today.
+    """
+    from memo.code_traceability import codegraph_uri
+
+    fixes: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for ref in extra.get("code_refs") or []:
+        if not isinstance(ref, dict) or _code_ref_exists(graph, ref, db_repo_id) is not False:
+            continue
+        cand = _repair_candidate(graph, ref)
+        if cand is not None:
+            fixes.append((ref, cand))
+    if not fixes:
+        return False
+    history = extra.get("code_refs_history")
+    if not isinstance(history, list):
+        history = []
+    entries: list[dict[str, str]] = []
+    for ref, cand in fixes:
+        new_uri = codegraph_uri(db_repo_id, cand["id"])
+        old = str(ref.get("uri") or ref.get("qualified_name") or ref.get("label") or "")
+        entries.append({"id": mid, "from": old, "to": new_uri})
+        if dry_run:
+            continue
+        history.append(dict(ref))
+        ref.update(
+            {
+                "uri": new_uri,
+                "repo_id": db_repo_id,
+                "stable_symbol_id": cand["id"],
+                "label": cand["name"],
+                "qualified_name": cand["qualified_name"],
+                "file_path": cand["file_path"],
+                "start_line": cand["start_line"],
+                "end_line": cand["end_line"],
+            }
+        )
+    if not dry_run:
+        extra["code_refs_history"] = history
+        try:
+            mem.update(mid, extra=extra)
+        except (MemoError, OSError, ValueError, TypeError, KeyError, sqlite3.Error) as exc:
+            result.setdefault("errors", []).append(f"code_drift: repair failed for {mid}: {exc}")
+            return True
+    result["repaired"].extend(entries)
+    return True
+
+
+def _drift_hub_gaps(mem: Memory, graph: sqlite3.Connection, result: dict[str, Any]) -> None:
+    """Persist tonight's "hub sin memoria" lines into the drift receipt.
+
+    Gated by MEMO_GAPS_CODE_HUBS. The SessionStart briefing reads these
+    receipt lines (``ask_gaps._hub_briefing_lines``) instead of querying the
+    graph live — its budget is zero graph queries.
+    """
+    from memo.flags import flag_bool
+
+    if not flag_bool("MEMO_GAPS_CODE_HUBS"):
+        return
+    from memo.ask_gaps import _HUB_TOP, _hub_gap_lines
+
+    result["hub_gaps"] = _hub_gap_lines(mem.store._conn, graph, top=_HUB_TOP)
 
 
 def _run_code_drift(
@@ -1109,14 +1241,20 @@ def _run_code_drift(
 
     For every non-reference memory whose ``extra.code_refs`` cite codegraph
     nodes, each ref is checked read-only against ``codegraph.db`` (one EXISTS
-    query per ref via :func:`_code_ref_exists`). A memory whose verifiable refs
-    are ALL gone is proposed outdated through ``mem.feedback_flag`` — the same
-    reversible-archive mechanism agents use, never a hard delete. Partially
-    drifted memories are only reported. Refs whose ``repo_id`` does not match
-    the repo this DB indexes are unverifiable (other indexed repos are not
-    drift). Gated on MEMO_DREAM_CODE_DRIFT_ENABLED
+    query per ref via :func:`_code_ref_exists`). A memory whose refs are ALL
+    verifiable here and ALL gone is proposed outdated through
+    ``mem.feedback_flag`` — the same reversible-archive mechanism agents use,
+    never a hard delete. Partially drifted memories — including any memory
+    carrying an unverifiable ref, which is never evidence of drift — are only
+    reported. Refs whose ``repo_id`` does not match the repo this DB indexes
+    are unverifiable (other indexed repos are not drift). Gated on MEMO_DREAM_CODE_DRIFT_ENABLED
     (default OFF); aborts when the index is missing or older than
     ``max_age_hours`` (a stale index would read as mass false drift).
+
+    With MEMO_DREAM_CODE_REPAIR_ENABLED (default OFF), a fully-drifted
+    memory is auto-repaired instead of archived when its dead refs have a
+    unique rename/move candidate (see :func:`_repair_dead_refs`); 0 or >1
+    candidates keep today's archive flow.
 
     Returns a dict with:
     - status: disabled | aborted | ok
@@ -1124,14 +1262,28 @@ def _run_code_drift(
     - outdated: list of {id, refs_dead, refs_total} archived (or would-archive
       in dry-run)
     - partial: list of {id, refs_dead, refs_total} reported only
+    - repaired: list of {id, from, to} re-pointed refs (or would-repair in
+      dry-run)
+    - hub_gaps (with MEMO_GAPS_CODE_HUBS): "hub sin memoria" lines computed
+      here so the SessionStart briefing reads the receipt, never the graph
     """
-    from memo.dream_flags import CODE_DRIFT_FLAG  # import registers the flag spec
+    from memo.dream_flags import (  # import registers the flag specs
+        CODE_DRIFT_FLAG,
+        CODE_REPAIR_FLAG,
+    )
     from memo.flags import flag_bool
 
     if not flag_bool(CODE_DRIFT_FLAG):
         return {"status": "disabled"}
 
-    result: dict[str, Any] = {"status": "ok", "scanned": 0, "outdated": [], "partial": []}
+    repair = flag_bool(CODE_REPAIR_FLAG)
+    result: dict[str, Any] = {
+        "status": "ok",
+        "scanned": 0,
+        "outdated": [],
+        "partial": [],
+        "repaired": [],
+    }
     try:
         if db_path is None:
             from memo import codegraph_loader
@@ -1173,8 +1325,6 @@ def _run_code_drift(
             "SELECT id, extra_json FROM meta WHERE type != 'reference' "
             "AND json_extract(extra_json, '$.code_refs') IS NOT NULL"
         ).fetchall()
-        if not rows:
-            return result
 
         graph = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
         try:
@@ -1187,21 +1337,26 @@ def _run_code_drift(
                 refs = extra.get("code_refs")
                 if not isinstance(refs, list):
                     continue
-                verdicts = [
-                    alive
-                    for r in refs
-                    if isinstance(r, dict)
-                    and (alive := _code_ref_exists(graph, r, db_repo_id)) is not None
+                statuses = [
+                    _code_ref_exists(graph, r, db_repo_id) for r in refs if isinstance(r, dict)
                 ]
-                if not verdicts:
+                dead = statuses.count(False)
+                live = statuses.count(True)
+                if dead + live == 0:
                     continue
                 result["scanned"] += 1
-                dead = sum(1 for alive in verdicts if not alive)
                 if dead == 0:
                     continue
-                entry = {"id": mid, "refs_dead": dead, "refs_total": len(verdicts)}
-                if dead < len(verdicts):
+                entry = {"id": mid, "refs_dead": dead, "refs_total": dead + live}
+                # Archive needs EVERY ref dead — a live ref OR an unverifiable
+                # one (e.g. a cross-repo codegraph:// citation, possibly fully
+                # vigente in its own repo) caps the memory at partial evidence.
+                if dead < len(statuses):
                     result["partial"].append(entry)
+                    continue
+                if repair and _repair_dead_refs(
+                    mem, graph, mid, extra, db_repo_id, dry_run=dry_run, result=result
+                ):
                     continue
                 if not dry_run:
                     try:
@@ -1212,6 +1367,7 @@ def _run_code_drift(
                         )
                         continue
                 result["outdated"].append(entry)
+            _drift_hub_gaps(mem, graph, result)
         finally:
             graph.close()
     except Exception as exc:

--- a/src/memo/cli_search.py
+++ b/src/memo/cli_search.py
@@ -371,6 +371,14 @@ def ask(
     show_default=True,
     help="Preview length for retrieved memory snippets.",
 )
+@click.option(
+    "--code",
+    default=None,
+    help="Anchor the pack on code: a symbol name, or a file path when it "
+    "contains '/'. Adds a '## Código relacionado' section (1-hop codegraph "
+    "neighbors + memories citing them); silently omitted when no codegraph "
+    "index is available.",
+)
 @click.option("--json", "as_json", is_flag=True)
 @click.option(
     "--source",
@@ -383,13 +391,19 @@ def context_pack_cmd(
     k: int,
     type_: str | None,
     snippet_chars: int,
+    code: str | None,
     as_json: bool,
     source: str | None,
 ) -> None:
     """Build an explicit composed context pack without running the LLM."""
     import time
 
-    from memo.context_pack import build_context_pack, consult_hits_from_pack
+    from memo.context_pack import (
+        DEFAULT_BUDGET_CHARS,
+        build_context_pack,
+        code_related_section,
+        consult_hits_from_pack,
+    )
     from memo.flags import flag_bool
 
     cfg = Config.from_env()
@@ -408,7 +422,13 @@ def context_pack_cmd(
         read_through=False,
         quality_rerank=True,
     )
-    pack = build_context_pack(question, hits, snippet_chars=snippet_chars)
+    code_section = code_related_section(code, mem.store._conn) if code else ""
+    budget_chars = DEFAULT_BUDGET_CHARS
+    if code_section:
+        budget_chars = max(1, budget_chars - len(code_section) - 2)
+    pack = build_context_pack(
+        question, hits, snippet_chars=snippet_chars, budget_chars=budget_chars
+    )
     log_cli_consult(
         cfg,
         verb="context_pack",
@@ -418,12 +438,14 @@ def context_pack_cmd(
         source=source,
     )
     payload = asdict(pack)
+    if code_section:
+        payload["code_context"] = code_section
     if as_json:
         click.echo(json.dumps(payload, ensure_ascii=False, indent=2))
         return
     console.print(
         Panel.fit(
-            pack.to_prompt(),
+            "\n\n".join(part for part in (pack.to_prompt(), code_section) if part),
             title=f"context-pack: {question[:60]}",
             border_style="cyan",
         )

--- a/src/memo/code_intel.py
+++ b/src/memo/code_intel.py
@@ -1,0 +1,235 @@
+"""code_intel — shared read-only engine joining codegraph with memories.
+
+Single home for the refs↔nodes verification semantics and the graph↔memory
+joins consumed by recall, dream, briefing, ask-gaps, and the code-* CLI
+commands. Three invariants, enforced HERE so consumers never re-implement
+them:
+
+- **Read-only.** The codegraph index is always opened ``mode=ro`` — this
+  module never writes it.
+- **Fail-open.** No error escapes to a consumer: a missing/broken index or a
+  malformed ref degrades to the feature being absent (None / empty result),
+  never to an exception on a hot path.
+- **repo_id gating is central.** A ref minted against another repo's graph
+  (``codegraph://<repo_id>/…``) is unverifiable against this DB — never dead.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Collection
+from pathlib import Path
+from typing import Any
+
+from memo import codegraph_loader
+from memo.code_traceability import codegraph_repo_id, parse_codegraph_uri
+
+# Undirected expansion depth cap: 2 hops already covers caller-of-caller /
+# callee-of-callee; deeper walks explode into whole-module neighborhoods.
+_MAX_HOPS = 2
+
+
+def open_graph(db_path: Path | None = None) -> tuple[sqlite3.Connection, str] | None:
+    """(read-only connection, db repo_id) or None when the DB is missing/unopenable.
+
+    The DB resolves via :func:`codegraph_loader._resolve_db` (explicit path >
+    cwd discovery > ``MEMO_CODEGRAPH_DB`` > checkout default). The repo_id is
+    the id of the repo the index lives in (``<repo_root>/.codegraph/…``) —
+    the value :func:`ref_status` gates foreign refs against. The caller closes
+    the connection.
+    """
+    db = codegraph_loader._resolve_db(db_path)
+    if not db.is_file():
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    except sqlite3.Error:
+        return None
+    return conn, codegraph_repo_id(db.parent.parent)
+
+
+def ref_repo_claim(ref: Any) -> str:
+    """The repo a ref claims to belong to; '' means "no claim" (verifiable here).
+
+    Single extraction shared by every consumer that gates on repo_id: the
+    explicit ``repo_id`` field wins when present (an empty value IS a claim of
+    "none"), else the host of the ref's ``codegraph://`` uri — the only claim
+    the refs minted by ``memo code-facts`` carry — else ''.
+    """
+    if not isinstance(ref, dict):
+        return ""
+    if "repo_id" in ref:
+        return str(ref.get("repo_id") or "").strip()
+    uri = str(ref.get("uri") or "").strip()
+    if uri:
+        parsed = parse_codegraph_uri(uri)
+        if parsed is not None:
+            return parsed[0]
+    return ""
+
+
+def ref_status(graph: sqlite3.Connection, ref: Any, db_repo_id: str) -> str | None:
+    """'vigente' | 'desaparecido' | None (unverifiable) for one code ref.
+
+    None when: ref is not a dict, has no file_path, was minted against another
+    repo, or the query fails — an unverifiable ref must never count as dead.
+    The ref's repo claim comes from :func:`ref_repo_claim`.
+
+    Match semantics (the ONE implementation recall and dream delegate to):
+    ``kind == 'file'`` or no symbol → the file_path exists in the nodes index;
+    a symbol ref (label falling back to qualified_name) additionally requires
+    a node whose ``name`` matches the symbol OR whose ``qualified_name``
+    matches (qualified or symbol). 'vigente' is never asserted without a
+    positive SELECT against the live index.
+    """
+    if graph is None or not isinstance(ref, dict):
+        return None
+    ref_repo_id = ref_repo_claim(ref)
+    if ref_repo_id and ref_repo_id != db_repo_id:
+        return None
+    file_path = str(ref.get("file_path") or "").strip()
+    if not file_path:
+        return None
+    kind = str(ref.get("kind") or "").strip().lower()
+    label = str(ref.get("label") or "").strip()
+    qualified = str(ref.get("qualified_name") or "").strip()
+    symbol = label or qualified
+    try:
+        if kind == "file" or not symbol:
+            row = graph.execute(
+                "SELECT 1 FROM nodes WHERE file_path = ? LIMIT 1", (file_path,)
+            ).fetchone()
+        else:
+            row = graph.execute(
+                "SELECT 1 FROM nodes WHERE file_path = ? AND (name = ? OR qualified_name = ?) "
+                "LIMIT 1",
+                (file_path, symbol, qualified or symbol),
+            ).fetchone()
+    except sqlite3.Error:
+        return None
+    return "vigente" if row else "desaparecido"
+
+
+def _ref_field(field: str) -> str:
+    """SQL fragment extracting one field from a code_refs entry, NULL-safe.
+
+    ``json_each`` yields scalar rows for malformed entries (a string where an
+    object belongs); the CASE guard keeps ``json_extract`` off non-objects,
+    where it would raise instead of matching nothing.
+    """
+    return f"CASE WHEN ref.type = 'object' THEN json_extract(ref.value, '$.{field}') END"
+
+
+def memories_citing(
+    store_conn: Any, *, paths: Collection[str] = (), symbols: Collection[str] = (), limit: int = 50
+) -> list[dict[str, Any]]:
+    """[{'id','title','refs'}] of non-reference memories citing those paths/symbols.
+
+    A memory matches when any ``extra.code_refs`` entry has an exact
+    ``file_path`` in ``paths`` or a ``label``/``qualified_name`` in
+    ``symbols``. Pure JSON1 (``json_each`` over ``meta.extra_json``) — no MLX,
+    no embeddings; corrupt ``extra_json`` rows are skipped via ``json_valid``.
+    [] when no criteria are given or on any sqlite error.
+    """
+    wanted_paths = [str(p) for p in paths if p]
+    wanted_symbols = [str(s) for s in symbols if s]
+    if not wanted_paths and not wanted_symbols:
+        return []
+    clauses: list[str] = []
+    params: list[Any] = []
+    if wanted_paths:
+        marks = ", ".join("?" * len(wanted_paths))
+        clauses.append(f"{_ref_field('file_path')} IN ({marks})")
+        params.extend(wanted_paths)
+    if wanted_symbols:
+        marks = ", ".join("?" * len(wanted_symbols))
+        clauses.append(f"{_ref_field('label')} IN ({marks})")
+        params.extend(wanted_symbols)
+        clauses.append(f"{_ref_field('qualified_name')} IN ({marks})")
+        params.extend(wanted_symbols)
+    sql = (
+        "SELECT DISTINCT m.id, m.title, m.extra_json "  # noqa: S608 — placeholders only
+        "FROM meta m, json_each(m.extra_json, '$.code_refs') ref "
+        "WHERE m.type != 'reference' AND json_valid(m.extra_json) "
+        f"AND ({' OR '.join(clauses)}) LIMIT ?"
+    )
+    params.append(int(limit))
+    try:
+        rows = store_conn.execute(sql, params).fetchall()
+    except sqlite3.Error:
+        return []
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            extra = json.loads(row[2] or "{}")
+        except (TypeError, json.JSONDecodeError):
+            extra = {}
+        refs = extra.get("code_refs")
+        out.append(
+            {
+                "id": str(row[0]),
+                "title": str(row[1] or ""),
+                "refs": refs if isinstance(refs, list) else [],
+            }
+        )
+    return out
+
+
+def symbols_for_files(graph: sqlite3.Connection, files: Collection[str]) -> set[str]:
+    """Names of nodes defined in those files (``kind='file'`` nodes excluded)."""
+    wanted = [str(f) for f in files if f]
+    if not wanted:
+        return set()
+    marks = ", ".join("?" * len(wanted))
+    try:
+        rows = graph.execute(
+            f"SELECT name FROM nodes WHERE kind != 'file' AND file_path IN ({marks})",  # noqa: S608 — placeholders only
+            wanted,
+        ).fetchall()
+    except sqlite3.Error:
+        return set()
+    return {str(row[0]) for row in rows if row[0]}
+
+
+def neighbors(graph: sqlite3.Connection, symbols: set[str], hops: int = 1) -> set[str]:
+    """Undirected expansion of ``symbols`` over the traversable edge kinds.
+
+    Traverses edges whose kind is in :data:`codegraph_loader._EDGE_KINDS`
+    (calls/instantiates/extends/decorates — 'contains'/'imports' are
+    structural noise). The seed is always included; ``hops`` is clamped to
+    ``_MAX_HOPS``. On any sqlite error the expansion so far is returned.
+    """
+    result = {str(s) for s in symbols if s}
+    frontier = set(result)
+    kind_marks = ", ".join("?" * len(codegraph_loader._EDGE_KINDS))
+    for _ in range(min(int(hops), _MAX_HOPS)):
+        if not frontier:
+            break
+        marks = ", ".join("?" * len(frontier))
+        sql = (
+            "SELECT s.name, t.name FROM edges e "  # noqa: S608 — placeholders only
+            "JOIN nodes s ON e.source = s.id "
+            "JOIN nodes t ON e.target = t.id "
+            f"WHERE e.kind IN ({kind_marks}) "
+            f"AND (s.name IN ({marks}) OR t.name IN ({marks}))"
+        )
+        seed = sorted(frontier)
+        try:
+            rows = graph.execute(sql, (*codegraph_loader._EDGE_KINDS, *seed, *seed)).fetchall()
+        except sqlite3.Error:
+            return result
+        reached = {str(name) for row in rows for name in row if name}
+        frontier = reached - result
+        result |= frontier
+    return result
+
+
+__all__ = [
+    "memories_citing",
+    "neighbors",
+    "open_graph",
+    "ref_repo_claim",
+    "ref_status",
+    "symbols_for_files",
+]

--- a/src/memo/context_pack.py
+++ b/src/memo/context_pack.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import sqlite3
 from dataclasses import dataclass
 from typing import Any
 
 from memo.quality import QualityDecision, classify_quality
+
+DEFAULT_BUDGET_CHARS = 4000
+
+# --code section caps: enough neighborhood to orient without flooding the pack.
+_CODE_SECTION_SYMBOL_CAP = 8
+_CODE_SECTION_MEMORY_CAP = 5
 
 
 @dataclass(frozen=True)
@@ -215,12 +222,64 @@ def _trim_to_budget(pack: ContextPack, budget_chars: int) -> ContextPack:
     return ContextPack(pack.question, summary, [], [], [], "")
 
 
+def _symbol_locations(graph: sqlite3.Connection, symbols: set[str]) -> list[tuple[str, str, int]]:
+    """(name, file_path, start_line) for each symbol node, alphabetical, capped."""
+    if not symbols:
+        return []
+    marks = ", ".join("?" * len(symbols))
+    sql = (
+        "SELECT DISTINCT name, file_path, start_line FROM nodes "  # noqa: S608 — placeholders only
+        f"WHERE kind != 'file' AND name IN ({marks}) ORDER BY name, file_path LIMIT ?"
+    )
+    try:
+        rows = graph.execute(sql, (*sorted(symbols), _CODE_SECTION_SYMBOL_CAP)).fetchall()
+    except sqlite3.Error:
+        return []
+    return [(str(row[0]), str(row[1] or ""), int(row[2] or 0)) for row in rows]
+
+
+def code_related_section(code: str, store_conn: Any) -> str:
+    """'## Código relacionado' block anchoring the pack on a symbol or path.
+
+    ``code`` containing '/' is treated as a file path (the symbols defined
+    there seed the walk); anything else is a literal symbol name. The seed
+    expands 1 hop over the codegraph into up to 8 symbol lines
+    (``name — file_path:start_line``) plus up to 5 memories citing the
+    neighborhood. Fail-open: missing index, unknown anchor, or any engine
+    error → '' (the pack renders exactly as without --code).
+    """
+    from memo import code_intel
+
+    anchor = str(code or "").strip()
+    if not anchor:
+        return ""
+    opened = code_intel.open_graph()
+    if opened is None:
+        return ""
+    graph, _db_repo_id = opened
+    try:
+        seeds = code_intel.symbols_for_files(graph, [anchor]) if "/" in anchor else {anchor}
+        symbols = code_intel.neighbors(graph, seeds, hops=1)
+        locations = _symbol_locations(graph, symbols)
+    finally:
+        graph.close()
+    if not locations:
+        return ""
+    lines = ["## Código relacionado"]
+    lines.extend(f"- {name} — {path}:{line}" for name, path, line in locations)
+    citing = code_intel.memories_citing(store_conn, symbols=symbols, limit=_CODE_SECTION_MEMORY_CAP)
+    if citing:
+        lines.append("Memorias que citan este código:")
+        lines.extend(f"- [{memory['id'][:8]}] {memory['title']}" for memory in citing)
+    return "\n".join(lines)
+
+
 def build_context_pack(
     question: str,
     hits: list[Any],
     *,
     snippet_chars: int,
-    budget_chars: int = 4000,
+    budget_chars: int = DEFAULT_BUDGET_CHARS,
 ) -> ContextPack:
     current: list[dict[str, Any]] = []
     supporting: list[dict[str, Any]] = []

--- a/src/memo/dev_audit.py
+++ b/src/memo/dev_audit.py
@@ -63,8 +63,8 @@ BROAD_EXCEPTION_ALLOWED: set[tuple[str, str, int]] = {
     # Code-citation lines (MEMO_RECALL_CODE_REFS_ENABLED): verification is
     # fail-open — a codegraph open/lookup error degrades the ref line to
     # '(no verificado)' and must never break the recall render or the 5s hook
-    # budget.
-    ("recall_logic.py", "_code_ref_status", 1),
+    # budget. (_code_ref_status now delegates to code_intel.ref_status, which
+    # catches concrete sqlite errors itself — no broad except left there.)
     ("recall_logic.py", "_code_ref_lines", 1),
     ("cli_recall_hook.py", "recall_hook", 1),
     ("cli_recall_hook.py", "recall_hook._bail", 1),

--- a/src/memo/dream_flags.py
+++ b/src/memo/dream_flags.py
@@ -54,6 +54,14 @@ GateKind = Literal["recall", "tuner", "manual"]
 # Gates the nightly code-drift pass (`cli_dream_passes._run_code_drift`); the
 # canonical FlagSpec lives in flags_misc.py with the other dream pass flags.
 CODE_DRIFT_FLAG = "MEMO_DREAM_CODE_DRIFT_ENABLED"
+# Gates auto-repair inside the code-drift pass; canonical FlagSpec in
+# flags_misc.py next to MEMO_DREAM_CODE_DRIFT_ENABLED.
+CODE_REPAIR_FLAG = "MEMO_DREAM_CODE_REPAIR_ENABLED"
+# Dark scalar flags (default 0.0 = OFF) that owe a graduation gate like any
+# bool dark flag: the A/B seam pins them "0"/"1" (0.0 = off, 1.0 = full
+# boost), so the recall gate measures them unchanged. Explicit allowlist —
+# most float knobs are tuner territory, not graduation candidates.
+_DARK_SCALAR_FLAGS = ("MEMO_RECALL_CODE_PROXIMITY_BOOST",)
 
 
 @dataclass(frozen=True)
@@ -91,6 +99,12 @@ GATES: dict[str, GateSpec] = dict(
         _g("MEMO_ENTITY_RETRIEVAL_ENABLED", "recall", "query-time entity-overlap boost"),
         _g("MEMO_CONTRADICT_PENALTY_ENABLED", "recall", "rank-time penalty on contradicted hits"),
         _g("MEMO_GRAPH_SIGNAL_ENABLED", "recall", "graph ranking signal; doc says eval-gated"),
+        _g(
+            "MEMO_RECALL_CODE_PROXIMITY_BOOST",
+            "recall",
+            "code-proximity additive boost (dark float, 0.0 = OFF); recall A/B "
+            "via the eval flag_overrides seam — the ON pin '1' measures boost=1.0",
+        ),
         _g(
             "MEMO_GRAPH_OUTCOME_SIGNAL_ENABLED",
             "recall",
@@ -189,6 +203,12 @@ GATES: dict[str, GateSpec] = dict(
             "meta: gates the code-drift pass; needs a trusted fresh codegraph index, "
             "not recall-measurable — human flips",
         ),
+        _g(
+            CODE_REPAIR_FLAG,
+            "manual",
+            "repairs correctos observados en receipts de N noches; "
+            "falso-repair = ref apuntando a símbolo equivocado",
+        ),
         _g("MEMO_DREAM_TUNE_ENABLED", "manual", "meta: gates the tuner pass; op cost decision"),
         _g("MEMO_DREAM_TUNE_BOOST_ENABLED", "manual", "meta: gates the boost explorer"),
         _g("MEMO_DREAM_HYDE_TUNE_ENABLED", "manual", "meta: gates the HyDE A/B pass"),
@@ -219,13 +239,14 @@ GATES: dict[str, GateSpec] = dict(
 
 
 def dark_flags() -> list[FlagSpec]:
-    """Every default-off ``*_ENABLED`` bool flag in the registry — the set
-    ``GATES`` must cover."""
-    return [
+    """Every default-off ``*_ENABLED`` bool flag in the registry, plus the
+    :data:`_DARK_SCALAR_FLAGS` allowlist — the set ``GATES`` must cover."""
+    bools = [
         s
         for s in REGISTRY.values()
         if s.kind == "bool" and s.name.endswith("_ENABLED") and not s.opt_out and not s.default
     ]
+    return bools + [REGISTRY[name] for name in _DARK_SCALAR_FLAGS if name in REGISTRY]
 
 
 def _human_value(name: str) -> str | None:
@@ -571,6 +592,7 @@ def status_rows(cfg: Any, *, today: date | None = None) -> list[dict[str, Any]]:
 
 __all__ = [
     "CODE_DRIFT_FLAG",
+    "CODE_REPAIR_FLAG",
     "FLAG_LATENCY_HEADROOM",
     "GATES",
     "GateSpec",

--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -348,6 +348,27 @@ SPECS: tuple[FlagSpec, ...] = (
         opt_out=True,
     ),
     _spec(
+        "MEMO_BRIEFING_CODE_DRIFT",
+        "bool",
+        True,
+        "misc",
+        "Surface last night's code-drift outcome (memories archived / partial / "
+        "repaired) as one line in the SessionStart briefing, read from the dream "
+        "receipt (state_dir/dream/last.json) — zero graph queries at "
+        "SessionStart. Default on.",
+        opt_out=True,
+    ),
+    _spec(
+        "MEMO_GAPS_CODE_HUBS",
+        "bool",
+        True,
+        "misc",
+        "Flag knowledge gaps on code hubs in `memo ask-gaps`: top codegraph "
+        "nodes by incoming call-edges with no memory citing them. On-demand "
+        "graph query only (never the recall hook). Default on.",
+        opt_out=True,
+    ),
+    _spec(
         "MEMO_OCR_ENABLED", "bool", True, "misc", "Enable OCR for image ingestion.", opt_out=True
     ),
     _spec(
@@ -1212,6 +1233,18 @@ SPECS: tuple[FlagSpec, ...] = (
         "re-verifies memories carrying code_refs against the live codegraph index "
         "and proposes fully-drifted ones as outdated (reversible archive, never a "
         "hard delete). Aborts when the index is missing or >24h stale.",
+    ),
+    # dream — code-drift auto-repair: re-point dead refs with a unique candidate
+    _spec(
+        "MEMO_DREAM_CODE_REPAIR_ENABLED",
+        "bool",
+        False,
+        "misc",
+        "Enable auto-repair inside the nightly code-drift pass. OFF by default; "
+        "a dead code_ref with EXACTLY one rename/move candidate in the "
+        "codegraph index is re-pointed in place (the old ref is preserved in "
+        "extra.code_refs_history) and the memory is not archived that night. "
+        "0 or >1 candidates -> archive as today.",
     ),
     # dream v2 — anticipatory pass (Phase 3): surface unmet gaps + prewarm
     _spec(

--- a/src/memo/flags_recall.py
+++ b/src/memo/flags_recall.py
@@ -211,6 +211,19 @@ SPECS: tuple[FlagSpec, ...] = (
         max_val=1.0,
     ),
     _spec(
+        "MEMO_RECALL_CODE_PROXIMITY_BOOST",
+        "float",
+        0.0,
+        "recall",
+        "Additive score boost for hits whose code_refs fall in the codegraph "
+        "neighborhood (2 hops) of the uncommitted working-tree changes "
+        "(git diff --name-only HEAD, once per render). Composes like the other "
+        "rank_hits boosts. Default 0.0 = OFF: zero subprocesses and zero graph "
+        "queries — ranking identical to today.",
+        min_val=0.0,
+        max_val=1.0,
+    ),
+    _spec(
         "MEMO_RECALL_RERANK_INPUT_K",
         "int",
         10,

--- a/src/memo/recall_logic.py
+++ b/src/memo/recall_logic.py
@@ -254,30 +254,23 @@ def _code_ref_status(
 ) -> str:
     """'vigente' | 'desaparecido' | 'no verificado' for one code ref.
 
-    Mirrors the dream pass verifier (_code_ref_exists in cli_dream_passes.py):
-    ``kind == 'file'`` or no symbol → judged on file_path existence alone;
-    a symbol ref additionally requires a node whose name OR qualified_name
-    matches. 'vigente' is NEVER asserted without a positive SELECT against the
-    live nodes index. ``conn`` None (DB unavailable) or any sqlite error
-    degrades to 'no verificado' — the render never breaks on a verification
-    failure."""
+    Thin adapter over :func:`memo.code_intel.ref_status` — the single
+    implementation of the verification semantics shared with the dream pass.
+    ``conn`` None (DB unavailable) or any verification failure degrades to
+    'no verificado' — the render never breaks. repo_id gating already happened
+    in _code_ref_lines (which parses the uri), so the ref passed down carries
+    no repo claim and ``db_repo_id`` is ''."""
     if conn is None:
         return "no verificado"
-    try:
-        if kind == "file" or not symbol:
-            row = conn.execute(
-                "SELECT 1 FROM nodes WHERE file_path = ? LIMIT 1", (path,)
-            ).fetchone()
-        else:
-            row = conn.execute(
-                "SELECT 1 FROM nodes WHERE file_path = ? AND (name = ? OR qualified_name = ?) "
-                "LIMIT 1",
-                (path, symbol, qualified or symbol),
-            ).fetchone()
-    except Exception as exc:
-        _logger.debug("code refs: verify failed for %s: %s", path, exc)
-        return "no verificado"
-    return "vigente" if row else "desaparecido"
+    from memo import code_intel
+
+    ref = {
+        "file_path": path,
+        "kind": kind,
+        "label": symbol or "",
+        "qualified_name": qualified or "",
+    }
+    return code_intel.ref_status(conn, ref, "") or "no verificado"
 
 
 def _code_ref_lines(relevant: list[Any]) -> dict[int, list[str]]:
@@ -799,6 +792,131 @@ def _apply_altitude_boost(hits: list[Any], boost: float, *, broad: bool) -> list
     return boosted
 
 
+def _apply_code_proximity_boost(
+    hits: list[Any],
+    explain: dict[str, dict[str, Any]] | None = None,
+    cwd: str | None = None,
+) -> list[Any]:
+    """Code-proximity stage of ``rank_hits`` (MEMO_RECALL_CODE_PROXIMITY_BOOST).
+
+    Flag 0.0 (the default) returns ``hits`` unchanged with zero extra work —
+    no subprocess, no graph query, no import: ranking identical to today.
+    Flag > 0: ``_code_proximity_bonus`` resolves the working-tree neighborhood
+    once (in the render ``cwd`` when given) and every matching hit gains
+    +flag, re-sorted like the other additive boost stages (new list — the
+    caller's is never mutated)."""
+    boost = flag_float("MEMO_RECALL_CODE_PROXIMITY_BOOST") or 0.0
+    if boost <= 0:
+        return hits
+    bonus = _code_proximity_bonus(hits, boost, cwd)
+    if bonus:
+        hits = [
+            replace(h, score=h.score + bonus[i]) if i in bonus and h.score is not None else h
+            for i, h in enumerate(hits)
+        ]
+        hits.sort(key=lambda h: h.score or 0.0, reverse=True)
+    if explain is not None:
+        _explain_stage(explain, hits, "code_proximity")
+    return hits
+
+
+def _code_proximity_bonus(
+    hits: list[Any], boost: float, cwd: str | None = None
+) -> dict[int, float]:
+    """Hit-index -> additive bonus for hits citing code near the working tree.
+
+    ONE ``git diff --name-only HEAD`` (1s timeout, run in the render ``cwd``
+    when given — the daemon's process cwd is / or $HOME and would be dead or
+    the wrong repo) resolves the uncommitted change set; ``symbols_for_files``
+    + ``neighbors(hops=2)`` expand it into the codegraph neighborhood, with
+    the index discovered from that same ``cwd`` (a render repo without its
+    own index gets no boost — never another repo's graph). A hit earns
+    ``+boost`` exactly once when any ``extra['code_refs']`` entry claiming
+    THIS repo (or none — ``code_intel.ref_repo_claim``) cites a changed
+    ``file_path`` or a ``label``/``qualified_name`` in the neighborhood.
+    Fail-open: git or graph failure -> {} (no boost, never an exception).
+    Only reached with the flag > 0 — flag 0.0 never calls this (zero
+    subprocesses, zero queries)."""
+    import subprocess
+
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--name-only", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=1,
+            cwd=cwd or None,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    if proc.returncode != 0:
+        return {}
+    changed = {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+    if not changed:
+        return {}
+    resolved = _proximity_neighborhood(changed, cwd)
+    if resolved is None:
+        return {}
+    hood, db_repo_id = resolved
+    bonus: dict[int, float] = {}
+    for i, hit in enumerate(hits):
+        refs = (getattr(hit, "extra", None) or {}).get("code_refs")
+        if not isinstance(refs, list):
+            continue
+        if any(_proximity_ref_matches(ref, changed, hood, db_repo_id) for ref in refs):
+            bonus[i] = boost
+    return bonus
+
+
+def _proximity_neighborhood(changed: set[str], cwd: str | None) -> tuple[set[str], str] | None:
+    """(2-hop neighborhood of the changed files, db repo_id), or None.
+
+    With a render ``cwd``, the index is discovered strictly from that path —
+    a render repo without its own ``.codegraph`` gets None (never the pinned
+    or module-default DB, which belongs to another repo). Without one, the
+    engine's usual resolution applies (process cwd = render cwd on the direct
+    CLI path)."""
+    from memo import code_intel, codegraph_loader
+
+    db_path = None
+    if cwd and codegraph_loader._discovery_enabled():
+        from pathlib import Path
+
+        db_path = codegraph_loader._discover_db(start=Path(cwd))
+        if db_path is None:
+            return None
+    opened = code_intel.open_graph(db_path)
+    if opened is None:
+        return None
+    conn, db_repo_id = opened
+    try:
+        hood = code_intel.neighbors(conn, code_intel.symbols_for_files(conn, changed), hops=2)
+        return hood, db_repo_id
+    finally:
+        with contextlib.suppress(Exception):
+            conn.close()
+
+
+def _proximity_ref_matches(ref: Any, changed: set[str], hood: set[str], db_repo_id: str) -> bool:
+    """One code ref vs the local change set / neighborhood, repo-gated.
+
+    A ref claiming another repo (``code_intel.ref_repo_claim``: field or
+    codegraph:// uri host) never matches — the neighborhood was computed
+    against THIS repo's graph and diff."""
+    from memo import code_intel
+
+    if not isinstance(ref, dict):
+        return False
+    claim = code_intel.ref_repo_claim(ref)
+    if claim and claim != db_repo_id:
+        return False
+    path = str(ref.get("file_path") or "").strip()
+    label = str(ref.get("label") or "").strip()
+    qualified = str(ref.get("qualified_name") or "").strip()
+    return bool(path in changed or (label and label in hood) or (qualified and qualified in hood))
+
+
 def _mmr_token_set(hit: Any) -> frozenset[str]:
     text = f"{getattr(hit, 'title', '') or ''} {getattr(hit, 'body', '') or ''}"
     return frozenset(text.lower().split())
@@ -918,6 +1036,10 @@ class RankKnobs:
     mmr_lambda: float = 0.0
     synthesis_boost: float = 0.0
     altitude: float = 0.0  # Phase 2: boost distilled hits on a BROAD query (0.0 = OFF)
+    # Render cwd (the hook payload's cwd, NOT the daemon's process cwd): drives
+    # the code-proximity stage's git diff + .codegraph discovery. None keeps
+    # process-cwd behavior (the direct CLI path, where they coincide).
+    cwd: str | None = None
 
 
 def knobs_from_flags(
@@ -942,6 +1064,9 @@ def knobs_from_flags(
     ``project_tag`` resolves from ``cwd`` (``current_project_tag``) only when
     not passed explicitly, gated on ``project_boost > 0`` — exactly the hook's
     behavior; with neither ``project_tag`` nor ``cwd`` it stays ``None``.
+    ``cwd`` is also carried on the knobs (``RankKnobs.cwd``) so the
+    code-proximity stage runs its git diff + index discovery in the RENDER's
+    repo, not the daemon's process cwd.
 
     NOTE (path-dependence, from the M3 knobs): like preference/graph boosts,
     ``mmr_lambda``/``synthesis_boost`` apply only where ``rank_hits`` runs —
@@ -982,6 +1107,7 @@ def knobs_from_flags(
         mmr_lambda=flag_float("MEMO_RECALL_MMR_LAMBDA") or 0.0,
         synthesis_boost=flag_float("MEMO_RECALL_SYNTHESIS_BOOST") or 0.0,
         altitude=flag_float("MEMO_RECALL_ALTITUDE") or 0.0,
+        cwd=cwd,
     )
     if overrides:
         knobs = replace(knobs, **overrides)
@@ -1089,7 +1215,7 @@ def rank_hits(
     """The daemon's post-search ranking core, pure + reusable.
 
     project-tiers -> preference-boost -> synthesis-boost -> altitude-boost ->
-    dedup_hits -> min_sim/cosine + min_body gate ->
+    code-proximity-boost -> dedup_hits -> min_sim/cosine + min_body gate ->
     synthesis-dedup -> [MMR diversity reorder]. Returns the gated,
     deduped, ordered candidate list (caller splits top_k vs nudge). Used by both
     ``_recall_logic`` and the eval harness so they cannot diverge. Graph ordering
@@ -1124,6 +1250,9 @@ def rank_hits(
         raw = _apply_altitude_boost(raw, knobs.altitude, broad=_is_broad_query(query))
         if explain is not None:
             _explain_stage(explain, raw, "altitude")
+    # Live flag (not a knob): MEMO_RECALL_CODE_PROXIMITY_BOOST default 0.0 = OFF
+    # ⇒ the stage returns `raw` untouched with zero extra work.
+    raw = _apply_code_proximity_boost(raw, explain, cwd=knobs.cwd)
 
     def _passes(h: Any) -> bool:
         # bm25-mode `h.score` is on the BM25 relevance scale, NOT cosine — applying

--- a/tests/test_ask_gaps_code_hubs.py
+++ b/tests/test_ask_gaps_code_hubs.py
@@ -1,0 +1,198 @@
+"""ask-gaps code-hub gaps — top call-magnets in the codegraph nobody documented.
+
+Covers:
+- code_hub_gaps: hub without a citing memory → "hub sin memoria" line, ordered
+  by incoming call-edges, src/ nodes only; hub WITH a citing memory → absent;
+  ``top`` caps the candidate pool BEFORE the citation filter; flag off → []
+  with zero graph work; missing index → [].
+- briefing integration: at most ONE hub line rides ``briefing_lines``, read
+  from the nightly dream receipt (``code_drift.hub_gaps``) — SessionStart does
+  ZERO graph work; flag off / no receipt → no line.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from memo import ask_gaps as ag
+
+# --- synthetic codegraph.db (shape copied from test_dream_code_drift) -----------
+
+_NODES = [
+    # (id, kind, name, qualified_name, file_path, start_line, end_line)
+    (
+        "function:flag_bool",
+        "function",
+        "flag_bool",
+        "memo.flags.flag_bool",
+        "src/memo/flags.py",
+        10,
+        20,
+    ),
+    ("function:save", "function", "save", "memo.store.save", "src/memo/store.py", 30, 60),
+    # Non-src hub: receives calls but must never surface (src/% anchor).
+    ("function:helper", "function", "helper", "tools.helper.helper", "tools/helper.py", 1, 5),
+    ("function:c1", "function", "c1", "memo.x.c1", "src/memo/x.py", 1, 2),
+    ("function:c2", "function", "c2", "memo.x.c2", "src/memo/x.py", 3, 4),
+    ("function:c3", "function", "c3", "memo.x.c3", "src/memo/x.py", 5, 6),
+]
+
+_EDGES = [
+    # flag_bool: 3 incoming calls; save: 1; helper (non-src): 2.
+    ("function:c1", "function:flag_bool", "calls"),
+    ("function:c2", "function:flag_bool", "calls"),
+    ("function:c3", "function:flag_bool", "calls"),
+    ("function:c1", "function:save", "calls"),
+    ("function:c1", "function:helper", "calls"),
+    ("function:c2", "function:helper", "calls"),
+]
+
+_TOP_HUB_LINE = "hub sin memoria: flag_bool (3 callers) — src/memo/flags.py"
+
+
+def _seed_graph(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE nodes (
+            id TEXT PRIMARY KEY, kind TEXT, name TEXT, qualified_name TEXT,
+            file_path TEXT, start_line INTEGER, end_line INTEGER
+        );
+        CREATE TABLE edges (source TEXT, target TEXT, kind TEXT);
+        """
+    )
+    conn.executemany("INSERT INTO nodes VALUES (?, ?, ?, ?, ?, ?, ?)", _NODES)
+    conn.executemany("INSERT INTO edges VALUES (?, ?, ?)", _EDGES)
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def graph_db(tmp_path: Path, monkeypatch) -> Path:
+    """Seeded index, pinned via MEMO_CODEGRAPH_DB (cwd discovery is off in tests)."""
+    db = tmp_path / "proj" / ".codegraph" / "codegraph.db"
+    db.parent.mkdir(parents=True)
+    _seed_graph(db)
+    monkeypatch.setenv("MEMO_CODEGRAPH_DB", str(db))
+    return db
+
+
+def _cite(mem, label: str, qualified: str, file_path: str):
+    return mem.save(
+        content=f"{label} is documented",
+        type_="fact",
+        extra={
+            "code_refs": [
+                {
+                    "kind": "function",
+                    "label": label,
+                    "qualified_name": qualified,
+                    "file_path": file_path,
+                }
+            ]
+        },
+    )
+
+
+# --- code_hub_gaps ---------------------------------------------------------------
+
+
+def test_uncited_hubs_are_gaps_ordered_by_callers(mock_memory, graph_db):
+    gaps = ag.code_hub_gaps(mock_memory)
+
+    assert gaps == [
+        _TOP_HUB_LINE,
+        "hub sin memoria: save (1 callers) — src/memo/store.py",
+    ]
+
+
+def test_non_src_hub_never_surfaces(mock_memory, graph_db):
+    assert not any("helper" in g for g in ag.code_hub_gaps(mock_memory))
+
+
+def test_cited_hub_is_not_a_gap(mock_memory, graph_db):
+    _cite(mock_memory, "flag_bool", "memo.flags.flag_bool", "src/memo/flags.py")
+
+    gaps = ag.code_hub_gaps(mock_memory)
+
+    assert not any("flag_bool" in g for g in gaps)
+    assert gaps == ["hub sin memoria: save (1 callers) — src/memo/store.py"]
+
+
+def test_top_caps_candidates_before_citation_filter(mock_memory, graph_db):
+    assert ag.code_hub_gaps(mock_memory, top=1) == [_TOP_HUB_LINE]
+    # The single candidate is cited -> nothing left, even with `save` uncited.
+    _cite(mock_memory, "flag_bool", "memo.flags.flag_bool", "src/memo/flags.py")
+    assert ag.code_hub_gaps(mock_memory, top=1) == []
+
+
+def test_flag_off_returns_empty_with_zero_graph_work(mock_memory, graph_db, monkeypatch):
+    from memo import code_intel
+
+    monkeypatch.setenv("MEMO_GAPS_CODE_HUBS", "0")
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("flag off must never open the graph")
+
+    monkeypatch.setattr(code_intel, "open_graph", _boom)
+
+    assert ag.code_hub_gaps(mock_memory) == []
+
+
+def test_missing_index_returns_empty(mock_memory, tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMO_CODEGRAPH_DB", str(tmp_path / "nope" / "codegraph.db"))
+
+    assert ag.code_hub_gaps(mock_memory) == []
+
+
+# --- briefing integration: receipt only, zero graph work at SessionStart ------------
+
+
+def _seed_receipt(cfg, hub_gaps: list) -> None:
+    path = Path(cfg.state_dir) / "dream" / "last.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"code_drift": {"status": "ok", "hub_gaps": hub_gaps}}), encoding="utf-8"
+    )
+
+
+def test_briefing_reads_at_most_one_hub_line_from_receipt(tmp_cfg, monkeypatch):
+    from memo import code_intel
+
+    _seed_receipt(tmp_cfg, [_TOP_HUB_LINE, "hub sin memoria: save (1 callers) — src/memo/store.py"])
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("SessionStart must never open the graph")
+
+    monkeypatch.setattr(code_intel, "open_graph", _boom)
+    monkeypatch.setattr(ag, "_hub_gap_lines", _boom)
+
+    assert ag.briefing_lines(tmp_cfg, session_id="s-hub") == [_TOP_HUB_LINE]
+
+
+def test_briefing_without_receipt_is_silent_even_with_live_hubs(mock_memory, tmp_cfg, graph_db):
+    # Uncited hubs exist in the live index, but no nightly receipt was written:
+    # the briefing budget is zero graph queries, so nothing is computed live.
+    assert ag.briefing_lines(tmp_cfg, session_id="s-hub2") == []
+
+
+def test_briefing_corrupt_receipt_hub_section_is_silent(tmp_cfg):
+    _seed_receipt(tmp_cfg, "not-a-list")  # type: ignore[arg-type]
+
+    assert ag.briefing_lines(tmp_cfg, session_id="s-bad") == []
+
+
+def test_briefing_flag_off_renders_nothing_and_does_no_work(tmp_cfg, monkeypatch):
+    monkeypatch.setenv("MEMO_GAPS_CODE_HUBS", "0")
+    _seed_receipt(tmp_cfg, [_TOP_HUB_LINE])
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("flag off must never touch the store or the graph")
+
+    monkeypatch.setattr(ag, "_hub_gap_lines", _boom)
+
+    assert ag.briefing_lines(tmp_cfg, session_id="s-off") == []

--- a/tests/test_briefing_code_drift.py
+++ b/tests/test_briefing_code_drift.py
@@ -1,0 +1,112 @@
+"""code_drift_lines — nightly code-drift outcome surfaced in the briefing."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from memo.briefing import code_drift_lines
+
+
+def _cfg(tmp_path: Path) -> Any:
+    return SimpleNamespace(state_dir=tmp_path)
+
+
+def _write_receipt(state_dir: Path, code_drift: dict[str, Any] | None) -> None:
+    d = state_dir / "dream"
+    d.mkdir(parents=True, exist_ok=True)
+    receipt: dict[str, Any] = {"ts": 123.0}
+    if code_drift is not None:
+        receipt["code_drift"] = code_drift
+    (d / "last.json").write_text(json.dumps(receipt), encoding="utf-8")
+
+
+def test_outdated_renders_line(tmp_path: Path) -> None:
+    _write_receipt(
+        tmp_path,
+        {
+            "status": "ok",
+            "scanned": 5,
+            "outdated": [
+                {"id": "a", "refs_dead": 1, "refs_total": 1},
+                {"id": "b", "refs_dead": 2, "refs_total": 2},
+            ],
+            "partial": [],
+        },
+    )
+    lines = code_drift_lines(_cfg(tmp_path))
+    joined = "\n".join(lines)
+    assert "code-drift" in joined
+    assert "2 memorias archivadas" in joined
+    assert "memo dream status" in joined
+
+
+def test_partial_and_repaired_counts(tmp_path: Path) -> None:
+    _write_receipt(
+        tmp_path,
+        {
+            "status": "ok",
+            "scanned": 4,
+            "outdated": [],
+            "partial": [{"id": "a", "refs_dead": 1, "refs_total": 3}],
+            "repaired": [
+                {"id": "b", "from": "x", "to": "y"},
+                {"id": "c", "from": "u", "to": "v"},
+                {"id": "d", "from": "p", "to": "q"},
+            ],
+        },
+    )
+    joined = "\n".join(code_drift_lines(_cfg(tmp_path)))
+    assert "0 memorias archivadas" in joined
+    assert "1 parciales" in joined
+    assert "3 reparadas" in joined
+
+
+def test_clean_ok_run_is_empty(tmp_path: Path) -> None:
+    _write_receipt(
+        tmp_path,
+        {"status": "ok", "scanned": 7, "outdated": [], "partial": []},
+    )
+    assert code_drift_lines(_cfg(tmp_path)) == []
+
+
+def test_status_disabled_is_empty(tmp_path: Path) -> None:
+    _write_receipt(tmp_path, {"status": "disabled"})
+    assert code_drift_lines(_cfg(tmp_path)) == []
+
+
+def test_status_aborted_is_empty(tmp_path: Path) -> None:
+    _write_receipt(tmp_path, {"status": "aborted", "reason": "codegraph_db_missing"})
+    assert code_drift_lines(_cfg(tmp_path)) == []
+
+
+def test_missing_receipt_is_empty(tmp_path: Path) -> None:
+    assert code_drift_lines(_cfg(tmp_path)) == []
+
+
+def test_receipt_without_code_drift_key_is_empty(tmp_path: Path) -> None:
+    _write_receipt(tmp_path, None)
+    assert code_drift_lines(_cfg(tmp_path)) == []
+
+
+def test_corrupt_receipt_is_empty(tmp_path: Path) -> None:
+    d = tmp_path / "dream"
+    d.mkdir(parents=True)
+    (d / "last.json").write_text("{corrupt", encoding="utf-8")
+    assert code_drift_lines(_cfg(tmp_path)) == []
+
+
+def test_flag_off_never_opens_the_receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_receipt(
+        tmp_path,
+        {"status": "ok", "scanned": 1, "outdated": [{"id": "a"}], "partial": []},
+    )
+    monkeypatch.setenv("MEMO_BRIEFING_CODE_DRIFT", "0")
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("flag off must not touch the receipt")
+
+    monkeypatch.setattr(Path, "open", _boom)
+    assert code_drift_lines(_cfg(tmp_path)) == []

--- a/tests/test_cli_code_facts.py
+++ b/tests/test_cli_code_facts.py
@@ -15,7 +15,7 @@ import pytest
 from click.testing import CliRunner
 
 from memo.cli import cli
-from memo.code_traceability import _explicit_references
+from memo.code_traceability import _explicit_references, codegraph_repo_id
 from memo.config import Config
 from memo.memory import Memory
 
@@ -217,7 +217,10 @@ def test_apply_saves_fact_memories_with_tags_and_code_refs(tmp_path: Path, tmp_c
     assert len(records) == _EXPECTED_FACTS
     for rec in records:
         assert "codegraph-derived" in rec.tags
-        assert "project:memo" in rec.tags
+        # The project tag derives from the mined repo's root basename
+        # (<root>/.codegraph/codegraph.db), never a hardcoded project:memo.
+        assert "project:cg" in rec.tags
+        assert "project:memo" not in rec.tags
         phash = rec.extra.get("provenance_hash")
         assert isinstance(phash, str) and len(phash) == 16
         # code_refs must be in the exact shape code_traceability parses.
@@ -342,6 +345,50 @@ def test_tests_files_never_rank_in_surface_or_hubs(tmp_path: Path, tmp_cfg: Conf
     hubs = [fact for fact in data["facts"] if fact["category"] == "call-hub"]
     assert len(hubs) == 1
     assert "store.writer.store_write" in hubs[0]["text"]
+
+
+def test_project_option_tags_facts_with_project_basename_and_repo_id(
+    tmp_path: Path, tmp_cfg: Config
+) -> None:
+    proj = tmp_path / "proj"
+    _seed_codegraph(proj / ".codegraph" / "codegraph.db")
+
+    res = CliRunner().invoke(
+        cli, ["code-facts", "--apply", "--project", str(proj), "--json"], env=_env(tmp_cfg)
+    )
+
+    assert res.exit_code == 0, res.output
+    data = json.loads(res.output)
+    # DB discovered from the --project path, not from cwd.
+    assert data["db"] == str(proj / ".codegraph" / "codegraph.db")
+    assert len(data["facts"]) == _EXPECTED_FACTS
+    # Minted refs carry proj's repo_id so drift never verifies them against
+    # the wrong repo.
+    prefix = f"codegraph://{codegraph_repo_id(proj)}/"
+    for fact in data["facts"]:
+        for ref in fact["code_refs"]:
+            assert ref["uri"].startswith(prefix), ref
+
+    mem = _read_memory(tmp_cfg)
+    try:
+        records = mem.list(type_="fact", limit=100)
+    finally:
+        mem.close()
+    assert len(records) == _EXPECTED_FACTS
+    for rec in records:
+        assert "project:proj" in rec.tags
+        assert "codegraph-derived" in rec.tags
+        assert "project:memo" not in rec.tags
+
+
+def test_project_without_index_errors_cleanly(tmp_path: Path, tmp_cfg: Config) -> None:
+    proj = tmp_path / "empty-proj"
+    proj.mkdir()
+
+    res = CliRunner().invoke(cli, ["code-facts", "--project", str(proj)], env=_env(tmp_cfg))
+
+    assert res.exit_code != 0
+    assert "codegraph index not found" in res.output
 
 
 def test_missing_db_errors_cleanly(tmp_path: Path, tmp_cfg: Config) -> None:

--- a/tests/test_cli_code_intel.py
+++ b/tests/test_cli_code_intel.py
@@ -1,0 +1,372 @@
+"""Tests for `memo code-nudge` + `memo code-health` — graph↔memory awareness.
+
+All tests run against a synthetic codegraph.db under tmp_path (never the
+real `.codegraph/codegraph.db`) and an isolated `Config` via `tmp_cfg`.
+git is never invoked for real: the diff-tree subprocess is monkeypatched.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memo.cli import cli
+from memo.config import Config
+from memo.memory import Memory
+
+_STUB_DIMS = 8
+
+# --- synthetic codegraph.db (shape of test_dream_code_drift._seed_graph) --------
+
+_NODES = [
+    # (id, kind, name, qualified_name, file_path, start_line, end_line)
+    ("function:save", "function", "save", "memo.store.save", "src/memo/store.py", 10, 42),
+    ("function:helper", "function", "helper", "memo.store.helper", "src/memo/store.py", 50, 60),
+    ("function:caller", "function", "caller", "memo.cli.caller", "src/memo/cli.py", 5, 30),
+    ("file:src/memo/store.py", "file", "store.py", None, "src/memo/store.py", None, None),
+]
+
+# `save` receives one call edge (the only hub); `helper` has zero callers.
+_EDGES = [("function:caller", "function:save", "calls")]
+
+
+def _seed_graph(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE nodes (
+            id TEXT PRIMARY KEY, kind TEXT, name TEXT, qualified_name TEXT,
+            file_path TEXT, start_line INTEGER, end_line INTEGER
+        );
+        CREATE TABLE edges (source TEXT, target TEXT, kind TEXT);
+        """
+    )
+    conn.executemany("INSERT INTO nodes VALUES (?, ?, ?, ?, ?, ?, ?)", _NODES)
+    conn.executemany("INSERT INTO edges VALUES (?, ?, ?)", _EDGES)
+    conn.commit()
+    conn.close()
+
+
+def _ref(file_path: str, label: str = "", qualified: str = "", kind: str = "function") -> dict:
+    # repo_id "" = no repo claim → verifiable against any DB (see code_intel).
+    return {
+        "uri": f"codegraph://testrepo/{label or file_path}",
+        "repo_id": "",
+        "kind": kind,
+        "label": label,
+        "qualified_name": qualified,
+        "file_path": file_path,
+        "relation": "modified",
+        "confidence": 0.9,
+    }
+
+
+# --- isolation: stub embedder + no vec-similarity dedup on hash embeddings ------
+
+
+@pytest.fixture(autouse=True)
+def _stub_embedder(monkeypatch):
+    """Deterministic per-text embeddings so seeding saves never load MLX."""
+
+    def _embed(self, inputs):
+        out = []
+        for text in inputs:
+            digest = hashlib.sha256((text or "").encode("utf-8")).digest()
+            values = [((digest[i] / 255.0) * 2.0) - 1.0 for i in range(_STUB_DIMS)]
+            norm = sum(v * v for v in values) ** 0.5
+            out.append([v / norm for v in values])
+        return out
+
+    monkeypatch.setattr("memo.embedder.MLXEmbedder.embed", _embed)
+    monkeypatch.setenv("MEMO_SAVE_DEDUP_CHECK", "0")
+
+
+def _env(cfg: Config) -> dict[str, str]:
+    return {
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_DATA_DIR": str(cfg.data_dir),
+        "MEMO_STATE_DIR": str(cfg.state_dir),
+        "MEMO_EMBEDDER_DIMS": str(_STUB_DIMS),
+        "MEMO_EMBEDDER_MODEL": "stub",
+        "MEMO_SAVE_DEDUP_CHECK": "0",
+        "MEMO_AUTO_PROJECT_TAG": "0",
+    }
+
+
+def _seed_memories(cfg: Config, entries: list[tuple[str, list[dict]]]) -> list[str]:
+    """Persist one type=fact memory per (title, code_refs) entry; return ids."""
+    mem = Memory(
+        Config(
+            data_dir=cfg.data_dir,
+            state_dir=cfg.state_dir,
+            embedder_dims=_STUB_DIMS,
+            reranker_enabled=False,
+        )
+    )
+    try:
+        return [
+            mem.save(content=title, title=title, type_="fact", extra={"code_refs": refs}).id
+            for title, refs in entries
+        ]
+    finally:
+        mem.close()
+
+
+def _patch_git(
+    monkeypatch,
+    *,
+    stdout: str = "",
+    returncode: int = 0,
+    exc: Exception | None = None,
+) -> list[list[str]]:
+    """Intercept the `git diff-tree` subprocess; delegate anything else."""
+    calls: list[list[str]] = []
+    real_run = subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        if isinstance(cmd, list) and cmd[:2] == ["git", "diff-tree"]:
+            calls.append(list(cmd))
+            if exc is not None:
+                raise exc
+            return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr="")
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr("memo.cli_code_intel.subprocess.run", fake_run)
+    return calls
+
+
+# --- code-nudge -------------------------------------------------------------------
+
+
+def test_nudge_prints_memories_citing_commit_files(tmp_cfg: Config, monkeypatch) -> None:
+    [mid] = _seed_memories(
+        tmp_cfg,
+        [("save() writes md first", [_ref("src/memo/store.py", "save", "memo.store.save")])],
+    )
+    _patch_git(monkeypatch, stdout="src/memo/store.py\ndocs/notes.md\n")
+
+    res = CliRunner().invoke(cli, ["code-nudge"], env=_env(tmp_cfg))
+
+    assert res.exit_code == 0, res.output
+    assert f"[{mid[:8]}]" in res.output
+    assert "save() writes md first" in res.output
+    assert "🧠" in res.output
+
+
+def test_nudge_forwards_commit_rev_to_git(tmp_cfg: Config, monkeypatch) -> None:
+    calls = _patch_git(monkeypatch, stdout="")
+
+    res = CliRunner().invoke(cli, ["code-nudge", "--commit", "abc123"], env=_env(tmp_cfg))
+
+    assert res.exit_code == 0, res.output
+    assert res.output == ""
+    assert calls and calls[0][-1] == "abc123"
+
+
+def test_nudge_without_match_is_silent(tmp_cfg: Config, monkeypatch) -> None:
+    _seed_memories(
+        tmp_cfg,
+        [("about another file", [_ref("src/memo/other.py", "other", "memo.other.other")])],
+    )
+    _patch_git(monkeypatch, stdout="src/memo/unrelated.py\n")
+
+    res = CliRunner().invoke(cli, ["code-nudge"], env=_env(tmp_cfg))
+
+    assert res.exit_code == 0, res.output
+    assert res.output == ""
+
+
+def test_nudge_git_failure_is_silent(tmp_cfg: Config, monkeypatch) -> None:
+    _patch_git(monkeypatch, exc=OSError("no git available"))
+
+    res = CliRunner().invoke(cli, ["code-nudge"], env=_env(tmp_cfg))
+
+    assert res.exit_code == 0, res.output
+    assert res.output == ""
+
+
+def test_nudge_caps_output_at_three_lines(tmp_cfg: Config, monkeypatch) -> None:
+    ref = [_ref("src/memo/store.py", "save", "memo.store.save")]
+    _seed_memories(tmp_cfg, [(f"memory number {i} about save", list(ref)) for i in range(4)])
+    _patch_git(monkeypatch, stdout="src/memo/store.py\n")
+
+    res = CliRunner().invoke(cli, ["code-nudge"], env=_env(tmp_cfg))
+
+    assert res.exit_code == 0, res.output
+    lines = [line for line in res.output.splitlines() if line.strip()]
+    assert len(lines) == 3
+    assert all(line.startswith("🧠") for line in lines)
+
+
+def test_nudge_json_output(tmp_cfg: Config, monkeypatch) -> None:
+    [mid] = _seed_memories(
+        tmp_cfg,
+        [("save() writes md first", [_ref("src/memo/store.py", "save", "memo.store.save")])],
+    )
+    _patch_git(monkeypatch, stdout="src/memo/store.py\n")
+
+    res = CliRunner().invoke(cli, ["code-nudge", "--json"], env=_env(tmp_cfg))
+
+    assert res.exit_code == 0, res.output
+    assert json.loads(res.output) == [{"id": mid, "title": "save() writes md first"}]
+
+
+# --- code-health ------------------------------------------------------------------
+
+
+def test_health_json_has_stable_keys_and_uncited_hub(tmp_path: Path, tmp_cfg: Config) -> None:
+    db = tmp_path / "cg" / ".codegraph" / "codegraph.db"
+    _seed_graph(db)
+    env = {**_env(tmp_cfg), "MEMO_CODEGRAPH_DB": str(db)}
+
+    res = CliRunner().invoke(cli, ["code-health", "--json"], env=env)
+
+    assert res.exit_code == 0, res.output
+    data = json.loads(res.output)
+    assert set(data) == {"drift", "dead_knowledge", "hubs_sin_memoria"}
+    assert data["drift"]["status"] == "no-receipt"
+    assert data["dead_knowledge"] == []
+    hubs = data["hubs_sin_memoria"]
+    assert [hub["name"] for hub in hubs] == ["save"]
+    assert hubs[0]["callers"] == 1
+    assert hubs[0]["file_path"] == "src/memo/store.py"
+
+
+def test_health_dead_knowledge_and_cited_hub_excluded(tmp_path: Path, tmp_cfg: Config) -> None:
+    db = tmp_path / "cg" / ".codegraph" / "codegraph.db"
+    _seed_graph(db)
+    dead_id, _ = _seed_memories(
+        tmp_cfg,
+        [
+            ("helper handles retries", [_ref("src/memo/store.py", "helper", "memo.store.helper")]),
+            ("save writes md first", [_ref("src/memo/store.py", "save", "memo.store.save")]),
+        ],
+    )
+    env = {**_env(tmp_cfg), "MEMO_CODEGRAPH_DB": str(db)}
+
+    res = CliRunner().invoke(cli, ["code-health", "--json"], env=env)
+
+    assert res.exit_code == 0, res.output
+    data = json.loads(res.output)
+    # `helper` exists in the graph with 0 incoming calls edges → dead knowledge.
+    assert [entry["id"] for entry in data["dead_knowledge"]] == [dead_id]
+    assert data["dead_knowledge"][0]["symbols"] == ["helper"]
+    # `save` (the only hub) is cited now → no hub gap.
+    assert data["hubs_sin_memoria"] == []
+
+
+def test_health_dead_knowledge_skips_foreign_repo_refs_by_uri(
+    tmp_path: Path, tmp_cfg: Config
+) -> None:
+    db = tmp_path / "cg" / ".codegraph" / "codegraph.db"
+    _seed_graph(db)
+    # No repo_id field: the codegraph:// uri host is the repo claim (exactly
+    # the refs `memo code-facts` mints). A foreign `helper` homonym must not
+    # be judged against THIS graph, where the local `helper` has 0 callers.
+    foreign_ref = {
+        "uri": "codegraph://feedfacefeedface/function:helper",
+        "kind": "function",
+        "label": "helper",
+        "qualified_name": "synapse.store.helper",
+        "file_path": "src/synapse/store.py",
+    }
+    _seed_memories(tmp_cfg, [("foreign helper fact", [foreign_ref])])
+    env = {**_env(tmp_cfg), "MEMO_CODEGRAPH_DB": str(db)}
+
+    res = CliRunner().invoke(cli, ["code-health", "--json"], env=env)
+
+    assert res.exit_code == 0, res.output
+    assert json.loads(res.output)["dead_knowledge"] == []
+
+
+def test_health_summarizes_last_drift_receipt(tmp_path: Path, tmp_cfg: Config) -> None:
+    db = tmp_path / "cg" / ".codegraph" / "codegraph.db"
+    _seed_graph(db)
+    receipt_dir = tmp_cfg.state_dir / "dream"
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    (receipt_dir / "last.json").write_text(
+        json.dumps(
+            {
+                "ts": 1.0,
+                "code_drift": {
+                    "status": "ok",
+                    "scanned": 3,
+                    "outdated": [{"id": "x"}],
+                    "partial": [],
+                    "repaired": [{"id": "y", "from": "a", "to": "b"}],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    env = {**_env(tmp_cfg), "MEMO_CODEGRAPH_DB": str(db)}
+
+    res = CliRunner().invoke(cli, ["code-health", "--json"], env=env)
+
+    assert res.exit_code == 0, res.output
+    data = json.loads(res.output)
+    assert data["drift"] == {
+        "status": "ok",
+        "scanned": 3,
+        "outdated": 1,
+        "partial": 0,
+        "repaired": 1,
+    }
+
+
+def test_health_live_reverifies_every_ref(tmp_path: Path, tmp_cfg: Config) -> None:
+    db = tmp_path / "cg" / ".codegraph" / "codegraph.db"
+    _seed_graph(db)
+    _seed_memories(
+        tmp_cfg,
+        [
+            ("cites a live symbol", [_ref("src/memo/store.py", "save", "memo.store.save")]),
+            ("cites a gone symbol", [_ref("src/memo/gone.py", "gone", "memo.gone.gone")]),
+        ],
+    )
+    env = {**_env(tmp_cfg), "MEMO_CODEGRAPH_DB": str(db)}
+
+    res = CliRunner().invoke(cli, ["code-health", "--live", "--json"], env=env)
+
+    assert res.exit_code == 0, res.output
+    data = json.loads(res.output)
+    assert data["drift"]["live"] == {"vigente": 1, "desaparecido": 1, "no_verificable": 0}
+
+
+def test_health_missing_db_notice_and_exit_zero(tmp_path: Path, tmp_cfg: Config) -> None:
+    env = {**_env(tmp_cfg), "MEMO_CODEGRAPH_DB": str(tmp_path / "missing.db")}
+
+    res = CliRunner().invoke(cli, ["code-health"], env=env)
+
+    assert res.exit_code == 0, res.output
+    assert "codegraph index no disponible" in res.output
+
+
+def test_health_missing_db_json_keeps_stable_keys(tmp_path: Path, tmp_cfg: Config) -> None:
+    env = {**_env(tmp_cfg), "MEMO_CODEGRAPH_DB": str(tmp_path / "missing.db")}
+
+    res = CliRunner().invoke(cli, ["code-health", "--json"], env=env)
+
+    assert res.exit_code == 0, res.output
+    data = json.loads(res.output)
+    assert set(data) == {"drift", "dead_knowledge", "hubs_sin_memoria"}
+    assert data["dead_knowledge"] == []
+    assert data["hubs_sin_memoria"] == []
+
+
+# --- wiring -------------------------------------------------------------------------
+
+
+def test_commands_registered_on_root_group(tmp_cfg: Config) -> None:
+    res = CliRunner().invoke(cli, ["--help"], env=_env(tmp_cfg))
+
+    assert res.exit_code == 0, res.output
+    assert "code-nudge" in res.output
+    assert "code-health" in res.output

--- a/tests/test_code_intel.py
+++ b/tests/test_code_intel.py
@@ -1,0 +1,370 @@
+"""code_intel engine — shared read-only joins between codegraph and memories.
+
+Covers:
+- open_graph: explicit path → (read-only connection, db repo_id); missing DB →
+  None; the connection refuses writes (mode=ro).
+- ref_status: the ONE verification semantics shared by recall and dream —
+  'vigente' / 'desaparecido' on file/symbol match, None (unverifiable) for
+  non-dict refs, refs without a file_path, refs minted against another repo
+  (explicit repo_id field, or codegraph:// uri host when the field is absent),
+  and sqlite errors. A present-but-empty repo_id field means "no repo claim"
+  and stays verifiable even when the uri names another repo (parity with the
+  dream fixtures).
+- memories_citing: JSON1 join over meta.extra_json code_refs by exact
+  file_path or symbol (label / qualified_name); reference tier excluded;
+  corrupt extra_json ignored; [] on error.
+- symbols_for_files / neighbors: undirected expansion over traversable edge
+  kinds only ('contains' never traverses), seed included, hops clamped to 2.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from memo.code_intel import (
+    memories_citing,
+    neighbors,
+    open_graph,
+    ref_repo_claim,
+    ref_status,
+    symbols_for_files,
+)
+from memo.code_traceability import codegraph_repo_id
+
+# --- synthetic codegraph.db (shape copied from test_dream_code_drift) -----------
+
+_NODES = [
+    # (id, kind, name, qualified_name, file_path, start_line, end_line)
+    ("function:save", "function", "save", "memo.store.save", "src/memo/store.py", 10, 42),
+    ("file:src/memo/store.py", "file", "store.py", None, "src/memo/store.py", None, None),
+    ("function:alpha", "function", "alpha", "memo.a.alpha", "src/memo/a.py", 1, 5),
+    ("function:beta", "function", "beta", "memo.b.beta", "src/memo/b.py", 1, 5),
+    ("function:gamma", "function", "gamma", "memo.c.gamma", "src/memo/c.py", 1, 5),
+    ("function:delta", "function", "delta", "memo.d.delta", "src/memo/d.py", 1, 5),
+    ("file:src/memo/a.py", "file", "a.py", None, "src/memo/a.py", None, None),
+]
+
+_EDGES = [
+    # a → b → c → d over 'calls'; the 'contains' edge must never traverse.
+    ("function:alpha", "function:beta", "calls"),
+    ("function:beta", "function:gamma", "calls"),
+    ("function:gamma", "function:delta", "calls"),
+    ("file:src/memo/a.py", "function:alpha", "contains"),
+]
+
+
+def _seed_graph(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE nodes (
+            id TEXT PRIMARY KEY, kind TEXT, name TEXT, qualified_name TEXT,
+            file_path TEXT, start_line INTEGER, end_line INTEGER
+        );
+        CREATE TABLE edges (source TEXT, target TEXT, kind TEXT);
+        """
+    )
+    conn.executemany("INSERT INTO nodes VALUES (?, ?, ?, ?, ?, ?, ?)", _NODES)
+    conn.executemany("INSERT INTO edges VALUES (?, ?, ?)", _EDGES)
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def graph_db(tmp_path: Path) -> Path:
+    db = tmp_path / ".codegraph" / "codegraph.db"
+    db.parent.mkdir(parents=True)
+    _seed_graph(db)
+    return db
+
+
+@pytest.fixture
+def engine(graph_db: Path):
+    opened = open_graph(graph_db)
+    assert opened is not None
+    conn, db_repo_id = opened
+    yield conn, db_repo_id
+    conn.close()
+
+
+def _ref(
+    file_path: str,
+    label: str = "",
+    qualified: str = "",
+    kind: str = "function",
+    repo_id: str = "",
+) -> dict:
+    # repo_id defaults to "" (explicit no-repo-claim → judged on file/symbol);
+    # a non-empty repo_id must match the DB's repo or the ref is unverifiable.
+    return {
+        "uri": f"codegraph://{repo_id or 'testrepo'}/{label or file_path}",
+        "repo_id": repo_id,
+        "stable_symbol_id": label or file_path,
+        "kind": kind,
+        "label": label,
+        "qualified_name": qualified,
+        "file_path": file_path,
+        "relation": "modified",
+        "confidence": 0.95,
+    }
+
+
+# --- open_graph ------------------------------------------------------------------
+
+
+def test_open_graph_returns_ro_connection_and_repo_id(graph_db):
+    opened = open_graph(graph_db)
+
+    assert opened is not None
+    conn, db_repo_id = opened
+    try:
+        assert db_repo_id == codegraph_repo_id(graph_db.parent.parent)
+        row = conn.execute("SELECT name FROM nodes WHERE id = 'function:save'").fetchone()
+        assert row[0] == "save"
+        # mode=ro: the engine can never write the codegraph index.
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("DELETE FROM nodes")
+    finally:
+        conn.close()
+
+
+def test_open_graph_missing_db_returns_none(tmp_path):
+    assert open_graph(tmp_path / "nowhere" / "codegraph.db") is None
+
+
+# --- ref_status ------------------------------------------------------------------
+
+
+def test_live_symbol_ref_is_vigente(engine):
+    conn, db_repo_id = engine
+    ref = _ref("src/memo/store.py", label="save", qualified="memo.store.save")
+
+    assert ref_status(conn, ref, db_repo_id) == "vigente"
+
+
+def test_renamed_symbol_is_desaparecido(engine):
+    conn, db_repo_id = engine
+    ref = _ref("src/memo/store.py", label="old_save", qualified="memo.store.old_save")
+
+    assert ref_status(conn, ref, db_repo_id) == "desaparecido"
+
+
+def test_missing_file_is_desaparecido(engine):
+    conn, db_repo_id = engine
+    ref = _ref("src/memo/gone.py", label="gone", qualified="memo.gone.gone")
+
+    assert ref_status(conn, ref, db_repo_id) == "desaparecido"
+
+
+def test_file_kind_judged_on_path_alone(engine):
+    conn, db_repo_id = engine
+    # label deliberately diverges from the node name: file refs carry no
+    # symbol, so existence is judged on file_path alone.
+    ref = _ref("src/memo/store.py", label="renamed.py", kind="file")
+
+    assert ref_status(conn, ref, db_repo_id) == "vigente"
+
+
+def test_foreign_repo_id_field_is_unverifiable(engine):
+    conn, db_repo_id = engine
+    ref = _ref(
+        "src/synapse/router.py",
+        label="route",
+        qualified="synapse.router.route",
+        repo_id="feedfacefeedface",
+    )
+
+    assert ref_status(conn, ref, db_repo_id) is None
+
+
+def test_matching_repo_id_is_verified(engine):
+    conn, db_repo_id = engine
+    ref = _ref("src/memo/store.py", label="save", repo_id=db_repo_id)
+
+    assert ref_status(conn, ref, db_repo_id) == "vigente"
+
+
+def test_ref_without_file_path_is_unverifiable(engine):
+    conn, db_repo_id = engine
+
+    assert ref_status(conn, _ref("", label="mystery"), db_repo_id) is None
+
+
+def test_non_dict_ref_is_unverifiable(engine):
+    conn, db_repo_id = engine
+
+    assert ref_status(conn, "codegraph://testrepo/save", db_repo_id) is None
+
+
+def test_foreign_uri_without_repo_id_field_is_unverifiable(engine):
+    conn, db_repo_id = engine
+    # No repo_id field at all → the codegraph:// uri host is the repo claim.
+    ref = _ref("src/memo/store.py", label="save")
+    del ref["repo_id"]
+
+    assert ref_status(conn, ref, db_repo_id) is None
+
+
+def test_empty_repo_id_field_wins_over_foreign_uri(engine):
+    conn, db_repo_id = engine
+    # Parity pin for the dream fixtures: an explicit repo_id="" means "no repo
+    # claim" and stays verifiable even though the uri names another repo.
+    ref = _ref("src/memo/store.py", label="save", qualified="memo.store.save")
+    assert ref["repo_id"] == "" and ref["uri"].startswith("codegraph://testrepo/")
+
+    assert ref_status(conn, ref, db_repo_id) == "vigente"
+
+
+def test_ref_repo_claim_field_wins_then_uri_then_empty():
+    # The ONE extraction every consumer shares: explicit repo_id field first
+    # (empty string = "no claim"), else the codegraph:// uri host, else ''.
+    assert ref_repo_claim({"repo_id": "aaa", "uri": "codegraph://bbb/x"}) == "aaa"
+    assert ref_repo_claim({"repo_id": "", "uri": "codegraph://bbb/x"}) == ""
+    assert ref_repo_claim({"uri": "codegraph://bbb/x"}) == "bbb"
+    assert ref_repo_claim({"uri": "https://example.com/x"}) == ""
+    assert ref_repo_claim({}) == ""
+    assert ref_repo_claim("not-a-dict") == ""
+
+
+def test_sqlite_error_degrades_to_unverifiable(engine):
+    _conn, db_repo_id = engine
+    empty = sqlite3.connect(":memory:")  # no nodes table → OperationalError
+    try:
+        assert ref_status(empty, _ref("src/memo/store.py", label="save"), db_repo_id) is None
+    finally:
+        empty.close()
+
+
+# --- memories_citing --------------------------------------------------------------
+
+_SAVE_REFS = [_ref("src/memo/store.py", label="save", qualified="memo.store.save")]
+_OTHER_REFS = [_ref("src/other/module.py", label="other", qualified="pkg.other")]
+
+
+def _meta_conn(rows: list[tuple[str, str, str, str]]) -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row  # mirrors mem.store._conn
+    conn.execute("CREATE TABLE meta (id TEXT PRIMARY KEY, type TEXT, title TEXT, extra_json TEXT)")
+    conn.executemany("INSERT INTO meta VALUES (?, ?, ?, ?)", rows)
+    conn.commit()
+    return conn
+
+
+@pytest.fixture
+def store_conn():
+    conn = _meta_conn(
+        [
+            ("m1", "fact", "save writes md first", json.dumps({"code_refs": _SAVE_REFS})),
+            ("m2", "reference", "vault chunk", json.dumps({"code_refs": _SAVE_REFS})),
+            ("m3", "fact", "corrupt extra", "{not json"),
+            ("m4", "note", "unrelated", json.dumps({"code_refs": _OTHER_REFS})),
+            ("m5", "fact", "no refs", json.dumps({})),
+            ("m6", "fact", "scalar refs", json.dumps({"code_refs": "oops"})),
+            ("m7", "fact", "non-dict entries", json.dumps({"code_refs": ["just-a-string"]})),
+        ]
+    )
+    yield conn
+    conn.close()
+
+
+def test_citing_by_path(store_conn):
+    out = memories_citing(store_conn, paths={"src/memo/store.py"})
+
+    assert [m["id"] for m in out] == ["m1"]
+    assert out[0]["title"] == "save writes md first"
+    assert out[0]["refs"] == _SAVE_REFS
+
+
+def test_citing_by_label_symbol(store_conn):
+    out = memories_citing(store_conn, symbols={"save"})
+
+    assert [m["id"] for m in out] == ["m1"]
+
+
+def test_citing_by_qualified_name(store_conn):
+    out = memories_citing(store_conn, symbols={"memo.store.save"})
+
+    assert [m["id"] for m in out] == ["m1"]
+
+
+def test_reference_tier_is_excluded(store_conn):
+    out = memories_citing(store_conn, paths={"src/memo/store.py"}, symbols={"save"})
+
+    assert "m2" not in [m["id"] for m in out]
+
+
+def test_no_criteria_returns_empty(store_conn):
+    assert memories_citing(store_conn) == []
+
+
+def test_limit_caps_results(store_conn):
+    out = memories_citing(store_conn, paths={"src/memo/store.py", "src/other/module.py"}, limit=1)
+
+    assert len(out) == 1
+
+
+def test_error_returns_empty():
+    conn = sqlite3.connect(":memory:")  # no meta table
+    try:
+        assert memories_citing(conn, paths={"src/memo/store.py"}) == []
+    finally:
+        conn.close()
+
+
+# --- symbols_for_files ------------------------------------------------------------
+
+
+def test_symbols_for_files_excludes_file_nodes(engine):
+    conn, _ = engine
+
+    assert symbols_for_files(conn, ["src/memo/store.py"]) == {"save"}
+    assert symbols_for_files(conn, ["src/memo/a.py", "src/memo/b.py"]) == {"alpha", "beta"}
+
+
+def test_symbols_for_files_empty_input(engine):
+    conn, _ = engine
+
+    assert symbols_for_files(conn, []) == set()
+
+
+# --- neighbors ----------------------------------------------------------------------
+
+
+def test_neighbors_one_hop_includes_seed(engine):
+    conn, _ = engine
+
+    assert neighbors(conn, {"alpha"}, hops=1) == {"alpha", "beta"}
+
+
+def test_neighbors_two_hops(engine):
+    conn, _ = engine
+
+    assert neighbors(conn, {"alpha"}, hops=2) == {"alpha", "beta", "gamma"}
+
+
+def test_neighbors_hops_clamped_to_two(engine):
+    conn, _ = engine
+
+    assert neighbors(conn, {"alpha"}, hops=5) == {"alpha", "beta", "gamma"}
+
+
+def test_neighbors_expansion_is_undirected(engine):
+    conn, _ = engine
+
+    assert neighbors(conn, {"gamma"}, hops=1) == {"beta", "gamma", "delta"}
+
+
+def test_neighbors_contains_edge_never_traverses(engine):
+    conn, _ = engine
+
+    assert neighbors(conn, {"a.py"}, hops=2) == {"a.py"}
+
+
+def test_neighbors_empty_seed(engine):
+    conn, _ = engine
+
+    assert neighbors(conn, set(), hops=2) == set()

--- a/tests/test_context_pack_code.py
+++ b/tests/test_context_pack_code.py
@@ -1,0 +1,258 @@
+"""context-pack --code — graph-neighborhood section in the context pack.
+
+Covers:
+- --code <symbol>: adds a '## Código relacionado' section with the 1-hop
+  neighbors (name — file_path:start_line) and the memories citing them.
+- --code <path containing '/'>: the file's defined symbols seed the walk.
+- without --code: payload identical to today (no section, no extra key).
+- missing codegraph DB / unknown anchor: section silently omitted, exit 0.
+- the section is budgeted with the pack (_trim_to_budget makes room for it).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from memo.cli import cli
+from memo.context_pack import DEFAULT_BUDGET_CHARS, ContextPack
+
+# --- synthetic codegraph.db (shape copied from test_dream_code_drift) -----------
+
+_NODES = [
+    # (id, kind, name, qualified_name, file_path, start_line, end_line)
+    ("function:alpha", "function", "alpha", "memo.a.alpha", "src/memo/a.py", 1, 5),
+    ("function:beta", "function", "beta", "memo.b.beta", "src/memo/b.py", 10, 15),
+    ("function:gamma", "function", "gamma", "memo.c.gamma", "src/memo/c.py", 20, 25),
+    ("file:src/memo/a.py", "file", "a.py", None, "src/memo/a.py", None, None),
+]
+
+_EDGES = [
+    # alpha → beta → gamma over 'calls'; the 'contains' edge never traverses.
+    ("function:alpha", "function:beta", "calls"),
+    ("function:beta", "function:gamma", "calls"),
+    ("file:src/memo/a.py", "function:alpha", "contains"),
+]
+
+_CITING_ID = "a1b2c3d4e5f60718"
+
+
+def _seed_graph(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE nodes (
+            id TEXT PRIMARY KEY, kind TEXT, name TEXT, qualified_name TEXT,
+            file_path TEXT, start_line INTEGER, end_line INTEGER
+        );
+        CREATE TABLE edges (source TEXT, target TEXT, kind TEXT);
+        """
+    )
+    conn.executemany("INSERT INTO nodes VALUES (?, ?, ?, ?, ?, ?, ?)", _NODES)
+    conn.executemany("INSERT INTO edges VALUES (?, ?, ?)", _EDGES)
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def graph_db(tmp_path: Path) -> Path:
+    db = tmp_path / "proj" / ".codegraph" / "codegraph.db"
+    db.parent.mkdir(parents=True)
+    _seed_graph(db)
+    return db
+
+
+def _meta_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row  # mirrors mem.store._conn
+    conn.execute("CREATE TABLE meta (id TEXT PRIMARY KEY, type TEXT, title TEXT, extra_json TEXT)")
+    refs = [
+        {
+            "file_path": "src/memo/b.py",
+            "kind": "function",
+            "label": "beta",
+            "qualified_name": "memo.b.beta",
+            "repo_id": "",
+        }
+    ]
+    conn.execute(
+        "INSERT INTO meta VALUES (?, ?, ?, ?)",
+        (_CITING_ID, "fact", "beta returns copies", json.dumps({"code_refs": refs})),
+    )
+    conn.commit()
+    return conn
+
+
+def _hit(body: str = "The current state is documented here.") -> SimpleNamespace:
+    return SimpleNamespace(
+        id="abc12345deadbeef",
+        title="Current status",
+        type="note",
+        body=body,
+        score=0.91,
+        tags=[],
+        extra={},
+    )
+
+
+class _FakeMemory:
+    def __init__(self, hits: list[SimpleNamespace]) -> None:
+        self._hits = hits
+        self.store = SimpleNamespace(_conn=_meta_conn())
+
+    def search(self, *args, **kwargs):
+        return list(self._hits)
+
+
+def _env(tmp_path: Path, codegraph_db: Path | None) -> dict[str, str]:
+    return {
+        "MEMO_CONFIG_FILE": str(tmp_path / "memo-config.toml"),
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_DATA_DIR": str(tmp_path / "data"),
+        "MEMO_STATE_DIR": str(tmp_path / "state"),
+        "MEMO_CONTEXT_PACK": "1",
+        "MEMO_CODEGRAPH_DISCOVERY": "0",
+        "MEMO_CODEGRAPH_DB": str(codegraph_db or tmp_path / "missing" / "codegraph.db"),
+        "MEMO_EMBEDDER_DIMS": "4",
+        "MEMO_RERANKER_ENABLED": "0",
+    }
+
+
+def _invoke(
+    tmp_path: Path,
+    monkeypatch,
+    args: list[str],
+    *,
+    codegraph_db: Path | None = None,
+    hits: list[SimpleNamespace] | None = None,
+):
+    fake = _FakeMemory(hits if hits is not None else [_hit()])
+    monkeypatch.setattr("memo.cli_search._get_memory", lambda cfg: fake)
+    return CliRunner().invoke(cli, args, env=_env(tmp_path, codegraph_db))
+
+
+def test_code_symbol_section_lists_neighbors_and_citing_memory(
+    tmp_path, graph_db, monkeypatch
+) -> None:
+    result = _invoke(
+        tmp_path,
+        monkeypatch,
+        ["context-pack", "how does alpha work?", "--code", "alpha", "--json"],
+        codegraph_db=graph_db,
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    section = payload["code_context"]
+    assert section.startswith("## Código relacionado")
+    assert "alpha — src/memo/a.py:1" in section
+    assert "beta — src/memo/b.py:10" in section
+    assert "gamma" not in section  # two hops away — the walk is 1 hop
+    assert f"[{_CITING_ID[:8]}] beta returns copies" in section
+
+
+def test_code_path_anchor_seeds_from_file_symbols(tmp_path, graph_db, monkeypatch) -> None:
+    result = _invoke(
+        tmp_path,
+        monkeypatch,
+        ["context-pack", "q", "--code", "src/memo/b.py", "--json"],
+        codegraph_db=graph_db,
+    )
+
+    assert result.exit_code == 0, result.output
+    section = json.loads(result.output)["code_context"]
+    # beta is defined in the file; alpha and gamma are its 1-hop neighbors.
+    assert "beta — src/memo/b.py:10" in section
+    assert "alpha — src/memo/a.py:1" in section
+    assert "gamma — src/memo/c.py:20" in section
+
+
+def test_without_code_pack_is_unchanged(tmp_path, graph_db, monkeypatch) -> None:
+    result = _invoke(
+        tmp_path,
+        monkeypatch,
+        ["context-pack", "q", "--json"],
+        codegraph_db=graph_db,
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert set(payload) == {
+        "question",
+        "summary",
+        "current_facts",
+        "supporting_context",
+        "stale_or_conflicting",
+        "omissions",
+    }
+    assert "Código relacionado" not in result.output
+
+
+def test_missing_db_omits_section_silently(tmp_path, monkeypatch) -> None:
+    result = _invoke(
+        tmp_path,
+        monkeypatch,
+        ["context-pack", "q", "--code", "alpha", "--json"],
+        codegraph_db=None,
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert "code_context" not in payload
+    assert payload["question"] == "q"
+
+
+def test_unknown_symbol_omits_section(tmp_path, graph_db, monkeypatch) -> None:
+    result = _invoke(
+        tmp_path,
+        monkeypatch,
+        ["context-pack", "q", "--code", "no_such_symbol", "--json"],
+        codegraph_db=graph_db,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "code_context" not in json.loads(result.output)
+
+
+def test_panel_output_renders_section(tmp_path, graph_db, monkeypatch) -> None:
+    result = _invoke(
+        tmp_path,
+        monkeypatch,
+        ["context-pack", "q", "--code", "alpha"],
+        codegraph_db=graph_db,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Código relacionado" in result.output
+
+
+def test_section_is_budgeted_with_the_pack(tmp_path, graph_db, monkeypatch) -> None:
+    # A single oversized current fact makes _trim_to_budget fill the budget
+    # tightly, so pack + section only fit if the section reserved its room.
+    result = _invoke(
+        tmp_path,
+        monkeypatch,
+        ["context-pack", "q", "--code", "alpha", "--snippet-chars", "10000", "--json"],
+        codegraph_db=graph_db,
+        hits=[_hit(body="A" * 10000)],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    section = payload["code_context"]
+    pack_prompt = ContextPack(
+        payload["question"],
+        payload["summary"],
+        payload["current_facts"],
+        payload["supporting_context"],
+        payload["stale_or_conflicting"],
+        payload["omissions"],
+    ).to_prompt()
+    assert len(pack_prompt) + 2 + len(section) <= DEFAULT_BUDGET_CHARS
+    # The pack itself was trimmed near the reserved cap, not far below it.
+    assert len(pack_prompt) >= DEFAULT_BUDGET_CHARS - len(section) - 200

--- a/tests/test_dream_code_drift.py
+++ b/tests/test_dream_code_drift.py
@@ -227,6 +227,28 @@ def test_foreign_repo_ref_is_unverifiable_never_dead(mock_memory, graph_db, monk
     assert mock_memory.get(rec.id) is not None
 
 
+def test_dead_local_ref_plus_foreign_ref_is_partial_not_archived(
+    mock_memory, graph_db, monkeypatch
+):
+    monkeypatch.setenv(CODE_DRIFT_FLAG, "1")
+    # The local ref is dead, but the foreign ref may be fully vigente in ITS
+    # repo — it was never checked against any DB. Archiving on the verifiable
+    # subset alone would archive on partial evidence: report as partial only.
+    foreign = _ref(
+        "src/synapse/router.py",
+        label="route",
+        qualified="synapse.router.route",
+        repo_id="feedfacefeedface",
+    )
+    rec = _save_with_refs(mock_memory, [DEAD_FILE_REF, foreign], "dead here, alive elsewhere")
+
+    res = _run_code_drift(mock_memory, db_path=graph_db)
+
+    assert res["outdated"] == []
+    assert [e["id"] for e in res["partial"]] == [rec.id]
+    assert mock_memory.get(rec.id) is not None
+
+
 def test_matching_repo_ref_is_still_verified(mock_memory, graph_db, monkeypatch):
     monkeypatch.setenv(CODE_DRIFT_FLAG, "1")
     # graph_db lives at <repo_root>/.codegraph/codegraph.db — a ref carrying
@@ -243,6 +265,35 @@ def test_matching_repo_ref_is_still_verified(mock_memory, graph_db, monkeypatch)
 
     assert res["scanned"] == 1
     assert [e["id"] for e in res["outdated"]] == [rec.id]
+
+
+# --- nightly hub gaps: computed here, read by the briefing from the receipt -------
+
+
+def test_hub_gaps_land_in_receipt_for_the_briefing(mock_memory, graph_db, monkeypatch):
+    monkeypatch.setenv(CODE_DRIFT_FLAG, "1")
+    monkeypatch.delenv("MEMO_GAPS_CODE_HUBS", raising=False)
+    conn = sqlite3.connect(graph_db)
+    conn.execute(
+        "INSERT INTO nodes VALUES "
+        "('function:caller', 'function', 'caller', 'memo.cli.caller', 'src/memo/cli.py', 1, 5)"
+    )
+    conn.execute("INSERT INTO edges VALUES ('function:caller', 'function:save', 'calls')")
+    conn.commit()
+    conn.close()
+
+    res = _run_code_drift(mock_memory, db_path=graph_db)
+
+    assert res["hub_gaps"] == ["hub sin memoria: save (1 callers) — src/memo/store.py"]
+
+
+def test_hub_gaps_absent_from_receipt_when_flag_off(mock_memory, graph_db, monkeypatch):
+    monkeypatch.setenv(CODE_DRIFT_FLAG, "1")
+    monkeypatch.setenv("MEMO_GAPS_CODE_HUBS", "0")
+
+    res = _run_code_drift(mock_memory, db_path=graph_db)
+
+    assert "hub_gaps" not in res
 
 
 # --- guard: missing or stale index aborts without marking anything ----------------

--- a/tests/test_dream_code_repair.py
+++ b/tests/test_dream_code_repair.py
@@ -1,0 +1,313 @@
+"""Dream code-drift auto-repair — re-point dead refs with a UNIQUE candidate.
+
+Covers the repair branch inside `_run_code_drift` (flag
+MEMO_DREAM_CODE_REPAIR_ENABLED, default OFF):
+- flag off → fully-drifted memories archive exactly as today (no repair,
+  receipt `repaired` stays empty);
+- unique rename candidate (same file, same kind, namespace preserved) → the
+  ref is re-pointed in place (uri regenerated), the old ref is preserved in
+  extra.code_refs_history, the memory is NOT archived, and the receipt
+  records {id, from, to};
+- unique move candidate (same name + kind in another file) → file_path
+  repaired;
+- 0 candidates or >1 candidates → archive as today (repair never guesses);
+- a same-file sibling whose name bears NO similarity to the dead symbol is
+  never a rename candidate (a deleted symbol must not be re-pointed at an
+  unrelated neighbor), with or without a namespace on the dead qualified;
+- partial drift (a live ref remains) → repair is never attempted;
+- dry-run reports would-repair entries without writing;
+- a failed persist lands in result["errors"] and neither repairs nor
+  archives (retries next night).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from memo.cli_dream_passes import _run_code_drift
+from memo.code_traceability import codegraph_repo_id, codegraph_uri
+from memo.dream_flags import CODE_DRIFT_FLAG, CODE_REPAIR_FLAG
+from memo.errors import StorageError
+
+# --- synthetic codegraph.db (shape copied from test_dream_code_drift) -----------
+
+SAVE_NODE = ("function:save", "function", "save", "memo.store.save", "src/memo/store.py", 10, 42)
+LOAD_NODE = ("function:load", "function", "load", "memo.store.load", "src/memo/store.py", 50, 80)
+MOVED_SAVE_NODE = (
+    "function:queries.save",
+    "function",
+    "save",
+    "memo.store.queries.save",
+    "src/memo/store/queries.py",
+    5,
+    40,
+)
+FILE_NODE = ("file:src/memo/store.py", "file", "store.py", None, "src/memo/store.py", None, None)
+
+
+def _graph_db(tmp_path: Path, nodes: list[tuple]) -> Path:
+    db = tmp_path / ".codegraph" / "codegraph.db"
+    db.parent.mkdir(parents=True)
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE nodes (
+            id TEXT PRIMARY KEY, kind TEXT, name TEXT, qualified_name TEXT,
+            file_path TEXT, start_line INTEGER, end_line INTEGER
+        );
+        CREATE TABLE edges (source TEXT, target TEXT, kind TEXT);
+        """
+    )
+    conn.executemany("INSERT INTO nodes VALUES (?, ?, ?, ?, ?, ?, ?)", nodes)
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _ref(
+    file_path: str,
+    label: str = "",
+    qualified: str = "",
+    kind: str = "function",
+    repo_id: str = "",
+) -> dict:
+    return {
+        "uri": f"codegraph://{repo_id or 'testrepo'}/{label or file_path}",
+        "repo_id": repo_id,
+        "stable_symbol_id": label or file_path,
+        "kind": kind,
+        "label": label,
+        "qualified_name": qualified,
+        "file_path": file_path,
+        "relation": "modified",
+        "confidence": 0.95,
+    }
+
+
+# The rename scenario: `old_save` no longer exists in store.py, but `save`
+# (same file, same kind, same `memo.store.` namespace) does.
+OLD_SAVE_REF = _ref("src/memo/store.py", label="old_save", qualified="memo.store.old_save")
+
+
+def _save_with_refs(mock_memory, refs: list[dict], content: str):
+    return mock_memory.save(content=content, type_="fact", extra={"code_refs": refs})
+
+
+def _enable(monkeypatch) -> None:
+    monkeypatch.setenv(CODE_DRIFT_FLAG, "1")
+    monkeypatch.setenv(CODE_REPAIR_FLAG, "1")
+
+
+# --- flag off → current archive behavior intact ----------------------------------
+
+
+def test_flag_off_archives_as_today(mock_memory, tmp_path, monkeypatch):
+    monkeypatch.setenv(CODE_DRIFT_FLAG, "1")
+    monkeypatch.delenv(CODE_REPAIR_FLAG, raising=False)
+    db = _graph_db(tmp_path, [SAVE_NODE, FILE_NODE])
+    rec = _save_with_refs(mock_memory, [OLD_SAVE_REF], "old_save() handles retries")
+
+    res = _run_code_drift(mock_memory, db_path=db)
+
+    assert res["repaired"] == []
+    assert [e["id"] for e in res["outdated"]] == [rec.id]
+    assert mock_memory.get(rec.id) is None
+
+
+# --- unique candidate → repaired in place, never archived ------------------------
+
+
+def test_unique_rename_candidate_repairs_in_place(mock_memory, tmp_path, monkeypatch):
+    _enable(monkeypatch)
+    db = _graph_db(tmp_path, [SAVE_NODE, FILE_NODE])
+    rec = _save_with_refs(mock_memory, [OLD_SAVE_REF], "old_save() writes md first")
+    repo = codegraph_repo_id(db.parent.parent)
+
+    res = _run_code_drift(mock_memory, db_path=db)
+
+    assert res["status"] == "ok"
+    assert res["scanned"] == 1
+    assert res["outdated"] == []
+    assert res["partial"] == []
+    assert res["repaired"] == [
+        {"id": rec.id, "from": OLD_SAVE_REF["uri"], "to": codegraph_uri(repo, "function:save")}
+    ]
+    got = mock_memory.get(rec.id)
+    assert got is not None
+    ref = got.extra["code_refs"][0]
+    assert ref["uri"] == codegraph_uri(repo, "function:save")
+    assert ref["repo_id"] == repo
+    assert ref["stable_symbol_id"] == "function:save"
+    assert ref["label"] == "save"
+    assert ref["qualified_name"] == "memo.store.save"
+    assert ref["file_path"] == "src/memo/store.py"
+    assert ref["start_line"] == 10
+    assert ref["end_line"] == 42
+    assert ref["relation"] == "modified"  # untouched fields preserved
+    history = got.extra["code_refs_history"]
+    assert len(history) == 1
+    assert history[0]["label"] == "old_save"
+    assert history[0]["uri"] == OLD_SAVE_REF["uri"]
+
+
+def test_unique_move_candidate_repairs_file_path(mock_memory, tmp_path, monkeypatch):
+    _enable(monkeypatch)
+    db = _graph_db(tmp_path, [MOVED_SAVE_NODE])
+    ref = _ref("src/memo/store.py", label="save", qualified="memo.store.save")
+    rec = _save_with_refs(mock_memory, [ref], "save() moved into the store subpackage")
+    repo = codegraph_repo_id(db.parent.parent)
+
+    res = _run_code_drift(mock_memory, db_path=db)
+
+    assert res["outdated"] == []
+    assert res["repaired"] == [
+        {"id": rec.id, "from": ref["uri"], "to": codegraph_uri(repo, "function:queries.save")}
+    ]
+    got = mock_memory.get(rec.id)
+    assert got is not None
+    repaired = got.extra["code_refs"][0]
+    assert repaired["file_path"] == "src/memo/store/queries.py"
+    assert repaired["qualified_name"] == "memo.store.queries.save"
+    assert repaired["label"] == "save"
+    assert repaired["start_line"] == 5
+
+
+# --- 0 or >1 candidates → today's archive flow ------------------------------------
+
+
+def test_two_candidates_archive_as_today(mock_memory, tmp_path, monkeypatch):
+    _enable(monkeypatch)
+    # Both `save` and `old_save2` are name-plausible renames of `old_save` in
+    # the same `memo.store.` namespace: two candidates -> repair must not guess.
+    old_save2 = (
+        "function:old_save2",
+        "function",
+        "old_save2",
+        "memo.store.old_save2",
+        "src/memo/store.py",
+        90,
+        99,
+    )
+    db = _graph_db(tmp_path, [SAVE_NODE, old_save2, FILE_NODE])
+    rec = _save_with_refs(mock_memory, [OLD_SAVE_REF], "old_save() handles retries")
+
+    res = _run_code_drift(mock_memory, db_path=db)
+
+    assert res["repaired"] == []
+    assert [e["id"] for e in res["outdated"]] == [rec.id]
+    assert mock_memory.get(rec.id) is None
+
+
+def test_deleted_symbol_with_single_unrelated_sibling_archives(mock_memory, tmp_path, monkeypatch):
+    _enable(monkeypatch)
+    # `old_save` was DELETED, not renamed: the only remaining function in the
+    # file (`load`, same `memo.store.` namespace) bears no name similarity, so
+    # it must never become the "rename" — re-pointing would silently corrupt
+    # the citation toward an unrelated symbol.
+    db = _graph_db(tmp_path, [LOAD_NODE, FILE_NODE])
+    rec = _save_with_refs(mock_memory, [OLD_SAVE_REF], "old_save() handles retries")
+
+    res = _run_code_drift(mock_memory, db_path=db)
+
+    assert res["repaired"] == []
+    assert [e["id"] for e in res["outdated"]] == [rec.id]
+    assert mock_memory.get(rec.id) is None
+
+
+def test_deleted_symbol_without_namespace_never_repairs_to_any_sibling(
+    mock_memory, tmp_path, monkeypatch
+):
+    _enable(monkeypatch)
+    # qualified_name without a dot (top-level symbol): no namespace filter is
+    # available, so the ONLY guard against "any sibling of the same kind" is
+    # name similarity. `write_log` must not repair a dead `parse_config` ref.
+    write_log = ("function:write_log", "function", "write_log", "write_log", "src/utils.py", 1, 10)
+    db = _graph_db(tmp_path, [write_log])
+    ref = _ref("src/utils.py", label="parse_config", qualified="parse_config")
+    rec = _save_with_refs(mock_memory, [ref], "parse_config() reads the ini")
+
+    res = _run_code_drift(mock_memory, db_path=db)
+
+    assert res["repaired"] == []
+    assert [e["id"] for e in res["outdated"]] == [rec.id]
+    assert mock_memory.get(rec.id) is None
+
+
+def test_zero_candidates_archive_as_today(mock_memory, tmp_path, monkeypatch):
+    _enable(monkeypatch)
+    db = _graph_db(tmp_path, [SAVE_NODE, FILE_NODE])
+    ref = _ref("src/memo/gone.py", label="gone", qualified="memo.gone.gone")
+    rec = _save_with_refs(mock_memory, [ref], "notes about a deleted module")
+
+    res = _run_code_drift(mock_memory, db_path=db)
+
+    assert res["repaired"] == []
+    assert [e["id"] for e in res["outdated"]] == [rec.id]
+    assert mock_memory.get(rec.id) is None
+
+
+# --- partial drift → repair never attempted ---------------------------------------
+
+
+def test_partial_drift_never_repairs(mock_memory, tmp_path, monkeypatch):
+    _enable(monkeypatch)
+    db = _graph_db(tmp_path, [SAVE_NODE, FILE_NODE])
+    live = _ref("src/memo/store.py", label="save", qualified="memo.store.save")
+    # The dead ref would have `save` as a unique rename candidate — but the
+    # memory still has a live ref, so it is partial, and partial never repairs.
+    dead = _ref("src/memo/store.py", label="old_load", qualified="memo.store.old_load")
+    rec = _save_with_refs(mock_memory, [live, dead], "save() plus a renamed helper")
+
+    res = _run_code_drift(mock_memory, db_path=db)
+
+    assert res["repaired"] == []
+    assert [e["id"] for e in res["partial"]] == [rec.id]
+    got = mock_memory.get(rec.id)
+    assert got is not None
+    assert got.extra["code_refs"][1]["label"] == "old_load"
+    assert "code_refs_history" not in got.extra
+
+
+# --- dry-run → would-repair reported, nothing written ------------------------------
+
+
+def test_dry_run_reports_would_repair_without_writing(mock_memory, tmp_path, monkeypatch):
+    _enable(monkeypatch)
+    db = _graph_db(tmp_path, [SAVE_NODE, FILE_NODE])
+    rec = _save_with_refs(mock_memory, [OLD_SAVE_REF], "old_save() writes md first")
+    repo = codegraph_repo_id(db.parent.parent)
+
+    res = _run_code_drift(mock_memory, db_path=db, dry_run=True)
+
+    assert res["repaired"] == [
+        {"id": rec.id, "from": OLD_SAVE_REF["uri"], "to": codegraph_uri(repo, "function:save")}
+    ]
+    assert res["outdated"] == []
+    got = mock_memory.get(rec.id)
+    assert got is not None
+    assert got.extra["code_refs"][0]["label"] == "old_save"
+    assert "code_refs_history" not in got.extra
+
+
+# --- failed persist → error recorded, neither repaired nor archived ----------------
+
+
+def test_failed_repair_persist_is_reported_not_archived(mock_memory, tmp_path, monkeypatch):
+    _enable(monkeypatch)
+    db = _graph_db(tmp_path, [SAVE_NODE, FILE_NODE])
+    rec = _save_with_refs(mock_memory, [OLD_SAVE_REF], "old_save() writes md first")
+
+    def _boom(*_args, **_kwargs):
+        raise StorageError("disk full")
+
+    monkeypatch.setattr(mock_memory, "update", _boom)
+
+    res = _run_code_drift(mock_memory, db_path=db)
+
+    assert res["repaired"] == []
+    assert res["outdated"] == []
+    assert any("repair failed" in err and rec.id in err for err in res.get("errors", []))
+    got = mock_memory.get(rec.id)
+    assert got is not None
+    assert got.extra["code_refs"][0]["label"] == "old_save"

--- a/tests/test_dream_flags.py
+++ b/tests/test_dream_flags.py
@@ -30,6 +30,16 @@ def test_every_dark_flag_has_a_gate():
     )
 
 
+def test_dark_scalar_boost_flags_are_inventoried_with_a_recall_gate():
+    """The spec's dark flags include the float proximity boost (default 0.0 =
+    OFF): it must be tracked by the graduation inventory and declare a recall
+    A/B gate, not escape GATES because it is not a bool *_ENABLED flag."""
+    name = "MEMO_RECALL_CODE_PROXIMITY_BOOST"
+    assert name in {s.name for s in df.dark_flags()}
+    assert name in df.GATES
+    assert df.GATES[name].kind == "recall"
+
+
 def test_no_graduated_or_stale_gates():
     dark = {s.name for s in df.dark_flags()}
     stale = sorted(set(df.GATES) - dark)

--- a/tests/test_recall_code_proximity.py
+++ b/tests/test_recall_code_proximity.py
@@ -1,0 +1,371 @@
+"""Recall code-proximity boost (MEMO_RECALL_CODE_PROXIMITY_BOOST, default 0.0 = OFF).
+
+Covers:
+- flag off (unset or explicit 0.0): rank_hits output identical AND zero extra
+  work — subprocess.run is patched to explode, proving no git call happens.
+- flag on: a hit whose code_ref cites a symbol in the 2-hop codegraph
+  neighborhood of the uncommitted changes (or a changed file directly) gains
+  +flag and reorders; refs outside the neighborhood stay untouched.
+- fail-open: git failure / non-zero exit / missing graph DB → no boost, no
+  exception.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from memo import codegraph_loader
+from memo import recall_logic as rl
+from memo.recall_logic import RankKnobs
+
+# --- synthetic codegraph.db (shape copied from test_dream_code_drift) -----------
+
+_NODES = [
+    # (id, kind, name, qualified_name, file_path, start_line, end_line)
+    ("function:alpha", "function", "alpha", "memo.a.alpha", "src/memo/a.py", 1, 5),
+    ("function:beta", "function", "beta", "memo.b.beta", "src/memo/b.py", 1, 5),
+    ("function:gamma", "function", "gamma", "memo.c.gamma", "src/memo/c.py", 1, 5),
+    ("function:delta", "function", "delta", "memo.d.delta", "src/memo/d.py", 1, 5),
+    ("file:src/memo/a.py", "file", "a.py", None, "src/memo/a.py", None, None),
+]
+
+_EDGES = [
+    # a → b → c → d over 'calls': changing a.py reaches gamma at 2 hops, never delta.
+    ("function:alpha", "function:beta", "calls"),
+    ("function:beta", "function:gamma", "calls"),
+    ("function:gamma", "function:delta", "calls"),
+    ("file:src/memo/a.py", "function:alpha", "contains"),
+]
+
+
+def _seed_graph(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE nodes (
+            id TEXT PRIMARY KEY, kind TEXT, name TEXT, qualified_name TEXT,
+            file_path TEXT, start_line INTEGER, end_line INTEGER
+        );
+        CREATE TABLE edges (source TEXT, target TEXT, kind TEXT);
+        """
+    )
+    conn.executemany("INSERT INTO nodes VALUES (?, ?, ?, ?, ?, ?, ?)", _NODES)
+    conn.executemany("INSERT INTO edges VALUES (?, ?, ?)", _EDGES)
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def graph_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db = tmp_path / ".codegraph" / "codegraph.db"
+    db.parent.mkdir(parents=True)
+    _seed_graph(db)
+    monkeypatch.setattr(codegraph_loader, "CODEGRAPH_DB", db)
+    monkeypatch.setenv("MEMO_CODEGRAPH_DISCOVERY", "0")
+    monkeypatch.delenv("MEMO_CODEGRAPH_DB", raising=False)
+    return db
+
+
+# --- hits --------------------------------------------------------------------------
+
+
+@dataclass
+class _Hit:
+    id: str
+    score: float | None
+    title: str = ""
+    body: str = ""
+    type: str = "note"
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+def _mk(id: str, score: float | None, **kw: Any) -> _Hit:
+    """Hit with content unique per id so dedup_hits never collapses distinct hits."""
+    kw.setdefault("title", f"title {id}")
+    kw.setdefault("body", f"distinct body for memory {id}, long enough to pass the gate")
+    return _Hit(id=id, score=score, **kw)
+
+
+def _citing(id: str, score: float | None, *refs: dict[str, Any]) -> _Hit:
+    return _mk(id, score, extra={"code_refs": list(refs)})
+
+
+_KNOBS = RankKnobs(top_k=5, min_sim=0.0, min_body_chars=0)
+
+
+def _fake_git(stdout: str, returncode: int = 0) -> Any:
+    def _run(args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args, returncode, stdout=stdout, stderr="")
+
+    return _run
+
+
+# --- flag off = ZERO extra work ------------------------------------------------------
+
+
+def _boom(*args: Any, **kwargs: Any) -> Any:
+    raise AssertionError("flag 0.0 must never spawn a subprocess")
+
+
+def test_flag_off_is_zero_work_and_ranking_identical(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", _boom)
+    hits = [
+        _mk("far", 0.8),
+        _citing("near", 0.7, {"file_path": "src/memo/c.py", "kind": "function", "label": "gamma"}),
+    ]
+
+    monkeypatch.delenv("MEMO_RECALL_CODE_PROXIMITY_BOOST", raising=False)
+    baseline = rl.rank_hits(hits, _KNOBS)
+    monkeypatch.setenv("MEMO_RECALL_CODE_PROXIMITY_BOOST", "0.0")
+    out = rl.rank_hits(hits, _KNOBS)
+
+    assert [h.id for h in baseline] == [h.id for h in out] == ["far", "near"]
+    assert [h.score for h in baseline] == [h.score for h in out] == [0.8, 0.7]
+
+
+# --- flag on: boost + reorder ---------------------------------------------------------
+
+
+def test_symbol_in_neighborhood_boosts_and_reorders(
+    monkeypatch: pytest.MonkeyPatch, graph_db: Path
+) -> None:
+    monkeypatch.setenv("MEMO_RECALL_CODE_PROXIMITY_BOOST", "0.3")
+    monkeypatch.setattr(subprocess, "run", _fake_git("src/memo/a.py\n"))
+    # changed a.py → symbols {alpha} → 2 hops = {alpha, beta, gamma}: 'gamma' is in.
+    hits = [
+        _mk("far", 0.8),
+        _citing("near", 0.7, {"file_path": "src/memo/c.py", "kind": "function", "label": "gamma"}),
+    ]
+
+    out = rl.rank_hits(hits, _KNOBS)
+
+    assert [h.id for h in out] == ["near", "far"]
+    assert out[0].score == pytest.approx(1.0)
+    assert out[1].score == pytest.approx(0.8)
+
+
+def test_qualified_name_in_neighborhood_boosts(
+    monkeypatch: pytest.MonkeyPatch, graph_db: Path
+) -> None:
+    monkeypatch.setenv("MEMO_RECALL_CODE_PROXIMITY_BOOST", "0.3")
+    # The neighborhood is node names; a ref carrying only a qualified_name that
+    # EQUALS a node name (label empty) still matches via the qualified branch.
+    monkeypatch.setattr(subprocess, "run", _fake_git("src/memo/a.py\n"))
+    hits = [
+        _citing(
+            "q",
+            0.7,
+            {
+                "file_path": "src/memo/c.py",
+                "kind": "function",
+                "label": "",
+                "qualified_name": "gamma",
+            },
+        ),
+    ]
+
+    out = rl.rank_hits(hits, _KNOBS)
+
+    assert out[0].score == pytest.approx(1.0)
+
+
+def test_ref_citing_changed_file_path_boosts(
+    monkeypatch: pytest.MonkeyPatch, graph_db: Path
+) -> None:
+    monkeypatch.setenv("MEMO_RECALL_CODE_PROXIMITY_BOOST", "0.2")
+    monkeypatch.setattr(subprocess, "run", _fake_git("src/memo/a.py\n"))
+    # file-kind ref, no symbol: matches because the file itself changed.
+    hits = [_citing("filehit", 0.5, {"file_path": "src/memo/a.py", "kind": "file", "label": ""})]
+
+    out = rl.rank_hits(hits, _KNOBS)
+
+    assert out[0].score == pytest.approx(0.7)
+
+
+def test_ref_outside_neighborhood_not_boosted(
+    monkeypatch: pytest.MonkeyPatch, graph_db: Path
+) -> None:
+    monkeypatch.setenv("MEMO_RECALL_CODE_PROXIMITY_BOOST", "0.3")
+    monkeypatch.setattr(subprocess, "run", _fake_git("src/memo/a.py\n"))
+    # delta is 3 hops from alpha → outside the clamped 2-hop neighborhood.
+    hits = [
+        _mk("far", 0.8),
+        _citing("delta", 0.7, {"file_path": "src/memo/d.py", "kind": "function", "label": "delta"}),
+    ]
+
+    out = rl.rank_hits(hits, _KNOBS)
+
+    assert [h.id for h in out] == ["far", "delta"]
+    assert [h.score for h in out] == [0.8, 0.7]
+
+
+def test_boost_applies_once_per_hit(monkeypatch: pytest.MonkeyPatch, graph_db: Path) -> None:
+    monkeypatch.setenv("MEMO_RECALL_CODE_PROXIMITY_BOOST", "0.3")
+    monkeypatch.setattr(subprocess, "run", _fake_git("src/memo/a.py\n"))
+    # Two matching refs on one hit still add +flag exactly once.
+    hits = [
+        _citing(
+            "multi",
+            0.5,
+            {"file_path": "src/memo/b.py", "kind": "function", "label": "beta"},
+            {"file_path": "src/memo/c.py", "kind": "function", "label": "gamma"},
+        )
+    ]
+
+    out = rl.rank_hits(hits, _KNOBS)
+
+    assert out[0].score == pytest.approx(0.8)
+
+
+# --- repo gating: refs claiming another repo never match the local neighborhood ---------
+
+
+def test_foreign_repo_refs_are_never_boosted(
+    monkeypatch: pytest.MonkeyPatch, graph_db: Path
+) -> None:
+    monkeypatch.setenv("MEMO_RECALL_CODE_PROXIMITY_BOOST", "0.3")
+    monkeypatch.setattr(subprocess, "run", _fake_git("src/memo/a.py\n"))
+    # Both refs name-match the LOCAL diff/neighborhood, but claim another repo
+    # (explicit field / codegraph:// uri host): the neighborhood was computed
+    # against THIS repo's graph, so neither may gain the boost.
+    hits = [
+        _citing(
+            "foreign-field",
+            0.7,
+            {
+                "file_path": "src/memo/a.py",
+                "kind": "file",
+                "label": "",
+                "repo_id": "feedfacefeedface",
+            },
+        ),
+        _citing(
+            "foreign-uri",
+            0.6,
+            {
+                "file_path": "src/memo/c.py",
+                "kind": "function",
+                "label": "gamma",
+                "uri": "codegraph://feedfacefeedface/function:gamma",
+            },
+        ),
+    ]
+
+    out = rl.rank_hits(hits, _KNOBS)
+
+    assert [h.id for h in out] == ["foreign-field", "foreign-uri"]
+    assert [h.score for h in out] == [0.7, 0.6]
+
+
+# --- render cwd: git diff + DB discovery follow the render, not the process -------------
+
+
+def test_git_diff_and_db_discovery_run_in_render_cwd(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    proj = tmp_path / "proj"
+    db = proj / ".codegraph" / "codegraph.db"
+    db.parent.mkdir(parents=True)
+    _seed_graph(db)
+    monkeypatch.delenv("MEMO_CODEGRAPH_DB", raising=False)
+    monkeypatch.delenv("MEMO_CODEGRAPH_DISCOVERY", raising=False)
+    monkeypatch.setenv("MEMO_RECALL_CODE_PROXIMITY_BOOST", "0.3")
+    seen: dict[str, Any] = {}
+
+    def _run(args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if isinstance(args, list) and args[:2] == ["git", "diff"]:
+            seen["cwd"] = kwargs.get("cwd")
+            return subprocess.CompletedProcess(args, 0, stdout="src/memo/a.py\n", stderr="")
+        # Anything else (the repo_id `git config` probe) fails → path fallback.
+        return subprocess.CompletedProcess(args, 1, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _run)
+    knobs = RankKnobs(top_k=5, min_sim=0.0, min_body_chars=0, cwd=str(proj))
+    hits = [
+        _citing("near", 0.7, {"file_path": "src/memo/c.py", "kind": "function", "label": "gamma"}),
+    ]
+
+    out = rl.rank_hits(hits, knobs)
+
+    # The daemon's process cwd is / or $HOME — the render cwd must drive both
+    # the git diff and the .codegraph discovery.
+    assert seen["cwd"] == str(proj)
+    assert out[0].score == pytest.approx(1.0)
+
+
+def test_render_cwd_without_index_never_boosts_from_another_db(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Another repo's index exists and is env-pinned, but the render repo has
+    # no .codegraph anywhere up its own tree: the pin must NOT answer for it.
+    other = tmp_path / "other" / ".codegraph" / "codegraph.db"
+    other.parent.mkdir(parents=True)
+    _seed_graph(other)
+    monkeypatch.setenv("MEMO_CODEGRAPH_DB", str(other))
+    monkeypatch.setenv("MEMO_CODEGRAPH_DISCOVERY", "1")
+    monkeypatch.setenv("MEMO_RECALL_CODE_PROXIMITY_BOOST", "0.3")
+    monkeypatch.setattr(subprocess, "run", _fake_git("src/memo/a.py\n"))
+    bare = tmp_path / "bare-repo"
+    bare.mkdir()
+    knobs = RankKnobs(top_k=5, min_sim=0.0, min_body_chars=0, cwd=str(bare))
+    hits = [
+        _citing("near", 0.7, {"file_path": "src/memo/c.py", "kind": "function", "label": "gamma"}),
+    ]
+
+    out = rl.rank_hits(hits, knobs)
+
+    assert out[0].score == pytest.approx(0.7)
+
+
+# --- fail-open -------------------------------------------------------------------------
+
+
+def test_git_failure_no_boost_no_exception(monkeypatch: pytest.MonkeyPatch, graph_db: Path) -> None:
+    monkeypatch.setenv("MEMO_RECALL_CODE_PROXIMITY_BOOST", "0.3")
+
+    def _raise(*args: Any, **kwargs: Any) -> Any:
+        raise OSError("git not found")
+
+    monkeypatch.setattr(subprocess, "run", _raise)
+    hits = [
+        _mk("far", 0.8),
+        _citing("near", 0.7, {"file_path": "src/memo/c.py", "kind": "function", "label": "gamma"}),
+    ]
+
+    out = rl.rank_hits(hits, _KNOBS)
+
+    assert [h.id for h in out] == ["far", "near"]
+    assert [h.score for h in out] == [0.8, 0.7]
+
+
+def test_git_nonzero_exit_no_boost(monkeypatch: pytest.MonkeyPatch, graph_db: Path) -> None:
+    monkeypatch.setenv("MEMO_RECALL_CODE_PROXIMITY_BOOST", "0.3")
+    monkeypatch.setattr(subprocess, "run", _fake_git("fatal: not a git repository\n", 128))
+    hits = [
+        _citing("near", 0.7, {"file_path": "src/memo/c.py", "kind": "function", "label": "gamma"}),
+    ]
+
+    out = rl.rank_hits(hits, _KNOBS)
+
+    assert out[0].score == pytest.approx(0.7)
+
+
+def test_missing_graph_db_no_boost(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(codegraph_loader, "CODEGRAPH_DB", tmp_path / "missing" / "codegraph.db")
+    monkeypatch.setenv("MEMO_CODEGRAPH_DISCOVERY", "0")
+    monkeypatch.delenv("MEMO_CODEGRAPH_DB", raising=False)
+    monkeypatch.setenv("MEMO_RECALL_CODE_PROXIMITY_BOOST", "0.3")
+    monkeypatch.setattr(subprocess, "run", _fake_git("src/memo/a.py\n"))
+    hits = [
+        _citing("near", 0.7, {"file_path": "src/memo/c.py", "kind": "function", "label": "gamma"}),
+    ]
+
+    out = rl.rank_hits(hits, _KNOBS)
+
+    assert out[0].score == pytest.approx(0.7)


### PR DESCRIPTION
## Qué trae

Motor compartido \`src/memo/code_intel.py\` (verificación de refs unificada + queries de vecindario del grafo, read-only/fail-open/repo_id-gated) + 8 consumers:

| Feature | Superficie | Default |
|---|---|---|
| Post-commit nudge (\`memo code-nudge\`) | CLI + git hook | comando explícito |
| Salud del conocimiento (\`memo code-health\`) | CLI | comando explícito |
| Staleness de drift en briefing | SessionStart (lee receipt, 0 queries) | ON (\`MEMO_BRIEFING_CODE_DRIFT\`) |
| Gaps por hubs sin memoria | ask-gaps | ON (\`MEMO_GAPS_CODE_HUBS\`) |
| Proximity boost por cambios sin commitear | recall ranking | OFF (\`MEMO_RECALL_CODE_PROXIMITY_BOOST=0.0\`) |
| Auto-repair de refs muertas (candidato único) | dream code-drift | OFF (\`MEMO_DREAM_CODE_REPAIR_ENABLED\`) |
| \`code-facts --project\` | CLI | comando explícito |
| \`context-pack --code\` | CLI | comando explícito |

Los refactors de paridad eliminan las 2 copias divergentes de la verificación de refs (recall + dream) delegándolas al motor — tests existentes verdes sin tocar asserts.

## Verificación

- Suite: **6.045 passed, 0 failed** (+106 tests nuevos)
- quality_gate, ruff, mypy: verdes
- Review adversarial (3 lentes) → 10 hallazgos HIGH/MEDIUM verificados → 9 confirmados y corregidos (repair con guard de similitud, briefing sin queries vivas, repo_id gating en nudge/boost/health/citing, cwd del render en proximity, gate del boost en GATES)

Spec y plan: \`docs/superpowers/\` (local, gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)