### PR TITLE
fix: bound priority GPU lock waits

### DIFF
--- a/src/memo/mlx_gpu.py
+++ b/src/memo/mlx_gpu.py
@@ -148,12 +148,14 @@ def _prio_path() -> Path:
     return _lock_path().with_name(_PRIO_FILENAME)
 
 
-def _acquire_prio_flock() -> None:
+def _acquire_prio_flock(timeout: float | None = None) -> bool:
     """Take the priority flock (priority process, outermost entry only).
 
     Contention here is priority-vs-priority only (one recall daemon per
-    machine), so a plain blocking acquire is fine. Failure degrades to
-    running without the fast lane — never blocks the caller's real work.
+    machine). An unbounded caller may use a blocking acquire, but a caller
+    with a deadline polls non-blocking so priority-state drift or a duplicate
+    daemon can never violate ``gpu_guard(timeout=...)``. Unexpected failures
+    degrade to running without the fast lane.
     """
     global _prio_fd
     try:
@@ -162,14 +164,34 @@ def _acquire_prio_flock() -> None:
         fd = os.open(str(path), os.O_CREAT | os.O_RDWR, 0o644)
     except OSError:
         _prio_fd = None
-        return
+        return True
+    if timeout is not None:
+        deadline = time.monotonic() + max(timeout, 0.0)
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as exc:
+                if exc.errno not in (errno.EAGAIN, errno.EWOULDBLOCK):
+                    os.close(fd)
+                    _prio_fd = None
+                    return True
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    os.close(fd)
+                    _prio_fd = None
+                    return False
+                time.sleep(min(_FLOCK_POLL_INTERVAL_S, remaining))
+            else:
+                _prio_fd = fd
+                return True
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)
     except OSError:
         os.close(fd)
         _prio_fd = None
-        return
+        return True
     _prio_fd = fd
+    return True
 
 
 def _release_prio_flock() -> None:
@@ -225,8 +247,10 @@ def _acquire_flock(timeout: float | None = None) -> bool:
     daemon at the next release instead of racing it for the grant.
     """
     global _lock_fd
-    if _process_priority:
-        _acquire_prio_flock()
+    deadline = time.monotonic() + max(timeout, 0.0) if timeout is not None else None
+    if _process_priority and not _acquire_prio_flock(timeout=timeout):
+        _lock_fd = None
+        return False
     path = _lock_path()
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -248,7 +272,6 @@ def _acquire_flock(timeout: float | None = None) -> bool:
             return True
         _lock_fd = fd
         return True
-    deadline = time.monotonic() + max(timeout, 0.0) if timeout is not None else None
     while True:
         if not _process_priority and _priority_waiting():
             # A live priority process wants (or holds) the GPU — don't

--- a/src/memo/recall_socket.py
+++ b/src/memo/recall_socket.py
@@ -709,3 +709,8 @@ def _run_server_locked(
                 mem.close()
         with contextlib.suppress(Exception):
             _cleanup(state_dir)
+        # This normally coincides with process exit, but keeping the module
+        # lifecycle balanced matters for embedded callers and test runners.
+        # Otherwise later GPU work in the same interpreter still identifies
+        # itself as the recall daemon and can block on the priority flock.
+        set_process_gpu_priority(False)

--- a/tests/test_daemon_lock_priority.py
+++ b/tests/test_daemon_lock_priority.py
@@ -337,3 +337,6 @@ def test_run_server_binds_first_then_warms_in_background(monkeypatch, tmp_path) 
     recall_socket.run_server(state_dir)
 
     assert events == ["bind", "warmup"], f"bind must precede the warm-up, got {events}"
+    from memo import mlx_gpu
+
+    assert mlx_gpu._process_priority is False

--- a/tests/test_mlx_gpu.py
+++ b/tests/test_mlx_gpu.py
@@ -176,6 +176,7 @@ def test_nonpriority_backs_off_while_priority_flock_held(tmp_path, monkeypatch) 
     # acquirers must NOT take the main lock even when it is free — they
     # yield the grant to the daemon and time out on their own deadline.
     monkeypatch.setenv("MEMO_GPU_LOCK_PATH", str(tmp_path / "gpu.lock"))
+    set_process_gpu_priority(False)
     prio_holder = _hold_lock_as_other_process(str(_prio_path()))
     try:
         with pytest.raises(TimeoutError):
@@ -188,6 +189,24 @@ def test_nonpriority_backs_off_while_priority_flock_held(tmp_path, monkeypatch) 
     with gpu_guard(timeout=1.0):
         entered = True
     assert entered
+
+
+def test_priority_flock_wait_honors_gpu_guard_timeout(tmp_path, monkeypatch) -> None:
+    # A duplicate daemon or stale in-process priority state must not turn a
+    # finite gpu_guard deadline into a blocking priority-flock acquisition.
+    monkeypatch.setenv("MEMO_GPU_LOCK_PATH", str(tmp_path / "gpu.lock"))
+    prio_holder = _hold_lock_as_other_process(str(_prio_path()))
+    set_process_gpu_priority(True)
+    try:
+        started = time.monotonic()
+        with pytest.raises(TimeoutError):
+            with gpu_guard(timeout=0.2):
+                pass  # pragma: no cover - must not enter
+        assert time.monotonic() - started < 2.0
+    finally:
+        set_process_gpu_priority(False)
+        fcntl.flock(prio_holder, fcntl.LOCK_UN)
+        os.close(prio_holder)
 
 
 def test_priority_releases_prio_flock_on_main_lock_timeout(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## What changed

- restore process GPU priority when the recall daemon lifecycle exits
- make priority-flock acquisition honor finite `gpu_guard` deadlines with non-blocking polling
- cover the leaked-priority order regression and priority-flock timeout

## Root cause

The stability seed ran the recall-daemon lifecycle test before the non-priority GPU guard test. The daemon set process-global priority and never restored it, so the later guard entered the priority path. That path used an unbounded blocking flock even when `gpu_guard(timeout=0.3)` supplied a deadline, hanging until pytest-timeout at 120 seconds.

## Validation

Rebased on master including #163 (`e03ff881`).

- `uv run --no-sync ruff check src/ tests/`
- `uv run --no-sync mypy src/memo` (484 source files)
- focused seed regressions: 47 passed, 1 skipped
- exact full stability seed: 6287 passed, 19 skipped, 9 deselected in 200.64s
- pre-push recall gate: PASS (precision@k 0.708 >= 0.697; noise 0)