### PR TITLE
fix(chat): harden local HTTP boundary

### DIFF
--- a/src/memo/chat/http.py
+++ b/src/memo/chat/http.py
@@ -1,14 +1,12 @@
 """FastAPI surface for the chat UI. Import-safe without the [http] extra."""
 
+import asyncio
 import json
 import time
 import uuid
-from collections.abc import Iterator
+from collections.abc import Generator, Iterator
 from pathlib import Path
 from typing import Any
-
-from starlette.requests import Request
-from starlette.responses import FileResponse, JSONResponse, StreamingResponse
 
 _CHAT_SECURITY_HEADERS = {
     "Cache-Control": "no-store",
@@ -22,61 +20,130 @@ _CHAT_SECURITY_HEADERS = {
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
 }
+_MAX_HEAVY_IN_FLIGHT = 4
+
+
+def _strict_text(
+    value: Any,
+    field: str,
+    *,
+    required: bool = False,
+    max_chars: int | None = None,
+) -> str:
+    if value is None and not required:
+        return ""
+    if not isinstance(value, str) or (required and not value.strip()):
+        raise ValueError(f"{field} required and must be a string")
+    if max_chars is not None and len(value) > max_chars:
+        raise ValueError(f"{field} must be at most {max_chars} characters")
+    try:
+        value.encode("utf-8", errors="strict")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{field} must contain valid UTF-8 text") from exc
+    return value
 
 
 def _normalize_history(history: Any) -> list[dict[str, str]] | None:
     """Map inbound UI turns ({role, text} per types.ts:54-57) onto the
     {role, content} shape rewrite._history_topic reads, tolerating either key."""
-    if not history:
+    if history is None:
         return None
-    return [
-        {
-            "role": str(t.get("role", "")),
-            "content": str(t.get("content") or t.get("text") or ""),
-        }
-        for t in history
-        if isinstance(t, dict)
-    ]
+    normalized = []
+    for turn in history:
+        if not isinstance(turn, dict):
+            continue
+        role = turn.get("role", "")
+        content = turn.get("content") if turn.get("content") is not None else turn.get("text")
+        if not isinstance(role, str) or not isinstance(content, str):
+            continue
+        normalized.append(
+            {
+                "role": _strict_text(role, "history role"),
+                "content": _strict_text(content, "history content"),
+            }
+        )
+    return normalized
+
+
+def _source_ids(sources: list[Any]) -> list[str]:
+    ids = []
+    for source in sources:
+        if not isinstance(source, dict) or "id" not in source:
+            continue
+        ids.append(_strict_text(source["id"], "sources[].id", required=True, max_chars=512))
+    return ids
+
+
+def _next_item(iterator: Iterator[str]) -> tuple[bool, str]:
+    try:
+        return True, next(iterator)
+    except StopIteration:
+        return False, ""
+
+
+class _HeavyLease:
+    """Idempotently return one chat-capacity slot."""
+
+    def __init__(self, semaphore: asyncio.Semaphore) -> None:
+        self.semaphore = semaphore
+        self.released = False
+
+    def release(self) -> None:
+        if self.released:
+            return
+        self.released = True
+        self.semaphore.release()
+
+    async def release_async(self) -> None:
+        self.release()
 
 
 def _spa_response(
     path: str,
     *,
     dist: Path,
+    file_response: Any,
+    json_response: Any,
 ) -> Any:
     """Serve one SPA path while keeping unknown API routes as JSON 404s."""
     if path == "api" or path.startswith("api/"):
-        return JSONResponse({"error": "unknown API route"}, status_code=404)
+        return json_response({"error": "unknown API route"}, status_code=404)
     candidate = (dist / path).resolve()
     if path and candidate.is_file() and candidate.is_relative_to(dist.resolve()):
-        return FileResponse(candidate)
-    return FileResponse(dist / "index.html")
+        return file_response(candidate)
+    return file_response(dist / "index.html")
 
 
 class _ChatApi:
     """Bound chat HTTP handlers, split from app wiring for auditable contracts."""
 
-    def __init__(self, memory: Any, cfg: Any, sessions: Any) -> None:
+    def __init__(
+        self,
+        memory: Any,
+        cfg: Any,
+        sessions: Any,
+        *,
+        json_response: Any,
+        streaming_response: Any,
+        background_task: Any,
+        run_sync: Any,
+    ) -> None:
         self.memory = memory
         self.cfg = cfg
         self.sessions = sessions
+        self.json_response = json_response
+        self.streaming_response = streaming_response
+        self.background_task = background_task
+        self.run_sync = run_sync
+        self.heavy_slots = asyncio.Semaphore(_MAX_HEAVY_IN_FLIGHT)
 
     @staticmethod
-    async def _json_body(request: Request) -> dict[str, Any] | None:
+    async def _json_body(request: Any) -> dict[str, Any] | None:
         try:
             body = await request.json()
         except Exception:
             return None
         return body if isinstance(body, dict) else None
-
-    def _sessions_history(self, session_id: str | None) -> list[dict[str, str]] | None:
-        if not session_id:
-            return None
-        try:
-            turns = self.sessions.get(session_id)
-        except ValueError:
-            return None
-        return [{"role": t.get("role", ""), "content": t.get("text", "")} for t in turns][-12:]
 
     def _requested_session_id(self, body: dict[str, Any]) -> str | None:
         raw = body.get("chat_session_id")
@@ -85,7 +152,7 @@ class _ChatApi:
         if not isinstance(raw, str):
             raise ValueError("invalid chat_session_id")
         try:
-            self.sessions.get(raw)
+            self.sessions.validate_id(raw)
         except ValueError as exc:
             raise ValueError("invalid chat_session_id") from exc
         return raw
@@ -94,31 +161,38 @@ class _ChatApi:
     def _request_inputs(
         body: dict[str, Any],
     ) -> tuple[str, int | None, list[dict[str, str]] | None]:
-        raw_question = body.get("q")
-        if not isinstance(raw_question, str) or not raw_question.strip():
-            raise ValueError("q required and must be a string")
-        if len(raw_question) > 4096:
-            raise ValueError("q must be at most 4096 characters")
+        question = _strict_text(body.get("q"), "q", required=True, max_chars=4096)
         raw_k = body.get("k")
         if raw_k is not None and (type(raw_k) is not int or not 1 <= raw_k <= 100):
             raise ValueError("k must be an integer between 1 and 100")
         raw_history = body.get("history")
         if raw_history is not None and not isinstance(raw_history, list):
             raise ValueError("history must be a list")
-        return raw_question.strip(), raw_k, _normalize_history(raw_history)
+        return question.strip(), raw_k, _normalize_history(raw_history)
 
     def _prepare_ask(
         self,
         body: dict[str, Any],
-    ) -> tuple[str, int | None, list[dict[str, str]] | None, str]:
+    ) -> tuple[str, int | None, list[dict[str, str]] | None, str, str | None]:
         question, k, explicit_history = self._request_inputs(body)
         given_session_id = self._requested_session_id(body)
         session_id = given_session_id or uuid.uuid4().hex[:12]
-        history = explicit_history or self._sessions_history(given_session_id)
-        return question, k, history, session_id
+        return question, k, explicit_history, session_id, given_session_id
+
+    async def _resolve_history(
+        self,
+        explicit_history: list[dict[str, str]] | None,
+        given_session_id: str | None,
+    ) -> list[dict[str, str]] | None:
+        if explicit_history is not None or given_session_id is None:
+            return explicit_history
+        turns = await self.run_sync(self.sessions.get_recent, given_session_id, limit=12)
+        return _normalize_history(turns)
 
     def _append_session(self, session_id: str, question: str, answer: str | None) -> None:
         try:
+            if answer is not None:
+                self.sessions.validate_text(answer, "answer")
             self.sessions.append_turn(session_id, "user", question)
             if answer is not None:
                 self.sessions.append_turn(session_id, "assistant", answer)
@@ -152,7 +226,7 @@ class _ChatApi:
         session_id: str,
         history: list[dict[str, str]] | None,
         k: int | None,
-    ) -> Iterator[str]:
+    ) -> Generator[str]:
         from memo.chat.pipeline import chat_stream
 
         answer = ""
@@ -161,118 +235,196 @@ class _ChatApi:
                 event = {**event, "chat_session_id": session_id}
             if event.get("type") == "done":
                 answer = str(event.get("answer", ""))
-            yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
+            yield f"data: {json.dumps(event, ensure_ascii=True)}\n\n"
         self._append_session(session_id, question, answer)
 
-    async def ask_stream(self, request: Request) -> Any:
-        body = await self._json_body(request)
-        if body is None:
-            return JSONResponse({"error": "invalid JSON body"}, status_code=400)
-        try:
-            question, k, history, session_id = self._prepare_ask(body)
-        except ValueError as exc:
-            return JSONResponse({"error": str(exc)}, status_code=400)
-        return StreamingResponse(
-            self._stream_frames(
-                question,
-                session_id=session_id,
-                history=history,
-                k=k,
-            ),
-            media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-        )
-
-    async def ask(self, request: Request) -> Any:
-        body = await self._json_body(request)
-        if body is None:
-            return JSONResponse({"error": "invalid JSON body"}, status_code=400)
-        try:
-            question, k, history, session_id = self._prepare_ask(body)
-        except ValueError as exc:
-            return JSONResponse({"error": str(exc)}, status_code=400)
-        events = self._run(
+    async def _stream_frames_async(
+        self,
+        question: str,
+        *,
+        session_id: str,
+        history: list[dict[str, str]] | None,
+        k: int | None,
+        lease: _HeavyLease,
+    ) -> Any:
+        iterator = self._stream_frames(
             question,
             session_id=session_id,
             history=history,
             k=k,
         )
-        done = next((event for event in reversed(events) if event.get("type") in {"done", "error"}), None)
-        return JSONResponse(done or {"type": "error", "message": "no events"})
+        try:
+            while True:
+                available, frame = await self.run_sync(_next_item, iterator)
+                if not available:
+                    return
+                yield frame
+        finally:
+            iterator.close()
+            lease.release()
 
-    async def feedback(self, request: Request) -> Any:
+    async def _reserve_heavy_slot(self) -> _HeavyLease | None:
+        if self.heavy_slots.locked():
+            return None
+        await self.heavy_slots.acquire()
+        return _HeavyLease(self.heavy_slots)
+
+    def _busy_response(self) -> Any:
+        return self.json_response(
+            {"error": "chat capacity exhausted; retry shortly"},
+            status_code=503,
+            headers={"Retry-After": "1"},
+        )
+
+    async def ask_stream(self, request: Any) -> Any:
+        body = await self._json_body(request)
+        if body is None:
+            return self.json_response({"error": "invalid JSON body"}, status_code=400)
+        try:
+            question, k, explicit_history, session_id, given_session_id = self._prepare_ask(body)
+        except ValueError:
+            return self.json_response({"error": "invalid chat request"}, status_code=400)
+        lease = await self._reserve_heavy_slot()
+        if lease is None:
+            return self._busy_response()
+        response = None
+        try:
+            history = await self._resolve_history(explicit_history, given_session_id)
+            response = self.streaming_response(
+                self._stream_frames_async(
+                    question,
+                    session_id=session_id,
+                    history=history,
+                    k=k,
+                    lease=lease,
+                ),
+                media_type="text/event-stream",
+                headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+                background=self.background_task(lease.release_async),
+            )
+            return response
+        finally:
+            if response is None:
+                lease.release()
+
+    async def ask(self, request: Any) -> Any:
+        body = await self._json_body(request)
+        if body is None:
+            return self.json_response({"error": "invalid JSON body"}, status_code=400)
+        try:
+            question, k, explicit_history, session_id, given_session_id = self._prepare_ask(body)
+        except ValueError:
+            return self.json_response({"error": "invalid chat request"}, status_code=400)
+        lease = await self._reserve_heavy_slot()
+        if lease is None:
+            return self._busy_response()
+        try:
+            history = await self._resolve_history(explicit_history, given_session_id)
+            events = await self.run_sync(
+                self._run,
+                question,
+                session_id=session_id,
+                history=history,
+                k=k,
+            )
+        finally:
+            lease.release()
+        done = next(
+            (event for event in reversed(events) if event.get("type") in {"done", "error"}), None
+        )
+        return self.json_response(done or {"type": "error", "message": "no events"})
+
+    async def feedback(self, request: Any) -> Any:
         from memo.chat.feedback import ChatFeedback, FeedbackStore
 
         body = await self._json_body(request)
         if body is None:
-            return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+            return self.json_response({"error": "invalid JSON body"}, status_code=400)
         sources = body.get("sources", [])
         rating = body.get("rating")
         if not isinstance(sources, list):
-            return JSONResponse({"error": "sources must be a list"}, status_code=400)
-        if rating not in {"up", "down"}:
-            return JSONResponse({"error": "rating must be 'up' or 'down'"}, status_code=400)
+            return self.json_response({"error": "sources must be a list"}, status_code=400)
+        if not isinstance(rating, str) or rating not in {"up", "down"}:
+            return self.json_response({"error": "rating must be 'up' or 'down'"}, status_code=400)
+        try:
+            chat_session_id = _strict_text(
+                body.get("chat_session_id"), "chat_session_id", max_chars=64
+            )
+            turn_id = _strict_text(body.get("turn_id"), "turn_id", max_chars=512)
+            query = _strict_text(body.get("query"), "query", max_chars=4096)
+            answer = _strict_text(body.get("answer"), "answer")
+            correction_text = _strict_text(body.get("correction_text"), "correction_text")
+            source_ids = _source_ids(sources)
+        except ValueError:
+            return self.json_response({"error": "invalid feedback request"}, status_code=400)
         feedback = ChatFeedback(
             feedback_id=uuid.uuid4().hex[:12],
             created_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
-            chat_session_id=str(body.get("chat_session_id") or ""),
-            turn_id=str(body.get("turn_id") or ""),
-            query=str(body.get("query") or ""),
-            answer=str(body.get("answer") or ""),
-            source_ids=[
-                source["id"]
-                for source in sources
-                if isinstance(source, dict) and isinstance(source.get("id"), str)
-            ],
+            chat_session_id=chat_session_id,
+            turn_id=turn_id,
+            query=query,
+            answer=answer,
+            source_ids=source_ids,
             rating=rating,
-            correction_text=str(body.get("correction_text") or ""),
+            correction_text=correction_text,
         )
-        FeedbackStore(self.cfg.feedback_dir).append(feedback)
+        await self.run_sync(FeedbackStore(self.cfg.feedback_dir).append, feedback)
         return {"ok": True, "feedback_id": feedback.feedback_id}
 
-    async def feedback_source(self, request: Request) -> Any:
+    async def feedback_source(self, request: Any) -> Any:
         from memo.chat.feedback import SourceVote, SourceVoteStore, question_key
 
         body = await self._json_body(request)
         if body is None:
-            return JSONResponse({"error": "invalid JSON body"}, status_code=400)
-        query = body.get("query")
-        source_id = body.get("source_id")
+            return self.json_response({"error": "invalid JSON body"}, status_code=400)
         rating = body.get("rating")
-        if not isinstance(query, str) or not query.strip() or len(query) > 4096:
-            return JSONResponse(
-                {"error": "query required as a string of at most 4096 characters"},
-                status_code=400,
-            )
-        if not isinstance(source_id, str) or not source_id:
-            return JSONResponse({"error": "source_id required as a string"}, status_code=400)
-        if rating not in {"up", "down"}:
-            return JSONResponse({"error": "rating must be 'up' or 'down'"}, status_code=400)
+        if not isinstance(rating, str) or rating not in {"up", "down"}:
+            return self.json_response({"error": "rating must be 'up' or 'down'"}, status_code=400)
         try:
-            embedding = self.memory.embedder.embed_query(query)
-        except Exception:
-            embedding = []
-        vote = SourceVote(
-            created_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
-            question_key=question_key(query),
-            query=query,
-            source_id=source_id,
-            rating=rating,
-            query_embedding=list(embedding),
-        )
-        SourceVoteStore(self.cfg.feedback_dir).record(vote)
+            query = _strict_text(body.get("query"), "query", required=True, max_chars=4096)
+            source_id = _strict_text(
+                body.get("source_id"), "source_id", required=True, max_chars=512
+            )
+        except ValueError:
+            return self.json_response({"error": "invalid source feedback request"}, status_code=400)
+
+        def record_vote() -> None:
+            try:
+                embedding = self.memory.embedder.embed_query(query)
+            except Exception:
+                embedding = []
+            vote = SourceVote(
+                created_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
+                question_key=question_key(query),
+                query=query,
+                source_id=source_id,
+                rating=rating,
+                query_embedding=list(embedding),
+            )
+            SourceVoteStore(self.cfg.feedback_dir).record(vote)
+
+        lease = await self._reserve_heavy_slot()
+        if lease is None:
+            return self._busy_response()
+        try:
+            await self.run_sync(record_vote)
+        finally:
+            lease.release()
         return {"ok": True}
 
     async def list_sessions(self, limit: int = 50) -> Any:
-        return {"sessions": self.sessions.list_sessions(limit=limit)}
+        if not 1 <= limit <= 100:
+            return self.json_response({"error": "limit must be between 1 and 100"}, status_code=400)
+        sessions = await self.run_sync(self.sessions.list_sessions, limit=limit)
+        return {"sessions": sessions}
 
     async def get_session(self, session_id: str) -> Any:
         from memo.chat.sessions import iso_ts
 
         try:
-            turns = self.sessions.get(session_id)
+            turns = await self.run_sync(self.sessions.get, session_id)
         except ValueError:
-            return JSONResponse({"error": "invalid session id"}, status_code=400)
+            return self.json_response({"error": "invalid session id"}, status_code=400)
         return {
             "session_id": session_id,
             "turns": [
@@ -285,39 +437,67 @@ class _ChatApi:
             ],
         }
 
-    async def delete_session(self, request: Request) -> Any:
+    async def delete_session(self, request: Any) -> Any:
         body = await self._json_body(request)
         if body is None:
-            return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+            return self.json_response({"error": "invalid JSON body"}, status_code=400)
+        session_id = body.get("session_id")
+        if not isinstance(session_id, str):
+            return self.json_response({"error": "invalid session id"}, status_code=400)
         try:
-            return {"ok": self.sessions.delete(str(body.get("session_id") or ""))}
+            return {"ok": await self.run_sync(self.sessions.delete, session_id)}
         except ValueError:
-            return JSONResponse({"error": "invalid session id"}, status_code=400)
+            return self.json_response({"error": "invalid session id"}, status_code=400)
 
     async def delete_all_sessions(self) -> Any:
-        return {"ok": True, "deleted": self.sessions.delete_all()}
+        deleted = await self.run_sync(self.sessions.delete_all)
+        return {"ok": True, "deleted": deleted}
 
     async def suggestions(self, limit: int = 8) -> Any:
-        chips = [{"label": query, "query": query} for query in self.sessions.recent_queries(limit=limit)]
+        if not 1 <= limit <= 100:
+            return self.json_response({"error": "limit must be between 1 and 100"}, status_code=400)
+        queries = await self.run_sync(self.sessions.recent_queries, limit=limit)
+        chips = [{"label": query, "query": query} for query in queries]
         return {"chips": chips}
 
-    @staticmethod
-    async def memory_delete() -> Any:
-        return JSONResponse({"error": "deferred to plan 2"}, status_code=501)
+    async def memory_delete(self) -> Any:
+        return self.json_response({"error": "deferred to plan 2"}, status_code=501)
 
-    @staticmethod
-    async def insight_capture() -> Any:
-        return JSONResponse({"error": "deferred to plan 2"}, status_code=501)
+    async def insight_capture(self) -> Any:
+        return self.json_response({"error": "deferred to plan 2"}, status_code=501)
 
 
-def _register_api_routes(app: Any, api: _ChatApi) -> None:
-    app.add_api_route("/api/ask/stream", api.ask_stream, methods=["POST"])
-    app.add_api_route("/api/ask", api.ask, methods=["POST"])
-    app.add_api_route("/api/feedback", api.feedback, methods=["POST"])
-    app.add_api_route("/api/feedback/source", api.feedback_source, methods=["POST"])
+def _request_endpoint(handler: Any, request_type: Any) -> Any:
+    """Give FastAPI a concrete Request annotation without importing it eagerly."""
+
+    async def endpoint(request: Any) -> Any:
+        return await handler(request)
+
+    endpoint.__name__ = handler.__name__
+    endpoint.__annotations__["request"] = request_type
+    return endpoint
+
+
+def _register_api_routes(app: Any, api: _ChatApi, request_type: Any) -> None:
+    app.add_api_route(
+        "/api/ask/stream", _request_endpoint(api.ask_stream, request_type), methods=["POST"]
+    )
+    app.add_api_route("/api/ask", _request_endpoint(api.ask, request_type), methods=["POST"])
+    app.add_api_route(
+        "/api/feedback", _request_endpoint(api.feedback, request_type), methods=["POST"]
+    )
+    app.add_api_route(
+        "/api/feedback/source",
+        _request_endpoint(api.feedback_source, request_type),
+        methods=["POST"],
+    )
     app.add_api_route("/api/sessions", api.list_sessions, methods=["GET"])
     app.add_api_route("/api/sessions/{session_id}", api.get_session, methods=["GET"])
-    app.add_api_route("/api/sessions/delete", api.delete_session, methods=["POST"])
+    app.add_api_route(
+        "/api/sessions/delete",
+        _request_endpoint(api.delete_session, request_type),
+        methods=["POST"],
+    )
     app.add_api_route("/api/sessions/delete-all", api.delete_all_sessions, methods=["POST"])
     app.add_api_route("/api/suggestions", api.suggestions, methods=["GET"])
     app.add_api_route("/api/memory/delete", api.memory_delete, methods=["POST"])
@@ -325,25 +505,44 @@ def _register_api_routes(app: Any, api: _ChatApi) -> None:
 
 
 class _SpaEndpoint:
-    def __init__(self, dist: Path) -> None:
+    def __init__(self, dist: Path, *, file_response: Any, json_response: Any) -> None:
         self.dist = dist
+        self.file_response = file_response
+        self.json_response = json_response
 
     async def __call__(self, path: str) -> Any:
-        return _spa_response(path, dist=self.dist)
+        return _spa_response(
+            path,
+            dist=self.dist,
+            file_response=self.file_response,
+            json_response=self.json_response,
+        )
 
 
-def _mount_spa(app: Any, dist: Path | None) -> None:
+def _mount_spa(
+    app: Any,
+    dist: Path | None,
+    *,
+    file_response: Any,
+    json_response: Any,
+) -> None:
     if dist is None or not (dist / "index.html").exists():
         return
     from fastapi.staticfiles import StaticFiles
 
     app.mount("/assets", StaticFiles(directory=dist / "assets"), name="assets")
-    app.add_api_route("/{path:path}", _SpaEndpoint(dist), methods=["GET"])
+    app.add_api_route(
+        "/{path:path}",
+        _SpaEndpoint(dist, file_response=file_response, json_response=json_response),
+        methods=["GET"],
+    )
 
 
 def build_app(memory: Any, *, dist: Path | None = None) -> Any:
-    from fastapi import FastAPI
-    from starlette.middleware import Middleware
+    from fastapi import BackgroundTasks, FastAPI, Request
+    from fastapi.concurrency import run_in_threadpool
+    from fastapi.middleware import Middleware
+    from fastapi.responses import FileResponse, Response, StreamingResponse
 
     from memo.chat.config import ChatConfig
     from memo.chat.sessions import SessionStore
@@ -356,6 +555,33 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
 
     cfg = ChatConfig.load(memory.cfg.state_dir)
     sessions = SessionStore(cfg.sessions_dir)
+
+    def json_response(
+        content: Any,
+        *,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
+        # Escaping non-ASCII makes even malformed third-party/model surrogates
+        # safe to encode as UTF-8 JSON instead of failing response construction.
+        payload = json.dumps(
+            content,
+            ensure_ascii=True,
+            allow_nan=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return Response(
+            content=payload,
+            status_code=status_code,
+            headers=headers,
+            media_type="application/json",
+        )
+
+    def background_task(function: Any) -> Any:
+        tasks = BackgroundTasks()
+        tasks.add_task(function)
+        return tasks
+
     # Chat has no bearer-token flow: constrain it to same-origin loopback HTTP,
     # reject DNS-rebinding/cross-site requests, and bound local request pressure.
     # `memo chat serve` independently rejects non-loopback bind addresses so the
@@ -371,6 +597,15 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
             Middleware(RequestSizeLimitMiddleware),
         ],
     )
-    _register_api_routes(app, _ChatApi(memory, cfg, sessions))
-    _mount_spa(app, dist)
+    api = _ChatApi(
+        memory,
+        cfg,
+        sessions,
+        json_response=json_response,
+        streaming_response=StreamingResponse,
+        background_task=background_task,
+        run_sync=run_in_threadpool,
+    )
+    _register_api_routes(app, api, Request)
+    _mount_spa(app, dist, file_response=FileResponse, json_response=json_response)
     return app

--- a/src/memo/chat/http.py
+++ b/src/memo/chat/http.py
@@ -94,8 +94,60 @@ class _HeavyLease:
         self.released = True
         self.semaphore.release()
 
-    async def release_async(self) -> None:
-        self.release()
+
+class _SessionLockState:
+    def __init__(self) -> None:
+        self.lock = asyncio.Lock()
+        self.users = 0
+
+
+class _SessionLease:
+    """Idempotently release one event-loop-local session lock."""
+
+    def __init__(
+        self,
+        pool: "_SessionLockPool",
+        session_id: str,
+        state: _SessionLockState,
+    ) -> None:
+        self.pool = pool
+        self.session_id = session_id
+        self.state = state
+        self.released = False
+
+    def release(self) -> None:
+        if self.released:
+            return
+        self.released = True
+        self.state.lock.release()
+        self.pool.drop(self.session_id, self.state)
+
+
+class _SessionLockPool:
+    """Serialize work per session without retaining locks for old sessions."""
+
+    def __init__(self) -> None:
+        self.states: dict[str, _SessionLockState] = {}
+
+    async def acquire(self, session_id: str) -> _SessionLease:
+        # Dictionary operations are atomic with respect to other tasks because
+        # this pool is only touched on the owning asyncio event loop.
+        state = self.states.get(session_id)
+        if state is None:
+            state = _SessionLockState()
+            self.states[session_id] = state
+        state.users += 1
+        try:
+            await state.lock.acquire()
+        except BaseException:
+            self.drop(session_id, state)
+            raise
+        return _SessionLease(self, session_id, state)
+
+    def drop(self, session_id: str, state: _SessionLockState) -> None:
+        state.users -= 1
+        if state.users == 0 and self.states.get(session_id) is state:
+            del self.states[session_id]
 
 
 def _spa_response(
@@ -125,7 +177,6 @@ class _ChatApi:
         *,
         json_response: Any,
         streaming_response: Any,
-        background_task: Any,
         run_sync: Any,
     ) -> None:
         self.memory = memory
@@ -133,9 +184,9 @@ class _ChatApi:
         self.sessions = sessions
         self.json_response = json_response
         self.streaming_response = streaming_response
-        self.background_task = background_task
         self.run_sync = run_sync
         self.heavy_slots = asyncio.Semaphore(_MAX_HEAVY_IN_FLIGHT)
+        self.session_locks = _SessionLockPool()
 
     @staticmethod
     async def _json_body(request: Any) -> dict[str, Any] | None:
@@ -192,10 +243,7 @@ class _ChatApi:
     def _append_session(self, session_id: str, question: str, answer: str | None) -> None:
         try:
             if answer is not None:
-                self.sessions.validate_text(answer, "answer")
-            self.sessions.append_turn(session_id, "user", question)
-            if answer is not None:
-                self.sessions.append_turn(session_id, "assistant", answer)
+                self.sessions.append_exchange(session_id, question, answer)
         except ValueError:
             pass
 
@@ -229,7 +277,7 @@ class _ChatApi:
     ) -> Generator[str]:
         from memo.chat.pipeline import chat_stream
 
-        answer = ""
+        answer = None
         for event in chat_stream(self.memory, question, history=history, k=k):
             if event.get("type") in ("context", "done"):
                 event = {**event, "chat_session_id": session_id}
@@ -245,7 +293,6 @@ class _ChatApi:
         session_id: str,
         history: list[dict[str, str]] | None,
         k: int | None,
-        lease: _HeavyLease,
     ) -> Any:
         iterator = self._stream_frames(
             question,
@@ -261,7 +308,6 @@ class _ChatApi:
                 yield frame
         finally:
             iterator.close()
-            lease.release()
 
     async def _reserve_heavy_slot(self) -> _HeavyLease | None:
         if self.heavy_slots.locked():
@@ -284,28 +330,36 @@ class _ChatApi:
             question, k, explicit_history, session_id, given_session_id = self._prepare_ask(body)
         except ValueError:
             return self.json_response({"error": "invalid chat request"}, status_code=400)
-        lease = await self._reserve_heavy_slot()
-        if lease is None:
-            return self._busy_response()
-        response = None
+        session_lease = await self.session_locks.acquire(session_id)
+        heavy_lease = None
         try:
+            heavy_lease = await self._reserve_heavy_slot()
+            if heavy_lease is None:
+                session_lease.release()
+                return self._busy_response()
+            lease = heavy_lease
             history = await self._resolve_history(explicit_history, given_session_id)
-            response = self.streaming_response(
+
+            def finalize() -> None:
+                lease.release()
+                session_lease.release()
+
+            return self.streaming_response(
                 self._stream_frames_async(
                     question,
                     session_id=session_id,
                     history=history,
                     k=k,
-                    lease=lease,
                 ),
                 media_type="text/event-stream",
                 headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-                background=self.background_task(lease.release_async),
+                finalizer=finalize,
             )
-            return response
-        finally:
-            if response is None:
-                lease.release()
+        except BaseException:
+            if heavy_lease is not None:
+                heavy_lease.release()
+            session_lease.release()
+            raise
 
     async def ask(self, request: Any) -> Any:
         body = await self._json_body(request)
@@ -315,10 +369,12 @@ class _ChatApi:
             question, k, explicit_history, session_id, given_session_id = self._prepare_ask(body)
         except ValueError:
             return self.json_response({"error": "invalid chat request"}, status_code=400)
-        lease = await self._reserve_heavy_slot()
-        if lease is None:
-            return self._busy_response()
+        session_lease = await self.session_locks.acquire(session_id)
+        heavy_lease = None
         try:
+            heavy_lease = await self._reserve_heavy_slot()
+            if heavy_lease is None:
+                return self._busy_response()
             history = await self._resolve_history(explicit_history, given_session_id)
             events = await self.run_sync(
                 self._run,
@@ -328,7 +384,9 @@ class _ChatApi:
                 k=k,
             )
         finally:
-            lease.release()
+            if heavy_lease is not None:
+                heavy_lease.release()
+            session_lease.release()
         done = next(
             (event for event in reversed(events) if event.get("type") in {"done", "error"}), None
         )
@@ -445,9 +503,14 @@ class _ChatApi:
         if not isinstance(session_id, str):
             return self.json_response({"error": "invalid session id"}, status_code=400)
         try:
-            return {"ok": await self.run_sync(self.sessions.delete, session_id)}
+            self.sessions.validate_id(session_id)
         except ValueError:
             return self.json_response({"error": "invalid session id"}, status_code=400)
+        session_lease = await self.session_locks.acquire(session_id)
+        try:
+            return {"ok": await self.run_sync(self.sessions.delete, session_id)}
+        finally:
+            session_lease.release()
 
     async def delete_all_sessions(self) -> Any:
         deleted = await self.run_sync(self.sessions.delete_all)
@@ -539,7 +602,7 @@ def _mount_spa(
 
 
 def build_app(memory: Any, *, dist: Path | None = None) -> Any:
-    from fastapi import BackgroundTasks, FastAPI, Request
+    from fastapi import FastAPI, Request
     from fastapi.concurrency import run_in_threadpool
     from fastapi.middleware import Middleware
     from fastapi.responses import FileResponse, Response, StreamingResponse
@@ -555,6 +618,19 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
 
     cfg = ChatConfig.load(memory.cfg.state_dir)
     sessions = SessionStore(cfg.sessions_dir)
+
+    class FinalizingStreamingResponse(StreamingResponse):
+        """Run cleanup for every ASGI exit, including early disconnects."""
+
+        def __init__(self, *args: Any, finalizer: Any, **kwargs: Any) -> None:
+            self._memo_finalizer = finalizer
+            super().__init__(*args, **kwargs)
+
+        async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+            try:
+                await super().__call__(scope, receive, send)
+            finally:
+                self._memo_finalizer()
 
     def json_response(
         content: Any,
@@ -577,11 +653,6 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
             media_type="application/json",
         )
 
-    def background_task(function: Any) -> Any:
-        tasks = BackgroundTasks()
-        tasks.add_task(function)
-        return tasks
-
     # Chat has no bearer-token flow: constrain it to same-origin loopback HTTP,
     # reject DNS-rebinding/cross-site requests, and bound local request pressure.
     # `memo chat serve` independently rejects non-loopback bind addresses so the
@@ -592,8 +663,8 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
         redoc_url=None,
         middleware=[
             Middleware(SecurityHeadersMiddleware, headers=_CHAT_SECURITY_HEADERS),
-            Middleware(RateLimitMiddleware),
             Middleware(LocalRequestGuardMiddleware),
+            Middleware(RateLimitMiddleware),
             Middleware(RequestSizeLimitMiddleware),
         ],
     )
@@ -602,8 +673,7 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
         cfg,
         sessions,
         json_response=json_response,
-        streaming_response=StreamingResponse,
-        background_task=background_task,
+        streaming_response=FinalizingStreamingResponse,
         run_sync=run_in_threadpool,
     )
     _register_api_routes(app, api, Request)

--- a/src/memo/chat/http.py
+++ b/src/memo/chat/http.py
@@ -172,6 +172,7 @@ class _OperationGate:
         self.readers = 0
         self.writer = False
         self.waiting_writers = 0
+        self.generation = 0
         self.changed = asyncio.Event()
 
     def _wake(self) -> None:
@@ -194,6 +195,9 @@ class _OperationGate:
                 changed = self.changed
                 await changed.wait()
             self.writer = True
+            # Requests that entered before a destructive reset must not recreate
+            # session files after the reset finishes.
+            self.generation += 1
             acquired = True
             return _OperationLease(self, exclusive=True)
         finally:
@@ -324,9 +328,6 @@ class _ChatApi:
             if event.get("type") in ("context", "done"):
                 event = {**event, "chat_session_id": session_id}
             events.append(event)
-        done = next((event for event in events if event.get("type") == "done"), None)
-        answer = str(done.get("answer", "")) if done else None
-        self._append_session(session_id, question, answer)
         return events
 
     def _stream_frames(
@@ -336,6 +337,7 @@ class _ChatApi:
         session_id: str,
         history: list[dict[str, str]] | None,
         k: int | None,
+        persist: bool,
     ) -> Generator[str]:
         from memo.chat.pipeline import chat_stream
 
@@ -346,7 +348,8 @@ class _ChatApi:
             if event.get("type") == "done":
                 answer = str(event.get("answer", ""))
             yield f"data: {json.dumps(event, ensure_ascii=True)}\n\n"
-        self._append_session(session_id, question, answer)
+        if persist:
+            self._append_session(session_id, question, answer)
 
     async def _stream_frames_async(
         self,
@@ -355,12 +358,14 @@ class _ChatApi:
         session_id: str,
         history: list[dict[str, str]] | None,
         k: int | None,
+        persist: bool,
     ) -> Any:
         iterator = self._stream_frames(
             question,
             session_id=session_id,
             history=history,
             k=k,
+            persist=persist,
         )
         try:
             while True:
@@ -392,19 +397,22 @@ class _ChatApi:
             question, k, explicit_history, session_id, given_session_id = self._prepare_ask(body)
         except ValueError:
             return self.json_response({"error": "invalid chat request"}, status_code=400)
-        operation_lease = await self.operation_gate.acquire_shared()
+        generation = self.operation_gate.generation
         session_lease = None
+        operation_lease = None
         heavy_lease = None
 
         def release_all() -> None:
             if heavy_lease is not None:
                 heavy_lease.release()
+            if operation_lease is not None:
+                operation_lease.release()
             if session_lease is not None:
                 session_lease.release()
-            operation_lease.release()
 
         try:
             session_lease = await self.session_locks.acquire(session_id)
+            operation_lease = await self.operation_gate.acquire_shared()
             heavy_lease = await self._reserve_heavy_slot()
             if heavy_lease is None:
                 release_all()
@@ -417,6 +425,7 @@ class _ChatApi:
                     session_id=session_id,
                     history=history,
                     k=k,
+                    persist=generation == self.operation_gate.generation,
                 ),
                 media_type="text/event-stream",
                 headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
@@ -434,11 +443,13 @@ class _ChatApi:
             question, k, explicit_history, session_id, given_session_id = self._prepare_ask(body)
         except ValueError:
             return self.json_response({"error": "invalid chat request"}, status_code=400)
-        operation_lease = await self.operation_gate.acquire_shared()
+        generation = self.operation_gate.generation
         session_lease = None
+        operation_lease = None
         heavy_lease = None
         try:
             session_lease = await self.session_locks.acquire(session_id)
+            operation_lease = await self.operation_gate.acquire_shared()
             heavy_lease = await self._reserve_heavy_slot()
             if heavy_lease is None:
                 return self._busy_response()
@@ -450,12 +461,17 @@ class _ChatApi:
                 history=history,
                 k=k,
             )
+            if generation == self.operation_gate.generation:
+                done = next((event for event in events if event.get("type") == "done"), None)
+                answer = str(done.get("answer", "")) if done else None
+                await self.run_sync(self._append_session, session_id, question, answer)
         finally:
             if heavy_lease is not None:
                 heavy_lease.release()
+            if operation_lease is not None:
+                operation_lease.release()
             if session_lease is not None:
                 session_lease.release()
-            operation_lease.release()
         done = next(
             (event for event in reversed(events) if event.get("type") in {"done", "error"}), None
         )
@@ -549,9 +565,20 @@ class _ChatApi:
         from memo.chat.sessions import iso_ts
 
         try:
-            turns = await self.run_sync(self.sessions.get, session_id)
+            self.sessions.validate_id(session_id)
         except ValueError:
             return self.json_response({"error": "invalid session id"}, status_code=400)
+        session_lease = None
+        operation_lease = None
+        try:
+            session_lease = await self.session_locks.acquire(session_id)
+            operation_lease = await self.operation_gate.acquire_shared()
+            turns = await self.run_sync(self.sessions.get, session_id)
+        finally:
+            if operation_lease is not None:
+                operation_lease.release()
+            if session_lease is not None:
+                session_lease.release()
         return {
             "session_id": session_id,
             "turns": [
@@ -575,15 +602,17 @@ class _ChatApi:
             self.sessions.validate_id(session_id)
         except ValueError:
             return self.json_response({"error": "invalid session id"}, status_code=400)
-        operation_lease = await self.operation_gate.acquire_shared()
         session_lease = None
+        operation_lease = None
         try:
             session_lease = await self.session_locks.acquire(session_id)
+            operation_lease = await self.operation_gate.acquire_shared()
             return {"ok": await self.run_sync(self.sessions.delete, session_id)}
         finally:
+            if operation_lease is not None:
+                operation_lease.release()
             if session_lease is not None:
                 session_lease.release()
-            operation_lease.release()
 
     async def delete_all_sessions(self) -> Any:
         operation_lease = await self.operation_gate.acquire_exclusive()

--- a/src/memo/chat/http.py
+++ b/src/memo/chat/http.py
@@ -41,6 +41,7 @@ def _spa_response(
 def build_app(memory: Any, *, dist: Path | None = None) -> Any:
     from fastapi import FastAPI, Request
     from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
+    from starlette.middleware import Middleware
 
     from memo.chat.config import ChatConfig
     from memo.chat.feedback import (
@@ -52,10 +53,28 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
     )
     from memo.chat.pipeline import chat_stream
     from memo.chat.sessions import SessionStore, iso_ts
+    from memo.http_auth import (
+        LocalRequestGuardMiddleware,
+        RateLimitMiddleware,
+        RequestSizeLimitMiddleware,
+    )
 
     cfg = ChatConfig.load(memory.cfg.state_dir)
     sessions = SessionStore(cfg.sessions_dir)
-    app = FastAPI(title="memo chat", docs_url=None, redoc_url=None)
+    # Chat has no bearer-token flow: constrain it to same-origin loopback HTTP,
+    # reject DNS-rebinding/cross-site requests, and bound local request pressure.
+    # `memo chat serve` independently rejects non-loopback bind addresses so the
+    # network policy remains safe even before the first request reaches ASGI.
+    app = FastAPI(
+        title="memo chat",
+        docs_url=None,
+        redoc_url=None,
+        middleware=[
+            Middleware(RateLimitMiddleware),
+            Middleware(LocalRequestGuardMiddleware),
+            Middleware(RequestSizeLimitMiddleware),
+        ],
+    )
 
     async def _json_body(request: Request) -> dict[str, Any] | None:
         try:
@@ -73,13 +92,48 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
             return None
         return [{"role": t.get("role", ""), "content": t.get("text", "")} for t in turns][-12:]
 
-    def _run(body: dict[str, Any]) -> list[dict[str, Any]]:
-        question = str(body.get("q") or "").strip()
-        given_session_id = body.get("chat_session_id") or None
+    def requested_session_id(body: dict[str, Any]) -> str | None:
+        """Validate an optional caller-owned id before doing retrieval work."""
+        raw = body.get("chat_session_id")
+        if raw is None or raw == "":
+            return None
+        if not isinstance(raw, str):
+            raise ValueError("invalid chat_session_id")
+        # SessionStore owns the path-safe id grammar. Reading here validates it
+        # without duplicating that security boundary in the HTTP layer.
+        try:
+            sessions.get(raw)
+        except ValueError as exc:
+            raise ValueError("invalid chat_session_id") from exc
+        return raw
+
+    def request_inputs(
+        body: dict[str, Any],
+    ) -> tuple[str, int | None, list[dict[str, str]] | None]:
+        """Validate the untyped JSON surface before it reaches retrieval."""
+        raw_question = body.get("q")
+        if not isinstance(raw_question, str) or not raw_question.strip():
+            raise ValueError("q required and must be a string")
+        if len(raw_question) > 4096:
+            raise ValueError("q must be at most 4096 characters")
+        raw_k = body.get("k")
+        if raw_k is not None and (type(raw_k) is not int or not 1 <= raw_k <= 100):
+            raise ValueError("k must be an integer between 1 and 100")
+        raw_history = body.get("history")
+        if raw_history is not None and not isinstance(raw_history, list):
+            raise ValueError("history must be a list")
+        return raw_question.strip(), raw_k, _normalize_history(raw_history)
+
+    def _run(
+        question: str,
+        *,
+        given_session_id: str | None,
+        history: list[dict[str, str]] | None,
+        k: int | None,
+    ) -> list[dict[str, Any]]:
         session_id = given_session_id or uuid.uuid4().hex[:12]
-        history = _normalize_history(body.get("history")) or sessions_history(given_session_id)
         events = []
-        for event in chat_stream(memory, question, history=history, k=body.get("k") or None):
+        for event in chat_stream(memory, question, history=history, k=k):
             if event.get("type") in ("context", "done"):
                 event = {**event, "chat_session_id": session_id}
             events.append(event)
@@ -97,16 +151,17 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
         body = await _json_body(request)
         if body is None:
             return JSONResponse({"error": "invalid JSON body"}, status_code=400)
-        question = str(body.get("q") or "").strip()
-        if not question:
-            return JSONResponse({"error": "q required"}, status_code=400)
-        given_session_id = body.get("chat_session_id") or None
+        try:
+            question, k, explicit_history = request_inputs(body)
+            given_session_id = requested_session_id(body)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
         session_id = given_session_id or uuid.uuid4().hex[:12]
-        history = _normalize_history(body.get("history")) or sessions_history(given_session_id)
+        history = explicit_history or sessions_history(given_session_id)
 
         def _generate() -> Any:
             answer = ""
-            for event in chat_stream(memory, question, history=history, k=body.get("k") or None):
+            for event in chat_stream(memory, question, history=history, k=k):
                 if event.get("type") in ("context", "done"):
                     event = {**event, "chat_session_id": session_id}
                 if event.get("type") == "done":
@@ -129,9 +184,18 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
         body = await _json_body(request)
         if body is None:
             return JSONResponse({"error": "invalid JSON body"}, status_code=400)
-        if not str(body.get("q") or "").strip():
-            return JSONResponse({"error": "q required"}, status_code=400)
-        events = _run(body)
+        try:
+            question, k, explicit_history = request_inputs(body)
+            given_session_id = requested_session_id(body)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        history = explicit_history or sessions_history(given_session_id)
+        events = _run(
+            question,
+            given_session_id=given_session_id,
+            history=history,
+            k=k,
+        )
         done = next((e for e in reversed(events) if e.get("type") in {"done", "error"}), None)
         return JSONResponse(done or {"type": "error", "message": "no events"})
 
@@ -140,6 +204,12 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
         body = await _json_body(request)
         if body is None:
             return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+        sources = body.get("sources", [])
+        rating = body.get("rating")
+        if not isinstance(sources, list):
+            return JSONResponse({"error": "sources must be a list"}, status_code=400)
+        if rating not in {"up", "down"}:
+            return JSONResponse({"error": "rating must be 'up' or 'down'"}, status_code=400)
         fb = ChatFeedback(
             feedback_id=uuid.uuid4().hex[:12],
             created_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
@@ -147,8 +217,10 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
             turn_id=str(body.get("turn_id") or ""),
             query=str(body.get("query") or ""),
             answer=str(body.get("answer") or ""),
-            source_ids=[str(s.get("id")) for s in body.get("sources") or [] if isinstance(s, dict)],
-            rating=str(body.get("rating") or ""),
+            source_ids=[
+                s["id"] for s in sources if isinstance(s, dict) and isinstance(s.get("id"), str)
+            ],
+            rating=rating,
             correction_text=str(body.get("correction_text") or ""),
         )
         FeedbackStore(cfg.feedback_dir).append(fb)
@@ -159,17 +231,28 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
         body = await _json_body(request)
         if body is None:
             return JSONResponse({"error": "invalid JSON body"}, status_code=400)
-        query = str(body.get("query") or "")
+        query = body.get("query")
+        source_id = body.get("source_id")
+        rating = body.get("rating")
+        if not isinstance(query, str) or not query.strip() or len(query) > 4096:
+            return JSONResponse(
+                {"error": "query required as a string of at most 4096 characters"},
+                status_code=400,
+            )
+        if not isinstance(source_id, str) or not source_id:
+            return JSONResponse({"error": "source_id required as a string"}, status_code=400)
+        if rating not in {"up", "down"}:
+            return JSONResponse({"error": "rating must be 'up' or 'down'"}, status_code=400)
         try:
-            embedding = memory.embedder.embed_query(query) if query else []
+            embedding = memory.embedder.embed_query(query)
         except Exception:
             embedding = []
         vote = SourceVote(
             created_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
             question_key=question_key(query),
             query=query,
-            source_id=str(body.get("source_id") or ""),
-            rating=str(body.get("rating") or ""),
+            source_id=source_id,
+            rating=rating,
             query_embedding=list(embedding),
         )
         SourceVoteStore(cfg.feedback_dir).record(vote)

--- a/src/memo/chat/http.py
+++ b/src/memo/chat/http.py
@@ -150,6 +150,67 @@ class _SessionLockPool:
             del self.states[session_id]
 
 
+class _OperationLease:
+    """Idempotently release a shared or exclusive operation gate lease."""
+
+    def __init__(self, gate: "_OperationGate", *, exclusive: bool) -> None:
+        self.gate = gate
+        self.exclusive = exclusive
+        self.released = False
+
+    def release(self) -> None:
+        if self.released:
+            return
+        self.released = True
+        self.gate.release(exclusive=self.exclusive)
+
+
+class _OperationGate:
+    """Fair event-loop-local reader/writer gate for session mutations."""
+
+    def __init__(self) -> None:
+        self.readers = 0
+        self.writer = False
+        self.waiting_writers = 0
+        self.changed = asyncio.Event()
+
+    def _wake(self) -> None:
+        previous = self.changed
+        self.changed = asyncio.Event()
+        previous.set()
+
+    async def acquire_shared(self) -> _OperationLease:
+        while self.writer or self.waiting_writers:
+            changed = self.changed
+            await changed.wait()
+        self.readers += 1
+        return _OperationLease(self, exclusive=False)
+
+    async def acquire_exclusive(self) -> _OperationLease:
+        self.waiting_writers += 1
+        acquired = False
+        try:
+            while self.writer or self.readers:
+                changed = self.changed
+                await changed.wait()
+            self.writer = True
+            acquired = True
+            return _OperationLease(self, exclusive=True)
+        finally:
+            self.waiting_writers -= 1
+            if not acquired and not self.writer and self.waiting_writers == 0:
+                self._wake()
+
+    def release(self, *, exclusive: bool) -> None:
+        if exclusive:
+            self.writer = False
+            self._wake()
+            return
+        self.readers -= 1
+        if self.readers == 0:
+            self._wake()
+
+
 def _spa_response(
     path: str,
     *,
@@ -187,6 +248,7 @@ class _ChatApi:
         self.run_sync = run_sync
         self.heavy_slots = asyncio.Semaphore(_MAX_HEAVY_IN_FLIGHT)
         self.session_locks = _SessionLockPool()
+        self.operation_gate = _OperationGate()
 
     @staticmethod
     async def _json_body(request: Any) -> dict[str, Any] | None:
@@ -330,19 +392,24 @@ class _ChatApi:
             question, k, explicit_history, session_id, given_session_id = self._prepare_ask(body)
         except ValueError:
             return self.json_response({"error": "invalid chat request"}, status_code=400)
-        session_lease = await self.session_locks.acquire(session_id)
+        operation_lease = await self.operation_gate.acquire_shared()
+        session_lease = None
         heavy_lease = None
+
+        def release_all() -> None:
+            if heavy_lease is not None:
+                heavy_lease.release()
+            if session_lease is not None:
+                session_lease.release()
+            operation_lease.release()
+
         try:
+            session_lease = await self.session_locks.acquire(session_id)
             heavy_lease = await self._reserve_heavy_slot()
             if heavy_lease is None:
-                session_lease.release()
+                release_all()
                 return self._busy_response()
-            lease = heavy_lease
             history = await self._resolve_history(explicit_history, given_session_id)
-
-            def finalize() -> None:
-                lease.release()
-                session_lease.release()
 
             return self.streaming_response(
                 self._stream_frames_async(
@@ -353,12 +420,10 @@ class _ChatApi:
                 ),
                 media_type="text/event-stream",
                 headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-                finalizer=finalize,
+                finalizer=release_all,
             )
         except BaseException:
-            if heavy_lease is not None:
-                heavy_lease.release()
-            session_lease.release()
+            release_all()
             raise
 
     async def ask(self, request: Any) -> Any:
@@ -369,9 +434,11 @@ class _ChatApi:
             question, k, explicit_history, session_id, given_session_id = self._prepare_ask(body)
         except ValueError:
             return self.json_response({"error": "invalid chat request"}, status_code=400)
-        session_lease = await self.session_locks.acquire(session_id)
+        operation_lease = await self.operation_gate.acquire_shared()
+        session_lease = None
         heavy_lease = None
         try:
+            session_lease = await self.session_locks.acquire(session_id)
             heavy_lease = await self._reserve_heavy_slot()
             if heavy_lease is None:
                 return self._busy_response()
@@ -386,7 +453,9 @@ class _ChatApi:
         finally:
             if heavy_lease is not None:
                 heavy_lease.release()
-            session_lease.release()
+            if session_lease is not None:
+                session_lease.release()
+            operation_lease.release()
         done = next(
             (event for event in reversed(events) if event.get("type") in {"done", "error"}), None
         )
@@ -506,15 +575,23 @@ class _ChatApi:
             self.sessions.validate_id(session_id)
         except ValueError:
             return self.json_response({"error": "invalid session id"}, status_code=400)
-        session_lease = await self.session_locks.acquire(session_id)
+        operation_lease = await self.operation_gate.acquire_shared()
+        session_lease = None
         try:
+            session_lease = await self.session_locks.acquire(session_id)
             return {"ok": await self.run_sync(self.sessions.delete, session_id)}
         finally:
-            session_lease.release()
+            if session_lease is not None:
+                session_lease.release()
+            operation_lease.release()
 
     async def delete_all_sessions(self) -> Any:
-        deleted = await self.run_sync(self.sessions.delete_all)
-        return {"ok": True, "deleted": deleted}
+        operation_lease = await self.operation_gate.acquire_exclusive()
+        try:
+            deleted = await self.run_sync(self.sessions.delete_all)
+            return {"ok": True, "deleted": deleted}
+        finally:
+            operation_lease.release()
 
     async def suggestions(self, limit: int = 8) -> Any:
         if not 1 <= limit <= 100:

--- a/src/memo/chat/http.py
+++ b/src/memo/chat/http.py
@@ -3,8 +3,25 @@
 import json
 import time
 import uuid
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
+
+from starlette.requests import Request
+from starlette.responses import FileResponse, JSONResponse, StreamingResponse
+
+_CHAT_SECURITY_HEADERS = {
+    "Cache-Control": "no-store",
+    "Content-Security-Policy": (
+        "default-src 'self'; script-src 'self'; "
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+        "font-src 'self' https://fonts.gstatic.com; connect-src 'self'; "
+        "img-src 'self' data:; frame-ancestors 'none'; base-uri 'none'; object-src 'none'"
+    ),
+    "Referrer-Policy": "no-referrer",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+}
 
 
 def _normalize_history(history: Any) -> list[dict[str, str]] | None:
@@ -26,56 +43,25 @@ def _spa_response(
     path: str,
     *,
     dist: Path,
-    file_response: Any,
-    json_response: Any,
 ) -> Any:
     """Serve one SPA path while keeping unknown API routes as JSON 404s."""
     if path == "api" or path.startswith("api/"):
-        return json_response({"error": "unknown API route"}, status_code=404)
+        return JSONResponse({"error": "unknown API route"}, status_code=404)
     candidate = (dist / path).resolve()
     if path and candidate.is_file() and candidate.is_relative_to(dist.resolve()):
-        return file_response(candidate)
-    return file_response(dist / "index.html")
+        return FileResponse(candidate)
+    return FileResponse(dist / "index.html")
 
 
-def build_app(memory: Any, *, dist: Path | None = None) -> Any:
-    from fastapi import FastAPI, Request
-    from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
-    from starlette.middleware import Middleware
+class _ChatApi:
+    """Bound chat HTTP handlers, split from app wiring for auditable contracts."""
 
-    from memo.chat.config import ChatConfig
-    from memo.chat.feedback import (
-        ChatFeedback,
-        FeedbackStore,
-        SourceVote,
-        SourceVoteStore,
-        question_key,
-    )
-    from memo.chat.pipeline import chat_stream
-    from memo.chat.sessions import SessionStore, iso_ts
-    from memo.http_auth import (
-        LocalRequestGuardMiddleware,
-        RateLimitMiddleware,
-        RequestSizeLimitMiddleware,
-    )
+    def __init__(self, memory: Any, cfg: Any, sessions: Any) -> None:
+        self.memory = memory
+        self.cfg = cfg
+        self.sessions = sessions
 
-    cfg = ChatConfig.load(memory.cfg.state_dir)
-    sessions = SessionStore(cfg.sessions_dir)
-    # Chat has no bearer-token flow: constrain it to same-origin loopback HTTP,
-    # reject DNS-rebinding/cross-site requests, and bound local request pressure.
-    # `memo chat serve` independently rejects non-loopback bind addresses so the
-    # network policy remains safe even before the first request reaches ASGI.
-    app = FastAPI(
-        title="memo chat",
-        docs_url=None,
-        redoc_url=None,
-        middleware=[
-            Middleware(RateLimitMiddleware),
-            Middleware(LocalRequestGuardMiddleware),
-            Middleware(RequestSizeLimitMiddleware),
-        ],
-    )
-
+    @staticmethod
     async def _json_body(request: Request) -> dict[str, Any] | None:
         try:
             body = await request.json()
@@ -83,34 +69,31 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
             return None
         return body if isinstance(body, dict) else None
 
-    def sessions_history(session_id: str | None) -> list[dict[str, str]] | None:
+    def _sessions_history(self, session_id: str | None) -> list[dict[str, str]] | None:
         if not session_id:
             return None
         try:
-            turns = sessions.get(session_id)
+            turns = self.sessions.get(session_id)
         except ValueError:
             return None
         return [{"role": t.get("role", ""), "content": t.get("text", "")} for t in turns][-12:]
 
-    def requested_session_id(body: dict[str, Any]) -> str | None:
-        """Validate an optional caller-owned id before doing retrieval work."""
+    def _requested_session_id(self, body: dict[str, Any]) -> str | None:
         raw = body.get("chat_session_id")
         if raw is None or raw == "":
             return None
         if not isinstance(raw, str):
             raise ValueError("invalid chat_session_id")
-        # SessionStore owns the path-safe id grammar. Reading here validates it
-        # without duplicating that security boundary in the HTTP layer.
         try:
-            sessions.get(raw)
+            self.sessions.get(raw)
         except ValueError as exc:
             raise ValueError("invalid chat_session_id") from exc
         return raw
 
-    def request_inputs(
+    @staticmethod
+    def _request_inputs(
         body: dict[str, Any],
     ) -> tuple[str, int | None, list[dict[str, str]] | None]:
-        """Validate the untyped JSON surface before it reaches retrieval."""
         raw_question = body.get("q")
         if not isinstance(raw_question, str) or not raw_question.strip():
             raise ValueError("q required and must be a string")
@@ -124,84 +107,103 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
             raise ValueError("history must be a list")
         return raw_question.strip(), raw_k, _normalize_history(raw_history)
 
+    def _prepare_ask(
+        self,
+        body: dict[str, Any],
+    ) -> tuple[str, int | None, list[dict[str, str]] | None, str]:
+        question, k, explicit_history = self._request_inputs(body)
+        given_session_id = self._requested_session_id(body)
+        session_id = given_session_id or uuid.uuid4().hex[:12]
+        history = explicit_history or self._sessions_history(given_session_id)
+        return question, k, history, session_id
+
+    def _append_session(self, session_id: str, question: str, answer: str | None) -> None:
+        try:
+            self.sessions.append_turn(session_id, "user", question)
+            if answer is not None:
+                self.sessions.append_turn(session_id, "assistant", answer)
+        except ValueError:
+            pass
+
     def _run(
+        self,
         question: str,
         *,
-        given_session_id: str | None,
+        session_id: str,
         history: list[dict[str, str]] | None,
         k: int | None,
     ) -> list[dict[str, Any]]:
-        session_id = given_session_id or uuid.uuid4().hex[:12]
+        from memo.chat.pipeline import chat_stream
+
         events = []
-        for event in chat_stream(memory, question, history=history, k=k):
+        for event in chat_stream(self.memory, question, history=history, k=k):
             if event.get("type") in ("context", "done"):
                 event = {**event, "chat_session_id": session_id}
             events.append(event)
-        done = next((e for e in events if e.get("type") == "done"), None)
-        try:
-            sessions.append_turn(session_id, "user", question)
-            if done:
-                sessions.append_turn(session_id, "assistant", str(done.get("answer", "")))
-        except ValueError:
-            pass
+        done = next((event for event in events if event.get("type") == "done"), None)
+        answer = str(done.get("answer", "")) if done else None
+        self._append_session(session_id, question, answer)
         return events
 
-    @app.post("/api/ask/stream")
-    async def ask_stream(request: Request) -> Any:
-        body = await _json_body(request)
+    def _stream_frames(
+        self,
+        question: str,
+        *,
+        session_id: str,
+        history: list[dict[str, str]] | None,
+        k: int | None,
+    ) -> Iterator[str]:
+        from memo.chat.pipeline import chat_stream
+
+        answer = ""
+        for event in chat_stream(self.memory, question, history=history, k=k):
+            if event.get("type") in ("context", "done"):
+                event = {**event, "chat_session_id": session_id}
+            if event.get("type") == "done":
+                answer = str(event.get("answer", ""))
+            yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
+        self._append_session(session_id, question, answer)
+
+    async def ask_stream(self, request: Request) -> Any:
+        body = await self._json_body(request)
         if body is None:
             return JSONResponse({"error": "invalid JSON body"}, status_code=400)
         try:
-            question, k, explicit_history = request_inputs(body)
-            given_session_id = requested_session_id(body)
+            question, k, history, session_id = self._prepare_ask(body)
         except ValueError as exc:
             return JSONResponse({"error": str(exc)}, status_code=400)
-        session_id = given_session_id or uuid.uuid4().hex[:12]
-        history = explicit_history or sessions_history(given_session_id)
-
-        def _generate() -> Any:
-            answer = ""
-            for event in chat_stream(memory, question, history=history, k=k):
-                if event.get("type") in ("context", "done"):
-                    event = {**event, "chat_session_id": session_id}
-                if event.get("type") == "done":
-                    answer = str(event.get("answer", ""))
-                yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
-            try:
-                sessions.append_turn(session_id, "user", question)
-                sessions.append_turn(session_id, "assistant", answer)
-            except ValueError:
-                pass
-
         return StreamingResponse(
-            _generate(),
+            self._stream_frames(
+                question,
+                session_id=session_id,
+                history=history,
+                k=k,
+            ),
             media_type="text/event-stream",
             headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
         )
 
-    @app.post("/api/ask")
-    async def ask(request: Request) -> Any:
-        body = await _json_body(request)
+    async def ask(self, request: Request) -> Any:
+        body = await self._json_body(request)
         if body is None:
             return JSONResponse({"error": "invalid JSON body"}, status_code=400)
         try:
-            question, k, explicit_history = request_inputs(body)
-            given_session_id = requested_session_id(body)
+            question, k, history, session_id = self._prepare_ask(body)
         except ValueError as exc:
             return JSONResponse({"error": str(exc)}, status_code=400)
-        history = explicit_history or sessions_history(given_session_id)
-        events = _run(
+        events = self._run(
             question,
-            given_session_id=given_session_id,
+            session_id=session_id,
             history=history,
             k=k,
         )
-        done = next((e for e in reversed(events) if e.get("type") in {"done", "error"}), None)
+        done = next((event for event in reversed(events) if event.get("type") in {"done", "error"}), None)
         return JSONResponse(done or {"type": "error", "message": "no events"})
 
-    @app.post("/api/feedback")
-    async def feedback(request: Request) -> Any:
-        body = await _json_body(request)
+    async def feedback(self, request: Request) -> Any:
+        from memo.chat.feedback import ChatFeedback, FeedbackStore
+
+        body = await self._json_body(request)
         if body is None:
             return JSONResponse({"error": "invalid JSON body"}, status_code=400)
         sources = body.get("sources", [])
@@ -210,7 +212,7 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
             return JSONResponse({"error": "sources must be a list"}, status_code=400)
         if rating not in {"up", "down"}:
             return JSONResponse({"error": "rating must be 'up' or 'down'"}, status_code=400)
-        fb = ChatFeedback(
+        feedback = ChatFeedback(
             feedback_id=uuid.uuid4().hex[:12],
             created_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
             chat_session_id=str(body.get("chat_session_id") or ""),
@@ -218,17 +220,20 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
             query=str(body.get("query") or ""),
             answer=str(body.get("answer") or ""),
             source_ids=[
-                s["id"] for s in sources if isinstance(s, dict) and isinstance(s.get("id"), str)
+                source["id"]
+                for source in sources
+                if isinstance(source, dict) and isinstance(source.get("id"), str)
             ],
             rating=rating,
             correction_text=str(body.get("correction_text") or ""),
         )
-        FeedbackStore(cfg.feedback_dir).append(fb)
-        return {"ok": True, "feedback_id": fb.feedback_id}
+        FeedbackStore(self.cfg.feedback_dir).append(feedback)
+        return {"ok": True, "feedback_id": feedback.feedback_id}
 
-    @app.post("/api/feedback/source")
-    async def feedback_source(request: Request) -> Any:
-        body = await _json_body(request)
+    async def feedback_source(self, request: Request) -> Any:
+        from memo.chat.feedback import SourceVote, SourceVoteStore, question_key
+
+        body = await self._json_body(request)
         if body is None:
             return JSONResponse({"error": "invalid JSON body"}, status_code=400)
         query = body.get("query")
@@ -244,7 +249,7 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
         if rating not in {"up", "down"}:
             return JSONResponse({"error": "rating must be 'up' or 'down'"}, status_code=400)
         try:
-            embedding = memory.embedder.embed_query(query)
+            embedding = self.memory.embedder.embed_query(query)
         except Exception:
             embedding = []
         vote = SourceVote(
@@ -255,70 +260,117 @@ def build_app(memory: Any, *, dist: Path | None = None) -> Any:
             rating=rating,
             query_embedding=list(embedding),
         )
-        SourceVoteStore(cfg.feedback_dir).record(vote)
+        SourceVoteStore(self.cfg.feedback_dir).record(vote)
         return {"ok": True}
 
-    @app.get("/api/sessions")
-    async def list_sessions(limit: int = 50) -> Any:
-        return {"sessions": sessions.list_sessions(limit=limit)}
+    async def list_sessions(self, limit: int = 50) -> Any:
+        return {"sessions": self.sessions.list_sessions(limit=limit)}
 
-    @app.get("/api/sessions/{session_id}")
-    async def get_session(session_id: str) -> Any:
+    async def get_session(self, session_id: str) -> Any:
+        from memo.chat.sessions import iso_ts
+
         try:
-            turns = sessions.get(session_id)
+            turns = self.sessions.get(session_id)
         except ValueError:
             return JSONResponse({"error": "invalid session id"}, status_code=400)
         return {
             "session_id": session_id,
             "turns": [
                 {
-                    "role": t.get("role", ""),
-                    "text": t.get("text", ""),
-                    "at": iso_ts(t["ts"]) if t.get("ts") is not None else None,
+                    "role": turn.get("role", ""),
+                    "text": turn.get("text", ""),
+                    "at": iso_ts(turn["ts"]) if turn.get("ts") is not None else None,
                 }
-                for t in turns
+                for turn in turns
             ],
         }
 
-    @app.post("/api/sessions/delete")
-    async def delete_session(request: Request) -> Any:
-        body = await _json_body(request)
+    async def delete_session(self, request: Request) -> Any:
+        body = await self._json_body(request)
         if body is None:
             return JSONResponse({"error": "invalid JSON body"}, status_code=400)
         try:
-            return {"ok": sessions.delete(str(body.get("session_id") or ""))}
+            return {"ok": self.sessions.delete(str(body.get("session_id") or ""))}
         except ValueError:
             return JSONResponse({"error": "invalid session id"}, status_code=400)
 
-    @app.post("/api/sessions/delete-all")
-    async def delete_all_sessions() -> Any:
-        return {"ok": True, "deleted": sessions.delete_all()}
+    async def delete_all_sessions(self) -> Any:
+        return {"ok": True, "deleted": self.sessions.delete_all()}
 
-    @app.get("/api/suggestions")
-    async def suggestions(limit: int = 8) -> Any:
-        chips = [{"label": q, "query": q} for q in sessions.recent_queries(limit=limit)]
+    async def suggestions(self, limit: int = 8) -> Any:
+        chips = [{"label": query, "query": query} for query in self.sessions.recent_queries(limit=limit)]
         return {"chips": chips}
 
-    @app.post("/api/memory/delete")
+    @staticmethod
     async def memory_delete() -> Any:
         return JSONResponse({"error": "deferred to plan 2"}, status_code=501)
 
-    @app.post("/api/insight/capture")
+    @staticmethod
     async def insight_capture() -> Any:
         return JSONResponse({"error": "deferred to plan 2"}, status_code=501)
 
-    if dist is not None and (dist / "index.html").exists():
-        from fastapi.staticfiles import StaticFiles
 
-        app.mount("/assets", StaticFiles(directory=dist / "assets"), name="assets")
+def _register_api_routes(app: Any, api: _ChatApi) -> None:
+    app.add_api_route("/api/ask/stream", api.ask_stream, methods=["POST"])
+    app.add_api_route("/api/ask", api.ask, methods=["POST"])
+    app.add_api_route("/api/feedback", api.feedback, methods=["POST"])
+    app.add_api_route("/api/feedback/source", api.feedback_source, methods=["POST"])
+    app.add_api_route("/api/sessions", api.list_sessions, methods=["GET"])
+    app.add_api_route("/api/sessions/{session_id}", api.get_session, methods=["GET"])
+    app.add_api_route("/api/sessions/delete", api.delete_session, methods=["POST"])
+    app.add_api_route("/api/sessions/delete-all", api.delete_all_sessions, methods=["POST"])
+    app.add_api_route("/api/suggestions", api.suggestions, methods=["GET"])
+    app.add_api_route("/api/memory/delete", api.memory_delete, methods=["POST"])
+    app.add_api_route("/api/insight/capture", api.insight_capture, methods=["POST"])
 
-        @app.get("/{path:path}")
-        async def spa(path: str) -> Any:
-            return _spa_response(
-                path,
-                dist=dist,
-                file_response=FileResponse,
-                json_response=JSONResponse,
-            )
 
+class _SpaEndpoint:
+    def __init__(self, dist: Path) -> None:
+        self.dist = dist
+
+    async def __call__(self, path: str) -> Any:
+        return _spa_response(path, dist=self.dist)
+
+
+def _mount_spa(app: Any, dist: Path | None) -> None:
+    if dist is None or not (dist / "index.html").exists():
+        return
+    from fastapi.staticfiles import StaticFiles
+
+    app.mount("/assets", StaticFiles(directory=dist / "assets"), name="assets")
+    app.add_api_route("/{path:path}", _SpaEndpoint(dist), methods=["GET"])
+
+
+def build_app(memory: Any, *, dist: Path | None = None) -> Any:
+    from fastapi import FastAPI
+    from starlette.middleware import Middleware
+
+    from memo.chat.config import ChatConfig
+    from memo.chat.sessions import SessionStore
+    from memo.http_auth import (
+        LocalRequestGuardMiddleware,
+        RateLimitMiddleware,
+        RequestSizeLimitMiddleware,
+        SecurityHeadersMiddleware,
+    )
+
+    cfg = ChatConfig.load(memory.cfg.state_dir)
+    sessions = SessionStore(cfg.sessions_dir)
+    # Chat has no bearer-token flow: constrain it to same-origin loopback HTTP,
+    # reject DNS-rebinding/cross-site requests, and bound local request pressure.
+    # `memo chat serve` independently rejects non-loopback bind addresses so the
+    # network policy remains safe even before the first request reaches ASGI.
+    app = FastAPI(
+        title="memo chat",
+        docs_url=None,
+        redoc_url=None,
+        middleware=[
+            Middleware(SecurityHeadersMiddleware, headers=_CHAT_SECURITY_HEADERS),
+            Middleware(RateLimitMiddleware),
+            Middleware(LocalRequestGuardMiddleware),
+            Middleware(RequestSizeLimitMiddleware),
+        ],
+    )
+    _register_api_routes(app, _ChatApi(memory, cfg, sessions))
+    _mount_spa(app, dist)
     return app

--- a/src/memo/chat/sessions.py
+++ b/src/memo/chat/sessions.py
@@ -6,6 +6,7 @@ import json
 import math
 import re
 import time
+from collections import deque
 from pathlib import Path
 from typing import Any
 
@@ -82,6 +83,23 @@ class SessionStore:
                 + "\n"
             )
 
+    def append_exchange(self, session_id: str, question: str, answer: str) -> None:
+        """Append one complete user/assistant exchange with a single write."""
+        path = self._path(session_id)
+        question = self.validate_text(question, "question")
+        answer = self.validate_text(answer, "answer")
+        timestamp = time.time()
+        payload = "".join(
+            json.dumps(turn, ensure_ascii=False) + "\n"
+            for turn in (
+                {"role": "user", "text": question, "ts": timestamp},
+                {"role": "assistant", "text": answer, "ts": timestamp},
+            )
+        ).encode("utf-8")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("ab") as fh:
+            fh.write(payload)
+
     def get(self, session_id: str) -> list[dict[str, Any]]:
         path = self._path(session_id)
         if not path.exists():
@@ -107,28 +125,46 @@ class SessionStore:
             return []
 
         chunk_size = 8192
+        newest_turns: list[dict[str, Any]] = []
+        # Fragments of the one line that crosses the next backwards-read
+        # boundary. A deque keeps even a multi-megabyte corrupt line linear.
+        pending: deque[bytes] = deque()
+
+        def collect(raw_line: bytes) -> None:
+            parsed = self._parse_turn(raw_line)
+            if parsed is not None:
+                newest_turns.append(parsed)
+
         with path.open("rb") as fh:
             fh.seek(0, 2)
             position = fh.tell()
-            data = b""
-            while position > 0 and len(data) < _MAX_RECENT_SCAN_BYTES:
-                read_size = min(chunk_size, position, _MAX_RECENT_SCAN_BYTES - len(data))
+            scanned = 0
+            while position > 0 and scanned < _MAX_RECENT_SCAN_BYTES and len(newest_turns) < limit:
+                read_size = min(chunk_size, position, _MAX_RECENT_SCAN_BYTES - scanned)
                 position -= read_size
                 fh.seek(position)
-                data = fh.read(read_size) + data
+                block = fh.read(read_size)
+                scanned += len(block)
+                parts = block.split(b"\n")
+                if len(parts) == 1:
+                    pending.appendleft(block)
+                    continue
 
-                raw_lines = data.splitlines()
-                # The first line is potentially partial until the start of
-                # the file is reached. Never parse that fragment as a turn.
-                complete_lines = raw_lines if position == 0 else raw_lines[1:]
-                turns = [
-                    parsed
-                    for raw_line in complete_lines
-                    if (parsed := self._parse_turn(raw_line)) is not None
-                ]
-                if len(turns) >= limit or position == 0 or len(data) >= _MAX_RECENT_SCAN_BYTES:
-                    return turns[-limit:]
-        return []
+                pending.appendleft(parts[-1])
+                collect(b"".join(pending))
+                if len(newest_turns) >= limit:
+                    break
+                for raw_line in reversed(parts[1:-1]):
+                    collect(raw_line)
+                    if len(newest_turns) >= limit:
+                        break
+                pending = deque([parts[0]])
+
+            # Only the start of the file proves the remaining fragment is a
+            # complete first line. At the scan cap it must stay unparsed.
+            if position == 0 and len(newest_turns) < limit and pending:
+                collect(b"".join(pending))
+        return list(reversed(newest_turns[:limit]))
 
     def list_sessions(self, limit: int = 50) -> list[dict[str, Any]]:
         if not self.root.exists():

--- a/src/memo/chat/sessions.py
+++ b/src/memo/chat/sessions.py
@@ -7,6 +7,7 @@ import math
 import re
 import time
 from collections import deque
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +19,36 @@ _MAX_RECENT_SCAN_BYTES = 4 * 1024 * 1024
 def iso_ts(ts: float) -> str:
     """Format an epoch-seconds timestamp the way the rest of chat/ does."""
     return time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(ts))
+
+
+def _iter_reverse_lines(path: Path) -> Iterator[bytes]:
+    """Yield bounded JSONL tail lines newest-first in linear time."""
+
+    chunk_size = 8192
+    pending: deque[bytes] = deque()
+    with path.open("rb") as fh:
+        fh.seek(0, 2)
+        position = fh.tell()
+        scanned = 0
+        while position > 0 and scanned < _MAX_RECENT_SCAN_BYTES:
+            read_size = min(chunk_size, position, _MAX_RECENT_SCAN_BYTES - scanned)
+            position -= read_size
+            fh.seek(position)
+            block = fh.read(read_size)
+            scanned += len(block)
+            parts = block.split(b"\n")
+            if len(parts) == 1:
+                pending.appendleft(block)
+                continue
+
+            pending.appendleft(parts[-1])
+            yield b"".join(pending)
+            yield from reversed(parts[1:-1])
+            pending = deque([parts[0]])
+
+        # Only reaching the start proves the remaining fragment is complete.
+        if position == 0 and pending:
+            yield b"".join(pending)
 
 
 class SessionStore:
@@ -124,46 +155,13 @@ class SessionStore:
         if not path.exists():
             return []
 
-        chunk_size = 8192
         newest_turns: list[dict[str, Any]] = []
-        # Fragments of the one line that crosses the next backwards-read
-        # boundary. A deque keeps even a multi-megabyte corrupt line linear.
-        pending: deque[bytes] = deque()
-
-        def collect(raw_line: bytes) -> None:
+        for raw_line in _iter_reverse_lines(path):
             parsed = self._parse_turn(raw_line)
             if parsed is not None:
                 newest_turns.append(parsed)
-
-        with path.open("rb") as fh:
-            fh.seek(0, 2)
-            position = fh.tell()
-            scanned = 0
-            while position > 0 and scanned < _MAX_RECENT_SCAN_BYTES and len(newest_turns) < limit:
-                read_size = min(chunk_size, position, _MAX_RECENT_SCAN_BYTES - scanned)
-                position -= read_size
-                fh.seek(position)
-                block = fh.read(read_size)
-                scanned += len(block)
-                parts = block.split(b"\n")
-                if len(parts) == 1:
-                    pending.appendleft(block)
-                    continue
-
-                pending.appendleft(parts[-1])
-                collect(b"".join(pending))
                 if len(newest_turns) >= limit:
                     break
-                for raw_line in reversed(parts[1:-1]):
-                    collect(raw_line)
-                    if len(newest_turns) >= limit:
-                        break
-                pending = deque([parts[0]])
-
-            # Only the start of the file proves the remaining fragment is a
-            # complete first line. At the scan cap it must stay unparsed.
-            if position == 0 and len(newest_turns) < limit and pending:
-                collect(b"".join(pending))
         return list(reversed(newest_turns[:limit]))
 
     def list_sessions(self, limit: int = 50) -> list[dict[str, Any]]:

--- a/src/memo/chat/sessions.py
+++ b/src/memo/chat/sessions.py
@@ -133,10 +133,12 @@ class SessionStore:
 
     def get(self, session_id: str) -> list[dict[str, Any]]:
         path = self._path(session_id)
-        if not path.exists():
+        try:
+            fh = path.open("rb")
+        except FileNotFoundError:
             return []
         turns = []
-        with path.open("rb") as fh:
+        with fh:
             for line in fh:
                 parsed = self._parse_turn(line)
                 if parsed is not None:
@@ -152,16 +154,16 @@ class SessionStore:
         if type(limit) is not int or limit < 1:
             raise ValueError("limit must be a positive integer")
         path = self._path(session_id)
-        if not path.exists():
-            return []
-
         newest_turns: list[dict[str, Any]] = []
-        for raw_line in _iter_reverse_lines(path):
-            parsed = self._parse_turn(raw_line)
-            if parsed is not None:
-                newest_turns.append(parsed)
-                if len(newest_turns) >= limit:
-                    break
+        try:
+            for raw_line in _iter_reverse_lines(path):
+                parsed = self._parse_turn(raw_line)
+                if parsed is not None:
+                    newest_turns.append(parsed)
+                    if len(newest_turns) >= limit:
+                        break
+        except FileNotFoundError:
+            return []
         return list(reversed(newest_turns[:limit]))
 
     def list_sessions(self, limit: int = 50) -> list[dict[str, Any]]:

--- a/src/memo/chat/sessions.py
+++ b/src/memo/chat/sessions.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 import time
 from pathlib import Path
 from typing import Any
 
 _SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+_MAX_REASONABLE_TS = 32_503_680_000  # 3000-01-01 UTC
+_MAX_RECENT_SCAN_BYTES = 4 * 1024 * 1024
 
 
 def iso_ts(ts: float) -> str:
@@ -20,13 +23,58 @@ class SessionStore:
     def __init__(self, root: Path) -> None:
         self.root = root
 
-    def _path(self, session_id: str) -> Path:
-        if not _SESSION_ID_RE.match(session_id or ""):
+    @staticmethod
+    def validate_id(session_id: object) -> str:
+        """Validate a session id without touching the filesystem."""
+        if not isinstance(session_id, str) or _SESSION_ID_RE.fullmatch(session_id) is None:
             raise ValueError(f"invalid session id: {session_id!r}")
-        return self.root / f"{session_id}.jsonl"
+        return session_id
+
+    def _path(self, session_id: str) -> Path:
+        return self.root / f"{self.validate_id(session_id)}.jsonl"
+
+    @staticmethod
+    def validate_text(value: object, field: str) -> str:
+        """Validate persisted text before creating or appending any file."""
+        if not isinstance(value, str):
+            raise ValueError(f"{field} must be a string")
+        try:
+            value.encode("utf-8", errors="strict")
+        except UnicodeEncodeError as exc:
+            raise ValueError(f"{field} must contain valid UTF-8 text") from exc
+        return value
+
+    @staticmethod
+    def _parse_turn(raw_line: str | bytes) -> dict[str, Any] | None:
+        try:
+            parsed = json.loads(raw_line)
+        except (ValueError, UnicodeDecodeError, RecursionError, OverflowError):
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        role = parsed.get("role")
+        text = parsed.get("text")
+        ts = parsed.get("ts")
+        if not isinstance(role, str) or not isinstance(text, str):
+            return None
+        if isinstance(ts, bool) or not isinstance(ts, int | float):
+            return None
+        if isinstance(ts, int):
+            if not 0 <= ts <= _MAX_REASONABLE_TS:
+                return None
+        elif not math.isfinite(ts) or not 0 <= ts <= _MAX_REASONABLE_TS:
+            return None
+        try:
+            role.encode("utf-8", errors="strict")
+            text.encode("utf-8", errors="strict")
+        except UnicodeEncodeError:
+            return None
+        return parsed
 
     def append_turn(self, session_id: str, role: str, text: str) -> None:
         path = self._path(session_id)
+        role = self.validate_text(role, "role")
+        text = self.validate_text(text, "text")
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as fh:
             fh.write(
@@ -39,36 +87,77 @@ class SessionStore:
         if not path.exists():
             return []
         turns = []
-        for line in path.read_text(encoding="utf-8").splitlines():
-            try:
-                parsed = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if isinstance(parsed, dict):
-                turns.append(parsed)
+        with path.open("rb") as fh:
+            for line in fh:
+                parsed = self._parse_turn(line)
+                if parsed is not None:
+                    turns.append(parsed)
         return turns
+
+    def get_recent(self, session_id: str, limit: int = 12) -> list[dict[str, Any]]:
+        """Read only the tail needed for prompt history.
+
+        Sessions can grow indefinitely. Reading backwards avoids loading and
+        decoding an entire JSONL transcript for every follow-up request.
+        """
+        if type(limit) is not int or limit < 1:
+            raise ValueError("limit must be a positive integer")
+        path = self._path(session_id)
+        if not path.exists():
+            return []
+
+        chunk_size = 8192
+        with path.open("rb") as fh:
+            fh.seek(0, 2)
+            position = fh.tell()
+            data = b""
+            while position > 0 and len(data) < _MAX_RECENT_SCAN_BYTES:
+                read_size = min(chunk_size, position, _MAX_RECENT_SCAN_BYTES - len(data))
+                position -= read_size
+                fh.seek(position)
+                data = fh.read(read_size) + data
+
+                raw_lines = data.splitlines()
+                # The first line is potentially partial until the start of
+                # the file is reached. Never parse that fragment as a turn.
+                complete_lines = raw_lines if position == 0 else raw_lines[1:]
+                turns = [
+                    parsed
+                    for raw_line in complete_lines
+                    if (parsed := self._parse_turn(raw_line)) is not None
+                ]
+                if len(turns) >= limit or position == 0 or len(data) >= _MAX_RECENT_SCAN_BYTES:
+                    return turns[-limit:]
+        return []
 
     def list_sessions(self, limit: int = 50) -> list[dict[str, Any]]:
         if not self.root.exists():
             return []
-        entries = []
+        entries: list[tuple[float, dict[str, Any]]] = []
         for path in self.root.glob("*.jsonl"):
-            turns = self.get(path.stem)
-            first_user = next((t["text"] for t in turns if t.get("role") == "user"), "")
-            first_ts = turns[0]["ts"] if turns else path.stat().st_mtime
-            last_ts = turns[-1]["ts"] if turns else path.stat().st_mtime
-            entries.append(
-                (
-                    last_ts,
-                    {
-                        "session_id": path.stem,
-                        "first_ts": iso_ts(first_ts),
-                        "last_ts": iso_ts(last_ts),
-                        "turn_count": len(turns),
-                        "label": first_user,
-                    },
+            try:
+                self.validate_id(path.stem)
+                turns = self.get(path.stem)
+                first_user = next((t["text"] for t in turns if t.get("role") == "user"), "")
+                if turns:
+                    first_ts = float(turns[0]["ts"])
+                    last_ts = float(turns[-1]["ts"])
+                else:
+                    first_ts = last_ts = path.stat().st_mtime
+                entries.append(
+                    (
+                        last_ts,
+                        {
+                            "session_id": path.stem,
+                            "first_ts": iso_ts(first_ts),
+                            "last_ts": iso_ts(last_ts),
+                            "turn_count": len(turns),
+                            "label": first_user,
+                        },
+                    )
                 )
-            )
+            except (OSError, ValueError):
+                continue
         entries.sort(key=lambda e: e[0], reverse=True)
         return [row for _, row in entries[:limit]]
 
@@ -90,7 +179,11 @@ class SessionStore:
     def recent_queries(self, limit: int = 8) -> list[str]:
         queries: list[str] = []
         for row in self.list_sessions(limit=limit * 3):
-            for turn in reversed(self.get(row["session_id"])):
+            try:
+                turns = self.get(row["session_id"])
+            except (OSError, ValueError):
+                continue
+            for turn in reversed(turns):
                 if turn.get("role") == "user" and turn.get("text"):
                     if turn["text"] not in queries:
                         queries.append(turn["text"])

--- a/src/memo/cli_chat.py
+++ b/src/memo/cli_chat.py
@@ -10,6 +10,7 @@ as `memo chat ask` — a more natural command hierarchy.
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import logging
 import sys
@@ -26,6 +27,20 @@ from memo.cli_search import _sources_as_hits
 from memo.config import Config
 
 _log = logging.getLogger(__name__)
+
+
+def _is_loopback_bind(host: str) -> bool:
+    """Check a chat bind without importing the optional HTTP stack."""
+
+    normalized = host.strip().lower().rstrip(".")
+    if normalized == "localhost":
+        return True
+    if normalized.startswith("[") and normalized.endswith("]"):
+        normalized = normalized[1:-1]
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
 
 
 def _format_source_score(score: object) -> str:
@@ -196,9 +211,7 @@ def chat_ask(
 )
 def chat_serve(host: str, port: int, dist: Path | None) -> None:
     """Serve the chat UI + API over HTTP (requires the [http] extra)."""
-    from memo.http_auth import is_loopback_host
-
-    if not is_loopback_host(host):
+    if not _is_loopback_bind(host):
         raise click.ClickException(
             "chat serve has no remote authentication and only accepts loopback "
             "hosts (127.0.0.1, ::1, or localhost)"

--- a/src/memo/cli_chat.py
+++ b/src/memo/cli_chat.py
@@ -196,6 +196,13 @@ def chat_ask(
 )
 def chat_serve(host: str, port: int, dist: Path | None) -> None:
     """Serve the chat UI + API over HTTP (requires the [http] extra)."""
+    from memo.http_auth import is_loopback_host
+
+    if not is_loopback_host(host):
+        raise click.ClickException(
+            "chat serve has no remote authentication and only accepts loopback "
+            "hosts (127.0.0.1, ::1, or localhost)"
+        )
     try:
         import uvicorn
     except ImportError as exc:

--- a/src/memo/http_auth.py
+++ b/src/memo/http_auth.py
@@ -8,6 +8,7 @@ import secrets
 import stat
 import time
 from collections import deque
+from collections.abc import Mapping
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -149,8 +150,9 @@ class RequestSizeLimitMiddleware:
 class SecurityHeadersMiddleware:
     """Apply defensive, API-safe response headers to every HTTP response."""
 
-    def __init__(self, app: Any) -> None:
+    def __init__(self, app: Any, *, headers: Mapping[str, str] | None = None) -> None:
         self.app = app
+        self.headers = dict(_SECURITY_HEADERS if headers is None else headers)
 
     async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
         if scope.get("type") != "http":
@@ -160,7 +162,7 @@ class SecurityHeadersMiddleware:
         async def secure_send(message: dict[str, Any]) -> None:
             if message.get("type") == "http.response.start":
                 headers = MutableHeaders(scope=message)
-                for name, value in _SECURITY_HEADERS.items():
+                for name, value in self.headers.items():
                     headers[name] = value
             await send(message)
 

--- a/src/memo/http_auth.py
+++ b/src/memo/http_auth.py
@@ -284,6 +284,16 @@ class LocalRequestGuardMiddleware:
             await self.app(scope, receive, send)
             return
 
+        client = scope.get("client")
+        if (
+            not isinstance(client, (list, tuple))
+            or not client
+            or not isinstance(client[0], str)
+            or not _is_loopback_address(client[0])
+        ):
+            await self._reject(scope, receive, send, status_code=403)
+            return
+
         headers = Headers(scope=scope)
         host_values = headers.getlist("host")
         authority = _split_authority(host_values[0]) if len(host_values) == 1 else None
@@ -348,16 +358,16 @@ def build_http_middleware(
 
     from starlette.middleware import Middleware
 
-    middleware = [
-        Middleware(SecurityHeadersMiddleware),
+    middleware = [Middleware(SecurityHeadersMiddleware)]
+    if allow_no_auth:
+        middleware.append(Middleware(LocalRequestGuardMiddleware))
+    middleware.append(
         Middleware(
             RateLimitMiddleware,
             max_requests=max_requests,
             window_seconds=window_seconds,
-        ),
-    ]
-    if allow_no_auth:
-        middleware.append(Middleware(LocalRequestGuardMiddleware))
+        )
+    )
     middleware.append(Middleware(RequestSizeLimitMiddleware))
     return middleware
 
@@ -478,6 +488,18 @@ def is_loopback_host(host: str) -> bool:
     normalized = host.strip().lower().rstrip(".")
     if normalized == "localhost":
         return True
+    if normalized.startswith("[") and normalized.endswith("]"):
+        normalized = normalized[1:-1]
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def _is_loopback_address(address: str) -> bool:
+    """Validate the numeric peer address supplied by the ASGI server."""
+
+    normalized = address.strip()
     if normalized.startswith("[") and normalized.endswith("]"):
         normalized = normalized[1:-1]
     try:

--- a/src/memo/http_auth.py
+++ b/src/memo/http_auth.py
@@ -28,6 +28,7 @@ _MIN_TOKEN_CHARS = 32
 _MAX_TOKEN_CHARS = 4096
 _DEFAULT_RATE_LIMIT = 300
 _DEFAULT_RATE_WINDOW_SECONDS = 60
+_DEFAULT_REJECTION_RATE_LIMIT = 1200
 _MAX_RATE_BUCKETS = 4096
 MAX_HTTP_REQUEST_BYTES = 1_048_576
 
@@ -169,6 +170,32 @@ class SecurityHeadersMiddleware:
         await self.app(scope, receive, secure_send)
 
 
+class _RateWindow:
+    """Thread-safe, process-local sliding-window counter by peer address."""
+
+    def __init__(self, max_requests: int, window_seconds: int) -> None:
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        self.requests: dict[str, deque[float]] = {}
+        self.lock = Lock()
+
+    def allow(self, scope: dict[str, Any]) -> bool:
+        client = scope.get("client")
+        key = str(client[0]) if isinstance(client, (list, tuple)) and client else "unknown"
+        now = time.monotonic()
+        cutoff = now - self.window_seconds
+        with self.lock:
+            if key not in self.requests and len(self.requests) >= _MAX_RATE_BUCKETS:
+                key = "overflow"
+            bucket = self.requests.setdefault(key, deque())
+            while bucket and bucket[0] <= cutoff:
+                bucket.popleft()
+            if len(bucket) >= self.max_requests:
+                return False
+            bucket.append(now)
+            return True
+
+
 class RateLimitMiddleware:
     """Bound HTTP requests per source address with process-local windows."""
 
@@ -184,8 +211,7 @@ class RateLimitMiddleware:
         self.app = app
         self.max_requests = max_requests
         self.window_seconds = window_seconds
-        self._requests: dict[str, deque[float]] = {}
-        self._lock = Lock()
+        self._window = _RateWindow(max_requests, window_seconds)
 
     async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
         if scope.get("type") != "http" or self._allow(scope):
@@ -198,20 +224,7 @@ class RateLimitMiddleware:
         )(scope, receive, send)
 
     def _allow(self, scope: dict[str, Any]) -> bool:
-        client = scope.get("client")
-        key = str(client[0]) if isinstance(client, (list, tuple)) and client else "unknown"
-        now = time.monotonic()
-        cutoff = now - self.window_seconds
-        with self._lock:
-            if key not in self._requests and len(self._requests) >= _MAX_RATE_BUCKETS:
-                key = "overflow"
-            bucket = self._requests.setdefault(key, deque())
-            while bucket and bucket[0] <= cutoff:
-                bucket.popleft()
-            if len(bucket) >= self.max_requests:
-                return False
-            bucket.append(now)
-            return True
+        return self._window.allow(scope)
 
 
 def _split_authority(value: str) -> tuple[str, int | None] | None:
@@ -276,8 +289,17 @@ def _same_loopback_origin(
 class LocalRequestGuardMiddleware:
     """Close browser CSRF and DNS-rebinding paths for unauthenticated MCP HTTP."""
 
-    def __init__(self, app: Any) -> None:
+    def __init__(
+        self,
+        app: Any,
+        *,
+        max_rejections: int = _DEFAULT_REJECTION_RATE_LIMIT,
+        rejection_window_seconds: int = _DEFAULT_RATE_WINDOW_SECONDS,
+    ) -> None:
+        if max_rejections < 1 or rejection_window_seconds < 1:
+            raise ValueError("HTTP rejection rate limit and window must be positive")
         self.app = app
+        self.rejections = _RateWindow(max_rejections, rejection_window_seconds)
 
     async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
         if scope.get("type") != "http":
@@ -332,14 +354,21 @@ class LocalRequestGuardMiddleware:
 
         await self.app(scope, receive, send)
 
-    @staticmethod
     async def _reject(
+        self,
         scope: dict[str, Any],
         receive: Any,
         send: Any,
         *,
         status_code: int,
     ) -> None:
+        if not self.rejections.allow(scope):
+            await JSONResponse(
+                {"detail": "Too many rejected requests"},
+                status_code=429,
+                headers={"Retry-After": str(self.rejections.window_seconds)},
+            )(scope, receive, send)
+            return
         detail = (
             "Content-Type must be application/json"
             if status_code == 415

--- a/tests/test_chat_http.py
+++ b/tests/test_chat_http.py
@@ -786,6 +786,43 @@ async def test_delete_waits_for_same_session_ask_and_cannot_be_recreated(
 
 
 @pytest.mark.asyncio
+async def test_delete_all_waits_for_in_flight_asks_and_cannot_be_recreated(
+    tmp_path, monkeypatch
+) -> None:
+    import httpx
+
+    from tests.test_chat_pipeline import _FakeMemory
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_stream(_memory, question, **_kwargs):
+        started.set()
+        assert release.wait(timeout=5)
+        yield {"type": "done", "answer": f"answer-{question}", "sources": []}
+
+    monkeypatch.setattr("memo.chat.pipeline.chat_stream", blocking_stream)
+    app = build_app(_FakeMemory(tmp_path))
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as client:
+        ask = asyncio.create_task(
+            client.post("/api/ask", json={"q": "question", "chat_session_id": "race-all"})
+        )
+        assert await asyncio.to_thread(started.wait, 2)
+        delete = asyncio.create_task(client.post("/api/sessions/delete-all", json={}))
+        await asyncio.sleep(0.05)
+        assert not delete.done()
+
+        release.set()
+        ask_response, delete_response = await asyncio.gather(ask, delete)
+        history = (await client.get("/api/sessions/race-all")).json()["turns"]
+
+    assert ask_response.status_code == 200
+    assert delete_response.json() == {"ok": True, "deleted": 1}
+    assert history == []
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("exit_mode", ["disconnect", "send_failure"])
 async def test_stream_capacity_is_released_when_asgi_exits_before_iteration(
     tmp_path, monkeypatch, exit_mode

--- a/tests/test_chat_http.py
+++ b/tests/test_chat_http.py
@@ -15,7 +15,7 @@ def client(tmp_path, monkeypatch):
 
     memory = _FakeMemory(tmp_path)
     app = build_app(memory)
-    return TestClient(app)
+    return TestClient(app, base_url="http://127.0.0.1")
 
 
 def test_ask_stream_sse(client) -> None:
@@ -34,10 +34,51 @@ def test_ask_non_stream(client) -> None:
     assert resp.json()["type"] == "done"
 
 
-def test_ask_non_stream_survives_invalid_session_id(client) -> None:
-    # SessionStore._path raises ValueError on an invalid session id — the
-    # stream path already guards append_turn against it; /api/ask must too.
+def test_ask_non_stream_rejects_invalid_session_id(client) -> None:
+    # Reject before running retrieval instead of silently answering without
+    # persisting the requested session.
     resp = client.post("/api/ask", json={"q": "hola", "chat_session_id": "bad id!"})
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "invalid chat_session_id"}
+
+
+@pytest.mark.parametrize("endpoint", ["/api/ask", "/api/ask/stream"])
+@pytest.mark.parametrize("session_id", [123, False, [], {}])
+def test_ask_rejects_non_string_session_ids(client, endpoint, session_id) -> None:
+    resp = client.post(endpoint, json={"q": "hola", "chat_session_id": session_id})
+
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "invalid chat_session_id"}
+
+
+@pytest.mark.parametrize("endpoint", ["/api/ask", "/api/ask/stream"])
+@pytest.mark.parametrize(
+    ("body", "error"),
+    [
+        ({"q": 123}, "q required and must be a string"),
+        ({"q": ["hola"]}, "q required and must be a string"),
+        ({"q": "hola", "history": 123}, "history must be a list"),
+        ({"q": "hola", "history": "not-a-list"}, "history must be a list"),
+        ({"q": "hola", "k": True}, "k must be an integer between 1 and 100"),
+        ({"q": "hola", "k": "5"}, "k must be an integer between 1 and 100"),
+        ({"q": "hola", "k": -1}, "k must be an integer between 1 and 100"),
+        ({"q": "hola", "k": 101}, "k must be an integer between 1 and 100"),
+    ],
+)
+def test_ask_rejects_invalid_typed_inputs(client, endpoint, body, error) -> None:
+    resp = client.post(endpoint, json=body)
+
+    assert resp.status_code == 400
+    assert resp.json() == {"error": error}
+
+
+@pytest.mark.parametrize("endpoint", ["/api/ask", "/api/ask/stream"])
+def test_ask_tolerates_malformed_items_inside_history_list(client, endpoint) -> None:
+    resp = client.post(
+        endpoint,
+        json={"q": "hola", "history": [1, "x", None, {"role": [], "text": {}}]},
+    )
+
     assert resp.status_code == 200
 
 
@@ -60,6 +101,23 @@ def test_feedback_source_malformed_json_returns_400(client) -> None:
     resp = client.post(
         "/api/feedback/source", content=b"not json", headers={"Content-Type": "application/json"}
     )
+    assert resp.status_code == 400
+    assert "error" in resp.json()
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "body"),
+    [
+        ("/api/feedback", {"rating": "up", "sources": 123}),
+        ("/api/feedback", {"rating": "sideways", "sources": []}),
+        ("/api/feedback/source", {"source_id": "m1", "query": 123, "rating": "up"}),
+        ("/api/feedback/source", {"source_id": "", "query": "hola", "rating": "up"}),
+        ("/api/feedback/source", {"source_id": "m1", "query": "hola", "rating": "x"}),
+    ],
+)
+def test_feedback_rejects_invalid_typed_inputs(client, endpoint, body) -> None:
+    resp = client.post(endpoint, json=body)
+
     assert resp.status_code == 400
     assert "error" in resp.json()
 
@@ -143,7 +201,7 @@ def test_ask_normalizes_ui_history_before_rewrite(tmp_path) -> None:
 
     memory = _SpyMemory(tmp_path)
     app = build_app(memory)
-    client = TestClient(app)
+    client = TestClient(app, base_url="http://127.0.0.1")
 
     history = [
         {"role": "user", "text": "qué sabés del proyecto memo daemon"},
@@ -170,7 +228,7 @@ def test_ask_stream_normalizes_ui_history_before_rewrite(tmp_path) -> None:
 
     memory = _SpyMemory(tmp_path)
     app = build_app(memory)
-    client = TestClient(app)
+    client = TestClient(app, base_url="http://127.0.0.1")
 
     history = [
         {"role": "user", "text": "qué sabés del proyecto memo daemon"},
@@ -216,7 +274,7 @@ def test_spa_fallback_does_not_swallow_unknown_api_routes(tmp_path) -> None:
     (dist / "assets").mkdir(parents=True)
     (dist / "index.html").write_text("<!doctype html><html></html>")
     app = build_app(_FakeMemory(tmp_path), dist=dist)
-    c = TestClient(app)
+    c = TestClient(app, base_url="http://127.0.0.1")
 
     resp = c.get("/api/nonexistent")
     assert resp.status_code == 404
@@ -226,3 +284,20 @@ def test_spa_fallback_does_not_swallow_unknown_api_routes(tmp_path) -> None:
     resp = c.get("/cualquier/ruta")
     assert resp.status_code == 200
     assert resp.headers["content-type"].startswith("text/html")
+
+
+def test_chat_http_rejects_dns_rebinding_and_cross_site_requests(client) -> None:
+    rebound = client.get("/api/sessions", headers={"Host": "attacker.example"})
+    assert rebound.status_code == 403
+
+    cross_site = client.get(
+        "/api/sessions",
+        headers={"Origin": "https://attacker.example", "Sec-Fetch-Site": "cross-site"},
+    )
+    assert cross_site.status_code == 403
+
+
+def test_chat_http_rejects_oversized_request_body(client) -> None:
+    resp = client.post("/api/ask", json={"q": "x" * 1_048_577})
+
+    assert resp.status_code == 413

--- a/tests/test_chat_http.py
+++ b/tests/test_chat_http.py
@@ -8,6 +8,19 @@ from fastapi.testclient import TestClient  # noqa: E402
 from memo.chat.http import build_app  # noqa: E402
 
 
+def _assert_chat_security_headers(resp) -> None:
+    assert resp.headers["cache-control"] == "no-store"
+    assert resp.headers["x-content-type-options"] == "nosniff"
+    assert resp.headers["x-frame-options"] == "DENY"
+    assert resp.headers["referrer-policy"] == "no-referrer"
+    csp = resp.headers["content-security-policy"]
+    assert "default-src 'self'" in csp
+    assert "script-src 'self'" in csp
+    assert "connect-src 'self'" in csp
+    assert "frame-ancestors 'none'" in csp
+    assert "object-src 'none'" in csp
+
+
 @pytest.fixture()
 def client(tmp_path, monkeypatch):
 
@@ -284,6 +297,14 @@ def test_spa_fallback_does_not_swallow_unknown_api_routes(tmp_path) -> None:
     resp = c.get("/cualquier/ruta")
     assert resp.status_code == 200
     assert resp.headers["content-type"].startswith("text/html")
+    _assert_chat_security_headers(resp)
+
+
+def test_chat_api_responses_include_spa_compatible_security_headers(client) -> None:
+    resp = client.get("/api/sessions")
+
+    assert resp.status_code == 200
+    _assert_chat_security_headers(resp)
 
 
 def test_chat_http_rejects_dns_rebinding_and_cross_site_requests(client) -> None:

--- a/tests/test_chat_http.py
+++ b/tests/test_chat_http.py
@@ -12,6 +12,14 @@ from fastapi.testclient import TestClient  # noqa: E402
 from memo.chat.http import build_app  # noqa: E402
 
 
+def _local_test_client(app) -> TestClient:
+    return TestClient(
+        app,
+        base_url="http://127.0.0.1",
+        client=("127.0.0.1", 50000),
+    )
+
+
 def _post_json_document(client, endpoint: str, body: dict) -> object:
     payload = json.dumps(body, ensure_ascii=True).encode()
     return client.post(endpoint, content=payload, headers={"Content-Type": "application/json"})
@@ -37,7 +45,7 @@ def client(tmp_path, monkeypatch):
 
     memory = _FakeMemory(tmp_path)
     app = build_app(memory)
-    return TestClient(app, base_url="http://127.0.0.1")
+    return _local_test_client(app)
 
 
 def test_ask_stream_sse(client) -> None:
@@ -61,7 +69,7 @@ def test_ask_stream_escapes_model_surrogate_and_releases_capacity(tmp_path, monk
     monkeypatch.setattr(chat_http, "_MAX_HEAVY_IN_FLIGHT", 1)
     monkeypatch.setattr("memo.chat.pipeline.chat_stream", surrogate_stream)
     app = build_app(_FakeMemory(tmp_path))
-    local_client = TestClient(app, base_url="http://127.0.0.1")
+    local_client = _local_test_client(app)
 
     first = local_client.post("/api/ask/stream", json={"q": "first"})
     second = local_client.post("/api/ask/stream", json={"q": "second"})
@@ -339,7 +347,7 @@ def test_ask_normalizes_ui_history_before_rewrite(tmp_path) -> None:
 
     memory = _SpyMemory(tmp_path)
     app = build_app(memory)
-    client = TestClient(app, base_url="http://127.0.0.1")
+    client = _local_test_client(app)
 
     history = [
         {"role": "user", "text": "qué sabés del proyecto memo daemon"},
@@ -366,7 +374,7 @@ def test_ask_stream_normalizes_ui_history_before_rewrite(tmp_path) -> None:
 
     memory = _SpyMemory(tmp_path)
     app = build_app(memory)
-    client = TestClient(app, base_url="http://127.0.0.1")
+    client = _local_test_client(app)
 
     history = [
         {"role": "user", "text": "qué sabés del proyecto memo daemon"},
@@ -412,7 +420,7 @@ def test_spa_fallback_does_not_swallow_unknown_api_routes(tmp_path) -> None:
     (dist / "assets").mkdir(parents=True)
     (dist / "index.html").write_text("<!doctype html><html></html>")
     app = build_app(_FakeMemory(tmp_path), dist=dist)
-    c = TestClient(app, base_url="http://127.0.0.1")
+    c = _local_test_client(app)
 
     resp = c.get("/api/nonexistent")
     assert resp.status_code == 404
@@ -441,6 +449,34 @@ def test_chat_http_rejects_dns_rebinding_and_cross_site_requests(client) -> None
         headers={"Origin": "https://attacker.example", "Sec-Fetch-Site": "cross-site"},
     )
     assert cross_site.status_code == 403
+
+
+def test_chat_http_rejects_remote_peer_even_with_loopback_host(tmp_path) -> None:
+    from tests.test_chat_pipeline import _FakeMemory
+
+    app = build_app(_FakeMemory(tmp_path))
+    remote_client = TestClient(
+        app,
+        base_url="http://127.0.0.1",
+        client=("192.0.2.10", 50000),
+    )
+
+    response = remote_client.get("/api/sessions")
+
+    assert response.status_code == 403
+
+
+def test_chat_guard_rejections_do_not_exhaust_rate_limit(client) -> None:
+    for _ in range(301):
+        rejected = client.get(
+            "/api/sessions",
+            headers={"Origin": "https://attacker.example"},
+        )
+        assert rejected.status_code == 403
+
+    allowed = client.get("/api/sessions")
+
+    assert allowed.status_code == 200
 
 
 def test_chat_http_rejects_oversized_request_body(client) -> None:
@@ -491,7 +527,7 @@ def test_ask_reads_only_recent_session_history_once(tmp_path, monkeypatch) -> No
     cfg = ChatConfig.load(memory.cfg.state_dir)
     SessionStore(cfg.sessions_dir).append_turn("once", "user", "primera")
     app = build_app(memory)
-    local_client = TestClient(app, base_url="http://127.0.0.1")
+    local_client = _local_test_client(app)
 
     response = local_client.post("/api/ask", json={"q": "seguimiento", "chat_session_id": "once"})
 
@@ -513,7 +549,7 @@ def test_session_endpoints_skip_corrupt_jsonl_turns(tmp_path) -> None:
         fh.write(json.dumps({"role": "user", "text": "\ud800", "ts": 1}) + "\n")
 
     app = build_app(memory)
-    local_client = TestClient(app, base_url="http://127.0.0.1")
+    local_client = _local_test_client(app)
     listing = local_client.get("/api/sessions")
     history = local_client.get("/api/sessions/legacy")
 
@@ -659,5 +695,151 @@ async def test_heavy_slot_is_recovered_after_request_cancellation(tmp_path, monk
 
         monkeypatch.setattr(chat_http._ChatApi, "_run", lambda *args, **kwargs: [])
         recovered = await async_client.post("/api/ask", json={"q": "works"})
+
+    assert recovered.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_same_session_asks_are_serialized_and_exchanges_stay_adjacent(
+    tmp_path, monkeypatch
+) -> None:
+    import httpx
+
+    from tests.test_chat_pipeline import _FakeMemory
+
+    first_started = threading.Event()
+    second_started = threading.Event()
+    release_first = threading.Event()
+
+    def ordered_stream(_memory, question, **_kwargs):
+        if question == "first":
+            first_started.set()
+            assert release_first.wait(timeout=5)
+        else:
+            second_started.set()
+        yield {"type": "done", "answer": f"answer-{question}", "sources": []}
+
+    monkeypatch.setattr("memo.chat.pipeline.chat_stream", ordered_stream)
+    app = build_app(_FakeMemory(tmp_path))
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as client:
+        first = asyncio.create_task(
+            client.post("/api/ask", json={"q": "first", "chat_session_id": "shared"})
+        )
+        assert await asyncio.to_thread(first_started.wait, 2)
+        second = asyncio.create_task(
+            client.post("/api/ask", json={"q": "second", "chat_session_id": "shared"})
+        )
+        await asyncio.sleep(0.05)
+        assert not second_started.is_set()
+
+        release_first.set()
+        responses = await asyncio.gather(first, second)
+        history = (await client.get("/api/sessions/shared")).json()["turns"]
+
+    assert all(response.status_code == 200 for response in responses)
+    assert [(turn["role"], turn["text"]) for turn in history] == [
+        ("user", "first"),
+        ("assistant", "answer-first"),
+        ("user", "second"),
+        ("assistant", "answer-second"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_waits_for_same_session_ask_and_cannot_be_recreated(
+    tmp_path, monkeypatch
+) -> None:
+    import httpx
+
+    from tests.test_chat_pipeline import _FakeMemory
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_stream(_memory, question, **_kwargs):
+        started.set()
+        assert release.wait(timeout=5)
+        yield {"type": "done", "answer": f"answer-{question}", "sources": []}
+
+    monkeypatch.setattr("memo.chat.pipeline.chat_stream", blocking_stream)
+    app = build_app(_FakeMemory(tmp_path))
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as client:
+        ask = asyncio.create_task(
+            client.post("/api/ask", json={"q": "question", "chat_session_id": "race"})
+        )
+        assert await asyncio.to_thread(started.wait, 2)
+        delete = asyncio.create_task(
+            client.post("/api/sessions/delete", json={"session_id": "race"})
+        )
+        await asyncio.sleep(0.05)
+        assert not delete.done()
+
+        release.set()
+        ask_response, delete_response = await asyncio.gather(ask, delete)
+        history = (await client.get("/api/sessions/race")).json()["turns"]
+
+    assert ask_response.status_code == 200
+    assert delete_response.json() == {"ok": True}
+    assert history == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exit_mode", ["disconnect", "send_failure"])
+async def test_stream_capacity_is_released_when_asgi_exits_before_iteration(
+    tmp_path, monkeypatch, exit_mode
+) -> None:
+    import httpx
+
+    import memo.chat.http as chat_http
+    from tests.test_chat_pipeline import _FakeMemory
+
+    monkeypatch.setattr(chat_http, "_MAX_HEAVY_IN_FLIGHT", 1)
+    app = build_app(_FakeMemory(tmp_path))
+    payload = json.dumps({"q": "abandoned"}).encode()
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/api/ask/stream",
+        "raw_path": b"/api/ask/stream",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"host", b"127.0.0.1"),
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(payload)).encode()),
+        ],
+        "client": ("127.0.0.1", 50000),
+        "server": ("127.0.0.1", 80),
+        "state": {},
+    }
+    incoming = [{"type": "http.request", "body": payload, "more_body": False}]
+    if exit_mode == "disconnect":
+        incoming.append({"type": "http.disconnect"})
+    never = asyncio.Event()
+
+    async def receive():
+        if incoming:
+            return incoming.pop(0)
+        await never.wait()
+        raise AssertionError("unreachable")
+
+    async def send(message):
+        if exit_mode == "send_failure" and message["type"] == "http.response.start":
+            raise RuntimeError("transport failed")
+
+    if exit_mode == "send_failure":
+        with pytest.raises(RuntimeError, match="transport failed"):
+            await asyncio.wait_for(app(scope, receive, send), timeout=2)
+    else:
+        await asyncio.wait_for(app(scope, receive, send), timeout=2)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as client:
+        recovered = await client.post("/api/ask", json={"q": "recovered"})
 
     assert recovered.status_code == 200

--- a/tests/test_chat_http.py
+++ b/tests/test_chat_http.py
@@ -1,4 +1,8 @@
+import asyncio
 import json
+import subprocess
+import sys
+import threading
 
 import pytest
 
@@ -8,17 +12,22 @@ from fastapi.testclient import TestClient  # noqa: E402
 from memo.chat.http import build_app  # noqa: E402
 
 
+def _post_json_document(client, endpoint: str, body: dict) -> object:
+    payload = json.dumps(body, ensure_ascii=True).encode()
+    return client.post(endpoint, content=payload, headers={"Content-Type": "application/json"})
+
+
 def _assert_chat_security_headers(resp) -> None:
     assert resp.headers["cache-control"] == "no-store"
     assert resp.headers["x-content-type-options"] == "nosniff"
     assert resp.headers["x-frame-options"] == "DENY"
     assert resp.headers["referrer-policy"] == "no-referrer"
-    csp = resp.headers["content-security-policy"]
-    assert "default-src 'self'" in csp
-    assert "script-src 'self'" in csp
-    assert "connect-src 'self'" in csp
-    assert "frame-ancestors 'none'" in csp
-    assert "object-src 'none'" in csp
+    assert resp.headers["content-security-policy"] == (
+        "default-src 'self'; script-src 'self'; "
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+        "font-src 'self' https://fonts.gstatic.com; connect-src 'self'; "
+        "img-src 'self' data:; frame-ancestors 'none'; base-uri 'none'; object-src 'none'"
+    )
 
 
 @pytest.fixture()
@@ -35,10 +44,38 @@ def test_ask_stream_sse(client) -> None:
     with client.stream("POST", "/api/ask/stream", json={"q": "hola", "history": []}) as resp:
         assert resp.status_code == 200
         assert resp.headers["content-type"].startswith("text/event-stream")
+        _assert_chat_security_headers(resp)
         body = "".join(chunk for chunk in resp.iter_text())
     frames = [json.loads(line[5:]) for line in body.split("\n\n") if line.startswith("data:")]
     kinds = [f["type"] for f in frames]
     assert "context" in kinds and "done" in kinds
+
+
+def test_ask_stream_escapes_model_surrogate_and_releases_capacity(tmp_path, monkeypatch) -> None:
+    import memo.chat.http as chat_http
+    from tests.test_chat_pipeline import _FakeMemory
+
+    def surrogate_stream(*args, **kwargs):
+        yield {"type": "done", "answer": "bad-\ud800-answer", "sources": []}
+
+    monkeypatch.setattr(chat_http, "_MAX_HEAVY_IN_FLIGHT", 1)
+    monkeypatch.setattr("memo.chat.pipeline.chat_stream", surrogate_stream)
+    app = build_app(_FakeMemory(tmp_path))
+    local_client = TestClient(app, base_url="http://127.0.0.1")
+
+    first = local_client.post("/api/ask/stream", json={"q": "first"})
+    second = local_client.post("/api/ask/stream", json={"q": "second"})
+    non_stream = local_client.post("/api/ask", json={"q": "third"})
+
+    assert first.status_code == 200
+    assert "\\ud800" in first.text
+    assert second.status_code == 200
+    assert non_stream.status_code == 200
+    assert "\\ud800" in non_stream.text
+    frame = json.loads(first.text.removeprefix("data: ").strip())
+    session_id = frame["chat_session_id"]
+    # Reject the invalid generated answer before writing either half of the exchange.
+    assert local_client.get(f"/api/sessions/{session_id}").json()["turns"] == []
 
 
 def test_ask_non_stream(client) -> None:
@@ -52,7 +89,7 @@ def test_ask_non_stream_rejects_invalid_session_id(client) -> None:
     # persisting the requested session.
     resp = client.post("/api/ask", json={"q": "hola", "chat_session_id": "bad id!"})
     assert resp.status_code == 400
-    assert resp.json() == {"error": "invalid chat_session_id"}
+    assert resp.json() == {"error": "invalid chat request"}
 
 
 @pytest.mark.parametrize("endpoint", ["/api/ask", "/api/ask/stream"])
@@ -61,28 +98,28 @@ def test_ask_rejects_non_string_session_ids(client, endpoint, session_id) -> Non
     resp = client.post(endpoint, json={"q": "hola", "chat_session_id": session_id})
 
     assert resp.status_code == 400
-    assert resp.json() == {"error": "invalid chat_session_id"}
+    assert resp.json() == {"error": "invalid chat request"}
 
 
 @pytest.mark.parametrize("endpoint", ["/api/ask", "/api/ask/stream"])
 @pytest.mark.parametrize(
-    ("body", "error"),
+    "body",
     [
-        ({"q": 123}, "q required and must be a string"),
-        ({"q": ["hola"]}, "q required and must be a string"),
-        ({"q": "hola", "history": 123}, "history must be a list"),
-        ({"q": "hola", "history": "not-a-list"}, "history must be a list"),
-        ({"q": "hola", "k": True}, "k must be an integer between 1 and 100"),
-        ({"q": "hola", "k": "5"}, "k must be an integer between 1 and 100"),
-        ({"q": "hola", "k": -1}, "k must be an integer between 1 and 100"),
-        ({"q": "hola", "k": 101}, "k must be an integer between 1 and 100"),
+        {"q": 123},
+        {"q": ["hola"]},
+        {"q": "hola", "history": 123},
+        {"q": "hola", "history": "not-a-list"},
+        {"q": "hola", "k": True},
+        {"q": "hola", "k": "5"},
+        {"q": "hola", "k": -1},
+        {"q": "hola", "k": 101},
     ],
 )
-def test_ask_rejects_invalid_typed_inputs(client, endpoint, body, error) -> None:
+def test_ask_rejects_invalid_typed_inputs(client, endpoint, body) -> None:
     resp = client.post(endpoint, json=body)
 
     assert resp.status_code == 400
-    assert resp.json() == {"error": error}
+    assert resp.json() == {"error": "invalid chat request"}
 
 
 @pytest.mark.parametrize("endpoint", ["/api/ask", "/api/ask/stream"])
@@ -101,6 +138,22 @@ def test_ask_malformed_json_returns_400(client) -> None:
     )
     assert resp.status_code == 400
     assert "error" in resp.json()
+
+
+@pytest.mark.parametrize("endpoint", ["/api/ask", "/api/ask/stream"])
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"q": "\ud800"},
+        {"q": "hola", "history": [{"role": "\ud800", "text": "ok"}]},
+        {"q": "hola", "history": [{"role": "user", "text": "\ud800"}]},
+    ],
+)
+def test_ask_rejects_isolated_unicode_surrogates(client, endpoint, body) -> None:
+    resp = _post_json_document(client, endpoint, body)
+
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "invalid chat request"}
 
 
 def test_feedback_source_roundtrip(client) -> None:
@@ -135,6 +188,61 @@ def test_feedback_rejects_invalid_typed_inputs(client, endpoint, body) -> None:
     assert "error" in resp.json()
 
 
+@pytest.mark.parametrize("endpoint", ["/api/feedback", "/api/feedback/source"])
+@pytest.mark.parametrize("rating", [None, True, [], {}])
+def test_feedback_rejects_non_string_ratings(client, endpoint, rating) -> None:
+    if endpoint.endswith("/source"):
+        body = {"source_id": "m1", "query": "hola", "rating": rating}
+    else:
+        body = {"sources": [], "rating": rating}
+
+    resp = client.post(endpoint, json=body)
+
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "rating must be 'up' or 'down'"}
+
+
+@pytest.mark.parametrize(
+    ("field", "body"),
+    [
+        ("chat_session_id", {"rating": "up", "sources": []}),
+        ("turn_id", {"rating": "up", "sources": []}),
+        ("query", {"rating": "up", "sources": []}),
+        ("answer", {"rating": "up", "sources": []}),
+        ("correction_text", {"rating": "up", "sources": []}),
+    ],
+)
+def test_feedback_rejects_surrogates_in_every_persisted_text_field(client, field, body) -> None:
+    body[field] = "\ud800"
+
+    resp = _post_json_document(client, "/api/feedback", body)
+
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "invalid feedback request"}
+
+
+def test_feedback_rejects_surrogate_source_id(client) -> None:
+    resp = _post_json_document(
+        client,
+        "/api/feedback",
+        {"rating": "up", "sources": [{"id": "\ud800"}]},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "invalid feedback request"}
+
+
+@pytest.mark.parametrize("field", ["query", "source_id"])
+def test_source_feedback_rejects_surrogates_in_persisted_fields(client, field) -> None:
+    body = {"source_id": "m1", "query": "hola", "rating": "up"}
+    body[field] = "\ud800"
+
+    resp = _post_json_document(client, "/api/feedback/source", body)
+
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "invalid source feedback request"}
+
+
 def test_deferred_endpoints_501(client) -> None:
     assert client.post("/api/memory/delete", json={}).status_code == 501
     assert client.post("/api/insight/capture", json={}).status_code == 501
@@ -160,6 +268,23 @@ def test_sessions_endpoints(client) -> None:
     assert "at" in history["turns"][0]
 
     assert client.post("/api/sessions/delete", json={"session_id": "s1"}).json()["ok"] is True
+
+
+@pytest.mark.parametrize("session_id", [None, 1, False, [], {}])
+def test_delete_session_rejects_non_string_ids(client, session_id) -> None:
+    resp = client.post("/api/sessions/delete", json={"session_id": session_id})
+
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "invalid session id"}
+
+
+@pytest.mark.parametrize("endpoint", ["/api/sessions", "/api/suggestions"])
+@pytest.mark.parametrize("limit", [0, -1, 101])
+def test_list_endpoints_reject_out_of_range_limits(client, endpoint, limit) -> None:
+    resp = client.get(endpoint, params={"limit": limit})
+
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "limit must be between 1 and 100"}
 
 
 def test_suggestions_returns_chip_objects(client) -> None:
@@ -322,3 +447,217 @@ def test_chat_http_rejects_oversized_request_body(client) -> None:
     resp = client.post("/api/ask", json={"q": "x" * 1_048_577})
 
     assert resp.status_code == 413
+
+
+def test_chat_http_module_imports_without_fastapi_or_starlette() -> None:
+    code = """
+import builtins
+
+real_import = builtins.__import__
+
+def guarded_import(name, *args, **kwargs):
+    if name.split('.', 1)[0] in {'fastapi', 'starlette'}:
+        raise ImportError(f'blocked optional dependency: {name}')
+    return real_import(name, *args, **kwargs)
+
+builtins.__import__ = guarded_import
+import memo.chat.http
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_ask_reads_only_recent_session_history_once(tmp_path, monkeypatch) -> None:
+    from memo.chat.config import ChatConfig
+    from memo.chat.sessions import SessionStore
+    from tests.test_chat_pipeline import _FakeMemory
+
+    calls: list[tuple[str, int]] = []
+    original_get_recent = SessionStore.get_recent
+
+    def spy_get_recent(self, session_id, limit=12):
+        calls.append((session_id, limit))
+        return original_get_recent(self, session_id, limit)
+
+    monkeypatch.setattr(SessionStore, "get_recent", spy_get_recent)
+    memory = _FakeMemory(tmp_path)
+    cfg = ChatConfig.load(memory.cfg.state_dir)
+    SessionStore(cfg.sessions_dir).append_turn("once", "user", "primera")
+    app = build_app(memory)
+    local_client = TestClient(app, base_url="http://127.0.0.1")
+
+    response = local_client.post("/api/ask", json={"q": "seguimiento", "chat_session_id": "once"})
+
+    assert response.status_code == 200
+    assert calls == [("once", 12)]
+
+
+def test_session_endpoints_skip_corrupt_jsonl_turns(tmp_path) -> None:
+    from memo.chat.config import ChatConfig
+    from memo.chat.sessions import SessionStore
+    from tests.test_chat_pipeline import _FakeMemory
+
+    memory = _FakeMemory(tmp_path)
+    cfg = ChatConfig.load(memory.cfg.state_dir)
+    store = SessionStore(cfg.sessions_dir)
+    store.append_turn("legacy", "user", "valid")
+    with store._path("legacy").open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"role": "user", "ts": "bad"}) + "\n")
+        fh.write(json.dumps({"role": "user", "text": "\ud800", "ts": 1}) + "\n")
+
+    app = build_app(memory)
+    local_client = TestClient(app, base_url="http://127.0.0.1")
+    listing = local_client.get("/api/sessions")
+    history = local_client.get("/api/sessions/legacy")
+
+    assert listing.status_code == 200
+    assert listing.json()["sessions"][0]["turn_count"] == 1
+    assert history.status_code == 200
+    assert [turn["text"] for turn in history.json()["turns"]] == ["valid"]
+
+
+@pytest.mark.asyncio
+async def test_source_feedback_shares_chat_capacity_and_slots_are_reused(
+    tmp_path, monkeypatch
+) -> None:
+    import httpx
+
+    import memo.chat.http as chat_http
+    from tests.test_chat_pipeline import _FakeMemory
+
+    started = threading.Event()
+    release = threading.Event()
+    state = {"active": 0, "peak": 0}
+    lock = threading.Lock()
+
+    def blocking_run(self, question, *, session_id, history, k):
+        with lock:
+            state["active"] += 1
+            state["peak"] = max(state["peak"], state["active"])
+            if state["active"] == 4:
+                started.set()
+        release.wait(timeout=5)
+        with lock:
+            state["active"] -= 1
+        return [{"type": "done", "answer": question, "chat_session_id": session_id}]
+
+    monkeypatch.setattr(chat_http._ChatApi, "_run", blocking_run)
+    app = build_app(_FakeMemory(tmp_path))
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as async_client:
+        requests = [
+            asyncio.create_task(async_client.post("/api/ask", json={"q": f"q-{index}"}))
+            for index in range(4)
+        ]
+        assert await asyncio.to_thread(started.wait, 2), "four requests never entered chat work"
+
+        overflow = await async_client.post(
+            "/api/feedback/source",
+            json={"source_id": "m1", "query": "overflow", "rating": "up"},
+        )
+
+        assert overflow.status_code == 503
+        assert overflow.headers["retry-after"] == "1"
+        assert state["peak"] == 4
+        release.set()
+        completed = await asyncio.gather(*requests)
+        assert all(response.status_code == 200 for response in completed)
+        recovered = await async_client.post("/api/ask", json={"q": "recovered"})
+        assert recovered.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_heavy_slot_is_recovered_after_worker_exception(tmp_path, monkeypatch) -> None:
+    import httpx
+
+    import memo.chat.http as chat_http
+    from tests.test_chat_pipeline import _FakeMemory
+
+    monkeypatch.setattr(chat_http, "_MAX_HEAVY_IN_FLIGHT", 1)
+    calls = 0
+
+    def flaky_run(self, question, *, session_id, history, k):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("boom")
+        return [{"type": "done", "answer": question, "chat_session_id": session_id}]
+
+    monkeypatch.setattr(chat_http._ChatApi, "_run", flaky_run)
+    app = build_app(_FakeMemory(tmp_path))
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as async_client:
+        failed = await async_client.post("/api/ask", json={"q": "fails"})
+        recovered = await async_client.post("/api/ask", json={"q": "works"})
+
+    assert failed.status_code == 500
+    assert recovered.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_stream_slot_is_recovered_if_response_construction_fails(
+    tmp_path, monkeypatch
+) -> None:
+    import httpx
+
+    import memo.chat.http as chat_http
+    from tests.test_chat_pipeline import _FakeMemory
+
+    monkeypatch.setattr(chat_http, "_MAX_HEAVY_IN_FLIGHT", 1)
+    calls = 0
+
+    class BrokenStreamingResponse:
+        def __init__(self, *args, **kwargs):
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("cannot construct stream")
+
+    monkeypatch.setattr("fastapi.responses.StreamingResponse", BrokenStreamingResponse)
+    app = build_app(_FakeMemory(tmp_path))
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as async_client:
+        first = await async_client.post("/api/ask/stream", json={"q": "first"})
+        second = await async_client.post("/api/ask/stream", json={"q": "second"})
+
+    assert first.status_code == 500
+    assert second.status_code == 500
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_heavy_slot_is_recovered_after_request_cancellation(tmp_path, monkeypatch) -> None:
+    import httpx
+
+    import memo.chat.http as chat_http
+    from tests.test_chat_pipeline import _FakeMemory
+
+    monkeypatch.setattr(chat_http, "_MAX_HEAVY_IN_FLIGHT", 1)
+    started = asyncio.Event()
+
+    async def cancellable_run_sync(function, *args, **kwargs):
+        if function.__name__ == "_run":
+            started.set()
+            await asyncio.sleep(30)
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr("fastapi.concurrency.run_in_threadpool", cancellable_run_sync)
+    app = build_app(_FakeMemory(tmp_path))
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as async_client:
+        request = asyncio.create_task(async_client.post("/api/ask", json={"q": "cancel"}))
+        await asyncio.wait_for(started.wait(), timeout=2)
+        request.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await request
+
+        monkeypatch.setattr(chat_http._ChatApi, "_run", lambda *args, **kwargs: [])
+        recovered = await async_client.post("/api/ask", json={"q": "works"})
+
+    assert recovered.status_code == 200

--- a/tests/test_chat_http.py
+++ b/tests/test_chat_http.py
@@ -823,6 +823,88 @@ async def test_delete_all_waits_for_in_flight_asks_and_cannot_be_recreated(
 
 
 @pytest.mark.asyncio
+async def test_delete_all_does_not_drain_same_session_backlog(tmp_path, monkeypatch) -> None:
+    import httpx
+
+    from tests.test_chat_pipeline import _FakeMemory
+
+    first_started = threading.Event()
+    second_started = threading.Event()
+    release_first = threading.Event()
+
+    def blocking_stream(_memory, question, **_kwargs):
+        if question == "first":
+            first_started.set()
+            assert release_first.wait(timeout=5)
+        else:
+            second_started.set()
+        yield {"type": "done", "answer": f"answer-{question}", "sources": []}
+
+    monkeypatch.setattr("memo.chat.pipeline.chat_stream", blocking_stream)
+    app = build_app(_FakeMemory(tmp_path))
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as client:
+        first = asyncio.create_task(
+            client.post("/api/ask", json={"q": "first", "chat_session_id": "backlog"})
+        )
+        assert await asyncio.to_thread(first_started.wait, 2)
+        second = asyncio.create_task(
+            client.post("/api/ask", json={"q": "second", "chat_session_id": "backlog"})
+        )
+        await asyncio.sleep(0.05)
+        delete = asyncio.create_task(client.post("/api/sessions/delete-all", json={}))
+        await asyncio.sleep(0.05)
+
+        release_first.set()
+        delete_response = await asyncio.wait_for(delete, timeout=2)
+        assert not second_started.is_set()
+        first_response, second_response = await asyncio.gather(first, second)
+        history = (await client.get("/api/sessions/backlog")).json()["turns"]
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert delete_response.json() == {"ok": True, "deleted": 1}
+    assert history == []
+
+
+@pytest.mark.asyncio
+async def test_get_session_blocks_delete_all_during_file_read(tmp_path, monkeypatch) -> None:
+    import httpx
+
+    from memo.chat.sessions import SessionStore
+    from tests.test_chat_pipeline import _FakeMemory
+
+    store = SessionStore(tmp_path / "chat" / "sessions")
+    store.append_exchange("read-race", "question", "answer")
+    real_get = SessionStore.get
+    read_started = threading.Event()
+    release_read = threading.Event()
+
+    def blocking_get(self, session_id):
+        if session_id == "read-race":
+            read_started.set()
+            assert release_read.wait(timeout=5)
+        return real_get(self, session_id)
+
+    monkeypatch.setattr(SessionStore, "get", blocking_get)
+    app = build_app(_FakeMemory(tmp_path))
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as client:
+        read = asyncio.create_task(client.get("/api/sessions/read-race"))
+        assert await asyncio.to_thread(read_started.wait, 2)
+        delete = asyncio.create_task(client.post("/api/sessions/delete-all", json={}))
+        await asyncio.sleep(0.05)
+        assert not delete.done()
+
+        release_read.set()
+        read_response, delete_response = await asyncio.gather(read, delete)
+
+    assert read_response.status_code == 200
+    assert [turn["text"] for turn in read_response.json()["turns"]] == ["question", "answer"]
+    assert delete_response.json() == {"ok": True, "deleted": 1}
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("exit_mode", ["disconnect", "send_failure"])
 async def test_stream_capacity_is_released_when_asgi_exits_before_iteration(
     tmp_path, monkeypatch, exit_mode

--- a/tests/test_chat_sessions.py
+++ b/tests/test_chat_sessions.py
@@ -46,6 +46,27 @@ def test_append_rejects_invalid_text_before_touching_file(tmp_path, role, text) 
     assert not store._path("s1").exists()
 
 
+def test_append_exchange_validates_both_turns_before_touching_file(tmp_path) -> None:
+    store = SessionStore(tmp_path)
+
+    with pytest.raises(ValueError):
+        store.append_exchange("s1", "valid question", "invalid \ud800 answer")
+
+    assert not store._path("s1").exists()
+
+
+def test_append_exchange_persists_adjacent_turns(tmp_path) -> None:
+    store = SessionStore(tmp_path)
+
+    store.append_exchange("s1", "question", "answer")
+
+    turns = store.get("s1")
+    assert [(turn["role"], turn["text"]) for turn in turns] == [
+        ("user", "question"),
+        ("assistant", "answer"),
+    ]
+
+
 def test_get_skips_non_dict_lines(tmp_path) -> None:
     store = SessionStore(tmp_path)
     store.append_turn("s1", "user", "hola")
@@ -100,6 +121,28 @@ def test_get_recent_reads_tail_and_skips_malformed_lines(tmp_path) -> None:
     turns = store.get_recent("s1", limit=3)
 
     assert [turn["text"] for turn in turns] == ["turn-18", "turn-19", "last"]
+
+
+def test_get_recent_parses_each_long_tail_line_once(tmp_path, monkeypatch) -> None:
+    store = SessionStore(tmp_path)
+    for index in range(30):
+        store.append_turn("s1", "user", f"turn-{index}-" + "x" * 9000)
+    original_parse = SessionStore._parse_turn
+    parse_calls = 0
+
+    def spy_parse(raw_line):
+        nonlocal parse_calls
+        parse_calls += 1
+        return original_parse(raw_line)
+
+    monkeypatch.setattr(SessionStore, "_parse_turn", staticmethod(spy_parse))
+
+    turns = store.get_recent("s1", limit=12)
+
+    assert [turn["text"].split("-", 2)[:2] for turn in turns] == [
+        ["turn", str(index)] for index in range(18, 30)
+    ]
+    assert parse_calls <= 13
 
 
 def test_readers_skip_json_integer_beyond_interpreter_limit(tmp_path) -> None:

--- a/tests/test_chat_sessions.py
+++ b/tests/test_chat_sessions.py
@@ -28,6 +28,24 @@ def test_delete(tmp_path) -> None:
     assert store.delete_all() == 2
 
 
+@pytest.mark.parametrize(
+    ("role", "text"),
+    [
+        (1, "text"),
+        ("user", 1),
+        ("\ud800", "text"),
+        ("user", "\ud800"),
+    ],
+)
+def test_append_rejects_invalid_text_before_touching_file(tmp_path, role, text) -> None:
+    store = SessionStore(tmp_path)
+
+    with pytest.raises(ValueError):
+        store.append_turn("s1", role, text)
+
+    assert not store._path("s1").exists()
+
+
 def test_get_skips_non_dict_lines(tmp_path) -> None:
     store = SessionStore(tmp_path)
     store.append_turn("s1", "user", "hola")
@@ -41,6 +59,96 @@ def test_get_skips_non_dict_lines(tmp_path) -> None:
 
     turns = store.get("s1")
     assert [t["role"] for t in turns] == ["user", "assistant"]
+
+
+@pytest.mark.parametrize(
+    "corrupt_turn",
+    [
+        {},
+        {"role": "user", "ts": 1.0},
+        {"text": "x", "ts": 1.0},
+        {"role": [], "text": "x", "ts": 1.0},
+        {"role": "user", "text": {}, "ts": 1.0},
+        {"role": "user", "text": "x", "ts": "yesterday"},
+        {"role": "user", "text": "x", "ts": True},
+        {"role": "user", "text": "x", "ts": float("nan")},
+        {"role": "user", "text": "x", "ts": -1},
+        {"role": "user", "text": "x", "ts": 10**20},
+        {"role": "\ud800", "text": "x", "ts": 1.0},
+        {"role": "user", "text": "\ud800", "ts": 1.0},
+    ],
+)
+def test_readers_skip_shape_corrupt_turn_objects(tmp_path, corrupt_turn) -> None:
+    store = SessionStore(tmp_path)
+    store.append_turn("s1", "user", "before")
+    with store._path("s1").open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(corrupt_turn, ensure_ascii=True) + "\n")
+    store.append_turn("s1", "assistant", "after")
+
+    assert [turn["text"] for turn in store.get("s1")] == ["before", "after"]
+    assert [turn["text"] for turn in store.get_recent("s1", limit=2)] == ["before", "after"]
+
+
+def test_get_recent_reads_tail_and_skips_malformed_lines(tmp_path) -> None:
+    store = SessionStore(tmp_path)
+    for index in range(20):
+        store.append_turn("s1", "user", f"turn-{index}")
+    with store._path("s1").open("a", encoding="utf-8") as fh:
+        fh.write("not-json\n")
+    store.append_turn("s1", "assistant", "last")
+
+    turns = store.get_recent("s1", limit=3)
+
+    assert [turn["text"] for turn in turns] == ["turn-18", "turn-19", "last"]
+
+
+def test_readers_skip_json_integer_beyond_interpreter_limit(tmp_path) -> None:
+    store = SessionStore(tmp_path)
+    store.append_turn("s1", "user", "before")
+    huge_integer = "9" * 5000
+    with store._path("s1").open("a", encoding="utf-8") as fh:
+        fh.write(f'{{"role":"user","text":"bad","ts":{huge_integer}}}\n')
+    store.append_turn("s1", "assistant", "after")
+
+    assert [turn["text"] for turn in store.get("s1")] == ["before", "after"]
+    assert [turn["text"] for turn in store.get_recent("s1", limit=2)] == ["before", "after"]
+
+
+def test_listing_skips_invalid_filename_and_per_file_io_errors(tmp_path, monkeypatch) -> None:
+    store = SessionStore(tmp_path)
+    store.append_turn("valid", "user", "keep")
+    (tmp_path / "bad id!.jsonl").write_text("{}\n", encoding="utf-8")
+    (tmp_path / "unreadable.jsonl").write_text("{}\n", encoding="utf-8")
+    (tmp_path / "unstatable.jsonl").touch()
+    original_get = SessionStore.get
+    original_stat = type(tmp_path).stat
+
+    def sometimes_unreadable(self, session_id):
+        if session_id == "unreadable":
+            raise OSError("unreadable")
+        return original_get(self, session_id)
+
+    def sometimes_unstatable(path, *args, **kwargs):
+        if path.name == "unstatable.jsonl":
+            raise OSError("unstatable")
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(SessionStore, "get", sometimes_unreadable)
+    monkeypatch.setattr(type(tmp_path), "stat", sometimes_unstatable)
+
+    sessions = store.list_sessions()
+
+    assert [row["session_id"] for row in sessions] == ["valid"]
+
+
+@pytest.mark.parametrize("session_id", [None, 1, False, [], {}, "../evil", "a/b", ""])
+def test_validate_id_is_strict_and_has_no_io(tmp_path, session_id) -> None:
+    store = SessionStore(tmp_path)
+
+    with pytest.raises(ValueError):
+        store.validate_id(session_id)
+
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_invalid_session_id_rejected(tmp_path) -> None:

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -5,8 +5,10 @@ memo. Mirrors test_cli_consult_attribution for the chat group surface."""
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from click.testing import CliRunner
 
 from memo.cli_chat import chat_group
@@ -71,3 +73,34 @@ def test_chat_ask_silent_without_source(tmp_cfg: Config, monkeypatch) -> None:
     res = CliRunner().invoke(chat_group, ["ask", "what?"], env=_env(tmp_cfg))
     assert res.exit_code == 0, res.output
     assert read_recall_log(tmp_cfg.state_dir, limit=10) == []
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "192.0.2.10"])  # noqa: S104
+def test_chat_serve_rejects_non_loopback_bind(host: str) -> None:
+    result = CliRunner().invoke(chat_group, ["serve", "--host", host])
+
+    assert result.exit_code == 1
+    assert "only accepts loopback hosts" in result.output
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "::1", "localhost"])
+def test_chat_serve_accepts_loopback_bind(host: str, monkeypatch, tmp_path: Path) -> None:
+    seen: dict[str, object] = {}
+    memory = SimpleNamespace()
+    monkeypatch.setattr("memo.cli_chat._build_memory", lambda: memory)
+    monkeypatch.setattr("memo.chat.http.build_app", lambda mem, dist=None: (mem, dist))
+
+    def fake_run(app, **kwargs) -> None:
+        seen.update(app=app, **kwargs)
+
+    monkeypatch.setattr("uvicorn.run", fake_run)
+
+    result = CliRunner().invoke(
+        chat_group,
+        ["serve", "--host", host, "--port", "9876", "--dist", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen["host"] == host
+    assert seen["port"] == 9876
+    assert seen["app"] == (memory, tmp_path)

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -5,6 +5,8 @@ memo. Mirrors test_cli_consult_attribution for the chat group surface."""
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -81,6 +83,35 @@ def test_chat_serve_rejects_non_loopback_bind(host: str) -> None:
 
     assert result.exit_code == 1
     assert "only accepts loopback hosts" in result.output
+
+
+def test_chat_serve_rejects_remote_bind_without_optional_http_imports() -> None:
+    code = r"""
+import builtins
+from click.testing import CliRunner
+
+real_import = builtins.__import__
+
+def guarded_import(name, *args, **kwargs):
+    if name.split('.', 1)[0] in {'fastapi', 'starlette'}:
+        raise ImportError(f'blocked optional dependency: {name}')
+    return real_import(name, *args, **kwargs)
+
+builtins.__import__ = guarded_import
+from memo.cli_chat import chat_group
+result = CliRunner().invoke(chat_group, ['serve', '--host', '0.0.0.0'])
+print(result.output)
+raise SystemExit(0 if result.exit_code == 1 and 'only accepts loopback hosts' in result.output else 1)
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
 
 
 @pytest.mark.parametrize("host", ["127.0.0.1", "::1", "localhost"])

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -430,6 +430,44 @@ def test_no_auth_guard_rejections_do_not_consume_rate_limit() -> None:
     assert allowed.status_code == 200
 
 
+def test_no_auth_guard_rate_limits_rejections_with_separate_quota() -> None:
+    from starlette.middleware import Middleware
+
+    from memo.http_auth import LocalRequestGuardMiddleware, RateLimitMiddleware
+
+    async def sensitive(_request) -> PlainTextResponse:
+        return PlainTextResponse("ok")
+
+    app = Starlette(
+        routes=[Route("/chat/stream", sensitive, methods=["POST"])],
+        middleware=[
+            Middleware(
+                LocalRequestGuardMiddleware,
+                max_rejections=2,
+                rejection_window_seconds=60,
+            ),
+            Middleware(RateLimitMiddleware, max_requests=1, window_seconds=60),
+        ],
+    )
+    with TestClient(
+        app,
+        base_url="http://127.0.0.1:18768",
+        client=("127.0.0.1", 50000),
+    ) as client:
+        statuses = [
+            client.post(
+                "/chat/stream",
+                json={},
+                headers={"Origin": "https://attacker.example"},
+            ).status_code
+            for _ in range(3)
+        ]
+        allowed = client.post("/chat/stream", json={})
+
+    assert statuses == [403, 403, 429]
+    assert allowed.status_code == 200
+
+
 def test_memo_mcp_server_attaches_shared_auth_provider(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -341,7 +341,11 @@ def test_no_auth_http_guard_rejects_browser_cross_site_and_simple_posts(
         routes=[Route("/chat/stream", sensitive, methods=["POST"])],
         middleware=build_http_middleware(allow_no_auth=True),
     )
-    with TestClient(app, base_url="http://127.0.0.1:18768") as client:
+    with TestClient(
+        app,
+        base_url="http://127.0.0.1:18768",
+        client=("127.0.0.1", 50000),
+    ) as client:
         response = client.post("/chat/stream", headers=headers, content=b"{}")
 
     assert response.status_code == status_code
@@ -357,7 +361,11 @@ def test_no_auth_http_guard_allows_loopback_json_posts() -> None:
         routes=[Route("/chat/stream", sensitive, methods=["POST"])],
         middleware=build_http_middleware(allow_no_auth=True),
     )
-    with TestClient(app, base_url="http://localhost:18768") as client:
+    with TestClient(
+        app,
+        base_url="http://localhost:18768",
+        client=("127.0.0.1", 50000),
+    ) as client:
         cli_response = client.post("/chat/stream", json={})
         browser_response = client.post(
             "/chat/stream",
@@ -370,6 +378,56 @@ def test_no_auth_http_guard_allows_loopback_json_posts() -> None:
 
     assert cli_response.status_code == 200
     assert browser_response.status_code == 200
+
+
+def test_no_auth_http_guard_rejects_remote_peer_with_loopback_host() -> None:
+    from memo.http_auth import build_http_middleware
+
+    async def sensitive(_request) -> PlainTextResponse:
+        pytest.fail("remote request reached the sensitive route")
+
+    app = Starlette(
+        routes=[Route("/chat/stream", sensitive, methods=["POST"])],
+        middleware=build_http_middleware(allow_no_auth=True),
+    )
+    with TestClient(
+        app,
+        base_url="http://127.0.0.1:18768",
+        client=("192.0.2.10", 50000),
+    ) as client:
+        response = client.post("/chat/stream", json={})
+
+    assert response.status_code == 403
+
+
+def test_no_auth_guard_rejections_do_not_consume_rate_limit() -> None:
+    from memo.http_auth import build_http_middleware
+
+    async def sensitive(_request) -> PlainTextResponse:
+        return PlainTextResponse("ok")
+
+    app = Starlette(
+        routes=[Route("/chat/stream", sensitive, methods=["POST"])],
+        middleware=build_http_middleware(
+            allow_no_auth=True,
+            max_requests=1,
+            window_seconds=60,
+        ),
+    )
+    with TestClient(
+        app,
+        base_url="http://127.0.0.1:18768",
+        client=("127.0.0.1", 50000),
+    ) as client:
+        rejected = client.post(
+            "/chat/stream",
+            json={},
+            headers={"Origin": "https://attacker.example"},
+        )
+        allowed = client.post("/chat/stream", json={})
+
+    assert rejected.status_code == 403
+    assert allowed.status_code == 200
 
 
 def test_memo_mcp_server_attaches_shared_auth_provider(


### PR DESCRIPTION
## Summary
- reject non-loopback `memo chat serve` binds because the chat UI has no remote bearer-auth flow
- protect loopback chat against DNS rebinding/cross-site requests, oversized bodies, and request floods
- validate ask/session/feedback payloads before retrieval or persistence so malformed JSON yields bounded 400 responses instead of 500s or poisoned feedback
- split the HTTP surface into cohesive route handlers; `build_app` is wiring-only and adds no complexity-budget regression
- apply SPA-compatible no-store/nosniff/frame/referrer/CSP response headers while preserving the shared API-only defaults

## Verification on head ab8ec8af
- rebased on master `490da629`
- `python scripts/quality_gate.py` — PASS (169 complexity / 174 exception budgets)
- `ruff check src/ tests/` — PASS
- `mypy src/memo` — PASS (484 files)
- focused chat/flags/MCP/packaging/resource/auth suite — 260 PASS
- malformed-payload fuzz — zero 500 responses across stream/non-stream ask routes
- recall pre-push gate — PASS (`prec@k 0.708`, noise `0.000`)
- Docker builder and full runtime image build passed with `EXPECTED_VERSION=4.7.0`
- container `memo config validate` passed; offline ST embed returned `(1, 1024)` as UID 1000
- MCP stdio schema/call verified with `defer_embed=True` through the write coordinator (`index_pending=True`)

Draft pending green CI and parent coordination; do not merge yet.