### PR TITLE
ci: extend stability workflow timeout

### DIFF
--- a/.github/workflows/test-stability.yml
+++ b/.github/workflows/test-stability.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   stability:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/tests/test_testing_workflows.py
+++ b/tests/test_testing_workflows.py
@@ -83,7 +83,7 @@ def test_stability_workflow_is_replayable_and_never_masks_flakes() -> None:
     }
     job = workflow["jobs"]["stability"]
     assert job["runs-on"] == "ubuntu-latest"
-    assert job["timeout-minutes"] == 30
+    assert job["timeout-minutes"] == 75
     assert job["steps"][:2] == [
         {"uses": CHECKOUT_ACTION, "with": {"persist-credentials": False}},
         {"uses": SETUP_PYTHON_ACTION, "with": {"python-version": "3.13"}},


### PR DESCRIPTION
## What changed

- raise the `test-stability` job timeout from 30 to 75 minutes
- update the workflow contract test to pin the new budget
- preserve `--count=10`, `--repeat-scope=session`, and per-test `--timeout=120` unchanged

## Evidence

Post-merge run 30723640249 on `b46ae1b1` completed the full random-order suite successfully, then the job was globally cancelled at 30m17s while the repeat gate was still progressing normally. Logs show:

- repeat gate started at 23:42:15Z
- 1,811 repeated tests selected
- reached 43% by 00:04:54Z
- no test failures or per-test timeouts
- cancellation annotation: `The job has exceeded the maximum execution time of 30m0s`

Linear projection is about 56 minutes for the repeat gate plus about 6 minutes for the full suite and setup/upload, or roughly 63 minutes total. A 75-minute job budget provides about 20% runner-variance margin without weakening either gate.

The uploaded full-suite XML reports 6,306 tests, 0 errors, 0 failures, 19 skipped, and 342.697 seconds. The repeat XML was not produced because pytest was terminated by the job-level timeout.

## Validation

- YAML parsed successfully and contract asserts `timeout-minutes == 75`
- `git diff --check`
- `uv run --no-sync ruff check src/ tests/`
- `uv run --no-sync mypy src/memo` (484 source files)
- `uv run --no-sync pytest tests/test_testing_workflows.py -q --tb=short` (6 passed)