### PR TITLE
fix(registry): restore mcp-name marker in README + guard test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- mcp-name: io.github.jagoff/memo -->
 <!-- Banner: keep it, but make sure it loads fast (<200KB, WebP if possible) -->
 [![memo — local memory for AI](https://raw.githubusercontent.com/jagoff/memo/master/docs/banner.webp)](https://raw.githubusercontent.com/jagoff/memo/master/docs/banner.webp)
 

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import tomllib
 from pathlib import Path
@@ -176,6 +177,15 @@ def test_security_policy_matches_current_release_and_opt_in_surfaces() -> None:
     assert "Authorization: Bearer" in policy
     assert "/security/advisories/new" in policy
     assert "private vulnerability report" in policy.lower()
+
+
+def test_readme_carries_the_mcp_registry_name_marker() -> None:
+    # The MCP registry validates PyPI ownership by requiring
+    # "mcp-name: <server.json name>" inside the package README; losing the
+    # marker (as the #130 rewrite did) breaks registry publishes.
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    name = json.loads((ROOT / "server.json").read_text(encoding="utf-8"))["name"]
+    assert f"mcp-name: {name}" in readme
 
 
 def test_readme_surface_counts_and_top_level_command_inventory_are_exact() -> None:


### PR DESCRIPTION
El rewrite del README (#130) borró `<!-- mcp-name: io.github.jagoff/memo -->`, que el MCP registry exige en el README de PyPI para validar ownership. Por eso el job **MCP Registry** de v4.6.1 falló con 400 (PyPI y GH Release salieron bien).

- Marker restaurado (línea 1, comentario invisible).
- Test nuevo en `test_supply_chain.py` que lo ata al `name` de `server.json` — el próximo rewrite no lo puede borrar sin romper CI.

Como el registry valida el README **publicado en PyPI** (inmutable), esto necesita un release 4.6.2 para que el registry vuelva a aceptar el server. Lo corto apenas mergee esto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)