### PR TITLE
ci(docker): publish linux/arm64 image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,7 +59,7 @@ jobs:
           build-args: |
             EXPECTED_VERSION=${{ steps.version.outputs.version }}
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Por qué

`docker run --rm ghcr.io/jagoff/memo:latest memo doctor` falla en Apple Silicon / ARM Linux: la imagen publica solo `linux/amd64`. Verificado hoy en M-series (colima): `no matching manifest for linux/arm64/v8`. Bajo `--platform linux/amd64` (emulación) `memo doctor` pasa entero — la imagen está sana, solo falta el manifest ARM.

## Qué

Una línea: `platforms: linux/amd64` → `linux/amd64,linux/arm64`.

## Por qué alcanza con eso

- QEMU (`setup-qemu-action`) y buildx ya están en el workflow.
- Base `python:3.14-slim` es multi-arch.
- `torch==2.13.0+cpu` tiene wheel `cp314 manylinux_2_28_aarch64` en `download.pytorch.org/whl/cpu` (verificado contra el índice).
- Los hashes de `runtime-requirements.txt` salen de `uv export --frozen` y `uv.lock` es cross-platform.

## Verificación

- `test_release_workflows.py` + `test_supply_chain.py`: 30 passed.
- Nota: el build arm64 corre bajo QEMU en el tag push → el job de release va a tardar más (estimo +15–30 min por la instalación de torch y el download del embedder emulados). Si molesta, el paso siguiente es un matrix con `ubuntu-24.04-arm` nativo, pero eso es un refactor aparte.

Se activa en el próximo tag `v*` — que además va a llevar el fix de PyPI de #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)