### PR TITLE
fix: skip _chronicle bucket silently on reindex

### DIFF
--- a/src/memo/memory/maintain_ops.py
+++ b/src/memo/memory/maintain_ops.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import frontmatter
 
+from memo.dream_chronicle import CHRONICLE_BUCKET
 from memo.embedder import assert_valid_embedding
 from memo.errors import StorageError
 from memo.fact_extraction import fact_edges_from_metadata, upsert_declared_fact_edges
@@ -260,6 +261,11 @@ class _MaintainOpsMixin(_MemoryBase):
             meta: dict[str, Any] = post.metadata
             md_id = meta.get("id")
             rel_path = md_path.relative_to(self.cfg.memory_dir)
+            if rel_path.parts[:1] == (CHRONICLE_BUCKET,):
+                # Chronicle diaries carry no id: frontmatter by design — skip
+                # without the invalid-id warning.
+                skipped += 1
+                continue
             is_secret = meta.get("type") == "secret" or rel_path.parts[:1] == ("secrets",)
             if is_secret:
                 if (

--- a/src/memo/memory/maintain_ops.py
+++ b/src/memo/memory/maintain_ops.py
@@ -50,6 +50,10 @@ from memo.tiers import VerificationState
 from memo.util import sha256_full as _sha256_full
 from memo.util import sha256_short as _sha256_short
 
+# Chronicle diaries carry no id: frontmatter by design (dream_chronicle) —
+# skip them like lifecycle archives instead of warning per file.
+_REINDEX_SKIP_DIRS: frozenset[str] = LIFECYCLE_ARCHIVE_DIRS | {CHRONICLE_BUCKET}
+
 
 def _purge_legacy_secret_index(
     store: Any,
@@ -231,13 +235,14 @@ class _MaintainOpsMixin(_MemoryBase):
         for md_path in sorted(memory_root.rglob("*.md")):
             checked += 1
             relative_parts = md_path.relative_to(memory_root).parts
-            if relative_parts[:1] and relative_parts[0] in LIFECYCLE_ARCHIVE_DIRS:
+            if relative_parts[:1] and relative_parts[0] in _REINDEX_SKIP_DIRS:
                 # Current lifecycle archives live under ``inactive``; older
                 # vaults used ``archived``.  Both may retain a canonical id so
                 # a human can recover a note by moving it back out, but neither
                 # may be re-absorbed automatically on reindex/sync.  A project
                 # bucket can never collide here — project_bucket() remaps those
                 # two slugs to ``_inactive``/``_archived`` (see project.py).
+                # ``_chronicle`` diaries are not memories at all.
                 skipped += 1
                 continue
             if _path_has_symlink_component(memory_root, relative_parts):
@@ -261,11 +266,6 @@ class _MaintainOpsMixin(_MemoryBase):
             meta: dict[str, Any] = post.metadata
             md_id = meta.get("id")
             rel_path = md_path.relative_to(self.cfg.memory_dir)
-            if rel_path.parts[:1] == (CHRONICLE_BUCKET,):
-                # Chronicle diaries carry no id: frontmatter by design — skip
-                # without the invalid-id warning.
-                skipped += 1
-                continue
             is_secret = meta.get("type") == "secret" or rel_path.parts[:1] == ("secrets",)
             if is_secret:
                 if (

--- a/tests/test_memory_reindex.py
+++ b/tests/test_memory_reindex.py
@@ -1201,3 +1201,18 @@ def test_reindex_rebuild_rejects_duplicate_canonical_ids(mem_with_stub: Memory):
 
     assert mem_with_stub.store.count() == 1
     assert mem_with_stub.get(rec.id) is not None
+
+
+def test_reindex_skips_chronicle_bucket_silently(mem_with_stub: Memory, caplog):
+    chronicle = mem_with_stub.cfg.memory_dir / "_chronicle"
+    chronicle.mkdir(parents=True, exist_ok=True)
+    (chronicle / "2026-07-18.md").write_text(
+        "# Chronicle — 2026-07-18\n\nDiario nocturno sin frontmatter id.\n",
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("WARNING", logger="memo.memory.record"):
+        mem_with_stub.reindex()
+
+    assert "invalid memory id" not in caplog.text
+    assert mem_with_stub.store.count() == 0


### PR DESCRIPTION
Chronicle diaries carry no `id:` frontmatter by design (`dream_chronicle`), so every sync/reindex logged a spurious `reindex: skipping <file> (invalid memory id)` warning per chronicle file.

Skip the `_chronicle` bucket before the invalid-id check, mirroring the existing `secrets/` and `LIFECYCLE_ARCHIVE_DIRS` special cases.

## Test plan
- [x] New `test_reindex_skips_chronicle_bucket_silently` (RED before fix, GREEN after)
- [x] `pytest tests/test_memory_reindex.py` — 43 passed on master + this change
- [x] `ruff check` + `mypy` clean on touched files