### PR TITLE
audit: harden CLI, MCP, Docker, migrations, and runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,12 +51,15 @@ ENV PYTHONUNBUFFERED=1 \
 
 COPY --from=builder /dist/ /tmp/dist/
 RUN wheel=$(find /tmp/dist -name '*.whl' -print -quit) \
-    && test -n "$wheel" \
-    && test -n "$EXPECTED_VERSION" \
+    && { test -n "$wheel" || { echo "ERROR: no wheel in /tmp/dist (builder stage produced nothing)" >&2; exit 1; }; } \
     && python -m pip install --index-url https://download.pytorch.org/whl/cpu torch==2.13.0 \
     && python -m pip install --require-hashes -r /tmp/dist/runtime-requirements.txt \
     && python -m pip install --no-deps "$wheel" \
-    && EXPECTED_VERSION="$EXPECTED_VERSION" python -c "import os; import memo; expected = os.environ['EXPECTED_VERSION']; installed = memo.__version__; assert installed == expected, f'{installed} != {expected}'" \
+    && if [ -n "$EXPECTED_VERSION" ]; then \
+         EXPECTED_VERSION="$EXPECTED_VERSION" python -c "import os; import memo; expected = os.environ['EXPECTED_VERSION']; installed = memo.__version__; assert installed == expected, f'{installed} != {expected}'"; \
+       else \
+         python -c "import memo; print('memo', memo.__version__, '(EXPECTED_VERSION not pinned — local build)')"; \
+       fi \
     && rm -rf /tmp/dist
 
 RUN python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['MEMO_ST_EMBEDDER_MODEL'], revision=os.environ['MEMO_ST_EMBEDDER_REVISION'])"

--- a/Dockerfile.glama
+++ b/Dockerfile.glama
@@ -51,12 +51,15 @@ ENV PYTHONUNBUFFERED=1 \
 
 COPY --from=builder /dist/ /tmp/dist/
 RUN wheel=$(find /tmp/dist -name '*.whl' -print -quit) \
-    && test -n "$wheel" \
-    && test -n "$EXPECTED_VERSION" \
+    && { test -n "$wheel" || { echo "ERROR: no wheel in /tmp/dist (builder stage produced nothing)" >&2; exit 1; }; } \
     && python -m pip install --index-url https://download.pytorch.org/whl/cpu torch==2.13.0 \
     && python -m pip install --require-hashes -r /tmp/dist/runtime-requirements.txt \
     && python -m pip install --no-deps "$wheel" \
-    && EXPECTED_VERSION="$EXPECTED_VERSION" python -c "import os; import memo; expected = os.environ['EXPECTED_VERSION']; installed = memo.__version__; assert installed == expected, f'{installed} != {expected}'" \
+    && if [ -n "$EXPECTED_VERSION" ]; then \
+         EXPECTED_VERSION="$EXPECTED_VERSION" python -c "import os; import memo; expected = os.environ['EXPECTED_VERSION']; installed = memo.__version__; assert installed == expected, f'{installed} != {expected}'"; \
+       else \
+         python -c "import memo; print('memo', memo.__version__, '(EXPECTED_VERSION not pinned — local build)')"; \
+       fi \
     && rm -rf /tmp/dist
 
 RUN python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['MEMO_ST_EMBEDDER_MODEL'], revision=os.environ['MEMO_ST_EMBEDDER_REVISION'])"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,6 +194,7 @@ packages = ["src/memo"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = ["--import-mode=importlib", "--strict-markers", "--strict-config"]
+asyncio_default_fixture_loop_scope = "function"
 markers = [
     "requires_mlx: smoke test que carga modelos MLX reales (Apple Silicon only). Auto-skipea sin mlx_lm.",
     "slow: tests >1s (real MLX model loads); no default deselection — CI jobs pass `-m 'not slow'` explicitly (nightly slow-tests runs them).",

--- a/src/memo/chat/http.py
+++ b/src/memo/chat/http.py
@@ -22,6 +22,22 @@ def _normalize_history(history: Any) -> list[dict[str, str]] | None:
     ]
 
 
+def _spa_response(
+    path: str,
+    *,
+    dist: Path,
+    file_response: Any,
+    json_response: Any,
+) -> Any:
+    """Serve one SPA path while keeping unknown API routes as JSON 404s."""
+    if path == "api" or path.startswith("api/"):
+        return json_response({"error": "unknown API route"}, status_code=404)
+    candidate = (dist / path).resolve()
+    if path and candidate.is_file() and candidate.is_relative_to(dist.resolve()):
+        return file_response(candidate)
+    return file_response(dist / "index.html")
+
+
 def build_app(memory: Any, *, dist: Path | None = None) -> Any:
     from fastapi import FastAPI, Request
     from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
@@ -215,11 +231,11 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
 
         @app.get("/{path:path}")
         async def spa(path: str) -> Any:
-            if path == "api" or path.startswith("api/"):
-                return JSONResponse({"error": "unknown API route"}, status_code=404)
-            candidate = (dist / path).resolve()
-            if path and candidate.is_file() and candidate.is_relative_to(dist.resolve()):
-                return FileResponse(candidate)
-            return FileResponse(dist / "index.html")
+            return _spa_response(
+                path,
+                dist=dist,
+                file_response=FileResponse,
+                json_response=JSONResponse,
+            )
 
     return app

--- a/src/memo/chat/http.py
+++ b/src/memo/chat/http.py
@@ -215,6 +215,8 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
 
         @app.get("/{path:path}")
         async def spa(path: str) -> Any:
+            if path == "api" or path.startswith("api/"):
+                return JSONResponse({"error": "unknown API route"}, status_code=404)
             candidate = (dist / path).resolve()
             if path and candidate.is_file() and candidate.is_relative_to(dist.resolve()):
                 return FileResponse(candidate)

--- a/src/memo/cli_operational.py
+++ b/src/memo/cli_operational.py
@@ -416,13 +416,20 @@ def migrate_independence_cmd(
 ) -> None:
     """Migrate legacy integration metadata into Memo-native contracts."""
     from memo.independence_migration import migrate_independence
+    from memo.runtime.agent_registry import resolve_isolated_memo_mcp
+    from memo.runtime.codex import _codex_home
+
+    runtime_mcp = resolve_isolated_memo_mcp()
+    memo_bin = str(runtime_mcp.with_name("memo")) if runtime_mcp is not None else "memo"
 
     _json(
         migrate_independence(
             memory,
             write=write,
             legacy_ledger=legacy_ledger,
-            config_paths=list(config_paths),
+            config_paths=list(config_paths) or None,
+            codex_hooks_path=_codex_home() / "hooks.json",
+            memo_bin=memo_bin,
         )
     )
 

--- a/src/memo/coordination.py
+++ b/src/memo/coordination.py
@@ -36,6 +36,7 @@ _log = logging.getLogger(__name__)
 
 DEFAULT_SCAN_INTERVAL_S = 300
 DEFAULT_ACTIVE_WINDOW_S = 21600
+DEFAULT_DELIVERY_LIVENESS_S = 1800
 TOPIC_JACCARD = 0.35
 RECENT_MEMORIES_PER_SESSION = 20
 _RECENT_ROWS_SCANNED = 400
@@ -184,6 +185,11 @@ def scan_interval_s() -> float:
 def active_window_s() -> float:
     value = flag_int("MEMO_COORD_ACTIVE_WINDOW")
     return float(DEFAULT_ACTIVE_WINDOW_S if value is None else value)
+
+
+def delivery_liveness_s() -> float:
+    value = flag_int("MEMO_COORD_DELIVERY_WINDOW")
+    return float(DEFAULT_DELIVERY_LIVENESS_S if value is None else value)
 
 
 def coordination_db_path(cfg: Any) -> Path:
@@ -391,6 +397,29 @@ def _active_session_snaps(state_dir: Path, *, now: datetime) -> list[dict[str, A
         if snap.get("session_id") and ts is not None and ts >= cutoff:
             out.append(snap)
     return out
+
+
+def _live_session_ids(state_dir: Path, *, now: datetime) -> frozenset[str] | None:
+    """Session ids updated within the delivery-liveness window.
+
+    Returns None when liveness can't be assessed (no snapshots on disk or an
+    unreadable sessions dir) — callers fail open and deliver as before.
+    """
+    from memo.session import list_sessions
+
+    try:
+        snaps = list_sessions(state_dir, limit=_MAX_SESSIONS)
+    except (OSError, ValueError):
+        return None
+    if not snaps:
+        return None
+    cutoff = now - timedelta(seconds=delivery_liveness_s())
+    out = set()
+    for snap in snaps:
+        ts = _parse_instant(snap.get("updated"))
+        if snap.get("session_id") and ts is not None and ts >= cutoff:
+            out.add(str(snap["session_id"]))
+    return frozenset(out)
 
 
 def _row_session_id(row: dict[str, Any]) -> str:
@@ -704,7 +733,17 @@ def deliver_pending_block(cfg: Any, session_id: str | None, *, now: datetime | N
             pending = store.pending_directives(session_id)
             if not pending:
                 return ""
-            ts = (now if now is not None else datetime.now(UTC)).isoformat()
+            now_dt = now if now is not None else datetime.now(UTC)
+            # A directive about a counterpart that already went idle is pure
+            # noise ("stop and await instructions" from a dead session blocks
+            # work forever). Hold it — the row stays open, so if the other
+            # session resumes, delivery happens on a later turn.
+            live = _live_session_ids(Path(cfg.state_dir), now=now_dt)
+            if live is not None:
+                pending = [d for d in pending if d.other_session in live]
+            if not pending:
+                return ""
+            ts = now_dt.isoformat()
             for directive in pending:
                 store.mark_delivered(directive.collision_id, session_id, ts)
             return render_directives_block(pending)

--- a/src/memo/flags.py
+++ b/src/memo/flags.py
@@ -282,6 +282,10 @@ def unknown_memo_vars(env: dict[str, str] | None = None) -> list[str]:
         "MEMO_AGENT_TTY",
         "MEMO_CODEX_BADGE_SHOWN",
         "MEMO_STARTUP_BANNER_SHOWN",
+        # User-facing banner toggle consumed by the bash shell shim
+        # (runtime/shims.py). Env-only: the shim can't see the markdown-config
+        # chain, so registering it as a flag would diverge silently.
+        "MEMO_STARTUP_BANNER",
         # chat/config.py-owned knobs: env-only + built-in defaults, read
         # directly (not through this registry's markdown/overlay chain).
         "MEMO_CHAT_BASE_K",

--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -1711,4 +1711,14 @@ SPECS: tuple[FlagSpec, ...] = (
         "collision scan; older open collisions expire to 'stale'.",
         min_val=1,
     ),
+    _spec(
+        "MEMO_COORD_DELIVERY_WINDOW",
+        "int",
+        1800,
+        "coordination",
+        "A pending directive is only injected while its counterpart session "
+        "was updated within this many seconds; directives about idle "
+        "counterparts are held (row stays open) until they resume.",
+        min_val=1,
+    ),
 )

--- a/src/memo/graph.py
+++ b/src/memo/graph.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import sqlite3
 import threading
+import weakref
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
@@ -221,9 +222,20 @@ class GraphStore:
             )
         # Higher layers may compose an application-specific read projection.
         # GraphStore stays a foundation leaf and owns only raw graph storage.
-        self.projection = (
-            projection_factory(self._conn, self._tx) if projection_factory is not None else None
-        )
+        if projection_factory is None:
+            self.projection = None
+        else:
+            owner_ref = weakref.ref(self)
+
+            @contextmanager
+            def projection_tx() -> Iterator[sqlite3.Connection]:
+                owner = owner_ref()
+                if owner is None:
+                    raise RuntimeError("graph store is closed")
+                with owner._tx() as connection:
+                    yield connection
+
+            self.projection = projection_factory(self._conn, projection_tx)
 
     @contextmanager
     def _tx(self) -> Iterator[sqlite3.Connection]:

--- a/src/memo/independence_migration.py
+++ b/src/memo/independence_migration.py
@@ -79,6 +79,86 @@ def _migrate_config(path: Path, *, write: bool) -> str:
     return "migrated"
 
 
+def _is_legacy_memflow_startup_hook(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    command = value.get("command")
+    if not isinstance(command, str):
+        return False
+    lowered = command.lower()
+    return "memflow" in lowered and "startup-banner" in lowered
+
+
+def _is_memo_briefing_hook(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    command = value.get("command")
+    return isinstance(command, str) and "memo" in command and "briefing --compact" in command
+
+
+def _migrate_codex_hooks(path: Path, *, write: bool, memo_bin: str) -> str:
+    """Replace the retired Memflow SessionStart hook without touching foreign hooks."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return "error"
+    if not isinstance(payload, dict):
+        return "error"
+    hooks = payload.get("hooks")
+    if not isinstance(hooks, dict):
+        return "unchanged"
+    session_start = hooks.get("SessionStart")
+    if not isinstance(session_start, list):
+        return "unchanged"
+
+    has_memo_briefing = any(
+        _is_memo_briefing_hook(hook)
+        for group in session_start
+        if isinstance(group, dict) and isinstance(group.get("hooks"), list)
+        for hook in group["hooks"]
+    )
+    migrated = False
+    migrated_groups: list[object] = []
+    for group in session_start:
+        if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
+            migrated_groups.append(group)
+            continue
+        original_hooks = group["hooks"]
+        migrated_hooks: list[object] = []
+        for hook in original_hooks:
+            if not _is_legacy_memflow_startup_hook(hook):
+                migrated_hooks.append(hook)
+                continue
+            migrated = True
+            if has_memo_briefing:
+                continue
+            replacement = dict(hook)
+            replacement.update(
+                {
+                    "type": "command",
+                    "command": f"MEMO_NONINTERACTIVE=1 {memo_bin} briefing --compact",
+                    "timeout": 5,
+                    "statusMessage": "Loading memo briefing",
+                }
+            )
+            migrated_hooks.append(replacement)
+            has_memo_briefing = True
+        if migrated_hooks or not original_hooks:
+            migrated_group = dict(group)
+            migrated_group["hooks"] = migrated_hooks
+            migrated_groups.append(migrated_group)
+
+    if not migrated:
+        return "unchanged"
+    hooks["SessionStart"] = migrated_groups
+    if write:
+        atomic_write_text(
+            path,
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        )
+    return "migrated"
+
+
 def _import_legacy_ledger(memory: Any, path: Path, *, write: bool) -> dict[str, int]:
     report = {"checked": 0, "imported": 0, "errors": 0, "skipped": 0}
     if not path.is_file():
@@ -231,6 +311,8 @@ def migrate_independence(
     write: bool = False,
     legacy_ledger: Path | None = None,
     config_paths: list[Path] | None = None,
+    codex_hooks_path: Path | None = None,
+    memo_bin: str = "memo",
 ) -> dict[str, Any]:
     """Migrate provenance/config/journal data without contacting another system."""
     markdown = {"checked": 0, "migrated": 0, "unchanged": 0, "errors": 0}
@@ -261,6 +343,13 @@ def migrate_independence(
         key = "errors" if result == "error" else result
         configs[key] += 1
 
+    integrations = {"checked": 0, "migrated": 0, "unchanged": 0, "errors": 0}
+    if codex_hooks_path is not None and codex_hooks_path.is_file():
+        integrations["checked"] = 1
+        result = _migrate_codex_hooks(codex_hooks_path, write=write, memo_bin=memo_bin)
+        key = "errors" if result == "error" else result
+        integrations[key] += 1
+
     ledger = (
         _import_legacy_ledger(memory, legacy_ledger, write=write)
         if legacy_ledger is not None
@@ -273,6 +362,7 @@ def migrate_independence(
         "mode": "write" if write else "dry-run",
         "markdown": markdown,
         "config": configs,
+        "agent_integrations": integrations,
         "legacy_ledger": ledger,
         "journal": memory.operational.ledger.verify(),
     }

--- a/src/memo/independence_migration.py
+++ b/src/memo/independence_migration.py
@@ -96,56 +96,92 @@ def _is_memo_briefing_hook(value: object) -> bool:
     return isinstance(command, str) and "memo" in command and "briefing --compact" in command
 
 
-def _migrate_codex_hooks(path: Path, *, write: bool, memo_bin: str) -> str:
-    """Replace the retired Memflow SessionStart hook without touching foreign hooks."""
+def _load_codex_session_start(
+    path: Path,
+) -> tuple[str, dict[str, Any] | None, dict[str, Any] | None, list[object] | None]:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return "error"
+        return "error", None, None, None
     if not isinstance(payload, dict):
-        return "error"
+        return "error", None, None, None
     hooks = payload.get("hooks")
     if not isinstance(hooks, dict):
-        return "unchanged"
+        return "unchanged", None, None, None
     session_start = hooks.get("SessionStart")
     if not isinstance(session_start, list):
-        return "unchanged"
+        return "unchanged", None, None, None
+    return "ready", payload, hooks, session_start
 
-    has_memo_briefing = any(
-        _is_memo_briefing_hook(hook)
-        for group in session_start
-        if isinstance(group, dict) and isinstance(group.get("hooks"), list)
-        for hook in group["hooks"]
-    )
+
+def _has_memo_briefing(session_start: list[object]) -> bool:
+    for group in session_start:
+        if not isinstance(group, dict):
+            continue
+        group_hooks = group.get("hooks")
+        if isinstance(group_hooks, list) and any(
+            _is_memo_briefing_hook(hook) for hook in group_hooks
+        ):
+            return True
+    return False
+
+
+def _migrate_codex_hook_group(
+    group: object,
+    *,
+    has_memo_briefing: bool,
+    memo_bin: str,
+) -> tuple[object | None, bool, bool]:
+    if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
+        return group, False, has_memo_briefing
+
+    original_hooks = group["hooks"]
+    migrated = False
+    migrated_hooks: list[object] = []
+    for hook in original_hooks:
+        if not _is_legacy_memflow_startup_hook(hook):
+            migrated_hooks.append(hook)
+            continue
+        migrated = True
+        if has_memo_briefing:
+            continue
+        replacement = dict(hook)
+        replacement.update(
+            {
+                "type": "command",
+                "command": f"MEMO_NONINTERACTIVE=1 {memo_bin} briefing --compact",
+                "timeout": 5,
+                "statusMessage": "Loading memo briefing",
+            }
+        )
+        migrated_hooks.append(replacement)
+        has_memo_briefing = True
+
+    if not migrated_hooks and original_hooks:
+        return None, migrated, has_memo_briefing
+    migrated_group = dict(group)
+    migrated_group["hooks"] = migrated_hooks
+    return migrated_group, migrated, has_memo_briefing
+
+
+def _migrate_codex_hooks(path: Path, *, write: bool, memo_bin: str) -> str:
+    """Replace the retired Memflow SessionStart hook without touching foreign hooks."""
+    status, payload, hooks, session_start = _load_codex_session_start(path)
+    if status != "ready":
+        return status
+    assert payload is not None and hooks is not None and session_start is not None
+
+    has_memo_briefing = _has_memo_briefing(session_start)
     migrated = False
     migrated_groups: list[object] = []
     for group in session_start:
-        if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
-            migrated_groups.append(group)
-            continue
-        original_hooks = group["hooks"]
-        migrated_hooks: list[object] = []
-        for hook in original_hooks:
-            if not _is_legacy_memflow_startup_hook(hook):
-                migrated_hooks.append(hook)
-                continue
-            migrated = True
-            if has_memo_briefing:
-                continue
-            replacement = dict(hook)
-            replacement.update(
-                {
-                    "type": "command",
-                    "command": f"MEMO_NONINTERACTIVE=1 {memo_bin} briefing --compact",
-                    "timeout": 5,
-                    "statusMessage": "Loading memo briefing",
-                }
-            )
-            migrated_hooks.append(replacement)
-            has_memo_briefing = True
-        if migrated_hooks or not original_hooks:
-            migrated_group = dict(group)
-            migrated_group["hooks"] = migrated_hooks
+        migrated_group, group_migrated, has_memo_briefing = _migrate_codex_hook_group(
+            group,
+            has_memo_briefing=has_memo_briefing,
+            memo_bin=memo_bin,
+        )
+        migrated = migrated or group_migrated
+        if migrated_group is not None:
             migrated_groups.append(migrated_group)
 
     if not migrated:

--- a/src/memo/runtime/agent_registry.py
+++ b/src/memo/runtime/agent_registry.py
@@ -432,6 +432,31 @@ def _isolated_runtime_smoke(
             return False, False, str(exc)[:500]
 
 
+def _runtime_command_matches(command: str, runtime: Path | None) -> bool:
+    if not command or runtime is None:
+        return False
+    candidate = Path(command)
+    if not candidate.is_absolute():
+        resolved = shutil.which(command)
+        if not resolved:
+            return False
+        candidate = Path(resolved)
+    try:
+        return candidate.resolve() == runtime.resolve()
+    except OSError:
+        return candidate == runtime
+
+
+def _runtime_detail_matches(raw_detail: str, runtime: Path | None) -> bool:
+    if runtime is not None and str(runtime) in raw_detail:
+        return True
+    for line in raw_detail.splitlines():
+        key, separator, value = line.partition(":")
+        if separator and key.strip().lower() == "command":
+            return _runtime_command_matches(value.strip(), runtime)
+    return False
+
+
 def _probe_agent_configuration(
     *,
     adapter: AgentAdapter,
@@ -463,7 +488,7 @@ def _probe_agent_configuration(
             except ValueError:
                 parsed = None
         if parsed is None:
-            config_runtime = bool(runtime and str(runtime) in raw_detail)
+            config_runtime = _runtime_detail_matches(raw_detail, runtime)
             profile_current = adapter.mcp_profile in raw_detail
         else:
             transport_value = parsed.get("transport")
@@ -471,7 +496,7 @@ def _probe_agent_configuration(
             command = str(transport.get("command") or "")
             env_value = transport.get("env")
             mcp_env = env_value if isinstance(env_value, dict) else {}
-            config_runtime = bool(runtime and command == str(runtime))
+            config_runtime = _runtime_command_matches(command, runtime)
             profile_current = mcp_env.get("MEMO_MCP_PROFILE") == adapter.mcp_profile
         return config_ok, config_runtime, profile_current, raw_detail[:500]
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:

--- a/src/memo/server_core_records.py
+++ b/src/memo/server_core_records.py
@@ -88,6 +88,13 @@ def register(server: Any, memory: Memory) -> None:
                 "'project' or None keep auto-detection. Other values are rejected."
             ),
         ] = None,
+        defer_embed: Annotated[
+            bool,
+            Field(
+                description="Persist markdown and the text index immediately, but leave "
+                "the semantic vector pending for a later memo_reindex call."
+            ),
+        ] = False,
     ) -> dict[str, Any]:
         """Persist `content` to memo.
 
@@ -108,6 +115,10 @@ def register(server: Any, memory: Memory) -> None:
         tier, +0.10 boost everywhere); `"project"` or None keep the default
         auto-detection. An explicit `project:` tag in `tags` always wins
         either way.
+
+        `defer_embed` mirrors CLI `memo save --defer-embed`: it persists
+        markdown + BM25 immediately and marks the semantic vector pending for
+        `memo_reindex`. Extraction mode ignores it, matching the CLI.
         """
         from memo.flags import flag_bool
         from memo.memory import WriteRefused
@@ -144,6 +155,7 @@ def register(server: Any, memory: Memory) -> None:
                 auto_derive=auto_derive,
                 auto_project=auto_project,
                 extra=safe_extra,
+                defer_embed=defer_embed,
             )
         except WriteRefused as exc:
             return {

--- a/tests/resource_hygiene_plugin.py
+++ b/tests/resource_hygiene_plugin.py
@@ -42,9 +42,9 @@ def _enforce_resource_hygiene(request: pytest.FixtureRequest):
         yield
         return
 
-    gc.collect()
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always", ResourceWarning)
+        gc.collect()
         yield
         gc.collect()
 

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -301,15 +301,13 @@ def test_claude_doctor_accepts_bare_command_resolved_to_isolated_runtime(
         ),
     )
 
-    configured, runtime_current, profile_current, _detail = (
-        registry._probe_agent_configuration(
-            adapter=adapter,
-            slug="claude-code",
-            root=tmp_path,
-            runtime=runtime,
-            probe=True,
-            binary="/usr/bin/claude",
-        )
+    configured, runtime_current, profile_current, _detail = registry._probe_agent_configuration(
+        adapter=adapter,
+        slug="claude-code",
+        root=tmp_path,
+        runtime=runtime,
+        probe=True,
+        binary="/usr/bin/claude",
     )
 
     assert configured is True

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -277,6 +277,46 @@ def test_codex_doctor_reads_unmasked_json_profile(monkeypatch, tmp_path: Path) -
     assert report["checks"]["profile_current"] is True
 
 
+def test_claude_doctor_accepts_bare_command_resolved_to_isolated_runtime(
+    monkeypatch, tmp_path: Path
+) -> None:
+    runtime = _runtime(tmp_path)
+    adapter = registry.AGENT_REGISTRY["claude-code"]
+
+    def fake_which(name: str) -> str | None:
+        return {
+            "claude": "/usr/bin/claude",
+            "memo-mcp": str(runtime),
+        }.get(name)
+
+    monkeypatch.setattr(registry.shutil, "which", fake_which)
+    monkeypatch.setattr(
+        registry.subprocess,
+        "run",
+        lambda argv, **_kwargs: subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout="Command: memo-mcp\nEnvironment: MEMO_MCP_PROFILE=agent\n",
+            stderr="",
+        ),
+    )
+
+    configured, runtime_current, profile_current, _detail = (
+        registry._probe_agent_configuration(
+            adapter=adapter,
+            slug="claude-code",
+            root=tmp_path,
+            runtime=runtime,
+            probe=True,
+            binary="/usr/bin/claude",
+        )
+    )
+
+    assert configured is True
+    assert runtime_current is True
+    assert profile_current is True
+
+
 def test_verify_agent_reports_probe_and_storage_failures(monkeypatch, tmp_path: Path) -> None:
     runtime = _runtime(tmp_path)
     registry._write_mandate(tmp_path / "AGENTS.md", dry_run=False)

--- a/tests/test_chat_feedback.py
+++ b/tests/test_chat_feedback.py
@@ -53,7 +53,8 @@ def test_store_roundtrip_and_latest_wins(tmp_path: Path) -> None:
     store = SourceVoteStore(tmp_path)
     store.record(_vote("k1", "s1", "up"))
     store.record(_vote("k1", "s1", "down"))
-    (tmp_path / "source_votes.jsonl").open("a").write("not json\n")
+    with (tmp_path / "source_votes.jsonl").open("a") as handle:
+        handle.write("not json\n")
     latest = SourceVoteStore(tmp_path).latest_by_pair()
     assert latest[("k1", "s1")].rating == "down"
 
@@ -90,9 +91,10 @@ def test_source_vote_skip_shape_corrupt(tmp_path: Path) -> None:
     store = SourceVoteStore(tmp_path)
     store.record(_vote("k1", "s1", "up"))
     # Append shape-corrupt line (valid JSON but missing required field)
-    (tmp_path / "source_votes.jsonl").open("a").write(
-        '{"created_at":"2026-07-30T00:00:00","question_key":"k1","query":"q","source_id":"s2"}\n'
-    )
+    with (tmp_path / "source_votes.jsonl").open("a") as handle:
+        handle.write(
+            '{"created_at":"2026-07-30T00:00:00","question_key":"k1","query":"q","source_id":"s2"}\n'
+        )
     store.record(_vote("k1", "s3", "down"))
     # Load should skip the shape-corrupt line and return only 2 valid votes
     votes = SourceVoteStore(tmp_path).load()
@@ -126,11 +128,12 @@ def test_feedback_store_roundtrip_and_corrupt(tmp_path: Path) -> None:
     store.append(fb1)
     store.append(fb2)
     # Append corrupt JSON line
-    (tmp_path / "events.jsonl").open("a").write("not json\n")
-    # Append shape-corrupt line (valid JSON but missing required field)
-    (tmp_path / "events.jsonl").open("a").write(
-        '{"feedback_id":"f3","created_at":"2026-07-30T00:00:00","chat_session_id":"s"}\n'
-    )
+    with (tmp_path / "events.jsonl").open("a") as handle:
+        handle.write("not json\n")
+        # Append shape-corrupt line (valid JSON but missing required field)
+        handle.write(
+            '{"feedback_id":"f3","created_at":"2026-07-30T00:00:00","chat_session_id":"s"}\n'
+        )
     # Load should skip corrupt lines and return only 2 valid events
     feedbacks = FeedbackStore(tmp_path).load()
     assert len(feedbacks) == 2

--- a/tests/test_chat_http.py
+++ b/tests/test_chat_http.py
@@ -205,3 +205,24 @@ def test_ask_stream_persists_under_given_session_id(client) -> None:
     assert len(history["turns"]) == 2
 
     client.post("/api/sessions/delete", json={"session_id": "given-1"})
+
+
+def test_spa_fallback_does_not_swallow_unknown_api_routes(tmp_path) -> None:
+    # An unknown /api/* path must 404 as JSON — not 200 with index.html —
+    # so API clients get a real error instead of silently parsing HTML.
+    from tests.test_chat_pipeline import _FakeMemory
+
+    dist = tmp_path / "dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "index.html").write_text("<!doctype html><html></html>")
+    app = build_app(_FakeMemory(tmp_path), dist=dist)
+    c = TestClient(app)
+
+    resp = c.get("/api/nonexistent")
+    assert resp.status_code == 404
+    assert resp.json()["error"]
+
+    # SPA routes still fall back to index.html.
+    resp = c.get("/cualquier/ruta")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -631,3 +631,40 @@ def test_cli_coordinate_scan_smoke(tmp_cfg: Config, monkeypatch: pytest.MonkeyPa
 
     assert result.exit_code == 0, result.output
     assert '"collisions": 1' in result.output
+
+
+# ── delivery liveness gate ───────────────────────────────────────────────────
+
+
+def _write_session_snap(cfg: Config, session_id: str, *, updated: datetime) -> None:
+    d = Path(cfg.state_dir) / "sessions"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{session_id}.json").write_text(
+        json.dumps({"session_id": session_id, "updated": updated.isoformat()})
+    )
+
+
+def test_deliver_skips_directive_when_counterpart_is_idle(tmp_cfg: Config) -> None:
+    # A "stop and await instructions" from a session idle for hours blocks
+    # work forever — the counterpart will never follow up. Don't inject it.
+    _write_session_snap(tmp_cfg, "sess-a", updated=NOW)
+    _write_session_snap(tmp_cfg, "sess-b", updated=NOW - timedelta(hours=3))
+    with CoordinationStore(coordination_db_path(tmp_cfg)) as store:
+        store.upsert(_collision())
+
+    assert deliver_pending_block(tmp_cfg, "sess-a", now=NOW) == ""
+
+    # Row stays open and unstamped: if sess-b resumes, delivery happens then.
+    with CoordinationStore(coordination_db_path(tmp_cfg)) as store:
+        row = store.list_collisions(statuses=("open",))[0]
+    assert row.status == "open" and row.delivered_a is None
+
+
+def test_deliver_proceeds_when_counterpart_is_live(tmp_cfg: Config) -> None:
+    _write_session_snap(tmp_cfg, "sess-a", updated=NOW)
+    _write_session_snap(tmp_cfg, "sess-b", updated=NOW - timedelta(minutes=5))
+    with CoordinationStore(coordination_db_path(tmp_cfg)) as store:
+        store.upsert(_collision())
+
+    block = deliver_pending_block(tmp_cfg, "sess-a", now=NOW)
+    assert "<memo-coordination>" in block

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -192,6 +192,14 @@ def test_internal_shim_state_vars_not_flagged_unknown() -> None:
     assert flags.validate(env=env) == []
 
 
+def test_startup_banner_toggle_not_flagged_unknown() -> None:
+    # MEMO_STARTUP_BANNER=0 is the documented user-facing toggle consumed by
+    # the bash shell shim (runtime/shims.py) — env-only, outside the registry.
+    env = {"MEMO_STARTUP_BANNER": "0"}
+    assert flags.unknown_memo_vars(env=env) == []
+    assert flags.validate(env=env) == []
+
+
 def test_chat_config_vars_not_flagged_unknown() -> None:
     # chat/config.py's 9 MEMO_CHAT_* knobs are env-only (read directly, not
     # through this registry) but must not be reported as typos.

--- a/tests/test_graph_projection.py
+++ b/tests/test_graph_projection.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import gc
+import weakref
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -122,6 +124,21 @@ def _connected_graph(tmp_path: Path) -> GraphStore:
         )
     graph.rebuild_edges()
     return graph
+
+
+def test_projection_store_does_not_keep_graph_store_alive(tmp_path: Path) -> None:
+    graph = _connected_graph(tmp_path)
+    graph_ref = weakref.ref(graph)
+
+    del graph
+    survivor = graph_ref()
+    try:
+        assert survivor is None
+    finally:
+        if survivor is not None:
+            survivor.close()
+        del survivor
+        gc.collect()
 
 
 def test_projection_rebuild_activates_complete_version(tmp_path: Path) -> None:

--- a/tests/test_mcp_stdio_end_user.py
+++ b/tests/test_mcp_stdio_end_user.py
@@ -104,9 +104,7 @@ async def test_stdio_process_exposes_full_surface_and_core_crud(tmp_path: Path) 
             assert [hit["id"] for hit in searched["hits"]] == [memory_id]
 
             assert (await client.call_tool("memo_rerank", {"query": "", "hits": []})).data == []
-            assert (
-                await client.call_tool("memo_consolidate_list_archived", {})
-            ).data == []
+            assert (await client.call_tool("memo_consolidate_list_archived", {})).data == []
             relation_reviews = (await client.call_tool("mem_relation_reviews", {})).data
             assert relation_reviews == {"pending": [], "count": 0}
 
@@ -127,9 +125,7 @@ async def test_stdio_process_exposes_full_surface_and_core_crud(tmp_path: Path) 
             ).data
             assert updated["title"] == "stdio journey updated"
 
-            history = (
-                await client.call_tool("memo_history", {"id": memory_id, "limit": 10})
-            ).data
+            history = (await client.call_tool("memo_history", {"id": memory_id, "limit": 10})).data
             assert {event["op"] for event in history} >= {"save", "update"}
 
             deleted = (await client.call_tool("memo_delete", {"id": memory_id})).data

--- a/tests/test_mcp_stdio_end_user.py
+++ b/tests/test_mcp_stdio_end_user.py
@@ -1,0 +1,139 @@
+"""End-user contract for the packaged MCP stdio process.
+
+Most server tests use FastMCP's in-process transport.  This test crosses the
+actual process/protocol boundary used by Codex, Claude Code, and other MCP
+clients so entry-point, environment, serialization, and shutdown regressions
+cannot hide behind the in-memory adapter.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from fastmcp import Client
+
+
+def _server_env(tmp_path: Path) -> dict[str, str]:
+    return {
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_DATA_DIR": str(tmp_path / "data"),
+        "MEMO_STATE_DIR": str(tmp_path / "state"),
+        "MEMO_VAULT_PATH": str(tmp_path / "vault"),
+        "MEMO_CONFIG_FILE": str(tmp_path / "missing-config.toml"),
+        "MEMO_CONFIG_DIR": str(tmp_path / "missing-config-dir"),
+        "MEMO_MCP_PROFILE": "full",
+        "MEMO_EMBEDDER_BACKEND": "mlx",
+        "MEMO_EMBEDDER_MODEL": str(tmp_path / "missing-model"),
+        "MEMO_EMBEDDER_DIMS": "4",
+        "MEMO_EMBEDDER_VIA_DAEMON": "0",
+        "MEMO_SKIP_MODEL_VERSION_CHECK": "1",
+        "MEMO_UPDATE_CHECK_ENABLED": "0",
+        "MEMO_AUTO_UPDATE": "0",
+        "MEMO_STATUSLINE_SELFHEAL": "0",
+        "MEMO_HOOK_SELFHEAL": "0",
+        "MEMO_CODEGRAPH_DISCOVERY": "0",
+    }
+
+
+def _stop_isolated_idle_daemon(env: dict[str, str]) -> None:
+    subprocess.run(
+        [sys.executable, "-m", "memo.cli", "idle-daemon", "stop"],
+        env={**os.environ, **env},
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stdio_process_exposes_full_surface_and_core_crud(tmp_path: Path) -> None:
+    env = _server_env(tmp_path)
+    config = {
+        "mcpServers": {
+            "memo": {
+                "command": sys.executable,
+                "args": ["-m", "memo.server"],
+                "env": env,
+            }
+        }
+    }
+
+    try:
+        async with Client(config, timeout=20, init_timeout=20) as client:
+            tools = await client.list_tools()
+            assert len(tools) == 161
+
+            version = (await client.call_tool("memo_version", {})).data
+            assert version["version"]
+
+            saved = (
+                await client.call_tool(
+                    "memo_save",
+                    {
+                        "content": "stdio end-user protocol proof",
+                        "title": "stdio journey",
+                        "type": "note",
+                        "tags": ["audit", "stdio"],
+                        "scope": "global",
+                        "defer_embed": True,
+                    },
+                )
+            ).data
+            memory_id = saved["id"]
+            assert saved["action"] == "created"
+            assert saved["index_pending"] is True
+
+            fetched = (await client.call_tool("memo_get", {"id": memory_id[:12]})).data
+            assert fetched["body"] == "stdio end-user protocol proof"
+
+            searched = (
+                await client.call_tool(
+                    "memo_search",
+                    {
+                        "query": "protocol proof",
+                        "mode": "bm25",
+                        "source": "codex-e2e",
+                    },
+                )
+            ).data
+            assert [hit["id"] for hit in searched["hits"]] == [memory_id]
+
+            assert (await client.call_tool("memo_rerank", {"query": "", "hits": []})).data == []
+            assert (
+                await client.call_tool("memo_consolidate_list_archived", {})
+            ).data == []
+            relation_reviews = (await client.call_tool("mem_relation_reviews", {})).data
+            assert relation_reviews == {"pending": [], "count": 0}
+
+            forgotten = (
+                await client.call_tool(
+                    "memo_forget", {"id": memory_id, "reason": "stdio round-trip"}
+                )
+            ).data
+            assert forgotten == {"forgotten": True, "id": memory_id}
+            restored = (await client.call_tool("memo_unforget", {"id": memory_id})).data
+            assert restored == {"unforgotten": True, "id": memory_id}
+
+            updated = (
+                await client.call_tool(
+                    "memo_update",
+                    {"id": memory_id, "title": "stdio journey updated"},
+                )
+            ).data
+            assert updated["title"] == "stdio journey updated"
+
+            history = (
+                await client.call_tool("memo_history", {"id": memory_id, "limit": 10})
+            ).data
+            assert {event["op"] for event in history} >= {"save", "update"}
+
+            deleted = (await client.call_tool("memo_delete", {"id": memory_id})).data
+            assert deleted == {"deleted": True}
+            assert (await client.call_tool("memo_get", {"id": memory_id})).data is None
+    finally:
+        _stop_isolated_idle_daemon(env)

--- a/tests/test_operational_memory.py
+++ b/tests/test_operational_memory.py
@@ -635,9 +635,7 @@ def test_independence_migration_replaces_dead_memflow_codex_hook_preserving_fore
     }
     migrated = json.loads(hooks_path.read_text(encoding="utf-8"))
     commands = [
-        hook["command"]
-        for group in migrated["hooks"]["SessionStart"]
-        for hook in group["hooks"]
+        hook["command"] for group in migrated["hooks"]["SessionStart"] for hook in group["hooks"]
     ]
     assert commands == [
         "MEMO_NONINTERACTIVE=1 /opt/memo/bin/memo briefing --compact",

--- a/tests/test_operational_memory.py
+++ b/tests/test_operational_memory.py
@@ -562,6 +562,180 @@ def test_independence_migration_rewrites_provenance_and_is_idempotent(
         memory.close()
 
 
+def test_independence_migration_replaces_dead_memflow_codex_hook_preserving_foreign(
+    tmp_cfg,
+    tmp_path,
+):
+    hooks_path = tmp_path / "codex" / "hooks.json"
+    hooks_path.parent.mkdir(parents=True)
+    hooks_path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "matcher": "startup|resume|clear",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": (
+                                        "MEMFLOW_PROJECT_ROOT=/Users/test/repos/memflow "
+                                        "/Users/test/repos/memflow/.venv/bin/memflow "
+                                        "startup-banner --agent codex --codex-hook"
+                                    ),
+                                    "statusMessage": "Loading Memflow status",
+                                    "timeout": 3,
+                                }
+                            ],
+                        },
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "foreign-tool session-start",
+                                    "timeout": 5,
+                                }
+                            ]
+                        },
+                    ],
+                    "UserPromptSubmit": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "MEMO_NONINTERACTIVE=1 memo recall-hook",
+                                    "timeout": 12,
+                                }
+                            ]
+                        }
+                    ],
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    memory = Memory(tmp_cfg)
+    try:
+        report = migrate_independence(
+            memory,
+            write=True,
+            config_paths=[],
+            codex_hooks_path=hooks_path,
+            memo_bin="/opt/memo/bin/memo",
+        )
+    finally:
+        memory.close()
+
+    assert report["agent_integrations"] == {
+        "checked": 1,
+        "migrated": 1,
+        "unchanged": 0,
+        "errors": 0,
+    }
+    migrated = json.loads(hooks_path.read_text(encoding="utf-8"))
+    commands = [
+        hook["command"]
+        for group in migrated["hooks"]["SessionStart"]
+        for hook in group["hooks"]
+    ]
+    assert commands == [
+        "MEMO_NONINTERACTIVE=1 /opt/memo/bin/memo briefing --compact",
+        "foreign-tool session-start",
+    ]
+    assert migrated["hooks"]["SessionStart"][0]["hooks"][0]["statusMessage"] == (
+        "Loading memo briefing"
+    )
+    assert migrated["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"].endswith(
+        "memo recall-hook"
+    )
+
+
+def test_migrate_independence_cli_discovers_default_config_paths(tmp_path):
+    home = tmp_path / "home"
+    config_path = home / ".config" / "memo" / "config.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        'MEMO_CACHE_BACKEND="memflow"\nMEMO_SYNC_MEMFLOW_ENABLED=1\n',
+        encoding="utf-8",
+    )
+    env = {
+        "HOME": str(home),
+        "CODEX_HOME": str(tmp_path / "codex"),
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_DATA_DIR": str(tmp_path / "data"),
+        "MEMO_STATE_DIR": str(tmp_path / "state"),
+        "MEMO_VAULT_PATH": str(tmp_path / "vault"),
+        "MEMO_EMBEDDER_DIMS": "4",
+        "MEMO_EMBEDDER_VIA_DAEMON": "0",
+        "MEMO_SKIP_MODEL_VERSION_CHECK": "1",
+    }
+
+    result = CliRunner().invoke(cli, ["migrate-independence", "--write"], env=env)
+
+    assert result.exit_code == 0, result.output
+    assert config_path.read_text(encoding="utf-8") == 'MEMO_CACHE_BACKEND="vault"\n'
+    assert json.loads(result.output)["config"] == {
+        "checked": 1,
+        "migrated": 1,
+        "unchanged": 0,
+        "errors": 0,
+    }
+
+
+def test_migrate_independence_cli_discovers_codex_hooks(tmp_path):
+    codex_home = tmp_path / "codex"
+    codex_home.mkdir()
+    hooks_path = codex_home / "hooks.json"
+    hooks_path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": (
+                                        "/Users/test/repos/memflow/.venv/bin/memflow "
+                                        "startup-banner --agent codex --codex-hook"
+                                    ),
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    env = {
+        "HOME": str(tmp_path / "home"),
+        "CODEX_HOME": str(codex_home),
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_DATA_DIR": str(tmp_path / "data"),
+        "MEMO_STATE_DIR": str(tmp_path / "state"),
+        "MEMO_VAULT_PATH": str(tmp_path / "vault"),
+        "MEMO_EMBEDDER_DIMS": "4",
+        "MEMO_EMBEDDER_VIA_DAEMON": "0",
+        "MEMO_SKIP_MODEL_VERSION_CHECK": "1",
+    }
+
+    result = CliRunner().invoke(
+        cli,
+        ["migrate-independence", "--write", "--config", str(tmp_path / "missing")],
+        env=env,
+    )
+
+    assert result.exit_code == 0, result.output
+    report = json.loads(result.output)
+    assert report["agent_integrations"]["migrated"] == 1
+    migrated = json.loads(hooks_path.read_text(encoding="utf-8"))
+    command = migrated["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+    assert command.endswith("memo briefing --compact")
+    assert "memflow" not in command.lower()
+
+
 def test_independence_migration_handles_nested_provenance_and_prevalidates_ledger(
     tmp_cfg,
     monkeypatch,

--- a/tests/test_resource_hygiene_plugin.py
+++ b/tests/test_resource_hygiene_plugin.py
@@ -62,6 +62,33 @@ def test_resource_hygiene_flag_fails_an_unclosed_sqlite_test(
     result.stdout.fnmatch_lines(["*unclosed database*"])
 
 
+def test_resource_hygiene_flag_catches_a_leak_pending_before_test_setup(
+    pytester, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _expose_repo_to_subprocess(monkeypatch)
+    monkeypatch.delenv("PYTHONWARNINGS", raising=False)
+    pytester.makepyfile(
+        """
+        import gc
+        import sqlite3
+
+        gc.disable()
+        cycle = []
+        connection = sqlite3.connect(\":memory:\")
+        cycle.append((cycle, connection))
+        del connection, cycle
+
+        def test_noop():
+            pass
+        """
+    )
+    result = pytester.runpytest_subprocess(
+        "-p", "tests.resource_hygiene_plugin", "--resource-hygiene", "-q"
+    )
+    result.assert_outcomes(passed=1, errors=1)
+    result.stdout.fnmatch_lines(["*unclosed database*"])
+
+
 def test_resource_hygiene_plugin_is_inert_without_flag(
     pytester, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_resource_hygiene_plugin.py
+++ b/tests/test_resource_hygiene_plugin.py
@@ -17,6 +17,10 @@ def _expose_repo_to_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(
         "PYTHONPATH", os.pathsep.join((repo_root, current)) if current else repo_root
     )
+    # Keep pytester's subprocess focused on the explicitly loaded hygiene plugin.
+    # Third-party auto-loaded plugins can emit unrelated startup warnings before
+    # pytest produces a terminal summary, especially under PYTHONWARNINGS=error.
+    monkeypatch.setenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
 
 
 def test_resource_warning_filter_rejects_only_unclosed_resources() -> None:
@@ -46,9 +50,7 @@ def test_resource_hygiene_flag_fails_an_unclosed_sqlite_test(
     pytester.makepyfile(
         """
         import sqlite3
-        import pytest
 
-        @pytest.mark.resource_hygiene
         def test_leak():
             sqlite3.connect(\":memory:\")
         """


### PR DESCRIPTION
## What changed

- complete end-user audit coverage for the CLI and MCP stdio surfaces
- support deferred saves through memo_save over MCP
- migrate legacy Memflow Codex hooks while preserving unrelated hooks
- release graph projection SQLite connections deterministically
- harden runtime diagnostics, resource tests, Docker builds, config validation, and SPA API fallbacks

## Why

The full product audit found gaps at real process and protocol boundaries: cold MCP writes lacked deferred embedding, legacy agent hooks could remain wired to Memflow, runtime checks rejected valid PATH-resolved binaries, and a reference cycle delayed SQLite cleanup.

## User impact

CLI, MCP, Docker, agent integrations, and Synapse/Memflow migration paths now behave consistently in isolated end-user journeys.

## Validation

- ruff passed
- mypy passed on 484 source files
- non-slow suite with warnings as errors: 6298 passed, 19 skipped, 78.50% coverage
- slow suite: 9 passed
- focused migration/runtime suite: 132 passed
- pre-push recall gate: PASS, precision@k 0.708, noise@k 0.000
- both Dockerfiles built and passed an MCP stdio container journey
- Synapse migration exact and idempotent: 28 events and 53 votes