### PR TITLE
fix: verify runtime package provenance

### DIFF
--- a/src/memo/runtime/detect.py
+++ b/src/memo/runtime/detect.py
@@ -90,8 +90,11 @@ def is_homebrew_install() -> bool:
     )
 
 
-def _runtime_install_report(cwd: Path | None = None) -> dict[str, Any]:
+def _runtime_install_report(
+    cwd: Path | None = None, *, package_file: Path | None = None
+) -> dict[str, Any]:
     cwd = _safe_resolve(cwd or Path.cwd())
+    package_path = _safe_resolve(package_file or Path(__file__))
     memo_cmd, memo_resolved = _resolve_command("memo", prefer_invoked=True)
     mcp_cmd, mcp_resolved = _resolve_command("memo-mcp", sibling_of=memo_resolved)
     py_resolved = _safe_resolve(Path(sys.executable))
@@ -128,6 +131,15 @@ def _runtime_install_report(cwd: Path | None = None) -> dict[str, Any]:
             "install mode is unknown; recommended: `pipx install mlx-memo` "
             "or `uv tool install mlx-memo`"
         )
+    if (
+        mode in {"pipx", "uv tool", "homebrew"}
+        and primary_root is not None
+        and not _path_is_relative_to(package_path, primary_root)
+    ):
+        warnings.append(
+            f"memo Python package loaded from {package_path}, outside the isolated runtime "
+            f"{primary_root}; clear PYTHONPATH or reinstall without an editable source link"
+        )
 
     return {
         "mode": mode,
@@ -137,6 +149,7 @@ def _runtime_install_report(cwd: Path | None = None) -> dict[str, Any]:
         "mcp_cmd": str(mcp_cmd) if mcp_cmd else None,
         "mcp_resolved": str(mcp_resolved) if mcp_resolved else None,
         "python": str(py_resolved),
+        "package_path": str(package_path),
         "warnings": warnings,
     }
 

--- a/tests/test_runtime_isolation.py
+++ b/tests/test_runtime_isolation.py
@@ -54,11 +54,34 @@ def test_runtime_report_accepts_pipx_install(monkeypatch, tmp_path):
     monkeypatch.setattr(cli_mod.shutil, "which", fake_which)
     monkeypatch.setattr(sys, "executable", str(bin_dir / "python"))
 
-    report = cli_mod._runtime_install_report(cwd=tmp_path / "repo")
+    report = cli_mod._runtime_install_report(
+        cwd=tmp_path / "repo", package_file=root / "lib" / "python" / "memo" / "detect.py"
+    )
 
     assert report["mode"] == "pipx"
     assert report["root"] == str(root)
     assert report["warnings"] == []
+
+
+def test_runtime_report_warns_when_pythonpath_shadows_isolated_install(monkeypatch, tmp_path):
+    root = tmp_path / ".local" / "share" / "uv" / "tools" / "mlx-memo"
+    bin_dir = root / "bin"
+    bin_dir.mkdir(parents=True)
+    for name in ("memo", "memo-mcp", "python"):
+        (bin_dir / name).touch()
+
+    source_file = tmp_path / "repo" / "src" / "memo" / "runtime" / "detect.py"
+    source_file.parent.mkdir(parents=True)
+    source_file.touch()
+
+    monkeypatch.setattr(cli_mod.shutil, "which", lambda name: str(bin_dir / name))
+    monkeypatch.setattr(sys, "executable", str(bin_dir / "python"))
+    report = cli_mod._runtime_install_report(cwd=tmp_path / "repo", package_file=source_file)
+
+    assert report["mode"] == "uv tool"
+    assert report["package_path"] == str(source_file)
+    assert any("outside the isolated runtime" in warning for warning in report["warnings"])
+    assert any("PYTHONPATH" in warning for warning in report["warnings"])
 
 
 def test_runtime_report_warns_for_project_venv(monkeypatch, tmp_path):
@@ -97,7 +120,10 @@ def test_runtime_report_prefers_invoked_memo_over_path(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "executable", str(active_bin / "python"))
     monkeypatch.setattr(cli_mod.shutil, "which", lambda name: str(path_bin / name))
 
-    report = cli_mod._runtime_install_report(cwd=tmp_path / "repo")
+    report = cli_mod._runtime_install_report(
+        cwd=tmp_path / "repo",
+        package_file=active_root / "lib" / "python" / "memo" / "detect.py",
+    )
 
     assert report["root"] == str(active_root)
     assert report["memo_resolved"] == str(active_bin / "memo")

--- a/tests/test_sqlite_cleanup.py
+++ b/tests/test_sqlite_cleanup.py
@@ -133,18 +133,19 @@ def _cleanup_without_warnings(factory) -> list[warnings.WarningMessage]:
 
 
 def test_cleanup_warning_capture_ignores_preexisting_garbage(tmp_path: Path) -> None:
-    class CyclicConnectionHolder:
+    class CyclicWarningEmitter:
         def __init__(self) -> None:
-            self.connection = sqlite3.connect(tmp_path / "ambient.db")
             self.cycle = self
 
-    holder = CyclicConnectionHolder()
-    del holder
+        def __del__(self) -> None:
+            warnings.warn("ambient sqlite resource", ResourceWarning, stacklevel=1)
 
-    # The preexisting connection is deliberately leaked to exercise the
-    # attribution boundary. Capture its warning here so it does not pollute the
-    # suite summary; the helper's inner filter still records warnings produced
-    # by VersionStore itself.
+    emitter = CyclicWarningEmitter()
+    del emitter
+
+    # Simulate an unrelated SQLite ResourceWarning without deliberately leaking
+    # a real connection. The helper's inner filter still records warnings
+    # produced by VersionStore itself.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", ResourceWarning)
         warnings_seen = _cleanup_without_warnings(lambda: VersionStore(tmp_path / "versions.db"))


### PR DESCRIPTION
## Summary
- make strict runtime diagnostics verify the actual imported memo package path, not only the executable path
- flag `PYTHONPATH` or editable-source shadowing of pipx/uv/Homebrew installs
- keep the SQLite resource-attribution regression test deterministic without deliberately leaking a real database connection

## Verification
- `uv run --no-sync ruff check src/ tests/`
- `uv run --no-sync mypy src/memo` (484 files)
- `uv run --no-sync pytest tests/test_runtime_isolation.py tests/test_sqlite_cleanup.py -W error -q` (49 passed)
- `uv run --no-sync pytest -m "not slow" -n auto --timeout=120 -W error -q` (6299 passed, 19 skipped; zero warnings)
- full non-slow coverage run (6299 passed, 19 skipped; 78.50%)
- pre-push recall gate passed (prec@k 0.708, noise@k 0.000)