### PR TITLE
feat: adopt synapse daemons natively (big-bang synapse deprecation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Python ≥ 3.13 (the installer handles this via `uv` if you don't have it). Firs
 | Architecture and design notes | [reference.md › Design](docs/reference.md#design-and-comparison) |
 | Privacy and network policy | [PRIVACY.md](PRIVACY.md) |
 
-### All 137 top-level CLI commands
+### All 138 top-level CLI commands
 
 <details>
 <summary>Complete command inventory (kept here so CI detects CLI/documentation drift)</summary>
@@ -181,7 +181,7 @@ Python ≥ 3.13 (the installer handles this via `uv` if you don't have it). Firs
 
 **Session & History:** `history` `as-of` `diff` `record-history` `session` `resume` `reflect` `mine-history` `episodes` `chronicle`
 
-**Maintenance:** `reindex` `maintain` `review` `dream` `consolidate` `synthesize` `dedupe` `retier` `contradict` `invalidate` `temporal` `compress-context`
+**Maintenance:** `reindex` `maintain` `review` `dream` `consolidate` `synthesize` `dedupe` `retier` `contradict` `invalidate` `temporal` `compress-context` `ops`
 
 **Analysis & Quality:** `health` `stats` `doctor` `journey-check` `lint` `drift` `analytics` `eval` `roi` `tokens` `token-savings` `usefulness` `gaps` `outcome` `profile` `confidence` `graduation` `hype` `definitive` `evidence`
 

--- a/docs/SPECS/2026-07-30-synapse-deprecation-design.md
+++ b/docs/SPECS/2026-07-30-synapse-deprecation-design.md
@@ -1,0 +1,74 @@
+# Deprecación big bang de synapse
+
+**Fecha:** 2026-07-30
+**Estado:** aprobado (brainstorming 2026-07-30)
+**Alcance:** una sola pasada — memo adopta sus daemons, synapse se desinstala y archiva por completo, `consciousness-contracts` se archiva con él.
+
+## Contexto
+
+La trinity (memo + memflow + synapse) ya está desacoplada a nivel código:
+
+- memflow es standalone desde `3b39a295fb` (`MEMFLOW_MEMO_BRIDGE` default OFF); cero referencias a synapse en `memflow/src`.
+- memo no importa synapse: `definitive.py` lo lista en `_RETIRED_IMPORTS`; `resume/` inlineó lo que usaba. Quedan solo nombres de campos de metadata (`synapse_trace_id`, …) y strings de tests — se conservan tal cual.
+- `consciousness_contracts` solo lo importa synapse (15 archivos; el hit en memo es el guard de retirados). Muere con synapse.
+
+Lo que sigue vivo es infraestructura: el fleet launchd `com.synapse.*` que synapse instala y posee (fuente: `synapse/src/synapse/ops.py`), el dashboard :8765 y `~/.synapse/` (estado + scripts generados).
+
+## Decisiones
+
+| Pieza | Destino |
+|---|---|
+| `memo-recall-daemon` | **memo la adopta.** El plist ya ejecuta `/Users/fer/.local/bin/memo recall-daemon _serve` — solo cambia label/dueño a `com.memo.recall-daemon`. |
+| `memo-nightly` + `vault-ingest` | **memo los adopta**, portando la poca lógica synapse-side (ver Port). |
+| `whatsapp-ingest` + `morning-digest` | **Mueren.** Sin reemplazo. |
+| dashboard + relay + watcher + runtime-loop + dream-synthesis + chat federado | **Mueren hoy.** Un dashboard/watcher memflow-nativo es una spec futura de memflow, fuera de este alcance. |
+| `consciousness-contracts` | **Se archiva** junto con synapse (ningún otro repo lo importa). |
+| `~/.synapse/` | **Se mueve al backup** (no se borra). |
+| Repos `synapse` y `consciousness-contracts` | **Archive:** GitHub archive si hay remote + mover el checkout local a `~/repos/_archived/`. |
+
+Secuenciación: **big bang** (elegida sobre strangler). Mitigación: snapshot completo previo + verify gates + rollback documentado.
+
+## Port a memo (único trabajo de código)
+
+Los 4 jobs nightly synapse-side son wrappers finos que shell-out al binario `memo`:
+
+1. **`gc-vault-orphans`** (`ops.py:515`): borra registros cuyo `extra.abs_path` ya no existe, solo `source=vault-ingest`. Lógica pura sobre `memo list --json`.
+2. **`gc-memo-duplicates`** (`ops.py:595`): borra duplicados exactos por SHA-256 del body, conserva el más nuevo. Lógica pura sobre `memo list --json`.
+3. **`contradict-scan`** (`ops.py:681`): wrapper de `memo contradict scan --max-memorias 500 --min-days-apart 3 --since <30d>` + `memo contradict list`. Casi solo re-wiring.
+4. **`vault-ingest`** (`ops.py:806`): por vault, `git pull --ff-only` best-effort + `memo ingest <root> --name <label> --prune` con excludes de sistema + tombstones de `IngestExcludeStore`.
+
+Se portan a memo como subcomandos CLI nativos (grupo `memo ops` o equivalente según convención del repo), con tests. `IngestExcludeStore` se porta a memo y su archivo de estado migra de `~/.synapse/` a `~/.local/share/memo/` (migración de datos incluida: si el archivo viejo existe, copiarlo).
+
+`memo-nightly.sh` se regenera memo-nativo, mismo orden, sin `PYTHONPATH=synapse`:
+codegraph sync (igual que hoy) → `memo contradict scan` → gc-dupes → gc-orphans → `memo consolidate apply --auto-threshold 0.95 --max-clusters 15`.
+
+Plists nuevos con templates en `memo/launchd/` (mismo patrón `__HOME__`/`__MEMO_BIN__` que `com.memo.dream`): `com.memo.recall-daemon`, `com.memo.nightly`, `com.memo.vault-ingest`.
+
+## Orden de ejecución
+
+1. **Snapshot:** copiar `~/Library/LaunchAgents/com.synapse.*.plist` + `~/.synapse/` completo a `~/.memo-daemon-backups/<timestamp>-synapse-final/`. Tag `deprecation-final` en el repo synapse.
+2. **Port + tests en memo** (branch → PR; master protegido).
+3. **Swap recall-daemon:** `launchctl bootout` del viejo → bootstrap `com.memo.recall-daemon` → verificar `recall.sock` responde y el hook queda bajo el budget de 5s. Ventana de segundos.
+4. **Instalar** `com.memo.nightly` + `com.memo.vault-ingest`; corrida manual verde de cada uno.
+5. **Teardown:** `synapse ops uninstall <svc>` para todo `SERVICE_TO_LABEL` (usar su propio tooling mientras existe). Desinstalar los git-hooks de awareness que synapse instaló en los repos. Sacar synapse de todo `.mcp.json` donde figure.
+6. **Archivo:** mover `~/.synapse/` al backup; archivar repos (GitHub + `~/repos/_archived/`).
+7. **Docs/memoria:** actualizar `~/CLAUDE.md` (trinity → memo+memflow, venvs, fleet) y guardar el resultado en memo.
+
+## Criterios de verificación (gates)
+
+- `launchctl list` sin ningún `com.synapse.*`; `com.memo.{recall-daemon,nightly,vault-ingest}` con exit 0.
+- Sesión Claude nueva: recall hook responde < 5s, sin errores de hooks.
+- `memo doctor` verde.
+- Corrida manual de nightly y vault-ingest verde de punta a punta.
+- memflow MCP (:18766) intacto.
+- `grep -r "synapse" ~/.claude/settings*.json ~/.mcp.json <repos>/.mcp.json` sin referencias activas.
+
+## Rollback
+
+Re-bootstrap desde los plists del snapshot (`launchctl bootstrap gui/$UID <plist>`); `~/.synapse/` restaurable desde el backup; el repo synapse queda intacto en `_archived` con tag `deprecation-final`. Nada se borra de forma irreversible.
+
+## Fuera de alcance
+
+- Dashboard/watcher memflow-nativos (spec futura en memflow).
+- Reemplazo de whatsapp-ingest / morning-digest / chat federado.
+- Limpieza de campos de metadata `synapse_*` en memo (`contracts.py`) — son datos históricos, se quedan.

--- a/docs/SPECS/2026-07-30-synapse-deprecation-plan.md
+++ b/docs/SPECS/2026-07-30-synapse-deprecation-plan.md
@@ -1,0 +1,316 @@
+# Synapse Deprecation (Big Bang) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** memo adopta sus 3 daemons (recall, nightly, vault-ingest) como agentes nativos `com.memo.*`, y synapse + consciousness-contracts se desinstalan y archivan por completo en una pasada.
+
+**Architecture:** El port a memo son 3 módulos nuevos (`ops_gc.py` lógica pura, `ingest_exclude.py` tombstones, `vault_ingest.py` orquestación) + un grupo CLI `memo ops` (`cli_ops.py`) + templates launchd en `memo/launchd/`. Nada de synapse se importa; los jobs nightly que memo ya tiene nativos (`contradict scan`, `consolidate`) se llaman directo desde el script. Después: swap de daemons, teardown del fleet `com.synapse.*`, archivo de repos.
+
+**Tech Stack:** Python 3 + click (convención `cli_*.py` de memo), pytest, launchd, uv tool (runtime aislado `mlx-memo`).
+
+**Spec:** `docs/SPECS/2026-07-30-synapse-deprecation-design.md`
+
+## Global Constraints
+
+- Working tree: worktree `~/repos/memo-spec` (branch `docs/synapse-deprecation-spec`); NO tocar `~/repos/memo` (branch de otra sesión).
+- Tests: `cd ~/repos/memo-spec && uv run --no-sync pytest tests/<file> -q` (convención memo).
+- El binario instalado es `~/.local/bin/memo` → uv tool `mlx-memo`; el código nuevo NO existe ahí hasta `uv tool install --from ~/repos/memo-spec mlx-memo --force --reinstall`.
+- Los ports NO deben importar synapse ni consciousness_contracts (guard `_RETIRED_IMPORTS` en `definitive.py` lo verifica).
+- Se descartan del vault-ingest de synapse: señal memflow, gbrain import, overview rebuild (extras synapse-side; se reporta la pérdida al final).
+- Rollback: nada se borra — plists y `~/.synapse/` van a `~/.memo-daemon-backups/<ts>-synapse-final/`.
+
+---
+
+### Task 1: `ops_gc.py` — lógica pura de GC
+
+**Files:**
+- Create: `src/memo/ops_gc.py`
+- Test: `tests/test_ops_gc.py`
+
+**Interfaces:**
+- Produces: `find_vault_orphans(records: list[dict], *, path_exists=os.path.exists) -> list[dict]`; `find_exact_duplicates(records: list[dict]) -> list[dict]` (registros stale a borrar; conserva el más nuevo por `updated`/`created`).
+- Records = shape de `Record.to_dict()` (`id`, `body`, `updated`, `created`, `extra.{source,abs_path}`).
+
+- [ ] **Step 1: test que falla**
+
+```python
+"""Tests for pure GC logic (ported from synapse ops on deprecation)."""
+from memo.ops_gc import find_exact_duplicates, find_vault_orphans
+
+
+def _rec(id_, body="x", updated="2026-01-02", source="", abs_path=None):
+    extra = {"source": source}
+    if abs_path is not None:
+        extra["abs_path"] = abs_path
+    return {"id": id_, "body": body, "updated": updated, "created": "2026-01-01", "extra": extra}
+
+
+def test_orphans_only_vault_ingest_missing_path():
+    recs = [
+        _rec("a", source="vault-ingest:notes", abs_path="/nope/gone.md"),
+        _rec("b", source="vault-ingest:notes", abs_path="/exists.md"),
+        _rec("c", source="chat", abs_path="/nope/gone.md"),
+        _rec("d", source="vault-ingest:notes"),
+    ]
+    got = find_vault_orphans(recs, path_exists=lambda p: p == "/exists.md")
+    assert [r["id"] for r in got] == ["a"]
+
+
+def test_exact_duplicates_keep_newest():
+    recs = [
+        _rec("old", body="same", updated="2026-01-01"),
+        _rec("new", body="same", updated="2026-02-01"),
+        _rec("uniq", body="other"),
+        _rec("empty1", body="  "),
+        _rec("empty2", body="  "),
+    ]
+    stale = find_exact_duplicates(recs)
+    assert [r["id"] for r in stale] == ["old"]
+```
+
+- [ ] **Step 2:** `uv run --no-sync pytest tests/test_ops_gc.py -q` → FAIL (ModuleNotFoundError)
+- [ ] **Step 3: implementación** — port literal de `synapse/ops.py:515,595` como funciones puras:
+
+```python
+"""Pure GC logic over memo record dicts (`Record.to_dict()` shape).
+
+Ported from synapse `ops.gc_vault_orphans` / `ops.gc_memo_duplicates` when the
+synapse control plane was deprecated (2026-07-30). Pure functions; cli_ops
+lists records and performs deletions.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+from collections.abc import Callable
+from typing import Any
+
+
+def find_vault_orphans(
+    records: list[dict[str, Any]],
+    *,
+    path_exists: Callable[[str], bool] = os.path.exists,
+) -> list[dict[str, Any]]:
+    """Vault-ingested records whose source file no longer exists on disk."""
+    orphans: list[dict[str, Any]] = []
+    for r in records:
+        extra = r.get("extra") or {}
+        abs_path = extra.get("abs_path")
+        source = str(extra.get("source") or "")
+        if "vault-ingest" in source and abs_path and not path_exists(abs_path):
+            orphans.append(r)
+    return orphans
+
+
+def find_exact_duplicates(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Records whose body is an exact duplicate of a newer record (the stale ones)."""
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for r in records:
+        body = str(r.get("body") or "")
+        if not body.strip():
+            continue
+        groups.setdefault(hashlib.sha256(body.encode()).hexdigest(), []).append(r)
+    stale: list[dict[str, Any]] = []
+    for members in groups.values():
+        if len(members) < 2:
+            continue
+        members.sort(key=lambda r: str(r.get("updated") or r.get("created") or ""), reverse=True)
+        stale.extend(members[1:])
+    return stale
+```
+
+- [ ] **Step 4:** pytest → PASS
+- [ ] **Step 5:** `git add … && git commit -m "feat(ops): pure GC logic ported from synapse"`
+
+---
+
+### Task 2: `ingest_exclude.py` — tombstones
+
+**Files:**
+- Create: `src/memo/ingest_exclude.py`
+- Test: `tests/test_ingest_exclude.py`
+
+**Interfaces:**
+- Produces: `IngestExcludeStore(state_dir: Path | None = None)` → `.globs(label) -> list[str]`, `.add(vault_label=, rel_path=) -> bool`, `.remove(vault_label=, rel_path=) -> bool`, `.all_labels() -> list[str]`. Estado en `<state_dir>/ingest_excludes/<label>.txt`; default `Config.from_env().state_dir`.
+- NO se portan `source_vault_rel` / `filter_tombstoned_sources` (chat synapse, muere).
+
+- [ ] **Step 1: test que falla**
+
+```python
+from memo.ingest_exclude import IngestExcludeStore
+
+
+def test_add_globs_remove_roundtrip(tmp_path):
+    store = IngestExcludeStore(state_dir=tmp_path)
+    assert store.globs("notes") == []
+    assert store.add(vault_label="notes", rel_path="a/b.md") is True
+    assert store.add(vault_label="notes", rel_path="a/b.md") is False  # idempotent
+    store.add(vault_label="notes", rel_path="c.md")
+    assert store.globs("notes") == ["a/b.md", "c.md"]
+    assert store.all_labels() == ["notes"]
+    assert store.remove(vault_label="notes", rel_path="a/b.md") is True
+    assert store.globs("notes") == ["c.md"]
+    assert store.remove(vault_label="notes", rel_path="zzz") is False
+
+
+def test_label_sanitized(tmp_path):
+    store = IngestExcludeStore(state_dir=tmp_path)
+    store.add(vault_label="Mi Vault!", rel_path="x.md")
+    assert (tmp_path / "ingest_excludes" / "mi-vault.txt").exists()
+```
+
+- [ ] **Step 2:** pytest → FAIL
+- [ ] **Step 3:** port de `synapse/ingest_exclude.py` (clase completa + `_safe_label`), con `default_state_dir()` reemplazado por `Config.from_env().state_dir` (import lazy en `__init__` para no pagar Config en import) y logger `logging.getLogger("memo.ingest_exclude")`. Mantener dedupe on read, append-on-add, rewrite-on-remove, skip de comentarios `#`.
+- [ ] **Step 4:** pytest → PASS
+- [ ] **Step 5:** commit `feat(ops): vault-ingest tombstone store ported from synapse`
+
+---
+
+### Task 3: `vault_ingest.py` — orquestación
+
+**Files:**
+- Create: `src/memo/vault_ingest.py`
+- Test: `tests/test_vault_ingest.py`
+
+**Interfaces:**
+- Consumes: `IngestExcludeStore` (Task 2).
+- Produces: `vault_paths() -> list[Path]` (env `MEMO_VAULT_PATHS` coma-separado override; default las 2 vaults iCloud existentes en disco); `vault_label(p: Path) -> str` (`Notes`→`notes`, `obsidian-work`→`work`); `build_ingest_command(memo_bin, path, label, excludes) -> list[str]`; `run_vault_ingest(*, memo_bin=None) -> dict` (`{"ok": True, "vaults": [{vault,path,returncode,excludes}]}`).
+
+- [ ] **Step 1: test que falla**
+
+```python
+from pathlib import Path
+
+from memo.vault_ingest import build_ingest_command, vault_label, vault_paths, _FIXED_VAULT_EXCLUDES
+
+
+def test_vault_label():
+    assert vault_label(Path("/x/Notes")) == "notes"
+    assert vault_label(Path("/x/obsidian-work")) == "work"
+
+
+def test_env_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMO_VAULT_PATHS", f"{tmp_path}/v1, {tmp_path}/v2")
+    assert vault_paths() == [tmp_path / "v1", tmp_path / "v2"]
+
+
+def test_build_ingest_command():
+    cmd = build_ingest_command("/bin/memo", Path("/v/Notes"), "notes", ["a/**", "b.md"])
+    assert cmd == [
+        "/bin/memo", "ingest", "/v/Notes", "--name", "notes", "--prune",
+        "--exclude", "a/**", "--exclude", "b.md",
+    ]
+
+
+def test_fixed_excludes_present():
+    assert "04-Archive/**" in _FIXED_VAULT_EXCLUDES
+```
+
+- [ ] **Step 2:** pytest → FAIL
+- [ ] **Step 3:** implementación — port de `synapse/ops.py:749-806+` con renombres de env (`SYNAPSE_VAULT_PATHS`→`MEMO_VAULT_PATHS`): `_DEFAULT_VAULT_PATHS` = las 2 vaults iCloud (`.../iCloud~md~obsidian/Documents/Notes` y `.../obsidian-work`), `_FIXED_VAULT_EXCLUDES` = las mismas 5 entradas (`Obsidian/Whatsapp/**`, `Obsidian/AI/**`, `04-Archive/**`, `Archive/**`, `archive/**`). `run_vault_ingest`: por vault `git pull --ff-only` best-effort si hay `.git`, luego subprocess `build_ingest_command(...)` con excludes = fijas + `IngestExcludeStore().globs(label)`; `memo_bin` default `shutil.which("memo") or "memo"`. SIN gbrain / señal memflow / overview rebuild.
+- [ ] **Step 4:** pytest → PASS
+- [ ] **Step 5:** commit `feat(ops): vault re-ingest orchestration ported from synapse`
+
+---
+
+### Task 4: `cli_ops.py` — grupo `memo ops`
+
+**Files:**
+- Create: `src/memo/cli_ops.py`
+- Modify: `src/memo/cli.py` (registrar `ops_group` donde se registran los demás grupos)
+- Test: `tests/test_cli_ops.py`
+
+**Interfaces:**
+- Consumes: Tasks 1-3; `from memo.cli_common import get_memory`; `from memo.contracts import ActorIdentity`.
+- Produces comandos: `memo ops gc-vault-orphans [--dry-run] [--json]`, `memo ops gc-memo-duplicates [--dry-run] [--json]`, `memo ops vault-ingest [--json]`, `memo ops exclude list|add|remove`.
+- Deletes: `mem.delete(id, actor=ActorIdentity(actor_id="memo-ops", actor_kind="system"))`. Listado: `[r.to_dict() for r in mem.list(limit=999999)]`.
+- Output JSON compatible con el de synapse: gc-orphans `{scanned, orphans, deleted, dry_run}`, gc-dupes `{scanned, dup_groups, deleted, dry_run}` (en dupes, `deleted` cuenta también en dry-run, fidelidad al original).
+
+- [ ] **Step 1: test que falla** — CliRunner sobre un memo vacío (`MEMO_DATA_DIR`/`MEMO_STATE_DIR` a tmp): `memo ops gc-vault-orphans --dry-run --json` sale 0 con `{"scanned": 0, ...}`; `memo ops exclude add notes a.md` + `exclude list --json` roundtrip.
+- [ ] **Step 2:** FAIL
+- [ ] **Step 3:** implementación click group, mirando `cli_dedupe.py` como referencia de estilo/registración; registrar en `cli.py`.
+- [ ] **Step 4:** PASS + `uv run --no-sync pytest tests/ -q -k "ops or ingest_exclude or vault_ingest"` verde
+- [ ] **Step 5:** commit `feat(cli): memo ops group (gc, vault-ingest, excludes)`
+
+---
+
+### Task 5: templates launchd + nightly script
+
+**Files:**
+- Create: `launchd/com.memo.recall-daemon.plist`, `launchd/com.memo.nightly.plist`, `launchd/com.memo.vault-ingest.plist`, `launchd/memo-nightly.sh`
+
+Convención de `com.memo.dream.plist`: placeholders `__HOME__` / `__MEMO_BIN__` (+ `__CODEGRAPH_BIN__` en nightly.sh), comentario de instalación arriba. Valores de schedule/env/WatchPaths: **copiar de los plists vivos** `~/Library/LaunchAgents/com.synapse.{memo-recall-daemon,memo-nightly,vault-ingest}.plist` (schedule nightly, ThrottleInterval y WatchPaths de vault-ingest, env vars MEMO_* y KeepAlive del recall daemon), cambiando solo label, paths de log (`__HOME__/Library/Logs/memo/*.log`) y comandos:
+- recall-daemon: `__MEMO_BIN__ recall-daemon _serve`, KeepAlive true.
+- nightly: `/bin/sh __HOME__/.local/share/memo/bin/memo-nightly.sh`.
+- vault-ingest: `__MEMO_BIN__ ops vault-ingest --json` (ya no hay shim shell con PYTHONPATH).
+
+`memo-nightly.sh` (template; codegraph sync SIN synapse):
+
+```sh
+#!/bin/sh
+# memo nightly maintenance — one wake, one MLX load. Template: replace
+# __MEMO_BIN__ / __CODEGRAPH_BIN__; install to ~/.local/share/memo/bin/.
+set -u
+log() { echo "[memo-nightly $(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+log "start codegraph-sync"
+for r in memo memflow; do
+  "__CODEGRAPH_BIN__" sync "$HOME/repos/$r" --quiet || "__CODEGRAPH_BIN__" unlock "$HOME/repos/$r"
+done || log "codegraph-sync FAILED (exit $?)"
+log "start contradict-scan"
+"__MEMO_BIN__" contradict scan --max-memorias 500 --min-days-apart 3 --since "$(date -v-30d +%Y-%m-%d)" || log "contradict-scan FAILED (exit $?)"
+log "start gc-memo-duplicates"
+"__MEMO_BIN__" ops gc-memo-duplicates --json || log "gc-memo-duplicates FAILED (exit $?)"
+log "start gc-vault-orphans"
+"__MEMO_BIN__" ops gc-vault-orphans --json || log "gc-vault-orphans FAILED (exit $?)"
+log "start memo-consolidate"
+"__MEMO_BIN__" consolidate apply --auto-threshold 0.95 --max-clusters 15 || log "memo-consolidate FAILED (exit $?)"
+log "done"
+```
+
+- [ ] Escribir los 4 archivos; commit `feat(launchd): native memo agents (recall, nightly, vault-ingest)`
+
+---
+
+### Task 6: PR + runtime reinstall
+
+- [ ] `git push` + `gh pr create` (branch `docs/synapse-deprecation-spec` → master) con spec+plan+port; merge cuando checks verdes (`gh pr merge --auto --squash` o merge directo si la policy lo permite).
+- [ ] Reinstalar runtime aislado desde el repo local: `uv tool install --from ~/repos/memo-spec mlx-memo --force --reinstall` → verificar `~/.local/bin/memo ops gc-vault-orphans --dry-run --json` responde.
+
+---
+
+### Task 7: snapshot + migración + swap de daemons
+
+- [ ] Snapshot: `TS=$(date +%Y%m%dT%H%M%S); D=~/.memo-daemon-backups/$TS-synapse-final; mkdir -p $D; cp ~/Library/LaunchAgents/com.synapse.*.plist $D/; cp -R ~/.synapse $D/dot-synapse`
+- [ ] Tag: `cd ~/repos/synapse && git tag deprecation-final && git push origin deprecation-final` (best-effort si hay remote)
+- [ ] Migrar tombstones: `cp -R ~/.synapse/ingest_excludes <memo-state-dir>/` (state dir real: `cd ~/repos/memo-spec && uv run --no-sync python -c "from memo.config import Config; print(Config.from_env().state_dir)"`)
+- [ ] Render de templates (sed `__HOME__`/`__MEMO_BIN__`/`__CODEGRAPH_BIN__`) → `~/Library/LaunchAgents/` + `~/.local/share/memo/bin/memo-nightly.sh` (chmod 755); `mkdir -p ~/Library/Logs/memo`
+- [ ] Swap recall: `launchctl bootout gui/$(id -u)/com.synapse.memo-recall-daemon` → `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.memo.recall-daemon.plist` → verificar socket vivo y respuesta (`launchctl list | grep com.memo.recall`, log sin crash-loop, y una búsqueda memo que use el daemon)
+- [ ] Bootstrap `com.memo.nightly` y `com.memo.vault-ingest`; corrida manual verde: `launchctl kickstart gui/$(id -u)/com.memo.vault-ingest` + `sh ~/.local/share/memo/bin/memo-nightly.sh` (o kickstart) revisando logs
+
+---
+
+### Task 8: teardown synapse
+
+- [ ] `cd ~/repos/synapse && for s in dashboard runtime-loop eval-nightly memo-daemon memo-recall-daemon vault-ingest whatsapp-ingest morning-digest gc-vault-orphans gc-memo-duplicates contradict-scan memo-consolidate memo-nightly dream-synthesis watcher; do PYTHONPATH=src ~/repos/memflow/.venv/bin/python -m synapse.cli ops uninstall $s; done` (+ `dashboard-relay` si está en el registro; si no, bootout+rm manual del plist)
+- [ ] Verificar `launchctl list | grep com.synapse` vacío; matar plists remanentes a mano (bootout + rm)
+- [ ] Git hooks: revisar `.git/hooks/post-commit` (marker "Synapse git awareness hook") en `~/repos/{memo,memflow,synapse,consciousness-contracts}` y borrar los instalados por synapse
+- [ ] MCP: `grep -l synapse ~/repos/*/.mcp.json ~/.mcp.json ~/.claude/settings*.json` → sacar entradas synapse
+- [ ] `mv ~/.synapse $D/dot-synapse-live` (el estado ya está copiado; mover = nada queda activo)
+- [ ] Archivar: `mkdir -p ~/repos/_archived && mv ~/repos/synapse ~/repos/consciousness-contracts ~/repos/_archived/`; `gh repo archive <owner>/<repo> --yes` para ambos si tienen remote
+
+---
+
+### Task 9: gates finales + docs + memoria
+
+- [ ] Gates: `launchctl list | grep -E 'com\.(synapse|memo)\.'` → solo `com.memo.*` exit 0 · recall hook < 5s (correr el comando del hook de `~/.claude/settings.json` con `time`) · `memo doctor` verde · logs de nightly y vault-ingest sin errores · memflow MCP :18766 responde
+- [ ] Actualizar `~/CLAUDE.md`: trinity → memo+memflow, tabla de venvs sin synapse, sección launchd reescrita (fleet `com.memo.*` + fuente launchd/ de memo), MCP sin synapse
+- [ ] `memo save` del resultado (deprecación completada, qué murió, dónde está el backup) + actualizar memorias que referencien synapse como vivo
+- [ ] Reporte final al usuario: qué murió sin reemplazo (dashboard, watcher, chat federado, whatsapp-ingest, morning-digest, gbrain import post-ingest, señal memflow post-ingest), dónde está el rollback
+
+---
+
+## Self-review
+
+- Cobertura spec: decisiones tabla → Tasks 1-5 (port), 7 (adopción/swap), 8 (teardown+archivo), 9 (gates/docs). ✓
+- Sin placeholders: código real en Tasks 1-3; Task 4-5 referencian archivos de convención concretos y valores copiables de plists vivos (fuente exacta indicada). ✓
+- Consistencia de tipos: `find_vault_orphans`/`find_exact_duplicates` (T1) consumidos en T4; `IngestExcludeStore` (T2) en T3/T4; nombres estables. ✓

--- a/launchd/com.memo.nightly.plist
+++ b/launchd/com.memo.nightly.plist
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Template: memo nightly maintenance LaunchAgent (macOS) — one wake, one MLX
+  load: codegraph sync → contradict scan → GC (dupes, orphans) → consolidate.
+  Replace __HOME__ with your home directory, install the script, then:
+
+    cp memo-nightly.sh ~/.local/share/memo/bin/   (render __MEMO_BIN__ / __CODEGRAPH_BIN__)
+    cp com.memo.nightly.plist ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.memo.nightly.plist
+
+  Adopted from com.synapse.memo-nightly on the synapse deprecation (2026-07-30).
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.memo.nightly</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/sh</string>
+    <string>__HOME__/.local/share/memo/bin/memo-nightly.sh</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HF_HUB_OFFLINE</key>
+    <string>1</string>
+    <key>MEMO_DECLARE_DISPUTES</key>
+    <string>1</string>
+    <key>MEMO_EMBEDDER_DIMS</key>
+    <string>2560</string>
+    <key>MEMO_EMBEDDER_MODEL</key>
+    <string>mlx-community/Qwen3-Embedding-4B-4bit-DWQ</string>
+    <key>MEMO_HELPER_MODEL</key>
+    <string>mlx-community/Qwen3-4B-4bit</string>
+    <key>MEMO_HIT_DOSSIER</key>
+    <string>1</string>
+    <key>MEMO_LLM_MODEL</key>
+    <string>mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit-DWQ</string>
+    <key>MEMO_RECALL_EPISTEMIC_LABELS</key>
+    <string>1</string>
+    <key>MEMO_RERANKER_ENABLED</key>
+    <string>0</string>
+    <key>MEMO_RERANKER_MODEL</key>
+    <string>vserifsaglam/Qwen3-Reranker-4B-4bit-MLX</string>
+    <key>MEMO_RERANKER_REVISION</key>
+    <string>9655b27c01d2ff1c49f7e672a04b70d630161b46</string>
+    <key>TRANSFORMERS_OFFLINE</key>
+    <string>1</string>
+    <key>PATH</key>
+    <string>__HOME__/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <false/>
+  <!-- 03:00 daily — same slot the synapse-era agent used -->
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>3</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>__HOME__/Library/Logs/memo/nightly.log</string>
+  <key>StandardErrorPath</key>
+  <string>__HOME__/Library/Logs/memo/nightly.err</string>
+</dict>
+</plist>

--- a/launchd/com.memo.recall-daemon.plist
+++ b/launchd/com.memo.recall-daemon.plist
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Template: memo recall daemon LaunchAgent (macOS) — warm MLX embedder shared
+  over ~/.local/share/memo/recall.sock so the recall hook stays under budget.
+  Replace __HOME__ with your home directory and __MEMO_BIN__ with the absolute
+  path to the `memo` binary (`command -v memo`), then:
+
+    cp com.memo.recall-daemon.plist ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.memo.recall-daemon.plist
+
+  Adopted from com.synapse.memo-recall-daemon on the synapse deprecation
+  (2026-07-30); command and env are unchanged, only ownership moved to memo.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.memo.recall-daemon</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>__MEMO_BIN__</string>
+    <string>recall-daemon</string>
+    <string>_serve</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HF_HUB_OFFLINE</key>
+    <string>1</string>
+    <key>MEMO_DECLARE_DISPUTES</key>
+    <string>1</string>
+    <key>MEMO_EMBEDDER_DIMS</key>
+    <string>2560</string>
+    <key>MEMO_EMBEDDER_MODEL</key>
+    <string>mlx-community/Qwen3-Embedding-4B-4bit-DWQ</string>
+    <key>MEMO_HELPER_MODEL</key>
+    <string>mlx-community/Qwen3-4B-4bit</string>
+    <key>MEMO_HIT_DOSSIER</key>
+    <string>1</string>
+    <key>MEMO_LLM_MODEL</key>
+    <string>mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit-DWQ</string>
+    <key>MEMO_RECALL_EPISTEMIC_LABELS</key>
+    <string>1</string>
+    <key>MEMO_RERANKER_ENABLED</key>
+    <string>0</string>
+    <key>MEMO_RERANKER_MODEL</key>
+    <string>vserifsaglam/Qwen3-Reranker-4B-4bit-MLX</string>
+    <key>MEMO_RERANKER_REVISION</key>
+    <string>9655b27c01d2ff1c49f7e672a04b70d630161b46</string>
+    <key>PYTHONUNBUFFERED</key>
+    <string>1</string>
+    <key>TRANSFORMERS_OFFLINE</key>
+    <string>1</string>
+    <key>PATH</key>
+    <string>__HOME__/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>KeepAlive</key>
+  <true/>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>__HOME__/Library/Logs/memo/recall-daemon.log</string>
+  <key>StandardErrorPath</key>
+  <string>__HOME__/Library/Logs/memo/recall-daemon.err</string>
+</dict>
+</plist>

--- a/launchd/com.memo.vault-ingest.plist
+++ b/launchd/com.memo.vault-ingest.plist
@@ -2,8 +2,9 @@
 <!--
   Template: memo vault re-ingest LaunchAgent (macOS) — fires when iCloud syncs
   Obsidian vault edits (WatchPaths); ThrottleInterval bounds the re-ingest
-  cadence. Uses the light 0.6B embedder deliberately: ingest runs often and
-  must stay cheap. Replace __HOME__ / __MEMO_BIN__, adjust WatchPaths to your
+  cadence. Embedder model/dims MUST match the live index (the synapse-era
+  agent shipped 0.6B/1024 against a 2560d index and silently failed every
+  run). Replace __HOME__ / __MEMO_BIN__, adjust WatchPaths to your
   vaults (or set MEMO_VAULT_PATHS), then:
 
     cp com.memo.vault-ingest.plist ~/Library/LaunchAgents/
@@ -30,9 +31,9 @@
     <key>HF_HUB_OFFLINE</key>
     <string>1</string>
     <key>MEMO_EMBEDDER_DIMS</key>
-    <string>1024</string>
+    <string>2560</string>
     <key>MEMO_EMBEDDER_MODEL</key>
-    <string>mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ</string>
+    <string>mlx-community/Qwen3-Embedding-4B-4bit-DWQ</string>
     <key>MEMO_HELPER_MODEL</key>
     <string>mlx-community/Qwen3-4B-4bit</string>
     <key>MEMO_LLM_MODEL</key>

--- a/launchd/com.memo.vault-ingest.plist
+++ b/launchd/com.memo.vault-ingest.plist
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Template: memo vault re-ingest LaunchAgent (macOS) — fires when iCloud syncs
+  Obsidian vault edits (WatchPaths); ThrottleInterval bounds the re-ingest
+  cadence. Uses the light 0.6B embedder deliberately: ingest runs often and
+  must stay cheap. Replace __HOME__ / __MEMO_BIN__, adjust WatchPaths to your
+  vaults (or set MEMO_VAULT_PATHS), then:
+
+    cp com.memo.vault-ingest.plist ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.memo.vault-ingest.plist
+
+  Adopted from com.synapse.vault-ingest on the synapse deprecation (2026-07-30);
+  the shell shim + PYTHONPATH indirection died with synapse — this runs
+  `memo ops vault-ingest` directly.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.memo.vault-ingest</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>__MEMO_BIN__</string>
+    <string>ops</string>
+    <string>vault-ingest</string>
+    <string>--json</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HF_HUB_OFFLINE</key>
+    <string>1</string>
+    <key>MEMO_EMBEDDER_DIMS</key>
+    <string>1024</string>
+    <key>MEMO_EMBEDDER_MODEL</key>
+    <string>mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ</string>
+    <key>MEMO_HELPER_MODEL</key>
+    <string>mlx-community/Qwen3-4B-4bit</string>
+    <key>MEMO_LLM_MODEL</key>
+    <string>mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit-DWQ</string>
+    <key>MEMO_RERANKER_ENABLED</key>
+    <string>0</string>
+    <key>MEMO_RERANKER_MODEL</key>
+    <string>vserifsaglam/Qwen3-Reranker-4B-4bit-MLX</string>
+    <key>MEMO_RERANKER_REVISION</key>
+    <string>9655b27c01d2ff1c49f7e672a04b70d630161b46</string>
+    <key>TRANSFORMERS_OFFLINE</key>
+    <string>1</string>
+    <key>PATH</key>
+    <string>__HOME__/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>120</integer>
+  <key>WatchPaths</key>
+  <array>
+    <string>__HOME__/Library/Mobile Documents/iCloud~md~obsidian/Documents/Notes</string>
+    <string>__HOME__/Library/Mobile Documents/iCloud~md~obsidian/Documents/obsidian-work</string>
+  </array>
+  <key>StandardOutPath</key>
+  <string>__HOME__/Library/Logs/memo/vault-ingest.log</string>
+  <key>StandardErrorPath</key>
+  <string>__HOME__/Library/Logs/memo/vault-ingest.err</string>
+</dict>
+</plist>

--- a/launchd/memo-nightly.sh
+++ b/launchd/memo-nightly.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# memo nightly maintenance — one wake, one MLX load. Sequential:
+# codegraph sync → contradict scan → gc dupes → gc orphans → consolidate.
+# Template: replace __MEMO_BIN__ (`command -v memo`) and __CODEGRAPH_BIN__
+# (`command -v codegraph`; delete that block if you don't use codegraph),
+# then install to ~/.local/share/memo/bin/memo-nightly.sh (chmod 755).
+# Driven by the com.memo.nightly LaunchAgent (see com.memo.nightly.plist).
+# Adopted from the synapse-era memo-nightly.sh on its deprecation (2026-07-30).
+set -u
+
+log() { echo "[memo-nightly $(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+log "start codegraph-sync"
+for r in memo memflow; do
+  "__CODEGRAPH_BIN__" sync "$HOME/repos/$r" --quiet || "__CODEGRAPH_BIN__" unlock "$HOME/repos/$r"
+done || log "codegraph-sync FAILED (exit $?)"
+
+log "start contradict-scan"
+"__MEMO_BIN__" contradict scan --max-memorias 500 --min-days-apart 3 --since "$(date -v-30d +%Y-%m-%d)" || log "contradict-scan FAILED (exit $?)"
+
+log "start gc-memo-duplicates"
+"__MEMO_BIN__" ops gc-memo-duplicates --json || log "gc-memo-duplicates FAILED (exit $?)"
+
+log "start gc-vault-orphans"
+"__MEMO_BIN__" ops gc-vault-orphans --json || log "gc-vault-orphans FAILED (exit $?)"
+
+log "start memo-consolidate"
+"__MEMO_BIN__" consolidate apply --auto-threshold 0.95 --max-clusters 15 || log "memo-consolidate FAILED (exit $?)"
+
+log "done"

--- a/src/memo/cli.py
+++ b/src/memo/cli.py
@@ -100,6 +100,7 @@ from memo.cli_memory import (
 )
 from memo.cli_onboard import onboard
 from memo.cli_operational import evidence_cmd, migrate_independence_cmd, operational_group
+from memo.cli_ops import ops_group
 from memo.cli_outcome import gaps as gaps_cmd
 from memo.cli_outcome import outcome as outcome_cmd
 from memo.cli_proactive import digest
@@ -507,6 +508,7 @@ cli.add_command(health_cmd)
 cli.add_command(dashboard_cmd)
 cli.add_command(compress_context_cmd)
 cli.add_command(dedupe_cmd)
+cli.add_command(ops_group)
 cli.add_command(contextual_group)
 cli.add_command(links_group)
 cli.add_command(version_group)

--- a/src/memo/cli_ops.py
+++ b/src/memo/cli_ops.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+from typing import Any
 
 import click
 
@@ -32,12 +33,12 @@ def ops_group() -> None:
     """Maintenance jobs (GC, vault re-ingest, ingest tombstones)."""
 
 
-def _all_records() -> tuple[object, list[dict]]:
+def _all_records() -> tuple[Any, list[dict]]:
     mem = _get_memory(Config.from_env())
     return mem, [r.to_dict() for r in mem.list(limit=_LIST_ALL)]
 
 
-def _delete_records(mem: object, records: list[dict]) -> int:
+def _delete_records(mem: Any, records: list[dict]) -> int:
     deleted = 0
     for r in records:
         with contextlib.suppress(ValueError):

--- a/src/memo/cli_ops.py
+++ b/src/memo/cli_ops.py
@@ -1,0 +1,162 @@
+"""`memo ops` command group — maintenance jobs adopted from synapse (2026-07-30).
+
+Hosts the nightly GC jobs (`gc-vault-orphans`, `gc-memo-duplicates`), the vault
+re-ingestion runner (`vault-ingest`, driven by the `com.memo.vault-ingest`
+launchd agent), and the ingest tombstone management (`exclude`). JSON output
+shapes stay wire-compatible with the synapse originals so logs and tooling
+keep parsing.
+
+Registered onto the root group in cli.py via `cli.add_command(ops_group)`.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+
+import click
+
+from memo.cli_common import console
+from memo.cli_common import get_memory as _get_memory
+from memo.config import Config
+from memo.contracts import ActorIdentity
+from memo.ingest_exclude import IngestExcludeStore
+from memo.ops_gc import find_exact_duplicates, find_vault_orphans
+
+_LIST_ALL = 999999
+_ACTOR = ActorIdentity(actor_id="memo-ops", actor_kind="system")
+
+
+@click.group(name="ops")
+def ops_group() -> None:
+    """Maintenance jobs (GC, vault re-ingest, ingest tombstones)."""
+
+
+def _all_records() -> tuple[object, list[dict]]:
+    mem = _get_memory(Config.from_env())
+    return mem, [r.to_dict() for r in mem.list(limit=_LIST_ALL)]
+
+
+def _delete_records(mem: object, records: list[dict]) -> int:
+    deleted = 0
+    for r in records:
+        with contextlib.suppress(ValueError):
+            if mem.delete(r["id"], actor=_ACTOR):
+                deleted += 1
+    return deleted
+
+
+@ops_group.command(name="gc-vault-orphans")
+@click.option("--dry-run", is_flag=True, help="List orphans without deleting.")
+@click.option("--json", "as_json", is_flag=True, help="Output raw JSON.")
+def gc_vault_orphans_cmd(dry_run: bool, as_json: bool) -> None:
+    """Delete memo records whose vault source file no longer exists on disk."""
+    mem, records = _all_records()
+    orphans = find_vault_orphans(records)
+    deleted = 0 if dry_run else _delete_records(mem, orphans)
+    result = {
+        "scanned": len(records),
+        "orphans": len(orphans),
+        "deleted": deleted,
+        "dry_run": dry_run,
+    }
+    if as_json:
+        click.echo(json.dumps(result))
+        return
+    console.print(
+        f"scanned: [cyan]{result['scanned']}[/cyan]  "
+        f"orphans: [yellow]{result['orphans']}[/yellow]  "
+        f"deleted: [green]{result['deleted']}[/green]"
+        f"{'  [dim](dry-run)[/dim]' if dry_run else ''}"
+    )
+
+
+@ops_group.command(name="gc-memo-duplicates")
+@click.option("--dry-run", is_flag=True, help="Count would-be deletions without deleting.")
+@click.option("--json", "as_json", is_flag=True, help="Output raw JSON.")
+def gc_memo_duplicates_cmd(dry_run: bool, as_json: bool) -> None:
+    """Delete records whose body is an exact duplicate of a newer record."""
+    mem, records = _all_records()
+    stale = find_exact_duplicates(records)
+    dup_groups = len(_dup_group_iter(stale))
+    deleted = len(stale) if dry_run else _delete_records(mem, stale)
+    result = {
+        "scanned": len(records),
+        "dup_groups": dup_groups,
+        "deleted": deleted,
+        "dry_run": dry_run,
+    }
+    if as_json:
+        click.echo(json.dumps(result))
+        return
+    console.print(
+        f"scanned: [cyan]{result['scanned']}[/cyan]  "
+        f"dup_groups: [yellow]{result['dup_groups']}[/yellow]  "
+        f"deleted: [green]{result['deleted']}[/green]"
+        f"{'  [dim](dry-run)[/dim]' if dry_run else ''}"
+    )
+
+
+def _dup_group_iter(stale: list[dict]) -> list[str]:
+    """Distinct duplicate groups represented in *stale* (by body hash)."""
+    import hashlib
+
+    return sorted({hashlib.sha256(str(s.get("body") or "").encode()).hexdigest() for s in stale})
+
+
+@ops_group.command(name="vault-ingest")
+@click.option("--json", "as_json", is_flag=True, help="Output raw JSON.")
+def vault_ingest_cmd(as_json: bool) -> None:
+    """Re-ingest each Obsidian vault (`git pull` + `memo ingest --prune` + tombstones)."""
+    from memo.vault_ingest import run_vault_ingest
+
+    result = run_vault_ingest()
+    if as_json:
+        click.echo(json.dumps(result))
+    else:
+        for v in result["vaults"]:
+            status = "[green]ok[/green]" if v["returncode"] == 0 else f"[red]exit {v['returncode']}[/red]"
+            console.print(f"{v['vault']}: {status}  [dim]{v['path']}[/dim]")
+    if not result["ok"]:
+        raise SystemExit(1)
+
+
+@ops_group.group(name="exclude")
+def exclude_group() -> None:
+    """Ingest tombstones: vault-relative globs skipped on every re-ingest."""
+
+
+@exclude_group.command(name="list")
+@click.option("--json", "as_json", is_flag=True, help="Output raw JSON.")
+def exclude_list_cmd(as_json: bool) -> None:
+    """List tombstoned paths per vault label."""
+    store = IngestExcludeStore()
+    data = {label: globs for label in store.all_labels() if (globs := store.globs(label))}
+    if as_json:
+        click.echo(json.dumps(data))
+        return
+    if not data:
+        console.print("[dim]no tombstones[/dim]")
+        return
+    for label, globs in data.items():
+        console.print(f"[bold]{label}[/bold]")
+        for g in globs:
+            console.print(f"  {g}")
+
+
+@exclude_group.command(name="add")
+@click.argument("vault_label")
+@click.argument("rel_path")
+def exclude_add_cmd(vault_label: str, rel_path: str) -> None:
+    """Tombstone REL_PATH (vault-relative) for VAULT_LABEL."""
+    added = IngestExcludeStore().add(vault_label=vault_label, rel_path=rel_path)
+    console.print("[green]✓ added[/green]" if added else "[dim]already present[/dim]")
+
+
+@exclude_group.command(name="remove")
+@click.argument("vault_label")
+@click.argument("rel_path")
+def exclude_remove_cmd(vault_label: str, rel_path: str) -> None:
+    """Drop REL_PATH from VAULT_LABEL's tombstones."""
+    removed = IngestExcludeStore().remove(vault_label=vault_label, rel_path=rel_path)
+    console.print("[green]✓ removed[/green]" if removed else "[dim]not found[/dim]")

--- a/src/memo/cli_ops.py
+++ b/src/memo/cli_ops.py
@@ -115,7 +115,11 @@ def vault_ingest_cmd(as_json: bool) -> None:
         click.echo(json.dumps(result))
     else:
         for v in result["vaults"]:
-            status = "[green]ok[/green]" if v["returncode"] == 0 else f"[red]exit {v['returncode']}[/red]"
+            status = (
+                "[green]ok[/green]"
+                if v["returncode"] == 0
+                else f"[red]exit {v['returncode']}[/red]"
+            )
             console.print(f"{v['vault']}: {status}  [dim]{v['path']}[/dim]")
     if not result["ok"]:
         raise SystemExit(1)

--- a/src/memo/flags_ingest.py
+++ b/src/memo/flags_ingest.py
@@ -14,6 +14,13 @@ SPECS: tuple[FlagSpec, ...] = (
     _spec("MEMO_INGEST_STRICT", "bool", False, "ingest", "Strict ingest filtering."),
     _spec("MEMO_INGEST_DEBUG", "bool", False, "ingest", "Verbose ingest diagnostics."),
     _spec(
+        "MEMO_VAULT_PATHS",
+        "str",
+        "",
+        "ingest",
+        "Comma-separated vault roots for `memo ops vault-ingest` (default: known iCloud vaults).",
+    ),
+    _spec(
         "MEMO_SAVE_EXTRACT",
         "bool",
         False,

--- a/src/memo/ingest_exclude.py
+++ b/src/memo/ingest_exclude.py
@@ -1,0 +1,100 @@
+"""Durable vault-ingest exclusion tombstones.
+
+When the user deletes a vault-derived memory, deleting the memo row is futile
+on its own: the ``com.memo.vault-ingest`` agent re-runs ``memo ingest`` and the
+surviving ``.md`` resurrects the row on the next tick. memo must not destroy
+the user's Obsidian file, so instead a *tombstone* is recorded here — a
+vault-relative glob fed to ``memo ingest --exclude`` so re-ingestion
+permanently skips that note.
+
+State lives under ``<state_dir>/ingest_excludes/<label>.txt`` (one glob per
+line, one file per vault ``--name`` label). Ported from synapse
+``ingest_exclude.py`` on its deprecation (2026-07-30); the synapse chat-side
+helpers (``source_vault_rel``, ``filter_tombstoned_sources``) died with it.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+_logger = logging.getLogger("memo.ingest_exclude")
+
+_SAFE_LABEL_RE = re.compile(r"[^a-z0-9_-]+")
+
+
+def _safe_label(label: str) -> str:
+    """Filesystem-safe vault label (lowercased, non ``[a-z0-9_-]`` collapsed)."""
+    cleaned = _SAFE_LABEL_RE.sub("-", str(label or "").strip().lower()).strip("-")
+    return cleaned or "vault"
+
+
+class IngestExcludeStore:
+    """Per-vault list of exclude globs (relative to the vault root).
+
+    Append-only-ish text files, deduped on read/write. Pure file management —
+    label↔path resolution lives in ``vault_ingest`` to avoid an import cycle.
+    """
+
+    def __init__(self, state_dir: Path | str | None = None) -> None:
+        if state_dir is None:
+            from memo.config import Config
+
+            state_dir = Config.from_env().state_dir
+        self.dir = Path(state_dir).expanduser() / "ingest_excludes"
+
+    def _path(self, vault_label: str) -> Path:
+        return self.dir / f"{_safe_label(vault_label)}.txt"
+
+    def globs(self, vault_label: str) -> list[str]:
+        """Distinct non-empty exclude globs for *vault_label*, order preserved."""
+        path = self._path(vault_label)
+        if not path.exists():
+            return []
+        seen: set[str] = set()
+        out: list[str] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            glob = line.strip()
+            if not glob or glob.startswith("#") or glob in seen:
+                continue
+            seen.add(glob)
+            out.append(glob)
+        return out
+
+    def add(self, *, vault_label: str, rel_path: str) -> bool:
+        """Record *rel_path* as excluded for *vault_label*. Idempotent.
+
+        Returns True if a new entry was written, False if already present.
+        """
+        glob = str(rel_path or "").strip()
+        if not glob:
+            raise ValueError("ingest_exclude.add: rel_path required")
+        if glob in self.globs(vault_label):
+            return False
+        path = self._path(vault_label)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(glob + "\n")
+        _logger.info("ingest_exclude_added: %s %s", _safe_label(vault_label), glob)
+        return True
+
+    def remove(self, *, vault_label: str, rel_path: str) -> bool:
+        """Drop *rel_path* from *vault_label*'s excludes. Returns True if removed."""
+        glob = str(rel_path or "").strip()
+        path = self._path(vault_label)
+        if not glob or not path.exists():
+            return False
+        existing = self.globs(vault_label)
+        kept = [g for g in existing if g != glob]
+        if len(kept) == len(existing):
+            return False
+        path.write_text("".join(f"{g}\n" for g in kept), encoding="utf-8")
+        _logger.info("ingest_exclude_removed: %s %s", _safe_label(vault_label), glob)
+        return True
+
+    def all_labels(self) -> list[str]:
+        """Vault labels that currently have at least one tombstone file."""
+        if not self.dir.exists():
+            return []
+        return sorted(p.stem for p in self.dir.glob("*.txt"))

--- a/src/memo/ops_gc.py
+++ b/src/memo/ops_gc.py
@@ -1,0 +1,55 @@
+"""Pure GC logic over memo record dicts (`Record.to_dict()` shape).
+
+Ported from synapse `ops.gc_vault_orphans` / `ops.gc_memo_duplicates` when the
+synapse control plane was deprecated (2026-07-30). Pure functions — callers
+(`cli_ops`) list records and perform the deletions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from collections.abc import Callable
+from typing import Any
+
+
+def find_vault_orphans(
+    records: list[dict[str, Any]],
+    *,
+    path_exists: Callable[[str], bool] = os.path.exists,
+) -> list[dict[str, Any]]:
+    """Vault-ingested records whose source file no longer exists on disk.
+
+    Only records where ``extra.source`` contains ``'vault-ingest'`` and
+    ``extra.abs_path`` is set are considered; everything else is untouchable.
+    """
+    orphans: list[dict[str, Any]] = []
+    for r in records:
+        extra = r.get("extra") or {}
+        abs_path = extra.get("abs_path")
+        source = str(extra.get("source") or "")
+        if "vault-ingest" in source and abs_path and not path_exists(abs_path):
+            orphans.append(r)
+    return orphans
+
+
+def find_exact_duplicates(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Records whose body is an exact duplicate of a newer record.
+
+    Groups by SHA-256 of the body; in each group the record with the newest
+    ``updated`` (fallback ``created``) survives and the rest are returned as
+    stale. Blank bodies are ignored entirely.
+    """
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for r in records:
+        body = str(r.get("body") or "")
+        if not body.strip():
+            continue
+        groups.setdefault(hashlib.sha256(body.encode()).hexdigest(), []).append(r)
+    stale: list[dict[str, Any]] = []
+    for members in groups.values():
+        if len(members) < 2:
+            continue
+        members.sort(key=lambda r: str(r.get("updated") or r.get("created") or ""), reverse=True)
+        stale.extend(members[1:])
+    return stale

--- a/src/memo/vault_ingest.py
+++ b/src/memo/vault_ingest.py
@@ -1,0 +1,115 @@
+"""Vault → memo re-ingestion orchestration.
+
+Ported from synapse ``ops.run_vault_ingest`` on its deprecation (2026-07-30).
+Per vault: best-effort ``git pull --ff-only``, then ``memo ingest <root>
+--name <label> --prune`` with the fixed system excludes plus any user-recorded
+tombstones (:class:`memo.ingest_exclude.IngestExcludeStore`) — so a note the
+user deleted stays out of the index. Args are assembled as a list and run
+without a shell, so note paths with spaces or metacharacters can't break
+quoting or inject. The synapse-era extras (gbrain import, memflow signal,
+overview rebuild) were dropped with synapse.
+
+Runs the installed ``memo`` binary in a subprocess so the WatchPaths launchd
+agent (``com.memo.vault-ingest``) stays a thin process that never loads the
+embedder itself.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from memo.ingest_exclude import IngestExcludeStore
+
+_logger = logging.getLogger("memo.vault_ingest")
+
+_DEFAULT_VAULT_PATHS = (
+    Path.home() / "Library/Mobile Documents/iCloud~md~obsidian/Documents/Notes",
+    Path.home() / "Library/Mobile Documents/iCloud~md~obsidian/Documents/obsidian-work",
+)
+
+# Fixed excludes applied to every vault ingest (system folders memo must never
+# index as personal/work notes). User-deleted notes are appended per-vault via
+# IngestExcludeStore so re-ingestion can't resurrect them. Archive casing
+# variants are enumerated here AND covered by memo's case-insensitive matcher
+# (defense in depth).
+_FIXED_VAULT_EXCLUDES = (
+    "Obsidian/Whatsapp/**",
+    "Obsidian/AI/**",
+    "04-Archive/**",
+    "Archive/**",
+    "archive/**",
+)
+
+
+def vault_paths() -> list[Path]:
+    """Obsidian vault roots to re-ingest.
+
+    ``MEMO_VAULT_PATHS`` (comma list) overrides; otherwise the known iCloud
+    vaults that exist on disk.
+    """
+    raw = os.environ.get("MEMO_VAULT_PATHS", "").strip()
+    if raw:
+        return [Path(p.strip()).expanduser() for p in raw.split(",") if p.strip()]
+    return [p for p in _DEFAULT_VAULT_PATHS if p.is_dir()]
+
+
+def vault_label(path: Path) -> str:
+    """memo ``--name`` label for a vault dir: Notes→notes, obsidian-work→work."""
+    name = path.name.lower()
+    if name.startswith("obsidian-"):
+        name = name[len("obsidian-"):]
+    return name or "vault"
+
+
+def build_ingest_command(
+    memo_bin: str, path: Path, label: str, excludes: list[str]
+) -> list[str]:
+    """Argv for one vault's ``memo ingest`` run (no shell, no quoting issues)."""
+    cmd = [memo_bin, "ingest", str(path), "--name", label, "--prune"]
+    for glob in excludes:
+        cmd += ["--exclude", glob]
+    return cmd
+
+
+def run_vault_ingest(*, memo_bin: str | None = None) -> dict[str, Any]:
+    """Re-ingest each vault into memo; returns per-vault results."""
+    memo_bin = memo_bin or shutil.which("memo") or "memo"
+    git_bin = shutil.which("git") or "git"
+    store = IngestExcludeStore()
+    results: list[dict[str, Any]] = []
+    for p in vault_paths():
+        label = vault_label(p)
+        if (p / ".git").is_dir():
+            subprocess.run(
+                [git_bin, "-C", str(p), "pull", "--ff-only"],
+                check=False,
+                capture_output=True,
+            )
+        excludes = list(_FIXED_VAULT_EXCLUDES) + store.globs(label)
+        proc = subprocess.run(
+            build_ingest_command(memo_bin, p, label, excludes),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        results.append(
+            {
+                "vault": label,
+                "path": str(p),
+                "returncode": proc.returncode,
+                "excludes": excludes,
+            }
+        )
+        if proc.returncode != 0:
+            _logger.warning(
+                "vault_ingest_failed: %s exit=%s stderr=%s",
+                label,
+                proc.returncode,
+                (proc.stderr or "").strip()[:500],
+            )
+    return {"ok": all(r["returncode"] == 0 for r in results), "vaults": results}

--- a/src/memo/vault_ingest.py
+++ b/src/memo/vault_ingest.py
@@ -62,13 +62,11 @@ def vault_label(path: Path) -> str:
     """memo ``--name`` label for a vault dir: Notes→notes, obsidian-work→work."""
     name = path.name.lower()
     if name.startswith("obsidian-"):
-        name = name[len("obsidian-"):]
+        name = name[len("obsidian-") :]
     return name or "vault"
 
 
-def build_ingest_command(
-    memo_bin: str, path: Path, label: str, excludes: list[str]
-) -> list[str]:
+def build_ingest_command(memo_bin: str, path: Path, label: str, excludes: list[str]) -> list[str]:
     """Argv for one vault's ``memo ingest`` run (no shell, no quoting issues)."""
     cmd = [memo_bin, "ingest", str(path), "--name", label, "--prune"]
     for glob in excludes:

--- a/src/memo/vault_ingest.py
+++ b/src/memo/vault_ingest.py
@@ -17,12 +17,12 @@ embedder itself.
 from __future__ import annotations
 
 import logging
-import os
 import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
 
+from memo.flags import flag_str
 from memo.ingest_exclude import IngestExcludeStore
 
 _logger = logging.getLogger("memo.vault_ingest")
@@ -52,7 +52,7 @@ def vault_paths() -> list[Path]:
     ``MEMO_VAULT_PATHS`` (comma list) overrides; otherwise the known iCloud
     vaults that exist on disk.
     """
-    raw = os.environ.get("MEMO_VAULT_PATHS", "").strip()
+    raw = flag_str("MEMO_VAULT_PATHS").strip()
     if raw:
         return [Path(p.strip()).expanduser() for p in raw.split(",") if p.strip()]
     return [p for p in _DEFAULT_VAULT_PATHS if p.is_dir()]

--- a/tests/test_cli_ops.py
+++ b/tests/test_cli_ops.py
@@ -1,0 +1,93 @@
+"""Tests for the `memo ops` command group."""
+
+import json
+
+from click.testing import CliRunner
+
+import memo.cli_ops as cli_ops
+from memo.cli_ops import ops_group
+
+
+class _FakeRec:
+    def __init__(self, d):
+        self._d = d
+
+    def to_dict(self):
+        return self._d
+
+
+class _FakeMem:
+    def __init__(self, records):
+        self.records = records
+        self.deleted = []
+
+    def list(self, limit=20, type_=None):
+        return [_FakeRec(r) for r in self.records]
+
+    def delete(self, id_, *, actor=None):
+        self.deleted.append(id_)
+        return True
+
+
+def _orphan(id_):
+    return {
+        "id": id_,
+        "body": "x",
+        "updated": "2026-01-01",
+        "created": "2026-01-01",
+        "extra": {"source": "vault-ingest:notes", "abs_path": "/definitely/gone.md"},
+    }
+
+
+def test_gc_vault_orphans_dry_run(monkeypatch):
+    fake = _FakeMem([_orphan("a"), _orphan("b")])
+    monkeypatch.setattr(cli_ops, "_get_memory", lambda cfg: fake)
+    result = CliRunner().invoke(ops_group, ["gc-vault-orphans", "--dry-run", "--json"])
+    assert result.exit_code == 0, result.output
+    out = json.loads(result.output)
+    assert out == {"scanned": 2, "orphans": 2, "deleted": 0, "dry_run": True}
+    assert fake.deleted == []
+
+
+def test_gc_vault_orphans_deletes(monkeypatch):
+    fake = _FakeMem([_orphan("a")])
+    monkeypatch.setattr(cli_ops, "_get_memory", lambda cfg: fake)
+    result = CliRunner().invoke(ops_group, ["gc-vault-orphans", "--json"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["deleted"] == 1
+    assert fake.deleted == ["a"]
+
+
+def test_gc_memo_duplicates_counts_dry_run(monkeypatch):
+    recs = [
+        {"id": "old", "body": "same", "updated": "2026-01-01", "created": "", "extra": {}},
+        {"id": "new", "body": "same", "updated": "2026-02-01", "created": "", "extra": {}},
+    ]
+    fake = _FakeMem(recs)
+    monkeypatch.setattr(cli_ops, "_get_memory", lambda cfg: fake)
+    result = CliRunner().invoke(ops_group, ["gc-memo-duplicates", "--dry-run", "--json"])
+    assert result.exit_code == 0, result.output
+    out = json.loads(result.output)
+    # Fidelity with the synapse original: dry-run counts would-be deletions.
+    assert out == {"scanned": 2, "dup_groups": 1, "deleted": 1, "dry_run": True}
+    assert fake.deleted == []
+
+
+def test_exclude_roundtrip(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMO_STATE_DIR", str(tmp_path))
+    runner = CliRunner()
+    result = runner.invoke(ops_group, ["exclude", "add", "notes", "a/b.md"])
+    assert result.exit_code == 0, result.output
+    result = runner.invoke(ops_group, ["exclude", "list", "--json"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {"notes": ["a/b.md"]}
+    result = runner.invoke(ops_group, ["exclude", "remove", "notes", "a/b.md"])
+    assert result.exit_code == 0, result.output
+    result = runner.invoke(ops_group, ["exclude", "list", "--json"])
+    assert json.loads(result.output) == {}
+
+
+def test_ops_registered_on_root_cli():
+    from memo.cli import cli
+
+    assert "ops" in cli.commands

--- a/tests/test_ingest_exclude.py
+++ b/tests/test_ingest_exclude.py
@@ -1,0 +1,40 @@
+"""Tests for the vault-ingest tombstone store (ported from synapse)."""
+
+from memo.ingest_exclude import IngestExcludeStore
+
+
+def test_add_globs_remove_roundtrip(tmp_path):
+    store = IngestExcludeStore(state_dir=tmp_path)
+    assert store.globs("notes") == []
+    assert store.add(vault_label="notes", rel_path="a/b.md") is True
+    assert store.add(vault_label="notes", rel_path="a/b.md") is False  # idempotent
+    store.add(vault_label="notes", rel_path="c.md")
+    assert store.globs("notes") == ["a/b.md", "c.md"]
+    assert store.all_labels() == ["notes"]
+    assert store.remove(vault_label="notes", rel_path="a/b.md") is True
+    assert store.globs("notes") == ["c.md"]
+    assert store.remove(vault_label="notes", rel_path="zzz") is False
+
+
+def test_label_sanitized(tmp_path):
+    store = IngestExcludeStore(state_dir=tmp_path)
+    store.add(vault_label="Mi Vault!", rel_path="x.md")
+    assert (tmp_path / "ingest_excludes" / "mi-vault.txt").exists()
+
+
+def test_globs_skips_comments_and_dedupes(tmp_path):
+    store = IngestExcludeStore(state_dir=tmp_path)
+    path = tmp_path / "ingest_excludes" / "notes.txt"
+    path.parent.mkdir(parents=True)
+    path.write_text("# comment\na.md\n\na.md\nb.md\n", encoding="utf-8")
+    assert store.globs("notes") == ["a.md", "b.md"]
+
+
+def test_add_empty_raises(tmp_path):
+    store = IngestExcludeStore(state_dir=tmp_path)
+    try:
+        store.add(vault_label="notes", rel_path="  ")
+    except ValueError:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")

--- a/tests/test_ops_gc.py
+++ b/tests/test_ops_gc.py
@@ -1,0 +1,48 @@
+"""Tests for pure GC logic (ported from synapse ops on deprecation)."""
+
+from memo.ops_gc import find_exact_duplicates, find_vault_orphans
+
+
+def _rec(id_, body="x", updated="2026-01-02", source="", abs_path=None):
+    extra = {"source": source}
+    if abs_path is not None:
+        extra["abs_path"] = abs_path
+    return {"id": id_, "body": body, "updated": updated, "created": "2026-01-01", "extra": extra}
+
+
+def test_orphans_only_vault_ingest_missing_path():
+    recs = [
+        _rec("a", source="vault-ingest:notes", abs_path="/nope/gone.md"),
+        _rec("b", source="vault-ingest:notes", abs_path="/exists.md"),
+        _rec("c", source="chat", abs_path="/nope/gone.md"),
+        _rec("d", source="vault-ingest:notes"),
+    ]
+    got = find_vault_orphans(recs, path_exists=lambda p: p == "/exists.md")
+    assert [r["id"] for r in got] == ["a"]
+
+
+def test_orphans_empty_records():
+    assert find_vault_orphans([]) == []
+
+
+def test_exact_duplicates_keep_newest():
+    recs = [
+        _rec("old", body="same", updated="2026-01-01"),
+        _rec("new", body="same", updated="2026-02-01"),
+        _rec("uniq", body="other"),
+        _rec("empty1", body="  "),
+        _rec("empty2", body="  "),
+    ]
+    stale = find_exact_duplicates(recs)
+    assert [r["id"] for r in stale] == ["old"]
+
+
+def test_exact_duplicates_falls_back_to_created():
+    recs = [
+        _rec("a", body="same", updated=""),
+        _rec("b", body="same", updated=""),
+    ]
+    recs[0]["created"] = "2026-03-01"
+    recs[1]["created"] = "2026-01-01"
+    stale = find_exact_duplicates(recs)
+    assert [r["id"] for r in stale] == ["b"]

--- a/tests/test_vault_ingest.py
+++ b/tests/test_vault_ingest.py
@@ -30,11 +30,25 @@ def test_default_paths_only_existing_dirs(monkeypatch):
 def test_build_ingest_command():
     cmd = build_ingest_command("/bin/memo", Path("/v/Notes"), "notes", ["a/**", "b.md"])
     assert cmd == [
-        "/bin/memo", "ingest", "/v/Notes", "--name", "notes", "--prune",
-        "--exclude", "a/**", "--exclude", "b.md",
+        "/bin/memo",
+        "ingest",
+        "/v/Notes",
+        "--name",
+        "notes",
+        "--prune",
+        "--exclude",
+        "a/**",
+        "--exclude",
+        "b.md",
     ]
 
 
 def test_fixed_excludes_present():
-    for glob in ("Obsidian/Whatsapp/**", "Obsidian/AI/**", "04-Archive/**", "Archive/**", "archive/**"):
+    for glob in (
+        "Obsidian/Whatsapp/**",
+        "Obsidian/AI/**",
+        "04-Archive/**",
+        "Archive/**",
+        "archive/**",
+    ):
         assert glob in _FIXED_VAULT_EXCLUDES

--- a/tests/test_vault_ingest.py
+++ b/tests/test_vault_ingest.py
@@ -1,0 +1,40 @@
+"""Tests for vault re-ingestion orchestration (ported from synapse)."""
+
+from pathlib import Path
+
+from memo.vault_ingest import (
+    _FIXED_VAULT_EXCLUDES,
+    build_ingest_command,
+    vault_label,
+    vault_paths,
+)
+
+
+def test_vault_label():
+    assert vault_label(Path("/x/Notes")) == "notes"
+    assert vault_label(Path("/x/obsidian-work")) == "work"
+    assert vault_label(Path("/x/obsidian-")) == "vault"
+
+
+def test_env_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMO_VAULT_PATHS", f"{tmp_path}/v1, {tmp_path}/v2")
+    assert vault_paths() == [tmp_path / "v1", tmp_path / "v2"]
+
+
+def test_default_paths_only_existing_dirs(monkeypatch):
+    monkeypatch.delenv("MEMO_VAULT_PATHS", raising=False)
+    for p in vault_paths():
+        assert p.is_dir()
+
+
+def test_build_ingest_command():
+    cmd = build_ingest_command("/bin/memo", Path("/v/Notes"), "notes", ["a/**", "b.md"])
+    assert cmd == [
+        "/bin/memo", "ingest", "/v/Notes", "--name", "notes", "--prune",
+        "--exclude", "a/**", "--exclude", "b.md",
+    ]
+
+
+def test_fixed_excludes_present():
+    for glob in ("Obsidian/Whatsapp/**", "Obsidian/AI/**", "04-Archive/**", "Archive/**", "archive/**"):
+        assert glob in _FIXED_VAULT_EXCLUDES


### PR DESCRIPTION
## Summary
- Spec + plan for the big-bang synapse deprecation (docs/SPECS/2026-07-30-*)
- Port of the synapse-side nightly jobs to memo: `ops_gc.py` (pure GC logic), `ingest_exclude.py` (tombstone store), `vault_ingest.py` (vault re-ingest orchestration)
- New `memo ops` CLI group: `gc-vault-orphans`, `gc-memo-duplicates`, `vault-ingest`, `exclude list|add|remove` (JSON wire-compatible with the synapse originals)
- New launchd templates: `com.memo.recall-daemon`, `com.memo.nightly`, `com.memo.vault-ingest` + `memo-nightly.sh` (adopted from the `com.synapse.*` fleet)
- `MEMO_VAULT_PATHS` declared as an ingest flag

Synapse-era extras deliberately dropped from vault-ingest: gbrain import, memflow signal, overview rebuild.

## Test plan
- [x] `pytest tests/test_ops_gc.py tests/test_ingest_exclude.py tests/test_vault_ingest.py tests/test_cli_ops.py` (18 passed)
- [x] `pytest tests/test_architecture_boundaries.py` (35 passed)
- [x] `pytest -k flag` (340 passed)
- [x] `plutil -lint launchd/*.plist`