### PR TITLE
fix: harden code intelligence and dream pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+### Changed
+
+- Normal MCP startup is fully offline again: remote update checks and
+  background auto-update now require explicit opt-in with
+  `MEMO_UPDATE_CHECK_ENABLED=1` or `MEMO_AUTO_UPDATE=1`.
+- Graph-enriched repo search now uses CodeGraph's indexed identifier-segment
+  vocabulary instead of scanning every symbol once per query term, ranks
+  multi-term identifier matches first, and ignores generic test/repo boilerplate
+  that previously crowded specific results out of the top ten. Unified fusion
+  also caps each file at two chunks so one verbose file cannot consume the
+  entire result window, and uses a stable candidate floor so increasing the
+  requested limit does not reveal candidates that should already rank in a
+  smaller window.
+- Repository embeddings now default to 16 chunks per MLX batch (configurable
+  with `MEMO_REPO_EMBED_BATCH`) after a real self-index run showed the previous
+  batch of 64 exceeding 19 GiB.
+- Repository watchers now observe a local source checkout (when the indexed URL
+  is local) and accept Git branch-ref events, so a commit reliably triggers an
+  incremental refresh instead of watching an otherwise idle managed clone.
+- Tantivy shutdown now commits pending writes, joins background merge threads,
+  and is idempotent, preventing immediate index-directory cleanup from racing
+  live merge files.
+
+### Security
+
+- Release workflow contracts now pin all platform smoke jobs as mandatory and
+  prohibit downstream publishing from bypassing skipped prerequisites.
+
 ## [4.5.0] - 2026-07-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ A 7-phase nightly pipeline: inventory → mine signals → resolve conflicts →
 
 **Markdown is the source of truth.** Every memory is a plain `.md` file you can read, grep, and version-control. SQLite is a derived index that rebuilds from the files at any time — hand-edit in Obsidian and your edit wins on the next `memo reindex`. Nothing is locked in a database you can't open.
 
-**Prompts and memories stay on your machine.** Embedder, reranker, and LLM all run in-process. No telemetry. Memory travels only if *you* point `memo sync` at a git remote you own. A throttled update tag check is on by default; set `MEMO_AUTO_UPDATE=0` for fully offline startup. → **[Privacy and network policy](PRIVACY.md)**
+**Prompts and memories stay on your machine.** Embedder, reranker, and LLM all run in-process. No telemetry. Memory travels only if *you* point `memo sync` at a git remote you own. Normal startup is fully offline; remote update checks and auto-update require an explicit opt-in. → **[Privacy and network policy](PRIVACY.md)**
 
 Also in the box: cross-agent `memo resume` (reopen any session from any agent), cross-Mac git sync, a knowledge graph with optional codegraph symbol edges, encrypted secret storage, OCR/audio ingestion, evidence packs, outcome learning, and signed federation. → **[Full feature reference](docs/reference.md)**
 

--- a/docs/eval/codebase-memory-empirical-validation-2026-07-30.md
+++ b/docs/eval/codebase-memory-empirical-validation-2026-07-30.md
@@ -1,0 +1,262 @@
+# Codebase-memory empirical validation — 2026-07-30
+
+## Decision
+
+Memo's codebase-memory work is empirically useful and safe to activate.
+Graph-enriched retrieval materially improves path recall over the symmetric
+lexical baseline; the complete graph+semantic configuration recovered every
+labelled target at `k=10` in three identical runs. Provider absence and artifact
+corruption degraded explicitly instead of producing silent evidence, and a real
+repository watcher refreshed after a real commit.
+
+The measurements also found four implementation bugs. All four were corrected
+before the final runs:
+
+1. CodeGraph symbol lookup scanned the complete nodes table once per query term.
+2. Generic symbols such as `test`, and one-term matches, crowded specific
+   multi-term identifiers out of the result window.
+3. Multiple chunks from one file could consume most of a unified result window,
+   and the candidate pool changed too much with the requested limit.
+4. A local-repository watcher observed the managed clone rather than the source
+   checkout and ignored the branch-ref event that proves a commit happened.
+
+A fifth operational defect was found while building the semantic index: the
+default 64-chunk MLX batch exceeded 19 GiB of process footprint. The default is
+now 16, with `MEMO_REPO_EMBED_BATCH` retained as an explicit override. The full
+test gate then exposed a sixth defect: Tantivy committed its writer without
+joining background merge threads, which could race immediate index-directory
+cleanup. Close now waits for those threads and is idempotent.
+
+## Provenance and frozen labels
+
+- Reference implementation originally audited:
+  `DeusData/codebase-memory-mcp@f2e97ff7c2944e62f57412a33b3e28d379ba2353`.
+- Reference HEAD rechecked for this validation:
+  `ee9833df2c72b750378273897ffec9410fc2c4f2`.
+- Memo base indexed for the reproducible runs:
+  `0c3224776b74e2115a21b41ca09434212dfefb69`.
+- Label set: [`eval/repo_search_labels.json`](../../eval/repo_search_labels.json),
+  36 hand-reviewed queries (22 production and 14 test queries).
+- Frozen label SHA-256:
+  `5987e2fac2e44f1327b0945613baa95a749a8f07e6c766c16ddf73d93a8f3288`.
+
+One label was corrected before freezing: the provider-degradation query now
+accepts `codegraph_loader.py`, because that module is a canonical implementation
+of missing-index discovery in addition to the repo provider modules. No expected
+path was derived from ranker scores.
+
+The deterministic judge only compares returned paths against the frozen path
+set. It does not inspect scores, snippets, provider metadata, or strategy names.
+Every label is run adjacently against both strategies:
+
+- `grep-first`: `mode=lexical`;
+- `graph-first`: `mode=unified`.
+
+The CLI gate fails if either strategy raises or graph-first recall falls below
+grep-first recall.
+
+## Corpus
+
+The exact/full corpus indexed Memo's complete tracked text surface:
+
+| Measurement | Value |
+|---|---:|
+| Checked files | 1,285 |
+| Indexed files | 1,283 |
+| Chunks | 4,529 |
+| Indexed lines | 319,074 |
+| Indexing errors | 0 |
+| Git commits analysed | 298 |
+| Git co-change pairs | 33,922 |
+
+The CodeGraph index over that managed checkout contained:
+
+| Measurement | Value |
+|---|---:|
+| Files | 1,040 |
+| Nodes | 20,783 |
+| Edges | 55,733 |
+| Database size | 60.40 MiB |
+
+The semantic-channel experiment used the same complete CodeGraph but embedded
+only the 28 unique files named by the frozen labels: 113 chunks and 9,178
+lines, all 113 embedded successfully. This makes the semantic comparison
+complete for the adjudicated targets without pretending that a long-running
+full-corpus embed completed during the experiment.
+
+## Final A/B results
+
+All values below are from three consecutive warm runs at `k=10`; ranking
+metrics were identical across the three runs. Latencies are medians of the
+reported cumulative search time for 36 queries.
+
+### Full corpus, graph and Git signals, no semantic vectors
+
+| Strategy | Recall@10 | MRR | Precision@10 | Zero-result queries | Failures | Median search time |
+|---|---:|---:|---:|---:|---:|---:|
+| grep-first | 0.3611 | 0.3611 | 0.9545 | 23 | 0 | 84.3 ms |
+| graph-first | 0.8333 | 0.5722 | 0.1000 | 0 | 0 | 2,828.1 ms |
+
+Graph-first adds **47.22 recall points**, raises MRR by **21.11 points**, and
+eliminates all 23 empty queries. Its median cost is about 78.6 ms/query versus
+2.3 ms/query for the sparse lexical baseline.
+
+### Label-complete semantic slice plus the full graph
+
+| Strategy | Recall@10 | MRR | Precision@10 | Zero-result queries | Failures | Median search time |
+|---|---:|---:|---:|---:|---:|---:|
+| grep-first | 0.3611 | 0.3611 | 0.9545 | 23 | 0 | 40.2 ms |
+| graph-first | **1.0000** | **0.8236** | 0.1778 | 0 | 0 | 4,838.5 ms |
+
+Graph+semantic adds **63.89 recall points**, raises MRR by **46.25 points**, and
+recovers every frozen target in all three runs. The median cost is about
+134.4 ms/query versus 1.1 ms/query for lexical-only retrieval.
+
+Precision is not directly comparable here: graph-first deliberately returns ten
+results for every query, while lexical returns only 22 results across the whole
+36-query set. Most labels name one relevant file, so a perfect ten-result window
+usually has a maximum judged precision of 0.10. Recall and MRR are the decision
+metrics for this sparse path-label design.
+
+## Before/after evidence for the retrieval fixes
+
+On the same complete graph-only corpus, before the structural lookup fixes:
+
+- graph-first recall@10: 0.5278;
+- graph-first MRR: 0.3819;
+- cumulative graph-first search time: about 5,720 ms.
+
+After indexed segment lookup, multi-term prioritisation, boilerplate filtering,
+path diversity, and a stable candidate floor:
+
+- graph-first recall@10: 0.8333;
+- graph-first MRR: 0.5722;
+- median cumulative graph-first search time: 2,828 ms.
+
+The final implementation therefore gained 30.55 recall points and cut the
+graph-only search time by roughly half relative to the first empirical run.
+A direct structural micro-probe fell from 118–227 ms to 5–24 ms for the same
+query after replacing full scans with CodeGraph's indexed identifier-segment
+vocabulary.
+
+## Fault and runtime probes
+
+### Artifact integrity
+
+The 2,223,143-byte Git change-signal artifact was backed up, truncated to 17
+bytes, checked through `memo repo status`, and restored.
+
+- During the fault: `ok=false`,
+  `ArtifactIntegrityError: artifact size mismatch: expected 2223143, got 17`.
+- After restoration: `ok=true`, with the original digest and size.
+
+No corrupted payload was consumed as valid change evidence.
+
+### Missing structural provider
+
+The managed checkout's `.codegraph` directory was temporarily hidden and a real
+unified query was executed.
+
+- The query still returned five lexical/Git-backed results.
+- Diagnostics reported
+  `codegraph: {status: unavailable, reason: index_missing, results: 0}`.
+- After restoration, `codegraph status` again reported 1,040 files, 20,783
+  nodes, 55,733 edges, and an up-to-date index.
+
+### Incremental watcher
+
+A fresh one-file Git repository was indexed, then watched by the actual
+`memo repo watch` CLI with a 150 ms debounce. The tracked file was edited and
+committed.
+
+- A pre-commit file event produced an unchanged refresh.
+- Git ref updates were debounced into one post-commit refresh.
+- The second refresh completed in 0.30 s with `indexed=1`.
+- Repo status advanced from commit `4afdee7` to `56ec4bb`.
+- Lexical retrieval returned the new `watcher-after-empirical` content.
+
+### Change impact and architecture
+
+After syncing Memo's own CodeGraph against this worktree:
+
+- bounded depth-1 impact was available with no limitations;
+- 19 changed files expanded to 642 impacted symbols and their downstream paths;
+- audit-mode architecture focused on `search_codegraph_paths` returned six
+  findings;
+- the pack carried provider generation
+  `codegraph:8:1785379694732396520` and explicitly disabled absence claims
+  because source-universe completeness was not proven.
+
+### Startup and release policy
+
+Eighty focused tests passed for:
+
+- offline MCP startup by default;
+- explicit update/auto-update opt-in;
+- no network call or updater process when the flag is unset;
+- mandatory Linux and macOS release smoke jobs;
+- no downstream publish job bypass through conditional execution.
+
+The publish workflow was already fail-closed; the new test makes that learned
+contract durable.
+
+The Tantivy cleanup regression and its surrounding backend suite then passed
+420/420 cases across 20 consecutive repetitions, including the exact MCP
+retrieval test that exposed the race.
+
+The complete non-slow gate subsequently passed 6,089 tests with one skip and
+78.47% coverage (74% required), under 14 parallel workers, randomized ordering,
+and 120-second per-test timeouts. Formatting, lint, typing over 461 source files,
+and all 168 complexity plus 170 exception budgets also passed. Pytest reported
+seven pre-existing unclosed-SQLite `ResourceWarning` instances in unrelated
+tests; they did not fail the suite and are not represented here as fixed.
+
+## Activation defaults
+
+The following code-intelligence features remain enabled by default:
+
+- `MEMO_GRAPH_USE_CODEGRAPH=1`;
+- `MEMO_CODEGRAPH_DISCOVERY=1`;
+- `MEMO_BRIEFING_GRAPH=1`;
+- `MEMO_BRIEFING_CODE_DRIFT=1`;
+- `MEMO_GAPS_CODE_HUBS=1`.
+
+Normal MCP startup is now offline by default:
+
+- `MEMO_UPDATE_CHECK_ENABLED=0`;
+- `MEMO_AUTO_UPDATE=0`.
+
+This is intentional hardening, not an inactive code-memory feature. Operators
+can explicitly opt in to either remote-update behavior.
+
+## Reproduction
+
+With a repo already indexed under the name `memo-self` and a CodeGraph index in
+its managed checkout:
+
+```bash
+memo eval repo-search \
+  --labels eval/repo_search_labels.json \
+  --repo memo-self \
+  --k 10 \
+  --json \
+  --gate
+```
+
+Run the command three times for the stability check. `memo repo status
+memo-self --json` reports generation/artifact integrity, and `codegraph status
+<managed-clone>` reports structural coverage.
+
+## Boundaries
+
+- This evaluation proves retrieval of the frozen path-labelled tasks; it does
+  not prove arbitrary natural-language correctness.
+- It does not claim token savings: no agent token counter participated in the
+  symmetric search calls.
+- The semantic result is target-complete, not full-corpus-complete. Full-corpus
+  exact/graph indexing is proven separately.
+- Provider absence is represented as unavailable, never as evidence that a
+  symbol or relationship does not exist.
+- Watcher activation is useful for local source checkouts and commit events; a
+  remote-only repo still needs an external fetch/poll trigger to create local
+  filesystem events.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -4,25 +4,23 @@ memo stores memories, embeddings, caches, and history locally. Every memory
 operation — search, recall, save, history, briefing — is offline by default and
 sends nothing to a hosted service.
 
-The one exception at startup is **auto-update, which is ON by default** so memo
-keeps itself current across every install. On `memo-mcp` start it makes a
+Normal `memo-mcp` startup is fully offline. Remote update checks and background
+auto-update are both opt-in. When `MEMO_AUTO_UPDATE=1`, startup makes a
 throttled `git ls-remote` to the memo repo to see whether a newer tagged release
 exists and, if so, installs it in the background for the next start. It sends no
-memory content, paths, identity, or IP — only the git tag probe. Set
-`MEMO_AUTO_UPDATE=0` to opt out and keep startup fully offline. Startup still
-does not modify Claude, Codex, or other agent configuration unless a self-heal
-opt-in below is enabled.
+memory content or paths—only the normal network metadata of a git request.
+Startup also does not modify Claude, Codex, or other agent configuration unless
+a self-heal opt-in below is enabled.
 
 ## Startup behaviors
 
-`MEMO_AUTO_UPDATE` defaults ON (see above); the remaining startup behaviors
-default to `0`/false:
+All startup behaviors below default to `0`/false:
 
 - `MEMO_UPDATE_CHECK_ENABLED=1` permits a throttled remote tag check and records
   a local update notification (this is the check-only half of auto-update; it is
   implied when `MEMO_AUTO_UPDATE` is on).
-- `MEMO_AUTO_UPDATE=0` opts out of the default auto-update: no tag check, no
-  background install, fully offline startup.
+- `MEMO_AUTO_UPDATE=1` opts in to the throttled remote tag check and background
+  install. Leaving it unset performs neither operation.
 - `MEMO_UPDATE_ENDPOINT=<url>` (empty by default) routes the tag check above
   through an HTTP endpoint instead of `git ls-remote`. It sends three anonymous
   fields — `id=sha256(device_id)[:16]` (hashed on-device, raw id never sent),

--- a/docs/superpowers/specs/2026-07-29-git-codebase-improvements-design.md
+++ b/docs/superpowers/specs/2026-07-29-git-codebase-improvements-design.md
@@ -1,0 +1,997 @@
+# Git Codebase Improvements for Memo
+
+**Date:** 2026-07-29
+
+**Status:** Approved design; written specification awaiting final user review
+
+**Scope:** Transfer only the highest-value engineering invariants from the
+`git/git` codebase into Memo when they produce a demonstrated improvement over
+Memo's current baseline.
+
+## Executive Decision
+
+Memo will not imitate Git as a product and will not pursue Git feature parity.
+It will selectively adopt six engineering patterns that Git demonstrates at
+production scale:
+
+1. atomic mutation transactions and quarantine;
+2. immutable content-addressed revisions, refs, reflogs, verification, and
+   recovery;
+3. explicit repository/request context and a plumbing/porcelain boundary;
+4. retrieval planning with backend filter pushdown;
+5. structured tracing plus performance, fuzz, and fault-injection discipline;
+6. incremental maintenance governed by measured need.
+
+Every transfer is conditional. It is admitted only when Memo has a reproduced
+gap, the smallest viable change improves a primary metric or invariant, all
+guardrails stay within a predeclared budget, and rollback is safe. A Git idea
+that merely looks elegant, adds conceptual parity, or fails to beat Memo's
+baseline is rejected.
+
+The objective is improvement, not accumulation.
+
+## Improvement-Only Rule
+
+This rule controls the complete program and overrides the breadth of the
+research backlog.
+
+Each proposed transfer must have an admission record containing:
+
+- the exact current Memo behavior and evidence;
+- a falsifiable improvement hypothesis;
+- the smallest implementation slice capable of testing it;
+- one primary improvement gate;
+- correctness, quality, latency, memory, storage, compatibility, and
+  maintainability guardrails as applicable;
+- a shadow or differential comparison against the existing path;
+- a rollback route that does not require destructive downgrade; and
+- a deletion or consolidation plan for any old mechanism it supersedes.
+
+The outcome is exactly one of:
+
+- **Admit:** the slice improves Memo and passes every guardrail.
+- **Defer:** the hypothesis is plausible but current scale or evidence does not
+  justify the complexity.
+- **Reject:** the slice does not improve Memo, duplicates an existing
+  capability, or violates a guardrail.
+
+No behavior is enabled by default merely because its implementation exists.
+No public surface is added before the underlying invariant is proven. Failed
+experiments are removed or left disabled with an explicit rejection receipt;
+they do not become permanent optional complexity.
+
+## Evidence Snapshot
+
+### Git source snapshot
+
+The analysis used the official publish-only `git/git` mirror at commit
+[`13c7afec212fc97ce257d15601659314c6673d6c`](https://github.com/git/git/tree/13c7afec212fc97ce257d15601659314c6673d6c),
+dated 2026-07-27. The inspected shallow history covered 300 commits.
+
+At that snapshot the repository contained approximately:
+
+- 4,828 tracked files;
+- 130 built-in commands;
+- 2,533 files under `t/`;
+- 980 files under `Documentation/`;
+- 75 unit-test source files;
+- 80 performance-test scripts; and
+- dedicated fuzzing, portability, compatibility, and technical-design
+  surfaces.
+
+The important lesson is not repository size. It is how Git maintains a small
+set of hard invariants while allowing storage, transport, indexing, and command
+implementations to evolve independently.
+
+### Recent code evidence
+
+Recent Git changes reinforce the patterns selected here:
+
+- [`55f961a`](https://github.com/git/git/commit/55f961a55) refactors
+  `receive-pack` to stage incoming objects through generic ODB transactions
+  instead of managing a temporary object directory directly. This separates
+  the transaction guarantee from one storage backend.
+- [`5183689`](https://github.com/git/git/commit/518368999) adds filters to
+  object enumeration so storage backends can optimize candidate selection
+  rather than forcing callers to over-enumerate and post-filter.
+- [`0c20b08`](https://github.com/git/git/commit/0c20b0863) continues removing
+  implicit `the_repository` use by passing repository context through refs and
+  worktree APIs.
+- [`ebc9fb5`](https://github.com/git/git/commit/ebc9fb587) memoizes shared graph
+  traversal and uses generation information to avoid repeated reachability
+  work.
+- [`7d64c1e`](https://github.com/git/git/commit/7d64c1e1f) removes quadratic
+  insertion behavior from a status path, illustrating the repository's
+  explicit complexity discipline.
+
+### Stable Git mechanisms
+
+The selected transfers are also grounded in Git's documented architecture:
+
+- the
+  [core tutorial](https://github.com/git/git/blob/master/Documentation/gitcore-tutorial.adoc)
+  separates low-level object/ref operations from user-facing commands;
+- the
+  [reftable design](https://github.com/git/git/blob/master/Documentation/technical/reftable.adoc)
+  uses immutable sorted tables, atomic ref transactions, tombstones, update
+  indices, consistent reader snapshots, and independent compaction;
+- [`git fsck`](https://github.com/git/git/blob/master/Documentation/git-fsck.adoc)
+  distinguishes object validity, connectivity, reachability, and recovery;
+- [Trace2](https://github.com/git/git/blob/master/Documentation/technical/api-trace2.adoc)
+  models nested regions, processes, threads, events, and performance data;
+- [`git maintenance`](https://github.com/git/git/blob/master/Documentation/git-maintenance.adoc)
+  runs tasks on different schedules and only when their cost is justified;
+- the
+  [commit-graph design](https://github.com/git/git/blob/master/Documentation/technical/commit-graph.adoc)
+  treats reachability acceleration as rebuildable derived data; and
+- the
+  [partial-clone design](https://github.com/git/git/blob/master/Documentation/technical/partial-clone.adoc)
+  explicitly distinguishes promised absence from corruption.
+
+Partial clone is evidence for a future experiment, not part of the initial
+implementation program.
+
+## Current Memo Baseline
+
+This design is grounded in Memo at commit
+`25e56dfee7df71fe0e555d2ca621ededde758970`. The source tree contains 461 Python
+files and 136,515 lines under `src/memo`; the test tree contains 537 Python
+files and 111,996 lines.
+
+Memo already has substantial relevant machinery:
+
+- Markdown is current-state authority and hand-edited Markdown wins on
+  reindex.
+- `Memory` is the high-level application facade and `VecStore` is the storage
+  entry point.
+- individual write paths already use atomic file replacement and targeted
+  rollback.
+- `ContentAddressedArtifactStore` already provides SHA-256 identity, immutable
+  artifact publication, exact size/hash verification, and atomic replacement
+  for repository-intelligence artifacts.
+- `HistoryStore` records append-only save/update/delete events in a separate
+  database.
+- `VersionStore` retains full bodies for versioning and rollback.
+- `time_machine` reconstructs historical state from current rows plus reverse
+  history replay.
+- `search_with_trace` already returns a structured list of retrieval stages,
+  while `memo.trace` propagates one process-local trace ID.
+- vector search already pushes several filters into SQL before kNN selection.
+- `memo maintain`, `memo dream`, the maintenance daemon, idle maintenance, and
+  the sleep cycle already perform different forms of maintenance.
+- Git sync, federation signatures, portable backups, path guards, secret
+  scanning, soft delete, tombstones, and derived-index rebuilds already exist.
+
+The program must extend or consolidate this machinery. It must not build a
+second CAS, ledger, daemon, identity model, trace identity, sync protocol, or
+maintenance authority.
+
+### Reproduced gaps
+
+The inspection found concrete gaps worth testing:
+
+1. `FederationManager.import_bundle` verifies a bundle up front but saves its
+   memories one at a time, accumulates errors, and can leave a partially
+   imported bundle.
+2. save/update/delete rollback is operation-specific; there is no shared
+   compare-and-swap contract or atomic multi-record mutation rail.
+3. `HistoryStore` explicitly swallows audit failures and does not retain full
+   bodies for save/delete events.
+4. `VersionStore`, `HistoryStore`, and `time_machine` overlap without one exact
+   historical authority. `time_machine` documents unavailable deleted bodies
+   and current-embedding historical search.
+5. `Memory.gc()` checks store/file orphans and stale syntheses, but it is not a
+   full hash, schema, connectivity, history, graph, ledger, and derived-state
+   verifier.
+6. filter handling is partially pushed down and partially repeated across
+   vector, BM25, exact, fuzzy, fact, graph, and post-fusion paths. In
+   particular, common date/tag checks still have post-generation seams.
+7. trace propagation, search-stage explanations, and slow-call logging exist,
+   but there is no single nested cross-process event model for CLI, MCP,
+   daemons, storage, and retrieval.
+8. maintenance behavior is spread across several schedulers and commands
+   without one task registry describing locks, cost, `is-needed`, dependencies,
+   budgets, and recovery.
+
+These are hypotheses for improvement slices, not blanket authorization to
+replace working code.
+
+## Goals
+
+1. Prevent accepted writes, imports, and sync operations from leaving
+   logically partial visible state.
+2. Detect concurrent lost updates with explicit expected/current revision
+   errors.
+3. Make historical state exact and verifiable when the immutable-revision gate
+   proves worthwhile.
+4. Make corruption, missing data, stale projections, and recoverable orphans
+   distinguishable.
+5. Make repository, project, principal, actor, transaction, and trace context
+   explicit at domain boundaries.
+6. Ensure every retrieval leg applies the same eligibility semantics before
+   candidate truncation when its backend supports doing so.
+7. Measure end-to-end behavior before and after every behavioral change.
+8. Replace fragmented maintenance scheduling with one native task registry
+   only if doing so reduces complexity and operational cost.
+9. Preserve Markdown portability, offline-first operation, existing CLI/MCP
+   contracts, and Memo's current trust and Memflow operational architecture.
+10. Produce net improvements: admitted work must improve an invariant or metric
+    without hiding unacceptable regressions elsewhere.
+
+## Non-Goals
+
+- Reimplementing Git's packfile format, branch model, wire protocol, clone,
+  fetch, push, checkout, or index.
+- Treating every memory edit as a source-control workflow.
+- Making staging mandatory for normal trusted capture.
+- Replacing current Markdown with an opaque object database.
+- Treating a content hash as an authenticity signature.
+- Introducing a second operational ledger, principal model, coordinator,
+  daemon, or delivery/ACK system alongside the approved Memflow absorption.
+- Adding arbitrary executable hooks.
+- Adding hidden replacement views equivalent to `git replace`.
+- Moving current Markdown out of the local machine.
+- Implementing cold tiers, sparse views, shared object pools, generation
+  numbers, bitmaps, or immutable index stacks before measured scale requires
+  them.
+- Guaranteeing atomic observation of several independent Markdown files to an
+  external editor. Memo can provide batch atomicity to Memo readers through a
+  commit marker and read barrier; filesystem-wide external atomicity would
+  require a different vault layout.
+- Keeping a failed experiment as permanent optional surface.
+
+## Priority Model
+
+Priority is based on user impact, not resemblance to Git:
+
+- **P0:** prevents corruption, loss, partial publication, or incorrect
+  concurrent writes.
+- **P1:** improves historical exactness, retrieval correctness, or the ability
+  to prove and diagnose behavior.
+- **P2:** reduces recurring operational cost or complexity.
+- **P3:** prepares for scale that has not yet been observed.
+
+Expected-value rank and implementation order are different. A thin explicit
+context and tracing slice must be established before changing high-value write
+behavior, even though transactions rank above those foundations by user
+impact.
+
+## Essential Transfer Set
+
+| Rank | Priority | Git invariant | Memo improvement candidate | Admission gate |
+| --- | --- | --- | --- | --- |
+| 1 | P0 | ODB/ref transactions and receive quarantine | shared CAS mutation rail; atomic import promotion | fault-injected and concurrent workloads show no accepted partial state or lost update, within frozen write budgets |
+| 2 | P0/P1 | immutable objects, refs, reflogs, `fsck` | exact revisions, head movement, verification, recovery | exact as-of/restore and corruption detection improve over the three current history paths without harming current Markdown |
+| 3 | P0 foundation | explicit repository APIs; plumbing/porcelain | explicit operation context and stable core primitives | removes ambient/scattered context hazards and reduces or holds complexity with zero behavior regression |
+| 4 | P1 | backend-aware filtered object enumeration | one search plan with capability-aware pushdown | adversarial eligibility tests reproduce and then eliminate candidate crowd-out or semantic divergence |
+| 5 | P1 | Trace2, `t/perf`, fuzzing, complexity tests | causal spans and stable quality/performance/fault gates | materially improves diagnosis and comparison while meeting disabled/sampled overhead and privacy budgets |
+| 6 | P2 | need-driven maintenance and incremental derived data | one task registry using the native coordinator | replaces fragmented scheduling, prevents incompatible overlap, and reduces measured maintenance cost or operator complexity |
+
+The table is the implementation ceiling for the first program. Supporting
+ideas do not become implementation tasks without a separate admission review.
+
+## Target Architecture
+
+```text
+                   CLI / MCP / daemon / hooks
+                              |
+                       porcelain adapters
+                              |
+                          MemoContext
+          vault · project · principal · actor · trace · txn
+                              |
+                       stable plumbing API
+          +-------------------+--------------------+
+          |                   |                    |
+     mutation rail       revision/ref store     search planner
+   prepare/validate/CAS   immutable history     pushed/residual filters
+          |                   |                    |
+          +--------- current Markdown authority --+
+                              |
+                   rebuildable projections
+             vector · BM25 · graph · facts · signals
+                              |
+                  fsck / Trace2 / maintenance
+```
+
+CLI and MCP remain wiring layers. `Memory` remains the supported application
+facade. The design introduces small internal contracts underneath or alongside
+the facade; callers must not import mixins or storage implementations directly.
+
+## Explicit Context and Plumbing Boundary
+
+### Context contract
+
+A minimal immutable operation context carries only values that must remain
+consistent across a domain operation:
+
+- vault identity and resolved paths through the existing `Config`;
+- project or namespace scope;
+- owner principal and actor identity;
+- trace ID and request ID;
+- transaction ID when a mutation exists;
+- configuration snapshot/version relevant to the operation; and
+- an injectable clock only where deterministic recovery/tests require it.
+
+The context does not replace `Config`, duplicate `ActorIdentity`, or become a
+service locator. Large dependencies such as `Memory`, stores, embedders, and
+models are not fields on the context.
+
+### Admission characterization
+
+Before introducing a new `MemoContext` type, the implementation plan must
+inventory:
+
+- ambient environment/config reads inside domain logic;
+- repeated trace/actor/project parameters;
+- cross-vault or cross-principal failure possibilities;
+- signatures that would grow or shrink; and
+- hot-path allocation and latency impact.
+
+If explicit parameters plus existing `Config` already provide a clearer
+contract, no new wrapper is introduced. The improvement is explicit context,
+not a mandatory class name.
+
+### Plumbing primitives
+
+The desired internal seams are conceptual:
+
+- prepare and validate a mutation;
+- compare and update a logical head;
+- store and verify an immutable revision;
+- recover or abort an interrupted mutation;
+- validate connectivity and projections;
+- plan and execute a filtered search; and
+- run one declared maintenance task.
+
+Porcelain adapters translate Click, MCP, HTTP, hook, and daemon inputs into
+these primitives. They do not own transaction, revision, filter, or recovery
+semantics.
+
+## Mutation Transaction and Quarantine
+
+### Mutation contract
+
+A mutation plan contains:
+
+- a unique transaction ID;
+- one or more logical memory IDs;
+- expected current revisions when applicable;
+- proposed canonical Markdown states or tombstones;
+- derived projection intents;
+- actor, principal, provenance, and policy decision;
+- validation results; and
+- an idempotency key for inbound or retryable operations.
+
+The state machine is:
+
+```text
+new → prepared → validated → committing → committed → projecting → finalized
+          \           \             \
+           +-----------+-------------+→ aborted
+```
+
+`committed` is the visibility boundary. Before it, recovery aborts and removes
+temporary state. At or after it, recovery completes idempotently. A transaction
+never transitions from committed back to aborted.
+
+### Publication
+
+For one memory, Markdown publication continues to use atomic file replacement.
+For a multi-memory batch:
+
+1. validate every item and expected revision;
+2. write immutable revisions and temporary Markdown files;
+3. persist and harden a recovery manifest;
+4. enter the committing state;
+5. publish current Markdown files;
+6. atomically publish the commit marker;
+7. update heads/reflogs and derived projections; and
+8. finalize the manifest and receipt.
+
+Memo readers honor the commit marker/read barrier and never expose a partially
+committed batch. The barrier is cross-process: while a transaction is
+`committing`, readers either wait for its durable outcome or serve the
+pre-transaction revisions recorded in the manifest. They do not read a mixture
+of replaced files. External filesystem readers may still observe a short
+mixed-file window; the CLI and documentation state this limitation rather than
+claiming filesystem atomicity that the layout cannot provide.
+
+### Compare-and-swap
+
+Update, delete, restore, merge, and promotion may provide an expected revision.
+Mismatch returns a typed conflict containing logical ID, expected revision,
+actual revision, and a safe retry/re-read instruction. It never silently
+chooses last writer wins.
+
+### Quarantine
+
+Federation, JSON/CSV imports, sync ingestion, and future streaming connectors
+stage untrusted input in an isolated, bounded path. Before promotion Memo
+checks:
+
+- archive and path safety;
+- schema and size limits;
+- signature/trust policy where applicable;
+- secret policy;
+- canonical IDs and hashes;
+- duplicate and idempotency keys;
+- internal references and operation-ledger validity; and
+- the mutation plan's complete CAS preconditions.
+
+Promotion uses the shared mutation rail. Rejection leaves no record in current
+Markdown or searchable projections. Quarantine cleanup is an explicit
+maintenance task with retention and size budgets.
+
+The durable-memory commit and the signed operational ledger are not forced
+into a fictitious filesystem/SQLite distributed transaction. When an import
+also carries operational events, the durable commit records an idempotent
+promotion outbox intent using the operational contracts approved by the
+Memflow absorption design. Recovery completes ledger application and the final
+receipt. It never rolls back or rewrites an already accepted signed ledger
+event.
+
+### Reuse requirement
+
+The implementation must reuse the existing authority lock, atomic-write
+helpers, actor/write-policy contracts, operational receipts, and backup/path
+guards where their contracts are sufficient. A new transaction abstraction
+must consolidate per-operation rollback code rather than wrap and duplicate
+it.
+
+## Immutable Revisions, Refs, and Verification
+
+### Authority model
+
+Current Markdown remains the human-readable authority for the current memory
+state. Immutable revisions are an additive historical authority. Losing the
+revision archive must never make the current corpus unreadable.
+
+The durable revision archive lives under a reserved vault-internal path so it
+participates in sync, backup, restore, secret scanning, and path validation. It
+is not placed where normal Markdown discovery or reindex can ingest it as a
+current memory.
+
+The exact directory and extension are frozen in the implementation plan only
+after backup/sync compatibility tests, but these properties are mandatory:
+
+- content-addressed sharding;
+- immutable atomic publication;
+- no symlink traversal;
+- portable relative references;
+- bounded manifest parsing;
+- explicit inclusion in portable backup and restore; and
+- current-vault readability when the archive is absent.
+
+### Revision object
+
+A versioned canonical envelope contains:
+
+- schema version;
+- logical memory ID;
+- canonical current-state digest;
+- complete reconstructable record state;
+- zero, one, or two parent revision IDs;
+- actor and provenance;
+- transaction and trace IDs;
+- creation time; and
+- reason/kind such as save, update, delete, restore, merge, or external edit.
+
+The revision ID is SHA-256 over the exact canonical envelope. The state digest
+is separate, so identical record state can be recognized even when history,
+actor, or time differs.
+
+Hashes establish identity and integrity, not authorization or authenticity.
+Where a signature is required, the revision uses Memo's approved principal and
+ledger identity contracts rather than inventing another key system.
+
+### Reuse of existing CAS
+
+`ContentAddressedArtifactStore` is the starting implementation candidate, not a
+guaranteed fit. A characterization must test concurrent same-object writes,
+crash points between payload/manifest publication, portable paths, durability,
+and backup behavior.
+
+If it passes after a small generalization, Memo reuses it. If revision
+requirements differ, common digest/atomic-write/verification primitives are
+extracted once; a second unrelated CAS implementation is forbidden.
+
+### Logical head and reflog
+
+The current Markdown records or deterministically exposes its active revision
+ID. Head changes use compare-and-swap. An append-only reflog records old/new
+revision, transaction, actor, reason, and time.
+
+Rollback creates a new revision whose state matches an earlier revision. It
+does not delete or rewrite history. A resolved merge may have two parents.
+
+### Historical convergence
+
+Migration is staged:
+
+1. characterize `HistoryStore`, `VersionStore`, and `time_machine` behavior;
+2. shadow-write revisions without changing reads;
+3. backfill current state and available historical state;
+4. run differential as-of, diff, restore, update, delete, and recovery tests;
+5. switch exact historical reads only after parity plus the new exactness
+   cases pass; and
+6. retire overlapping writes only after rollback no longer depends on them.
+
+Legacy history is never fabricated. Missing bodies remain explicitly unknown
+until a real source supplies them.
+
+### `memo fsck`
+
+The verifier has three levels:
+
+- `--connectivity-only`: current Markdown IDs, revision heads, required files,
+  store rows, and referenced objects.
+- `--full`: hashes, canonical schemas, reflogs, history connectivity, graph and
+  fact references, embedding dimensions, ledger invariants, and derived
+  revision correspondence.
+- `--strict`: full checks plus deprecated formats, policy violations, and
+  migration debt.
+
+The default is read-only. Repairs require an explicit subcommand or flag and
+produce a receipt. Recoverable but unreachable objects are copied or linked
+into `lost-found`; evidence is never silently deleted.
+
+`Memory.gc()` remains a conservative cleanup surface until the verifier proves
+replacement coverage. `fsck` and GC are not synonyms: verification discovers
+and classifies; GC removes only policy-expired unreachable data.
+
+## Retrieval Planning and Filter Pushdown
+
+### Existing baseline
+
+Memo already pushes date, excluded tags, validity, and related predicates into
+parts of vector SQL, and it applies validity to several non-vector candidate
+legs. It also has final date/tag filters after candidate generation.
+
+The first task is therefore not a new planner. It is an adversarial
+characterization matrix across exact, BM25, fuzzy, vector, fact, graph, hybrid,
+HyPE, cached, and federated candidates.
+
+### Admission gate
+
+The planner is admitted only if tests demonstrate at least one of:
+
+- an eligible result is crowded out because an unsupported leg truncates
+  before a common filter;
+- two modes disagree on eligibility for the same filter;
+- a filter is implemented repeatedly with observable drift; or
+- pushing the predicate down produces a statistically sound latency or
+  candidate-volume improvement without recall loss.
+
+If no material gap is reproduced, the existing implementation remains.
+
+### Planner contract
+
+When admitted, the design uses:
+
+- `SearchFilter`: one typed predicate tree or normalized conjunction for type,
+  tags, date, valid time, project/namespace, trust, visibility, verification,
+  and deletion state;
+- `BackendCapabilities`: predicates and boolean forms a candidate source can
+  execute exactly;
+- `SearchPlan`: pushed predicates, residual predicates, per-leg limits,
+  fusion/rerank budget, and trace explanation; and
+- `EligibilityOracle`: one reference implementation used by differential and
+  property tests.
+
+Supported predicates run before backend limits. Residual predicates run before
+cross-leg fusion whenever possible, never only after the final `top-k`.
+`search_with_trace` explains which predicates were pushed, residual, or
+unsupported.
+
+The planner does not change ranking policy by itself. Candidate-generation
+changes and ranking changes receive separate evaluation receipts.
+
+## Structured Tracing and Evaluation Discipline
+
+### Trace model
+
+Memo keeps the native trace ID and extends it with versioned structured events:
+
+- process/request start and finish;
+- child process and daemon ancestry;
+- nested region enter/leave;
+- transaction state transitions;
+- storage/file/SQLite operations;
+- candidate generation by leg;
+- filter pushdown and residual counts;
+- fusion, rerank, graph, fact, cache, and model regions;
+- maintenance task decisions; and
+- typed errors and recovery outcomes.
+
+Events contain IDs, names, timing, counts, status, and bounded metadata. Memory
+bodies, raw prompts, embeddings, secrets, credentials, and unapproved
+configuration are excluded.
+
+### Overhead and privacy
+
+Phase 0 freezes overhead budgets on representative cold and warm paths.
+Disabled tracing must remain statistically indistinguishable from the baseline
+within the benchmark's noise floor. Sampled tracing receives an explicit
+latency and allocation budget before implementation.
+
+If cross-process propagation or event capture violates privacy or hot-path
+budgets, the relevant span is rejected or sampled more narrowly; observability
+does not automatically outrank the recall-hook budget.
+
+### Test discipline transferred from Git
+
+The program adds or strengthens:
+
+- state-machine/model tests for transactions and refs;
+- deterministic kill-points at every durable transition;
+- multi-process and multi-thread CAS tests;
+- property tests for filter semantics, canonicalization, and merge/ref
+  invariants;
+- fuzz targets for manifests, bundles, revision envelopes, and verifier input;
+- complexity tests for large candidate sets and history traversals;
+- stable performance cases for save/update/import/search/as-of/fsck/maintenance;
+- differential tests against the existing implementation; and
+- platform coverage on Linux and macOS.
+
+Retrieval receipts record dataset, corpus revision, configuration, model,
+hardware, code commit, and cold/warm state. Quality and performance gates are
+separate so a latency win cannot hide recall loss and a recall win cannot hide
+an unacceptable resource regression.
+
+## Need-Driven Maintenance
+
+### Admission condition
+
+Memo already has several valuable maintenance paths. A unified registry is
+admitted only if it replaces duplicated scheduling/locking/decision code and
+improves at least one of:
+
+- incompatible-task overlap;
+- unnecessary task executions;
+- recovery after interruption;
+- operator understanding;
+- maintenance wall time or resource use; or
+- the amount of scheduling code and configuration.
+
+It must not become another daemon or a wrapper that leaves every old scheduler
+active underneath.
+
+### Task descriptor
+
+Each registered task declares:
+
+- stable name and schema version;
+- dependencies and incompatible tasks;
+- required locks and scope;
+- `is-needed` evidence and threshold;
+- estimated/observed cost;
+- hourly, daily, weekly, idle, or manual eligibility;
+- time, CPU, memory, I/O, and model budgets;
+- checkpoint/restart behavior;
+- verification after completion; and
+- dry-run explanation.
+
+Candidate tasks include reindex drift, WAL checkpointing, SQLite maintenance,
+`fsck-lite`, revision/ref cleanup, artifact cleanup, graph refresh, embedding
+repair, and selected semantic dream passes.
+
+The native Memo coordinator approved by the Memflow absorption design executes
+the registry. Existing CLI commands may remain as porcelain aliases for direct
+task execution, but task semantics and locking live in one place.
+
+### Incremental data structures
+
+Git's reftable stacks, commit-graph chains, MIDX, generations, and bitmaps are
+not initial implementation requirements. They become separate P3 proposals
+only when Trace2 and maintenance receipts show that simple storage and indexes
+violate an agreed SLA.
+
+## End-to-End Data Flow
+
+```text
+capture / update / delete / import / sync
+                    |
+                    v
+         policy + explicit operation context
+                    |
+            trusted direct input?
+              /              \
+            yes               no
+             |                 |
+             |            quarantine
+             |                 |
+             +------ validation + CAS
+                            |
+                    mutation manifest
+                            |
+               immutable revision objects
+                            |
+                  current Markdown publish
+                            |
+                 atomic batch commit marker
+                            |
+                    heads + reflog
+                            |
+                rebuildable projections
+             vector / BM25 / graph / facts
+                            |
+                     search planner
+              pushed filters → residuals
+                            |
+                   fusion → rerank
+                            |
+                         result
+
+        Trace2 spans and fsck identities cross every stage.
+```
+
+## Error Handling and Recovery
+
+| Failure | Required behavior |
+| --- | --- |
+| policy, schema, secret, size, hash, or reference validation fails | abort before commit; current corpus and projections unchanged |
+| expected revision differs | typed CAS conflict; include expected/actual; no implicit overwrite |
+| crash before commit marker | recovery restores every already-replaced Markdown preimage, then aborts and removes prepared temporary state |
+| crash after commit marker | recovery completes heads, reflog, projections, and receipt idempotently |
+| one derived projection fails | current Markdown remains valid; mark repair debt; stale projection cannot surface an inactive revision |
+| revision hash or schema is invalid | fail closed for that object; preserve evidence; report through `fsck` and `lost-found` |
+| history backfill lacks a deleted body | preserve explicit unknown state; never fabricate content |
+| external Markdown edit changes current state | detect as an external revision; apply policy or staging; hand-edited current Markdown remains authoritative |
+| trace export fails | operation continues unless the trace is a required audit receipt; record bounded local failure telemetry |
+| maintenance task exceeds budget | stop at a safe checkpoint; retain resumable state; do not cascade into later tasks |
+| quarantine promotion partially reaches storage | transaction recovery finishes or aborts according to the durable commit boundary |
+
+Domain failures use typed `MemoError` subclasses. Recovery actions are
+idempotent and produce receipts with transaction and trace IDs.
+
+## Rollout
+
+### Phase 0 — Characterize and freeze gates
+
+- Freeze Memo and test snapshots.
+- Build failure, concurrency, history, filter, tracing, and maintenance
+  baselines.
+- Define explicit improvement and guardrail budgets before behavioral code.
+- Inventory context propagation and plumbing boundaries.
+- Instrument only the minimum spans needed to compare later phases.
+- Produce admission records for all six transfers.
+
+This phase may reject or narrow any later phase.
+
+### Phase 1 — Integrity foundation
+
+- Introduce the minimum explicit context/plumbing seams needed by writes.
+- Characterize and consolidate per-operation rollback helpers.
+- Add mutation manifests and compare-and-swap.
+- Add quarantine and all-or-nothing promotion for one importer first.
+- Add `fsck --connectivity-only`.
+- Run fault, concurrency, migration, and write-performance gates.
+
+The first importer is selected by highest reproduced partial-state risk, not by
+implementation convenience. Other importers migrate only after the first slice
+proves an improvement.
+
+### Phase 2 — Exact revision experiment
+
+- Characterize the existing CAS for reuse.
+- Shadow-write immutable revisions.
+- Add exact head/ref checks and a reflog.
+- Add full verifier coverage.
+- Backfill and compare history/version/time-machine results.
+- Switch one historical read path only after exactness and resource gates pass.
+
+If storage growth, write cost, portability, or operational complexity fails its
+budget, the revision experiment remains off and the useful verifier work may
+ship independently.
+
+### Phase 3 — Retrieval experiment
+
+- Build the cross-backend eligibility matrix.
+- Reproduce a concrete pushdown/crowd-out or semantic-parity problem.
+- Introduce the smallest planner slice for that problem.
+- Measure candidate counts, recall, ranking, latency, and memory.
+- Expand predicate/backend coverage only while each slice improves Memo.
+
+No reproduced problem means no new planner.
+
+### Phase 4 — Trace and maintenance convergence
+
+- Expand tracing only where it closes a demonstrated diagnostic gap.
+- Define the maintenance task descriptor.
+- Migrate one overlapping scheduler/task decision.
+- Prove lock, budget, recovery, and complexity improvement.
+- Migrate remaining tasks incrementally and retire replaced scheduler logic.
+
+### Default-on policy
+
+Behavioral features begin default-off through Memo's registered flag system.
+They become default-on only after:
+
+- all primary and guardrail gates pass;
+- shadow/differential receipts show no unresolved mismatch;
+- migration and rollback are tested on copied real-world vault layouts;
+- portable backup and restore include every new durable artifact;
+- strict doctor and `fsck` are clean;
+- Linux and macOS gates pass; and
+- the old path has a documented retirement or ongoing necessity.
+
+Disabling a new path never deletes its data. Old stores are not removed until
+the new path has passed the agreed stability window and rollback no longer
+depends on them.
+
+## Verification Matrix
+
+### Correctness
+
+- save/update/delete/restore/merge state-machine transitions;
+- exact CAS conflicts across threads and processes;
+- batch read-barrier behavior;
+- quarantine rejection and idempotent promotion;
+- canonical revision and state hashes;
+- reflog order and rollback-as-new-revision;
+- exact as-of bodies across update/delete/restore;
+- `fsck` classification and `lost-found`;
+- filter eligibility parity across every candidate source; and
+- maintenance lock/dependency decisions.
+
+### Fault injection
+
+- before and after every manifest write, fsync, atomic replace, commit marker,
+  head update, reflog append, projection update, receipt, and cleanup;
+- truncated, duplicated, reordered, oversized, and malformed manifests;
+- corrupt revision payloads and manifests;
+- stale writers and concurrent expected-revision updates;
+- interrupted backup, restore, backfill, fsck, and maintenance; and
+- unavailable daemon/model/index components.
+
+### Security
+
+- symlink, traversal, archive bomb, unsafe URL, and path-boundary cases;
+- secret scanning before quarantine promotion and support export;
+- principal/actor/visibility preservation;
+- signatures verified by existing trust contracts;
+- unauthorized hash knowledge does not grant object access; and
+- traces contain no bodies, prompts, embeddings, credentials, or secrets.
+
+### Compatibility
+
+- legacy vaults without revision IDs;
+- hand-edited Markdown;
+- current Git sync and conflict markers;
+- backup/restore with and without historical objects;
+- CLI, MCP, HTTP, hooks, and daemons from the same isolated runtime;
+- no module-level MLX/MLX-LM load; and
+- stable current API behavior when every new flag is off.
+
+### Quality and performance
+
+- existing `eval/regression_labels.json` recall gate;
+- capability-bucket evaluation for candidate-generation changes;
+- cold/warm p50/p95 search and write latency;
+- import throughput and peak memory;
+- revision storage amplification;
+- `fsck` connectivity/full runtime;
+- maintenance work avoided versus performed;
+- disabled and sampled trace overhead; and
+- algorithmic scaling tests that catch quadratic behavior.
+
+CI order remains Ruff, mypy, and pytest. Slow/MLX and platform smokes stay
+separate as required by the repository.
+
+## Supporting Ideas, Not Initial Tasks
+
+These ideas remain useful but subordinate. Each requires a separate
+improvement admission record after the essential program:
+
+1. streaming, checkpointed bulk import built on the proven mutation rail;
+2. a redacted `memo diagnose` bundle built on proven Trace2 and `fsck`;
+3. trust-aware staging for low-confidence captures only;
+4. structured three-way memory merge and exact-fingerprint resolution reuse;
+5. `memo blame` and revision notes for provenance and review; and
+6. `memo bisect` for reproducible retrieval/configuration regressions.
+
+They are not implied implementation scope.
+
+## Deferred P3 Experiments
+
+The following remain design ideas until measured thresholds justify them:
+
+- promisor-style cold storage for historical revisions or artifacts;
+- immutable split index segments and logarithmic compaction;
+- generation numbers and reachability bitmaps;
+- shared immutable object pools; and
+- sparse project or namespace views.
+
+Current Markdown must remain local even if a future historical cold tier is
+admitted.
+
+## Explicit Rejections
+
+The initial analysis rejects these Git concepts for Memo:
+
+- branches as competing knowledge truths;
+- mandatory index/staging for ordinary capture;
+- Git packfiles or delta chains as Memo's base storage;
+- Git's wire protocol;
+- clone/fetch/push semantics as the user model;
+- hidden object replacement;
+- arbitrary executable hooks;
+- content hashes presented as signatures;
+- another sync, ledger, coordinator, or daemon architecture; and
+- optimizing for hypothetical repository scale before benchmarks demonstrate
+  the need.
+
+## Risks and Controls
+
+### Overengineering
+
+The largest risk is importing Git's complexity without Git's scale. The
+admission record, minimal slice, and reject/defer outcome are mandatory
+controls.
+
+### Dual historical authorities
+
+Shadow-write migration temporarily increases overlap. Reads stay on the old
+path until parity; writes to overlapping stores are retired as soon as the new
+path is stable. The program must not leave four permanent history mechanisms.
+
+### Write amplification
+
+Manifests, revisions, reflogs, fsync, and projections can increase latency and
+storage. Phase 0 freezes budgets; integrity slices can trade a bounded amount
+of performance only when they eliminate a reproduced correctness failure.
+
+### Manual-edit portability
+
+Revision metadata must not make current Markdown unreadable or uneditable.
+External edits are incorporated as real revisions rather than rejected.
+
+### Partial abstraction
+
+A new context, planner, transaction rail, or task registry that merely wraps
+old duplicated logic fails the maintainability gate. Admission requires
+consolidation or deletion.
+
+### Scope collision with Memflow absorption
+
+Operational identity, signing, coordination, presence, delivery/ACK, and the
+native coordinator come from the approved Memflow absorption design. This
+program consumes those contracts and never forks them.
+
+## Definition of Success
+
+The program succeeds when:
+
+1. every shipped transfer has a before/after admission receipt;
+2. no shipped transfer exists solely for Git parity;
+3. accepted batch/import mutations cannot expose logically partial state to
+   Memo readers;
+4. concurrent stale writers receive deterministic CAS conflicts;
+5. exact revisions and historical convergence ship only if they beat the
+   current history/version/time-machine baseline;
+6. `fsck` detects and classifies seeded corruption without destructive default
+   behavior;
+7. retrieval changes fix a reproduced eligibility or efficiency problem and
+   pass quality gates;
+8. tracing improves diagnosis within privacy and overhead budgets;
+9. maintenance convergence removes duplicated scheduling or avoids measured
+   work; and
+10. rejected or deferred Git ideas add no permanent runtime surface.
+
+## Planning Boundary
+
+This specification authorizes design documentation only. It does not authorize
+implementation.
+
+After user review, the implementation plan must:
+
+- start with Phase 0 characterization;
+- split each transfer into an independent admit/defer/reject decision;
+- include exact files, tests, commands, baselines, thresholds, and rollback;
+- preserve unrelated work in the shared repository;
+- avoid bundling the six transfers into one large migration; and
+- stop a transfer when its improvement gate fails.
+
+The first implementation milestone is evidence and contracts, not a feature
+count.

--- a/eval/repo_search_labels.json
+++ b/eval/repo_search_labels.json
@@ -1,0 +1,232 @@
+{
+  "schema": "memo.eval.repo_search.labels.v1",
+  "description": "Hand-reviewed path labels for symmetric lexical-first versus graph-enriched retrieval over Memo's own repository.",
+  "queries": [
+    {
+      "id": "p01-artifact-integrity",
+      "query": "verified content addressed artifact digest manifest integrity",
+      "expected_paths": ["src/memo/artifact_store.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p02-code-evidence",
+      "query": "CodeEvidenceEnvelope coverage freshness gaps index generation",
+      "expected_paths": ["src/memo/code_evidence.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p03-change-impact",
+      "query": "bounded change impact traversal callers downstream symbols",
+      "expected_paths": ["src/memo/code_impact.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p04-context-modes",
+      "query": "provider neutral code context scout verify audit modes",
+      "expected_paths": ["src/memo/code_context.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p05-unified-retrieval",
+      "query": "unified repository retrieval codegraph cochange channels diagnostics",
+      "expected_paths": ["src/memo/repo_intelligence.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p06-structural-provider",
+      "query": "structural symbol path search one hop relationships",
+      "expected_paths": ["src/memo/repo_structural.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p07-git-signals",
+      "query": "git history cochange pairs cross service change signals",
+      "expected_paths": ["src/memo/repo_signals.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p08-repo-watcher",
+      "query": "incremental repository watcher debounce deduplicate refresh jobs",
+      "expected_paths": ["src/memo/repo_watcher.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p09-atomic-generation",
+      "query": "atomic repository index generation semantic pending active generation",
+      "expected_paths": ["src/memo/repo_index.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p10-rrf-ranking",
+      "query": "RRF fusion path name boost repository search scopes",
+      "expected_paths": ["src/memo/repo_index_search.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p11-symmetric-eval",
+      "query": "symmetric graph first grep first evaluation recall precision MRR",
+      "expected_paths": ["src/memo/repo_eval.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p12-codegraph-discovery",
+      "query": "discover nearest codegraph database cache graph by mtime",
+      "expected_paths": ["src/memo/codegraph_loader.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p13-mcp-repo-tools",
+      "query": "MCP repository search status index artifact tools",
+      "expected_paths": ["src/memo/server_repo.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p14-cli-repo",
+      "query": "CLI repository index search watch artifact operational receipt",
+      "expected_paths": ["src/memo/cli_repo.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p15-failure-ledger",
+      "query": "persistent ingest failure ledger hash chained events",
+      "expected_paths": ["src/memo/ingest_ledger.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p16-quarantine",
+      "query": "quarantine repeated fatal worker failures job fingerprint",
+      "expected_paths": ["src/memo/ingest_server.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p17-artifact-export",
+      "query": "export portable verified artifact and manifest",
+      "expected_paths": ["src/memo/artifact_store.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p18-provider-degradation",
+      "query": "codegraph provider unavailable index missing graceful diagnostics",
+      "expected_paths": [
+        "src/memo/repo_structural.py",
+        "src/memo/repo_intelligence.py",
+        "src/memo/codegraph_loader.py"
+      ],
+      "scope": "production"
+    },
+    {
+      "id": "p19-scope-classifier",
+      "query": "classify repository paths production tests vendor",
+      "expected_paths": ["src/memo/repo_index_search.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p20-cochange-expansion",
+      "query": "expand related paths from cochange seed confidence",
+      "expected_paths": ["src/memo/repo_signals.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p21-context-pagination",
+      "query": "code context cursor fingerprint pagination generation",
+      "expected_paths": ["src/memo/code_context.py"],
+      "scope": "production"
+    },
+    {
+      "id": "p22-search-evidence",
+      "query": "repository hit channel scores rank explanation provider evidence",
+      "expected_paths": [
+        "src/memo/repo_index_search.py",
+        "src/memo/repo_intelligence.py"
+      ],
+      "scope": "production"
+    },
+    {
+      "id": "t01-artifact-tampering",
+      "query": "test artifact read rejects tampering digest mismatch",
+      "expected_paths": ["tests/test_artifact_store.py"],
+      "scope": "tests"
+    },
+    {
+      "id": "t02-impact-hop",
+      "query": "test code change impact traverses one hop",
+      "expected_paths": ["tests/test_code_evidence.py"],
+      "scope": "tests"
+    },
+    {
+      "id": "t03-context-cursor",
+      "query": "test code context cursor bound to focus and generation",
+      "expected_paths": ["tests/test_code_context.py"],
+      "scope": "tests"
+    },
+    {
+      "id": "t04-structural-hop",
+      "query": "test structural provider reads codegraph one hop",
+      "expected_paths": ["tests/test_repo_intelligence.py"],
+      "scope": "tests"
+    },
+    {
+      "id": "t05-unified-atomic",
+      "query": "test unified search scopes artifacts cochange atomic visibility",
+      "expected_paths": ["tests/test_repo_intelligence.py"],
+      "scope": "tests"
+    },
+    {
+      "id": "t06-watcher-debounce",
+      "query": "test debounced repository refresh coalesces events",
+      "expected_paths": ["tests/test_watcher.py"],
+      "scope": "tests"
+    },
+    {
+      "id": "t07-repo-generation",
+      "query": "test repository index preserves code evidence generation",
+      "expected_paths": ["tests/test_repo_index.py"],
+      "scope": "tests"
+    },
+    {
+      "id": "t08-cli-repo-search",
+      "query": "test CLI repository search unified mode scope",
+      "expected_paths": ["tests/test_cli_repo.py"],
+      "scope": "tests"
+    },
+    {
+      "id": "t09-mcp-repo",
+      "query": "test MCP repository search result evidence",
+      "expected_paths": ["tests/test_server_repo.py"],
+      "scope": "tests"
+    },
+    {
+      "id": "t10-eval-failures",
+      "query": "test repository eval records failures zero results symmetrically",
+      "expected_paths": ["tests/test_repo_eval.py"],
+      "scope": "tests"
+    },
+    {
+      "id": "t11-symbol-chunks",
+      "query": "test repository chunking follows codegraph symbol boundaries",
+      "expected_paths": ["tests/test_repo_chunk_symbols.py"],
+      "scope": "tests"
+    },
+    {
+      "id": "t12-ingest-quarantine",
+      "query": "test ingest daemon quarantines repeated fatal jobs",
+      "expected_paths": ["tests/test_ingest_daemon.py"],
+      "scope": "tests"
+    },
+    {
+      "id": "t13-missing-graph",
+      "query": "test missing codegraph degrades without failure",
+      "expected_paths": [
+        "tests/test_repo_intelligence.py",
+        "tests/test_code_evidence.py"
+      ],
+      "scope": "tests"
+    },
+    {
+      "id": "t14-dimension-mismatch",
+      "query": "test repository embedding dimension mismatch",
+      "expected_paths": ["tests/test_repo_dim_mismatches.py"],
+      "scope": "tests"
+    }
+  ]
+}

--- a/src/memo/consolidation.py
+++ b/src/memo/consolidation.py
@@ -108,6 +108,7 @@ class AdvancedConsolidator:
     def __init__(self, memory: Any, chat: ChatBackend | None = None) -> None:
         self.memory = memory
         self._chat = chat
+        self._llm_available = True
         self._archival_dir = memory.cfg.memory_dir / "archived"
 
     def _ensure_chat(self) -> ChatBackend:
@@ -152,6 +153,8 @@ class AdvancedConsolidator:
             )
 
         # For duplicates and facets, use LLM to synthesize
+        if not self._llm_available:
+            return None
         return self._llm_propose_merge(cluster)
 
     def _llm_propose_merge(self, cluster: dict[str, Any]) -> MergeProposal | None:
@@ -212,9 +215,11 @@ class AdvancedConsolidator:
                     },
                 )
             except Exception as exc:
+                self._llm_available = False
                 _log.warning("consolidation: merge-proposal LLM call failed: %s", exc)
                 return None
             if out is None:
+                self._llm_available = False
                 _log.warning("consolidation: merge-proposal LLM timeout")
                 return None
             raw = (out.get("message") or {}).get("content") or ""
@@ -451,6 +456,11 @@ class AdvancedConsolidator:
             Dict with clusters, proposals, and results lists.
         """
         from memo.flags import flag_float
+
+        # One cold-load timeout makes every remaining LLM-backed proposal in
+        # this pass predictably fail. Retry on the next consolidation run, not
+        # once per cluster in the current run.
+        self._llm_available = True
 
         if auto_threshold is None:
             auto_threshold = flag_float("MEMO_CONSOLIDATE_AUTO_THRESHOLD")

--- a/src/memo/eval_recall.py
+++ b/src/memo/eval_recall.py
@@ -713,12 +713,19 @@ def _run_config_inner(
     # No base project_tag/cwd: per-label project (when a label carries one)
     # is applied per prompt inside the loop; project-less labels rank with
     # project_tag=None (tiers stay inert).
+    # Code proximity is render-cwd-dependent, but eval labels only carry a
+    # project tag. Letting rank_hits fall back to the evaluator's ambient cwd
+    # both measures the wrong repository and spawns one `git diff` per prompt
+    # (multiplied by every tuner candidate). Keep every scalar ranking knob
+    # live/pinnable while disabling only that unmeasurable I/O stage.
+    knob_overrides = dict(cfg.knob_overrides or {})
+    knob_overrides["code_proximity"] = False
     knobs = knobs_from_flags(
         top_k=k,
         min_sim=cfg.floor,
         min_body_chars=0,
         mode=cfg.mode,
-        overrides=cfg.knob_overrides,
+        overrides=knob_overrides,
     )
     # Recall-faithful candidate pool: the hook SQL-excludes the bulk
     # `reference` tier (MEMO_RECALL_EXCLUDE_REFERENCE, default on) but the

--- a/src/memo/flags_ingest.py
+++ b/src/memo/flags_ingest.py
@@ -150,7 +150,11 @@ SPECS: tuple[FlagSpec, ...] = (
         "MEMO_REPO_MAX_FILE_BYTES", "int", None, "repo", "Skip repo files larger than this (bytes)."
     ),
     _spec(
-        "MEMO_REPO_EMBED_BATCH", "int", None, "repo", "Chunks per embed batch during repo index."
+        "MEMO_REPO_EMBED_BATCH",
+        "int",
+        None,
+        "repo",
+        "Chunks per embed batch during repo index (default 16).",
     ),
     _spec("MEMO_REPO_FLUSH_BATCH", "int", None, "repo", "Rows per DB flush during repo index."),
     _spec(

--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -48,13 +48,12 @@ SPECS: tuple[FlagSpec, ...] = (
     _spec(
         "MEMO_AUTO_UPDATE",
         "bool",
-        True,
+        False,
         "update",
         "On memo-mcp start, check for a newer git TAG and update in the "
-        "background (takes effect next start). Default ON: memo keeps itself "
-        "current across every install. This is the one default-on outbound "
-        "call (a throttled `git ls-remote` to the memo repo); set =0 to opt out "
-        "and keep startup fully offline.",
+        "background (takes effect next start). Default off: normal startup is "
+        "fully offline; set =1 to opt in to the throttled remote tag check and "
+        "background install.",
     ),
     _spec(
         "MEMO_AUTO_UPDATE_INTERVAL_S",

--- a/src/memo/memory/record.py
+++ b/src/memo/memory/record.py
@@ -13,11 +13,13 @@ from __future__ import annotations
 import base64
 import concurrent.futures as _futures
 import contextlib
+import contextvars
 import hashlib
 import logging
 import re
 import threading
 import time
+from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
@@ -359,35 +361,48 @@ _CHAT_ACTIVE: _futures.Future[dict[str, Any]] | None = None
 _CHAT_ACTIVE_TIMED_OUT = False
 
 
-def chat_with_timeout(chat: Any, *, timeout: float, **kwargs: Any) -> dict[str, Any] | None:
-    """Run ``chat.chat(**kwargs)`` with a hard wall-clock timeout.
+def _run_chat_call(chat: Any, timeout: float, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Invoke chat with the matching GPU-lock deadline in the worker."""
+    try:
+        from memo.mlx_gpu import _gpu_tl
 
-    Returns the result dict, or ``None`` if it exceeds ``timeout``. MLX work
-    cannot be interrupted mid-flight, so a timed-out worker continues in one
-    daemon thread. Calls made while that worker is still alive fail closed
-    immediately instead of starting competing model loads. A daemon is used
-    deliberately: unlike ``ThreadPoolExecutor`` workers, it does not get joined
-    by ``concurrent.futures`` during interpreter shutdown.
+        _gpu_tl.timeout = timeout
+    except Exception:  # noqa: S110
+        pass
+    return chat.chat(**kwargs)
 
-    Errors raised by ``chat.chat`` propagate (caller's try/except handles them).
-    """
+
+def _chat_worker(
+    fut: _futures.Future[dict[str, Any]],
+    context: contextvars.Context,
+    run: Callable[[], dict[str, Any]],
+) -> None:
+    """Complete one reserved chat future and release the global slot."""
     global _CHAT_ACTIVE, _CHAT_ACTIVE_TIMED_OUT
 
-    _timeout = timeout
+    if not fut.set_running_or_notify_cancel():
+        return
+    try:
+        result = context.run(run)
+    except BaseException as exc:
+        fut.set_exception(exc)
+    else:
+        fut.set_result(result)
+    finally:
+        with _CHAT_WORKER_CONDITION:
+            if _CHAT_ACTIVE is fut:
+                _CHAT_ACTIVE = None
+                _CHAT_ACTIVE_TIMED_OUT = False
+            _CHAT_WORKER_CONDITION.notify_all()
 
-    def _run() -> dict[str, Any]:
-        # Set thread-local GPU timeout so gpu_guard() in this thread uses a
-        # matching deadline instead of blocking indefinitely.
-        try:
-            from memo.mlx_gpu import _gpu_tl
 
-            _gpu_tl.timeout = _timeout
-        except Exception:  # noqa: S110
-            pass
-        return chat.chat(**kwargs)
-
-    deadline = time.monotonic() + timeout
-    import contextvars
+def _reserve_chat_worker(
+    run: Callable[[], dict[str, Any]],
+    *,
+    deadline: float,
+) -> tuple[_futures.Future[dict[str, Any]], float] | None:
+    """Wait for and reserve the single chat slot within ``deadline``."""
+    global _CHAT_ACTIVE, _CHAT_ACTIVE_TIMED_OUT
 
     with _CHAT_WORKER_CONDITION:
         while _CHAT_ACTIVE is not None:
@@ -406,32 +421,49 @@ def chat_with_timeout(chat: Any, *, timeout: float, **kwargs: Any) -> dict[str, 
         _CHAT_ACTIVE = fut
         _CHAT_ACTIVE_TIMED_OUT = False
         context = contextvars.copy_context()
+        threading.Thread(
+            target=_chat_worker,
+            args=(fut, context, run),
+            name="chat-timeout",
+            daemon=True,
+        ).start()
+        return fut, remaining
 
-        def _worker() -> None:
-            global _CHAT_ACTIVE, _CHAT_ACTIVE_TIMED_OUT
-            if not fut.set_running_or_notify_cancel():
-                return
-            try:
-                result = context.run(_run)
-            except BaseException as exc:
-                fut.set_exception(exc)
-            else:
-                fut.set_result(result)
-            finally:
-                with _CHAT_WORKER_CONDITION:
-                    if _CHAT_ACTIVE is fut:
-                        _CHAT_ACTIVE = None
-                        _CHAT_ACTIVE_TIMED_OUT = False
-                    _CHAT_WORKER_CONDITION.notify_all()
 
-        threading.Thread(target=_worker, name="chat-timeout", daemon=True).start()
+def _mark_chat_worker_timed_out(fut: _futures.Future[dict[str, Any]]) -> None:
+    """Keep later calls from competing with an abandoned MLX operation."""
+    global _CHAT_ACTIVE_TIMED_OUT
+
+    with _CHAT_WORKER_CONDITION:
+        if _CHAT_ACTIVE is fut:
+            _CHAT_ACTIVE_TIMED_OUT = True
+
+
+def chat_with_timeout(chat: Any, *, timeout: float, **kwargs: Any) -> dict[str, Any] | None:
+    """Run ``chat.chat(**kwargs)`` with a hard wall-clock timeout.
+
+    Returns the result dict, or ``None`` if it exceeds ``timeout``. MLX work
+    cannot be interrupted mid-flight, so a timed-out worker continues in one
+    daemon thread. Calls made while that worker is still alive fail closed
+    immediately instead of starting competing model loads. A daemon is used
+    deliberately: unlike ``ThreadPoolExecutor`` workers, it does not get joined
+    by ``concurrent.futures`` during interpreter shutdown.
+
+    Errors raised by ``chat.chat`` propagate (caller's try/except handles them).
+    """
+    deadline = time.monotonic() + timeout
+    reservation = _reserve_chat_worker(
+        lambda: _run_chat_call(chat, timeout, kwargs),
+        deadline=deadline,
+    )
+    if reservation is None:
+        return None
+    fut, remaining = reservation
 
     try:
         return fut.result(timeout=remaining)
     except _futures.TimeoutError:
-        with _CHAT_WORKER_CONDITION:
-            if _CHAT_ACTIVE is fut:
-                _CHAT_ACTIVE_TIMED_OUT = True
+        _mark_chat_worker_timed_out(fut)
         return None
 
 

--- a/src/memo/memory/record.py
+++ b/src/memo/memory/record.py
@@ -354,33 +354,24 @@ def _recency_key(rec: MemoryRecord) -> str:
 
 # -- LLM-call helpers (shared by the maintain/consolidate/synthesize loops) ----
 
-_CHAT_EXECUTOR: _futures.ThreadPoolExecutor | None = None
-_EXECUTOR_LOCK = threading.Lock()
-
-
-def _get_chat_executor() -> _futures.ThreadPoolExecutor:
-    global _CHAT_EXECUTOR
-    with _EXECUTOR_LOCK:
-        if _CHAT_EXECUTOR is None:
-            _CHAT_EXECUTOR = _futures.ThreadPoolExecutor(
-                max_workers=1, thread_name_prefix="chat-timeout"
-            )
-        return _CHAT_EXECUTOR
+_CHAT_WORKER_CONDITION = threading.Condition()
+_CHAT_ACTIVE: _futures.Future[dict[str, Any]] | None = None
+_CHAT_ACTIVE_TIMED_OUT = False
 
 
 def chat_with_timeout(chat: Any, *, timeout: float, **kwargs: Any) -> dict[str, Any] | None:
     """Run ``chat.chat(**kwargs)`` with a hard wall-clock timeout.
 
-    Returns the result dict, or ``None`` if it exceeds ``timeout``. On timeout
-    the executor is shut down (``shutdown(wait=False)``) and replaced with a
-    fresh one — an MLX forward pass can't be interrupted mid-flight, but the
-    next caller gets a full timeout budget instead of queueing behind the
-    abandoned thread.  The submitted thread sets ``_gpu_tl.timeout`` so
-    ``gpu_guard()`` imposes a deadline on the GPU lock rather than blocking
-    forever.
+    Returns the result dict, or ``None`` if it exceeds ``timeout``. MLX work
+    cannot be interrupted mid-flight, so a timed-out worker continues in one
+    daemon thread. Calls made while that worker is still alive fail closed
+    immediately instead of starting competing model loads. A daemon is used
+    deliberately: unlike ``ThreadPoolExecutor`` workers, it does not get joined
+    by ``concurrent.futures`` during interpreter shutdown.
 
     Errors raised by ``chat.chat`` propagate (caller's try/except handles them).
     """
+    global _CHAT_ACTIVE, _CHAT_ACTIVE_TIMED_OUT
 
     _timeout = timeout
 
@@ -395,30 +386,52 @@ def chat_with_timeout(chat: Any, *, timeout: float, **kwargs: Any) -> dict[str, 
             pass
         return chat.chat(**kwargs)
 
-    ex = _get_chat_executor()
-    if getattr(ex, "_shutdown", False):
-        with _EXECUTOR_LOCK:
-            _CHAT_EXECUTOR = None
-            _CHAT_EXECUTOR = _futures.ThreadPoolExecutor(
-                max_workers=1, thread_name_prefix="chat-timeout"
-            )
-            ex = _CHAT_EXECUTOR
-    # copy_context: the sampling contextvar (memo.sampling) must survive the
-    # executor hop or client-sampling silently degrades to MLX mid-request.
+    deadline = time.monotonic() + timeout
     import contextvars
 
-    fut = ex.submit(contextvars.copy_context().run, _run)
+    with _CHAT_WORKER_CONDITION:
+        while _CHAT_ACTIVE is not None:
+            if _CHAT_ACTIVE_TIMED_OUT:
+                return None
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            _CHAT_WORKER_CONDITION.wait(timeout=remaining)
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+
+        fut: _futures.Future[dict[str, Any]] = _futures.Future()
+        _CHAT_ACTIVE = fut
+        _CHAT_ACTIVE_TIMED_OUT = False
+        context = contextvars.copy_context()
+
+        def _worker() -> None:
+            global _CHAT_ACTIVE, _CHAT_ACTIVE_TIMED_OUT
+            if not fut.set_running_or_notify_cancel():
+                return
+            try:
+                result = context.run(_run)
+            except BaseException as exc:
+                fut.set_exception(exc)
+            else:
+                fut.set_result(result)
+            finally:
+                with _CHAT_WORKER_CONDITION:
+                    if _CHAT_ACTIVE is fut:
+                        _CHAT_ACTIVE = None
+                        _CHAT_ACTIVE_TIMED_OUT = False
+                    _CHAT_WORKER_CONDITION.notify_all()
+
+        threading.Thread(target=_worker, name="chat-timeout", daemon=True).start()
+
     try:
-        return fut.result(timeout=timeout)
+        return fut.result(timeout=remaining)
     except _futures.TimeoutError:
-        # Shutdown the executor so the next caller doesn't queue behind
-        # the abandoned MLX thread.  An MLX forward pass can't be
-        # interrupted in-flight, so the old thread runs to completion in
-        # the background, but the next call gets a fresh executor+worker
-        # and its full timeout budget instead of cascading.
-        with _EXECUTOR_LOCK:
-            ex.shutdown(wait=False)
-            _CHAT_EXECUTOR = None
+        with _CHAT_WORKER_CONDITION:
+            if _CHAT_ACTIVE is fut:
+                _CHAT_ACTIVE_TIMED_OUT = True
         return None
 
 

--- a/src/memo/recall_logic.py
+++ b/src/memo/recall_logic.py
@@ -796,6 +796,8 @@ def _apply_code_proximity_boost(
     hits: list[Any],
     explain: dict[str, dict[str, Any]] | None = None,
     cwd: str | None = None,
+    *,
+    enabled: bool = True,
 ) -> list[Any]:
     """Code-proximity stage of ``rank_hits`` (MEMO_RECALL_CODE_PROXIMITY_BOOST).
 
@@ -805,6 +807,8 @@ def _apply_code_proximity_boost(
     once (in the render ``cwd`` when given) and every matching hit gains
     +flag, re-sorted like the other additive boost stages (new list — the
     caller's is never mutated)."""
+    if not enabled:
+        return hits
     boost = flag_float("MEMO_RECALL_CODE_PROXIMITY_BOOST") or 0.0
     if boost <= 0:
         return hits
@@ -1258,8 +1262,12 @@ def rank_hits(
     # default 0.0 = OFF ⇒ the stage returns `raw` untouched with zero extra
     # work. Offline evals also disable it explicitly because they have no
     # trustworthy render cwd from which to resolve a working-tree diff.
-    if knobs.code_proximity:
-        raw = _apply_code_proximity_boost(raw, explain, cwd=knobs.cwd)
+    raw = _apply_code_proximity_boost(
+        raw,
+        explain,
+        knobs.cwd,
+        enabled=knobs.code_proximity,
+    )
 
     def _passes(h: Any) -> bool:
         # bm25-mode `h.score` is on the BM25 relevance scale, NOT cosine — applying

--- a/src/memo/recall_logic.py
+++ b/src/memo/recall_logic.py
@@ -1036,6 +1036,10 @@ class RankKnobs:
     mmr_lambda: float = 0.0
     synthesis_boost: float = 0.0
     altitude: float = 0.0  # Phase 2: boost distilled hits on a BROAD query (0.0 = OFF)
+    # Eval runs have project tags but no trustworthy render cwd. They disable
+    # this stage so an ambient process cwd cannot trigger one `git diff`
+    # subprocess per evaluated prompt.
+    code_proximity: bool = True
     # Render cwd (the hook payload's cwd, NOT the daemon's process cwd): drives
     # the code-proximity stage's git diff + .codegraph discovery. None keeps
     # process-cwd behavior (the direct CLI path, where they coincide).
@@ -1250,9 +1254,12 @@ def rank_hits(
         raw = _apply_altitude_boost(raw, knobs.altitude, broad=_is_broad_query(query))
         if explain is not None:
             _explain_stage(explain, raw, "altitude")
-    # Live flag (not a knob): MEMO_RECALL_CODE_PROXIMITY_BOOST default 0.0 = OFF
-    # ⇒ the stage returns `raw` untouched with zero extra work.
-    raw = _apply_code_proximity_boost(raw, explain, cwd=knobs.cwd)
+    # Live flag (not a tunable scalar): MEMO_RECALL_CODE_PROXIMITY_BOOST
+    # default 0.0 = OFF ⇒ the stage returns `raw` untouched with zero extra
+    # work. Offline evals also disable it explicitly because they have no
+    # trustworthy render cwd from which to resolve a working-tree diff.
+    if knobs.code_proximity:
+        raw = _apply_code_proximity_boost(raw, explain, cwd=knobs.cwd)
 
     def _passes(h: Any) -> bool:
         # bm25-mode `h.score` is on the BM25 relevance scale, NOT cosine — applying

--- a/src/memo/repo_index_helpers.py
+++ b/src/memo/repo_index_helpers.py
@@ -89,7 +89,10 @@ DEFAULT_CHUNK_OVERLAP_LINES = 8
 MIN_CHUNK_CHARS = 60
 _LINK_RE = re.compile(r"\[\[.+?\]\]|\[.+?\]\(.+?\)|https?://\S+")
 
-DEFAULT_EMBED_BATCH = 64
+# A 64-chunk Qwen3/MLX batch can exceed 19 GiB on real repositories even when
+# individual chunks are bounded. Sixteen keeps peak memory practical on common
+# Apple Silicon machines; operators with more headroom can still override it.
+DEFAULT_EMBED_BATCH = 16
 MIN_EMBED_BATCH = 1
 DEFAULT_FLUSH_BATCH = 25
 MIN_FLUSH_BATCH = 1

--- a/src/memo/repo_index_search.py
+++ b/src/memo/repo_index_search.py
@@ -187,6 +187,14 @@ _QUERY_TERM_STOPWORDS = frozenset(
         "cuando",
         "este",
         "esta",
+        # Structural/search-domain boilerplate. Keeping these terms gives every
+        # test or repo module the same filename boost and lets generic symbols
+        # crowd out the query-specific identifiers.
+        "test",
+        "tests",
+        "code",
+        "repo",
+        "repository",
     }
 )
 
@@ -273,6 +281,7 @@ def _rrf_fuse_repo(
     k: int = 60,
     query_terms: list[str] | None = None,
     channel_names: list[str] | None = None,
+    max_per_path: int | None = None,
 ) -> list[dict[str, Any]]:
     fused: dict[str, float] = {}
     canon: dict[str, dict[str, Any]] = {}
@@ -306,7 +315,12 @@ def _rrf_fuse_repo(
             if boost:
                 fused[rid] = score * (1.0 + boost)
                 path_boosts[rid] = boost
-    ranked = sorted(fused.items(), key=lambda kv: kv[1], reverse=True)[:limit]
+    ranked = _select_ranked_with_path_cap(
+        fused,
+        canon,
+        limit=limit,
+        max_per_path=max_per_path,
+    )
     out: list[dict[str, Any]] = []
     for rid, score in ranked:
         d = dict(canon[rid])
@@ -325,7 +339,31 @@ def _rrf_fuse_repo(
             "channel_ranks": dict(sorted(ranks[rid].items())),
             "path_name_boost": path_boosts.get(rid, 0.0),
             "channel_details": channel_details.get(rid, {}),
+            "max_per_path": max_per_path,
         }
         d["scope"] = classify_repo_path(str(d.get("path") or ""))
         out.append(d)
     return out
+
+
+def _select_ranked_with_path_cap(
+    fused: dict[str, float],
+    canon: dict[str, dict[str, Any]],
+    *,
+    limit: int,
+    max_per_path: int | None,
+) -> list[tuple[str, float]]:
+    ranked_all = sorted(fused.items(), key=lambda kv: kv[1], reverse=True)
+    if max_per_path is None:
+        return ranked_all[:limit]
+    ranked: list[tuple[str, float]] = []
+    path_counts: dict[str, int] = {}
+    for rid, score in ranked_all:
+        hit_path = str(canon[rid].get("path") or "")
+        if path_counts.get(hit_path, 0) >= max_per_path:
+            continue
+        ranked.append((rid, score))
+        path_counts[hit_path] = path_counts.get(hit_path, 0) + 1
+        if len(ranked) >= limit:
+            break
+    return ranked

--- a/src/memo/repo_intelligence.py
+++ b/src/memo/repo_intelligence.py
@@ -110,7 +110,10 @@ class _RepoIntelligenceMixin:
             return simple
 
         query_terms = _extract_query_terms(query)
-        input_k = max(limit * 3, 40)
+        # Keep the candidate pool stable for normal result windows (5-20).
+        # A smaller pool made a relevant file appear at limit=20 but disappear
+        # at limit=10 because RRF never saw its lower-ranked vector/graph hit.
+        input_k = max(limit * 3, 60)
         bm_hits = self.store.search_repo_bm25(
             query,
             limit=input_k,
@@ -251,7 +254,7 @@ class _RepoIntelligenceMixin:
                 Path(str(source["clone_path"])),
                 query,
                 scope=scope,
-                limit=max(limit * 4, 40),
+                limit=max(limit * 4, 80),
             )
             structural_entries = [
                 {**entry, "match_type": "codegraph"}
@@ -262,7 +265,7 @@ class _RepoIntelligenceMixin:
                 self.store.repo_chunks_for_paths(
                     source_id,
                     structural_entries,
-                    limit=max(limit * 3, 30),
+                    limit=max(limit * 3, 60),
                 )
             )
             provider_diagnostics["codegraph"].append(
@@ -283,7 +286,7 @@ class _RepoIntelligenceMixin:
             )[:20]
             signals, signal_status = self._load_change_signals(source)
             expanded = (
-                expand_cochange_paths(signals, seed_paths, limit=max(limit * 4, 40))
+                expand_cochange_paths(signals, seed_paths, limit=max(limit * 4, 80))
                 if signals is not None
                 else []
             )
@@ -310,7 +313,7 @@ class _RepoIntelligenceMixin:
                 self.store.repo_chunks_for_paths(
                     source_id,
                     change_entries,
-                    limit=max(limit * 3, 30),
+                    limit=max(limit * 3, 60),
                 )
             )
             provider_diagnostics["cochange"].append(
@@ -332,6 +335,7 @@ class _RepoIntelligenceMixin:
             channel_names=[channel for channel, _rows in named_channels],
             limit=max(limit * 3, 40),
             query_terms=query_terms,
+            max_per_path=2,
         )
         self.last_search_diagnostics = {
             "schema": "memo.repo_search_diagnostics.v1",

--- a/src/memo/repo_structural.py
+++ b/src/memo/repo_structural.py
@@ -137,6 +137,35 @@ def _direct_nodes(
     *,
     limit: int,
 ) -> list[sqlite3.Row]:
+    # Current CodeGraph indexes expose a segment vocabulary for snake_case and
+    # CamelCase identifiers. Prefix lookups use its primary key and the nodes
+    # name index; this avoids one full nodes-table scan per query term. Keep the
+    # LIKE fallback for older/minimal provider schemas.
+    has_segment_vocab = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'name_segment_vocab'"
+    ).fetchone()
+    if has_segment_vocab is not None:
+        segment_predicates = ["vocab.segment GLOB ?" for _term in terms]
+        segment_params: list[Any] = [f"{term.lower()}*" for term in terms]
+        sql = (
+            "WITH matching_names AS ("  # noqa: S608 — fixed placeholders; bound terms.
+            "  SELECT vocab.name, COUNT(DISTINCT vocab.segment) AS match_count "
+            "  FROM name_segment_vocab AS vocab WHERE "
+            + " OR ".join(segment_predicates)
+            + "  GROUP BY vocab.name"
+            ") "
+            "SELECT nodes.id, nodes.kind, nodes.name, nodes.qualified_name, "
+            "       nodes.file_path, nodes.start_line, nodes.end_line, "
+            "       nodes.signature, nodes.is_exported, matching_names.match_count "
+            "FROM matching_names "
+            "JOIN nodes ON nodes.name = matching_names.name "
+            "ORDER BY matching_names.match_count DESC, nodes.is_exported DESC, "
+            "         length(nodes.name) ASC, "
+            "         nodes.file_path ASC LIMIT ?"
+        )
+        segment_params.append(limit)
+        return connection.execute(sql, segment_params).fetchall()
+
     predicates: list[str] = []
     params: list[Any] = []
     for term in terms:
@@ -193,6 +222,8 @@ def _node_score(row: sqlite3.Row, terms: list[str]) -> float:
             score = max(score, 0.76)
         elif term in qualified:
             score = max(score, 0.64)
+    if "match_count" in row.keys():  # noqa: SIM118 — sqlite3.Row checks values.
+        score = max(score, 0.55 + min(0.4, 0.12 * int(row["match_count"] or 0)))
     if int(row["is_exported"] or 0):
         score += 0.04
     return min(score, 1.0)

--- a/src/memo/repo_watcher.py
+++ b/src/memo/repo_watcher.py
@@ -14,6 +14,11 @@ from typing import Any
 from memo.errors import MemoError
 
 
+def _is_git_commit_signal(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    return "/.git/refs/heads/" in normalized or normalized.endswith("/.git/HEAD")
+
+
 class DebouncedRepoRefresh:
     """Coalesce repository file events into one hash-incremental refresh."""
 
@@ -36,7 +41,8 @@ class DebouncedRepoRefresh:
 
     def schedule(self, path: Path) -> None:
         value = str(path)
-        if "/.git/" in value.replace("\\", "/"):
+        normalized = value.replace("\\", "/")
+        if "/.git/" in normalized and not _is_git_commit_signal(normalized):
             return
         with self._lock:
             self._pending_paths.add(value)
@@ -111,6 +117,9 @@ class DebouncedRepoRefresh:
 def _watch_target(source: dict[str, Any] | None, repo: str) -> Path:
     if source is None:
         raise SystemExit(f"repo not found: {repo}")
+    source_url = Path(str(source.get("url") or "")).expanduser()
+    if source_url.is_dir():
+        return source_url.resolve()
     target = Path(str(source["clone_path"]))
     if not target.is_dir():
         raise SystemExit(f"managed clone is missing: {target}")
@@ -127,7 +136,14 @@ def _watch_handler(base: Any, target: Path, refresh: DebouncedRepoRefresh) -> An
                 relative = path.relative_to(target)
             except ValueError:
                 return
-            if relative.parts and relative.parts[0] == ".git":
+            relative_text = relative.as_posix()
+            if (
+                relative.parts
+                and relative.parts[0] == ".git"
+                and not (
+                    relative_text.startswith(".git/refs/heads/") or relative_text == ".git/HEAD"
+                )
+            ):
                 return
             refresh.schedule(path)
 

--- a/src/memo/runtime/mcp.py
+++ b/src/memo/runtime/mcp.py
@@ -38,10 +38,9 @@ _MCP_ENV_FORWARD_KEYS = (
     "MEMO_RERANKER_REVISION",
     "MEMO_RERANK_INPUT_K",
     "MEMO_RERANK_FUSION_ALPHA",
-    # auto-update: default ON (resolved from the built-in default when unset, so a
-    # fresh install auto-updates without any injected env). Forwarded only when set
-    # at install time, letting a machine pin a value — e.g. opt out with
-    # `MEMO_AUTO_UPDATE=0 memo install-mcp --write`.
+    # Update checks and auto-update are opt-in. Forward explicit values only so
+    # an operator can enable them without turning normal MCP startup into an
+    # implicit network operation.
     "MEMO_UPDATE_CHECK_ENABLED",
     "MEMO_AUTO_UPDATE",
     "MEMO_AUTO_UPDATE_INTERVAL_S",

--- a/src/memo/store/tantivy_index.py
+++ b/src/memo/store/tantivy_index.py
@@ -59,6 +59,7 @@ class TantivyFTSIndex:
         self._index = tantivy.Index(self._schema, path=str(index_dir))
         self._writer = self._index.writer(heap_size=writer_heap_mb * 1024 * 1024)
         self._lock = threading.Lock()
+        self._closed = False
 
     @classmethod
     def open_or_create(cls, index_dir: Path) -> TantivyFTSIndex:
@@ -71,11 +72,22 @@ class TantivyFTSIndex:
     # -- write -----------------------------------------------------------------
 
     def close(self) -> None:
-        """Release the tantivy writer and index resources."""
+        """Commit pending writes and wait until Tantivy releases merge files."""
         import contextlib
 
-        with contextlib.suppress(Exception):
-            self._writer.commit()
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            with contextlib.suppress(Exception):
+                self._writer.commit()
+            # Tantivy merges index segments on background threads.  Merely
+            # committing can leave those threads holding temporary files,
+            # which races callers that immediately remove the index directory
+            # (including TemporaryDirectory cleanup).  This call consumes the
+            # writer and joins every outstanding merge thread.
+            with contextlib.suppress(Exception):
+                self._writer.wait_merging_threads()
 
     def add_document(self, id_: str, title: str, tags: str, body: str) -> None:
         import tantivy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,12 +117,8 @@ os.environ["MEMO_EMBEDDER_CLIENT_REQUIRE_DAEMON"] = "0"
 os.environ["MEMO_SUPPORT_CONFIDENCE_LIFT"] = "0"
 os.environ["MEMO_SUPERSEDE_SUPPORT_GATE"] = "0"
 
-# Auto-update (memo v4.1.0+) graduated to a default-ON behavior: a real
-# memo-mcp start now does a throttled `git ls-remote` and may self-install.
-# Hard-set off so `pytest` never touches the network (and an activated dev
-# machine's `update.auto_update=on` markdown config can't leak in). Tests that
-# exercise the updater opt back in via `monkeypatch.setenv("MEMO_AUTO_UPDATE", …)`
-# or `monkeypatch.delenv(...)` to assert the real default.
+# Hard-set auto-update off so a developer's explicit opt-in cannot leak into
+# pytest. Tests that exercise the updater opt back in explicitly.
 os.environ["MEMO_AUTO_UPDATE"] = "0"
 
 # Trust & belief-revision program flags (memo v3.0.0+). A machine running the

--- a/tests/test_autoupdate.py
+++ b/tests/test_autoupdate.py
@@ -270,8 +270,8 @@ def test_throttle_first_check_then_blocked(tmp_cfg):
 
 
 def test_runtime_flag_defaults(monkeypatch):
-    # memo v4.1.0+: MEMO_AUTO_UPDATE defaults ON (memo keeps itself current);
-    # the check/self-heal flags stay opt-in (default off).
+    # Normal startup is offline: update checks, auto-update, and self-heal all
+    # require explicit opt-in.
     from memo.flags import flag_bool
 
     names = (
@@ -285,24 +285,27 @@ def test_runtime_flag_defaults(monkeypatch):
 
     assert {name: flag_bool(name) for name in names} == {
         "MEMO_UPDATE_CHECK_ENABLED": False,
-        "MEMO_AUTO_UPDATE": True,
+        "MEMO_AUTO_UPDATE": False,
         "MEMO_STATUSLINE_SELFHEAL": False,
         "MEMO_HOOK_SELFHEAL": False,
     }
 
 
-def test_maybe_auto_update_enabled_by_default(tmp_cfg, monkeypatch):
-    # memo v4.1.0+: MEMO_AUTO_UPDATE defaults ON. With no explicit env var (the
-    # conftest hermetic pin removed), a memo-mcp start checks for a newer tag and
-    # spawns the background updater. The isolated MEMO_CONFIG_DIR means no
-    # markdown config leaks in, so this exercises the real built-in default.
+def test_maybe_auto_update_disabled_by_default(tmp_cfg, monkeypatch):
+    # No explicit env var means no outbound tag check and no subprocess.
     monkeypatch.delenv("MEMO_AUTO_UPDATE", raising=False)
-    monkeypatch.setattr(au, "latest_remote_tag", lambda *a, **k: "v999.0.0")
-    monkeypatch.setattr(au, "tag_is_on_remote_master", lambda *a, **k: True)
-    monkeypatch.setattr(au, "_process_identity", lambda pid: f"test:{pid}")
-    monkeypatch.setattr(au.subprocess, "Popen", lambda *a, **k: _FakeUpdateProc(4242))
+    monkeypatch.setattr(
+        au,
+        "latest_remote_tag",
+        lambda *a, **k: pytest.fail("default startup must not access the network"),
+    )
+    monkeypatch.setattr(
+        au.subprocess,
+        "Popen",
+        lambda *a, **k: pytest.fail("default startup must not spawn an updater"),
+    )
 
-    assert au.maybe_auto_update(tmp_cfg) is True
+    assert au.maybe_auto_update(tmp_cfg) is False
 
 
 def test_maybe_auto_update_respects_explicit_optout(tmp_cfg, monkeypatch):

--- a/tests/test_consolidation.py
+++ b/tests/test_consolidation.py
@@ -171,6 +171,51 @@ def test_consolidate_all_with_data(consolidator, mock_memory):
     assert "proposals" in result
 
 
+def test_consolidate_all_stops_llm_calls_after_first_timeout(consolidator, monkeypatch):
+    clusters = [
+        {
+            "cluster_id": cluster_id,
+            "relationship": "duplicate",
+            "members": [
+                {
+                    "id": f"{cluster_id:032x}",
+                    "title": f"Memory {cluster_id}",
+                    "updated": "2026-01-01T00:00:00+00:00",
+                    "body_preview": "same fact",
+                },
+                {
+                    "id": f"{cluster_id + 100:032x}",
+                    "title": f"Memory {cluster_id} copy",
+                    "updated": "2026-01-02T00:00:00+00:00",
+                    "body_preview": "same fact",
+                },
+            ],
+        }
+        for cluster_id in range(1, 4)
+    ]
+    monkeypatch.setattr(consolidator.memory, "consolidate", lambda **kwargs: clusters)
+    consolidator._chat = object()
+    calls = 0
+
+    def timeout_once(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return None
+
+    monkeypatch.setattr("memo.consolidation.chat_with_timeout", timeout_once)
+
+    result = consolidator.consolidate_all(
+        threshold=0.85,
+        max_clusters=20,
+        auto_apply=False,
+        dry_run=True,
+        auto_threshold=0.85,
+    )
+
+    assert calls == 1
+    assert result["proposals"] == []
+
+
 def test_merge_proposal_dataclass():
     """Test MergeProposal dataclass structure."""
     p = MergeProposal(

--- a/tests/test_eval_recall.py
+++ b/tests/test_eval_recall.py
@@ -771,6 +771,7 @@ def test_run_config_pins_eval_fields_and_inherits_live_flags(monkeypatch):
     assert knobs.min_body_chars == 0
     assert knobs.mode == "vec"
     assert knobs.project_tag is None  # labels carry no project yet
+    assert knobs.code_proximity is False  # no render cwd: never spawn git per prompt
     # everything else inherits the LIVE flag/overlay resolution
     assert knobs.mmr_lambda == 0.4
     assert knobs.synthesis_boost == 0.07

--- a/tests/test_gpu_deadlock_fix.py
+++ b/tests/test_gpu_deadlock_fix.py
@@ -147,6 +147,7 @@ class TestChatWithTimeoutSetsThreadLocal:
 
         _started = threading.Event()
         _release = threading.Event()
+        _finished = threading.Event()
 
         class SlowChat:
             _gen_lock = threading.Lock()
@@ -154,8 +155,72 @@ class TestChatWithTimeoutSetsThreadLocal:
             def chat(self, model, messages, options=None):
                 _started.set()
                 _release.wait(timeout=5.0)
+                _finished.set()
                 return {"message": {"content": "done"}}
 
         result = chat_with_timeout(SlowChat(), timeout=0.1, model="m", messages=[])
         assert result is None
         _release.set()
+        assert _finished.wait(timeout=2.0)
+
+    def test_timed_out_worker_does_not_block_interpreter_shutdown(self):
+        import subprocess
+        import sys
+        import textwrap
+
+        script = textwrap.dedent(
+            """
+            import threading
+
+            from memo.memory.record import chat_with_timeout
+
+            blocker = threading.Event()
+
+            class SlowChat:
+                def chat(self, **kwargs):
+                    blocker.wait()
+                    return {"message": {"content": "done"}}
+
+            assert chat_with_timeout(SlowChat(), timeout=0.05, model="m", messages=[]) is None
+            print("returned", flush=True)
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        )
+        assert completed.stdout.strip() == "returned"
+
+    def test_call_is_rejected_while_timed_out_worker_is_still_running(self):
+        import time
+
+        from memo.memory.record import chat_with_timeout
+
+        release = threading.Event()
+        finished = threading.Event()
+        second_calls = 0
+
+        class SlowChat:
+            def chat(self, **kwargs):
+                release.wait(timeout=5.0)
+                finished.set()
+                return {"message": {"content": "slow"}}
+
+        class SecondChat:
+            def chat(self, **kwargs):
+                nonlocal second_calls
+                second_calls += 1
+                return {"message": {"content": "unexpected"}}
+
+        assert chat_with_timeout(SlowChat(), timeout=0.05, model="m", messages=[]) is None
+        started = time.monotonic()
+        assert chat_with_timeout(SecondChat(), timeout=1.0, model="m", messages=[]) is None
+        assert time.monotonic() - started < 0.25
+        assert second_calls == 0
+
+        release.set()
+        assert finished.wait(timeout=2.0)

--- a/tests/test_recall_code_proximity.py
+++ b/tests/test_recall_code_proximity.py
@@ -129,6 +129,28 @@ def test_flag_off_is_zero_work_and_ranking_identical(monkeypatch: pytest.MonkeyP
     assert [h.score for h in baseline] == [h.score for h in out] == [0.8, 0.7]
 
 
+def test_eval_knob_disables_repo_io_even_when_live_flag_is_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MEMO_RECALL_CODE_PROXIMITY_BOOST", "0.3")
+    monkeypatch.setattr(subprocess, "run", _boom)
+    hits = [
+        _mk("far", 0.8),
+        _citing("near", 0.7, {"file_path": "src/memo/c.py", "kind": "function", "label": "gamma"}),
+    ]
+    knobs = RankKnobs(
+        top_k=5,
+        min_sim=0.0,
+        min_body_chars=0,
+        code_proximity=False,
+    )
+
+    out = rl.rank_hits(hits, knobs)
+
+    assert [h.id for h in out] == ["far", "near"]
+    assert [h.score for h in out] == [0.8, 0.7]
+
+
 # --- flag on: boost + reorder ---------------------------------------------------------
 
 

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -196,6 +196,19 @@ def test_publish_jobs_run_full_qa_on_the_exact_tagged_sha() -> None:
     assert docker_jobs["build-and-push"]["needs"] == "quality-gate"
 
 
+def test_release_quality_and_publish_chain_fail_closed() -> None:
+    """Required smoke jobs cannot be skipped while downstream publish still runs."""
+    quality_jobs = yaml.safe_load((WORKFLOWS / "release-quality.yml").read_text(encoding="utf-8"))[
+        "jobs"
+    ]
+    publish_jobs = yaml.safe_load((WORKFLOWS / "publish.yml").read_text(encoding="utf-8"))["jobs"]
+
+    assert set(quality_jobs) == {"quality", "linux-cpu-smoke", "macos-mlx-smoke"}
+    assert all("if" not in job for job in quality_jobs.values())
+    for job_name in ("github-release", "build", "pypi", "mcp-registry"):
+        assert "if" not in publish_jobs[job_name]
+
+
 def test_publish_has_one_automatic_release_trigger() -> None:
     workflow = (WORKFLOWS / "publish.yml").read_text(encoding="utf-8")
     config = yaml.safe_load(workflow)

--- a/tests/test_repo_index.py
+++ b/tests/test_repo_index.py
@@ -16,6 +16,7 @@ from memo.repo_index import (
     _extract_query_terms,
     _path_name_boost,
 )
+from memo.repo_index_helpers import _repo_embed_batch_size
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -298,6 +299,12 @@ def test_repo_embed_sorts_batches_by_input_length(tmp_path: Path, monkeypatch):
 
     assert len(seen_lengths) == 3
     assert seen_lengths == sorted(seen_lengths)
+
+
+def test_repo_embed_default_batch_is_memory_safe(monkeypatch):
+    monkeypatch.delenv("MEMO_REPO_EMBED_BATCH", raising=False)
+
+    assert _repo_embed_batch_size() == 16
 
 
 def test_repo_embed_reduces_batch_size_after_runtime_error(tmp_path: Path, monkeypatch):

--- a/tests/test_repo_intelligence.py
+++ b/tests/test_repo_intelligence.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from memo.config import Config
 from memo.memory import Memory
-from memo.repo_index_search import classify_repo_path
+from memo.repo_index_search import _rrf_fuse_repo, classify_repo_path
 from memo.repo_signals import (
     collect_git_change_signals,
     expand_cochange_paths,
@@ -74,6 +74,21 @@ def test_scope_classification() -> None:
     assert classify_repo_path("third_party/lib/x.cc") == "vendor"
 
 
+def test_unified_fusion_can_bound_chunks_per_path() -> None:
+    rows = [
+        {"id": "a1", "path": "src/a.py"},
+        {"id": "a2", "path": "src/a.py"},
+        {"id": "a3", "path": "src/a.py"},
+        {"id": "b1", "path": "src/b.py"},
+        {"id": "c1", "path": "src/c.py"},
+    ]
+
+    fused = _rrf_fuse_repo([rows], limit=3, max_per_path=1)
+
+    assert [row["path"] for row in fused] == ["src/a.py", "src/b.py", "src/c.py"]
+    assert all(row["rank_explanation"]["max_per_path"] == 1 for row in fused)
+
+
 def test_structural_provider_reads_codegraph_and_one_hop(tmp_path: Path) -> None:
     root = tmp_path / "repo"
     db_path = root / ".codegraph" / "codegraph.db"
@@ -105,6 +120,51 @@ def test_structural_provider_reads_codegraph_and_one_hop(tmp_path: Path) -> None
     assert "src/alpha.py" in paths
     assert "services/beta/worker.py" in paths
     assert paths["src/alpha.py"]["evidence"][0]["kind"] == "symbol_match"
+
+
+def test_structural_provider_uses_codegraph_segment_vocabulary(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    db_path = root / ".codegraph" / "codegraph.db"
+    db_path.parent.mkdir(parents=True)
+    connection = sqlite3.connect(db_path)
+    connection.executescript(
+        """
+        CREATE TABLE nodes (
+          id TEXT PRIMARY KEY, kind TEXT, name TEXT, qualified_name TEXT,
+          file_path TEXT, start_line INTEGER, end_line INTEGER,
+          signature TEXT, is_exported INTEGER
+        );
+        CREATE INDEX idx_nodes_name ON nodes(name);
+        CREATE TABLE edges (source TEXT, target TEXT, kind TEXT);
+        CREATE TABLE name_segment_vocab (
+          segment TEXT NOT NULL, name TEXT NOT NULL, PRIMARY KEY (segment, name)
+        ) WITHOUT ROWID;
+        INSERT INTO nodes VALUES
+          ('a', 'class', 'ContentAddressedArtifactStore',
+           'memo.artifact_store.ContentAddressedArtifactStore',
+           'src/memo/artifact_store.py', 53, 280,
+           'class ContentAddressedArtifactStore', 1),
+          ('b', 'class', 'AddressBook',
+           'memo.contacts.AddressBook',
+           'src/memo/contacts.py', 1, 20,
+           'class AddressBook', 1);
+        INSERT INTO name_segment_vocab VALUES
+          ('addressed', 'ContentAddressedArtifactStore'),
+          ('artifact', 'ContentAddressedArtifactStore'),
+          ('content', 'ContentAddressedArtifactStore'),
+          ('store', 'ContentAddressedArtifactStore'),
+          ('address', 'AddressBook'),
+          ('book', 'AddressBook');
+        """
+    )
+    connection.commit()
+    connection.close()
+
+    result = search_codegraph_paths(root, "addressed artifact", limit=10)
+
+    assert result["status"] == "available"
+    assert result["paths"][0]["path"] == "src/memo/artifact_store.py"
+    assert result["paths"][0]["evidence"][0]["score"] == 0.83
 
 
 def test_unified_search_scopes_artifacts_cochange_and_atomic_visibility(

--- a/tests/test_server_startup_policy.py
+++ b/tests/test_server_startup_policy.py
@@ -21,9 +21,8 @@ class _RecordingThread:
 
 
 def _clear_policy_flags(monkeypatch: pytest.MonkeyPatch) -> None:
-    # MEMO_AUTO_UPDATE defaults ON (memo v4.1.0+); force it off so these wiring
-    # tests have a deterministic all-disabled baseline. The default-ON behavior
-    # is asserted separately by test_auto_update_runs_by_default.
+    # Force every policy flag off so these wiring tests have a deterministic
+    # all-disabled baseline even when a developer opted in in the parent shell.
     for name in (
         "MEMO_UPDATE_CHECK_ENABLED",
         "MEMO_STATUSLINE_SELFHEAL",
@@ -46,10 +45,8 @@ def test_background_tasks_silent_when_all_disabled(
     assert _RecordingThread.names == []
 
 
-def test_auto_update_runs_by_default(tmp_cfg, monkeypatch: pytest.MonkeyPatch) -> None:
-    # With no policy flag set at all, memo v4.1.0+ runs the tag check + the
-    # background updater by default (the self-heal tasks stay opt-in). The
-    # isolated MEMO_CONFIG_DIR means no markdown config leaks into the default.
+def test_no_background_work_runs_by_default(tmp_cfg, monkeypatch: pytest.MonkeyPatch) -> None:
+    # With no policy flag set, startup must stay offline and side-effect free.
     for name in (
         "MEMO_UPDATE_CHECK_ENABLED",
         "MEMO_AUTO_UPDATE",
@@ -62,8 +59,8 @@ def test_auto_update_runs_by_default(tmp_cfg, monkeypatch: pytest.MonkeyPatch) -
 
     started = server._start_background_tasks(tmp_cfg)
 
-    assert started == ("memo-update-check", "memo-auto-update")
-    assert tuple(_RecordingThread.names) == ("memo-update-check", "memo-auto-update")
+    assert started == ()
+    assert _RecordingThread.names == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tantivy_index.py
+++ b/tests/test_tantivy_index.py
@@ -7,6 +7,8 @@ so it runs in all environments.
 
 from __future__ import annotations
 
+import tempfile
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -39,8 +41,10 @@ def test_fold_diacritics_ascii_unchanged() -> None:
 
 
 @pytest.fixture()
-def idx(tmp_path: Path) -> TantivyFTSIndex:
-    return TantivyFTSIndex.open_or_create(tmp_path / "tantivy")
+def idx(tmp_path: Path) -> Iterator[TantivyFTSIndex]:
+    index = TantivyFTSIndex.open_or_create(tmp_path / "tantivy")
+    yield index
+    index.close()
 
 
 @requires_tantivy
@@ -50,8 +54,26 @@ def test_exists_false_before_creation(tmp_path: Path) -> None:
 
 @requires_tantivy
 def test_exists_true_after_creation(tmp_path: Path) -> None:
-    TantivyFTSIndex.open_or_create(tmp_path / "idx")
+    index = TantivyFTSIndex.open_or_create(tmp_path / "idx")
     assert TantivyFTSIndex.exists(tmp_path / "idx")
+    index.close()
+
+
+@requires_tantivy
+def test_close_waits_for_merging_threads_and_is_idempotent() -> None:
+    """Closing permits immediate directory cleanup even after many commits."""
+    with tempfile.TemporaryDirectory() as tmp:
+        index = TantivyFTSIndex.open_or_create(Path(tmp) / "tantivy")
+        for i in range(100):
+            index.add_document(
+                f"id{i}",
+                f"document number {i}",
+                "",
+                f"content for merge segment {i}",
+            )
+            index.commit()
+        index.close()
+        index.close()
 
 
 @requires_tantivy
@@ -206,6 +228,7 @@ def test_thread_safety_concurrent_upserts(tmp_path: Path) -> None:
     assert not errors, f"thread errors: {errors}"
     results = idx.search_bm25("document", 20)
     assert len(results) == 8
+    idx.close()
 
 
 # ---------------------------------------------------------------------------
@@ -244,3 +267,4 @@ def test_fallback_to_fts5_when_tantivy_absent(
     results = store.search_bm25("testing", limit=5)
     assert len(results) == 1
     assert results[0]["id"] == "abc"
+    store.close()

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1,6 +1,7 @@
 """Tests for temporal reasoning module."""
 
 import time
+from threading import Event
 from types import SimpleNamespace
 
 import pytest
@@ -26,10 +27,15 @@ def test_temporal_analyzer_init(temporal_analyzer):
 
 
 def test_classify_pair_timeout_does_not_wait_for_worker(mock_memory, monkeypatch):
+    finished = Event()
+
     class SlowChat:
         def chat(self, **_kwargs):
-            time.sleep(0.3)
-            return {"message": {"content": '{"relationship":"unrelated"}'}}
+            try:
+                time.sleep(0.3)
+                return {"message": {"content": '{"relationship":"unrelated"}'}}
+            finally:
+                finished.set()
 
     monkeypatch.setattr("memo.temporal._pair_classify_timeout", lambda: 0.05)
     analyzer = TemporalAnalyzer(mock_memory, chat=SlowChat())
@@ -54,6 +60,10 @@ def test_classify_pair_timeout_does_not_wait_for_worker(mock_memory, monkeypatch
 
     assert result is None
     assert elapsed < 0.2
+    # The production helper deliberately keeps the timed-out MLX worker alive
+    # and rejects competing calls. Drain this synthetic worker so its global
+    # fail-closed state cannot leak into the next test in the same xdist process.
+    assert finished.wait(timeout=1.0)
 
 
 def test_classify_pair_disables_thinking_for_json_response(mock_memory):

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from memo.repo_watcher import DebouncedRepoRefresh
+from memo.repo_watcher import DebouncedRepoRefresh, _watch_target
 from memo.watcher import _PLIST_LABEL, _DebouncedReindex, render_plist
 
 
@@ -99,3 +99,40 @@ def test_repo_debounce_refreshes_incrementally_and_ignores_git(tmp_path: Path) -
     assert url == source["url"]
     assert kwargs["refresh"] is True
     assert kwargs["include"] == ["*.py"]
+
+
+def test_repo_debounce_accepts_git_commit_ref_signal(tmp_path: Path) -> None:
+    class RepoSpy:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def repo_index(self, url: str, **kwargs: Any) -> dict[str, Any]:
+            del url, kwargs
+            self.calls += 1
+            return {"indexed_files": 0, "deleted_files": 0, "unchanged_files": 3}
+
+    spy = RepoSpy()
+    debounce = DebouncedRepoRefresh(
+        spy,
+        {"url": str(tmp_path), "name": "repo", "ref": "HEAD", "extra": {}},
+        delay=0.05,
+    )
+    debounce.schedule(tmp_path / ".git" / "index")
+    debounce.schedule(tmp_path / ".git" / "refs" / "heads" / "master")
+    time.sleep(0.2)
+
+    assert spy.calls == 1
+
+
+def test_repo_watcher_prefers_local_source_checkout(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    clone = tmp_path / "managed-clone"
+    source.mkdir()
+    clone.mkdir()
+
+    target = _watch_target(
+        {"url": str(source), "clone_path": str(clone), "name": "repo"},
+        "repo",
+    )
+
+    assert target == source.resolve()


### PR DESCRIPTION
## What changed

- document and harden graph-backed repository intelligence
- validate code-intelligence configuration and integration paths
- disable code-proximity subprocess work during offline recall evaluation, where no trustworthy render cwd exists
- serialize timeout-bound LLM work in one daemon worker
- stop remaining consolidation proposals after the first LLM timeout and retry on the next run

## Why

`memo dream run` invoked code-proximity ranking once per offline evaluation prompt, which spawned repeated `git` subprocesses and surfaced macOS `MallocStackLogging` noise. A separate cold model load could time out while its executor worker remained alive, causing later consolidation calls to cascade and Python to hang during interpreter shutdown.

## Impact

Offline self-tuning no longer performs repository-proximity subprocess work. A cold LLM load now degrades cleanly for the current consolidation pass without launching competing loads or blocking process exit. Live recall keeps code-proximity ranking enabled.

## Validation

- `uv run --no-sync ruff check src/ tests/`
- `uv run --no-sync ruff format --check src/ tests/`
- `uv run --no-sync mypy src/`
- `uv run --no-sync pytest -m 'not slow' -n auto --timeout=120 --cov=memo --cov-report=term-missing` — 6093 passed, 1 skipped, 78.52% coverage
- recall gate — 301 searches, `prec@k 0.708`, `noise@k 0.000`
- bounded `memo dream run --dry-run --skip-maintain` smoke — completed without malloc-log flooding, timeout cascade, or shutdown hang
