### PR TITLE
test: enforce SQLite snapshot read-only URI

### DIFF
--- a/tests/test_sqlite_cleanup.py
+++ b/tests/test_sqlite_cleanup.py
@@ -49,6 +49,27 @@ def test_snapshot_backup_resolves_source_strictly(tmp_path: Path, monkeypatch) -
         assert connection.execute("PRAGMA integrity_check").fetchone() == ("ok",)
 
 
+def test_snapshot_backup_opens_source_as_read_only_uri(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "source.db"
+    destination = tmp_path / "destination.db"
+    with closing(sqlite3.connect(source)) as connection:
+        connection.execute("CREATE TABLE items (id INTEGER PRIMARY KEY)")
+
+    original_connect = sqlite3.connect
+    connect_calls: list[tuple[str | Path, object]] = []
+
+    def recording_connect(database: str | Path, *args, **kwargs):
+        connect_calls.append((database, kwargs.get("uri")))
+        return original_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(sqlite_snapshot.sqlite3, "connect", recording_connect)
+
+    sqlite_snapshot._backup_database(source, destination)
+
+    source_uri = f"{source.resolve(strict=True).as_uri()}?mode=ro"
+    assert connect_calls == [(source_uri, True), (destination, None)]
+
+
 def test_snapshot_contract_uses_private_sanitized_scratch(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary

- assert the SQLite snapshot source is opened with its `mode=ro` URI and `uri=True`
- assert the destination remains a normal file connection
- kill the three surviving `_backup_database` mutants without changing the zero-survivor baseline

## Root cause

The snapshot implementation correctly requested URI parsing, but the test suite only checked that a backup succeeded. SQLite on the CI build still interpreted the `file:` URI when `uri=True` was removed, set to `None`, or set to `False`, so those mutations survived even though they weakened an explicit safety contract.

## Validation

- focused snapshot tests: 21 passed
- mutation workflow selection: 215 passed
- exact mutants `_6`, `_8`, `_9`: killed
- full mutation run: 1,379/1,379 killed; reviewed baseline matched with 0 blocking
- `ruff check src/ tests/`
- `mypy src/memo` (484 files)
- pre-push recall gate: PASS
