### PR TITLE
feat: add live registered-terminal chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,12 +167,12 @@ Python ≥ 3.13 (the installer handles this via `uv` if you don't have it). Firs
 | Install detail, installer knobs, new-Mac migration | [reference.md › Install](https://github.com/jagoff/memo/blob/master/docs/reference.md#install-detail) |
 | Per-client MCP setup (Claude Desktop, Cursor, Cline, Continue) | [reference.md › MCP setup](https://github.com/jagoff/memo/blob/master/docs/reference.md#mcp-setup) |
 | Ambient recall, capture, and tuning | [reference.md › Ambient memory](https://github.com/jagoff/memo/blob/master/docs/reference.md#ambient-memory) |
-| Full CLI reference (141 commands) + `memo tui` | [reference.md › CLI](https://github.com/jagoff/memo/blob/master/docs/reference.md#cli-reference) |
+| Full CLI reference (142 commands) + `memo tui` | [reference.md › CLI](https://github.com/jagoff/memo/blob/master/docs/reference.md#cli-reference) |
 | All `MEMO_*` flags and model profiles | [reference.md › Configuration](https://github.com/jagoff/memo/blob/master/docs/reference.md#configuration) |
 | Architecture and design notes | [reference.md › Design](https://github.com/jagoff/memo/blob/master/docs/reference.md#design-and-comparison) |
 | Privacy and network policy | [PRIVACY.md](https://github.com/jagoff/memo/blob/master/PRIVACY.md) |
 
-### All 141 top-level CLI commands
+### All 142 top-level CLI commands
 
 <details>
 <summary>Complete command inventory (kept here so CI detects CLI/documentation drift)</summary>

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ Most memory servers *add* context. memo is built to remove it.
 
 | Profile | Tools | Schema tokens |
 |---|---:|---:|
-| `agent` (default) | 40 | ~4.0k |
-| `core` / `slim` | 57 | ~5.2k |
-| `full` / `default` | 161 | ~18k |
+| `agent` (default) | 43 | ~4.3k |
+| `core` / `slim` | 60 | ~5.5k |
+| `full` / `default` | 164 | ~18.3k |
 
-The default MCP surface is 40 tools, not 161: about 75% fewer tool schemas. It exposes **40 tools / ~4.0k schema tokens** versus **161 tools / ~18k tokens** on the full surface — overhead paid every session, in every client.
+The default MCP surface is 43 tools, not 164: about 74% fewer tool schemas. It exposes **43 tools / ~4.3k schema tokens** versus **164 tools / ~18.3k tokens** on the full surface — overhead paid every session, in every client.
 
 Ambient recall injects one relevant memory before the model answers. The bundled Claude Code hook caps that injection at ~160 tokens. `memo roi` reads the real grounding and re-ask ledgers, then estimates accumulated savings with disclosed defaults (350 tokens per grounded recall and 900 per avoided re-ask).
 
@@ -183,7 +183,7 @@ Python ≥ 3.13 (the installer handles this via `uv` if you don't have it). Firs
 
 **Session & History:** `history` `as-of` `diff` `record-history` `session` `chat-session` `resume` `reflect` `mine-history` `episodes` `chronicle`
 
-**Maintenance:** `reindex` `maintain` `review` `dream` `consolidate` `synthesize` `dedupe` `retier` `contradict` `coordinate` `invalidate` `temporal` `compress-context` `ops`
+**Maintenance:** `reindex` `maintain` `review` `dream` `consolidate` `synthesize` `dedupe` `retier` `contradict` `coordinate` `terminal` `invalidate` `temporal` `compress-context` `ops`
 
 **Analysis & Quality:** `health` `stats` `doctor` `journey-check` `lint` `drift` `analytics` `eval` `roi` `tokens` `token-savings` `usefulness` `gaps` `outcome` `profile` `confidence` `graduation` `hype` `definitive` `evidence`
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -44,7 +44,7 @@ agent-memory projects. For the complete live flag registry, run
   wording of past local transcript turns through a private, lexical-only FTS5
   index that never enters ambient recall.
 - **Fewer tokens, not more.** Recall injects the relevant answer on a bounded
-  budget, and the default MCP surface exposes 40 tools instead of the full 161.
+  budget, and the default MCP surface exposes 43 tools instead of the full 164.
 
 ---
 
@@ -248,12 +248,12 @@ Released wheels include the Claude/Codex/Devin agent assets, so a normal
 checkout, pass `--repo /path/to/memo` to test uncommitted plugin changes.
 
 Tools surface inside the agent as `mcp__memo__memo_*`. Agent installs default to
-a 40-tool surface (`ask`, `context`, `get`, `graph`, `offload`, `rename`, `save`,
+a 43-tool surface (`ask`, `context`, `get`, `graph`, `offload`, `rename`, `save`,
 `search`, `unified_briefing`, `version`, lifecycle, session/capture
 notifications, and Memo-native evidence, operational-continuity, and
-outcome-learning helpers) so
+outcome-learning helpers, plus registered-terminal live chat) so
 administrative schemas don't consume model context — set
-`MEMO_MCP_PROFILE=core`/`slim` (57 tools) or `full`/`default` (161 tools) only
+`MEMO_MCP_PROFILE=core`/`slim` (60 tools) or `full`/`default` (164 tools) only
 for clients that genuinely need the larger administrative surface.
 
 ### Claude Code
@@ -383,15 +383,36 @@ are intentionally absent from the default agent profile:
 
 ---
 
+## Live terminal coordination
+
+Agent shims installed by `memo install-shims` register their exact local TTY,
+PID, agent name, terminal application, and project. Registrations are scoped to
+the current OS user and revalidated before each delivery. Use the CLI to inspect
+or address them directly:
+
+```bash
+memo terminal list --json
+memo terminal send --to term-0123456789abcdef --message "status?" --submit
+memo terminal enter --to term-0123456789abcdef
+memo terminal history --json
+```
+
+The equivalent always-on MCP tools are `memo_terminal_list`,
+`memo_terminal_send`, and `memo_terminal_enter`. A live message contains a
+reply-to terminal id so the receiving agent can answer through the same tool.
+`enter` sends only a carriage return and refuses stale, mismatched, or
+non-foreground targets. Handoffs and attention remain the durable asynchronous
+channel; terminal chat is immediate and same-machine only.
+
 ## MCP tools
 
 The live MCP server is profile-gated by `MEMO_MCP_PROFILE`:
 
 | Profile | Tool count | Schema tokens | Use |
 |---|---:|---:|---|
-| `agent` (default) | 40 | ~4.0k | Essential memory, evidence, continuity, lifecycle, and outcome-learning surface. |
-| `core` / `slim` | 57 | ~5.2k | Agent tools plus CRUD, embeddings, history, sessions, and lint. |
-| `full` / `default` | 161 | ~18k | Every advanced domain module and diagnostic tool. |
+| `agent` (default) | 43 | ~4.3k | Essential memory, evidence, continuity, lifecycle, live terminal chat, and outcome-learning surface. |
+| `core` / `slim` | 60 | ~5.5k | Agent tools plus CRUD, embeddings, history, sessions, and lint. |
+| `full` / `default` | 164 | ~18.3k | Every advanced domain module and diagnostic tool. |
 
 Mutating MCP calls pass through a bounded process-local FIFO by default
 (`MEMO_MCP_WRITE_QUEUE_SIZE=32`); read-only calls bypass it. The
@@ -406,7 +427,7 @@ metadata. Use the full profile's `mem_relation_reviews`, `mem_judge`, and
 `MEMO_RELATION_CANDIDATES_ENABLED=0` and
 `MEMO_RELATION_ANNOTATIONS_ENABLED=0` flags remain rollback controls.
 
-The default `agent` profile exposes exactly 40 tools:
+The default `agent` profile exposes exactly 43 tools:
 
 `memo_ask`, `memo_attention_ack`, `memo_attention_add`, `memo_conflict_open`,
 `memo_conflict_resolve`, `memo_context`, `memo_delete`, `memo_evidence_pack`,
@@ -418,7 +439,8 @@ The default `agent` profile exposes exactly 40 tools:
 `memo_procedure_promote`, `memo_profile`, `memo_rename`, `memo_review_due`,
 `memo_save`, `memo_save_text`, `memo_search`, `memo_signal_list`,
 `memo_signal_remember`, `memo_start_session`,
-`memo_supersede`, `memo_unified_briefing`, `memo_update`, `memo_version`,
+`memo_supersede`, `memo_terminal_enter`, `memo_terminal_list`,
+`memo_terminal_send`, `memo_unified_briefing`, `memo_update`, `memo_version`,
 `memo_write_queue_status`.
 
 The `core` / `slim` profile adds CRUD/admin-lite tools:
@@ -1331,8 +1353,8 @@ read-only, `$EDITOR`, and backup restore paths.
 
 ### Token economy
 
-The default MCP profile exposes 40 tools (~4.0k schema tokens), compared with
-161 tools (~18k) on the full profile. The bundled Claude Code recall hook also
+The default MCP profile exposes 43 tools (~4.3k schema tokens), compared with
+164 tools (~18.3k) on the full profile. The bundled Claude Code recall hook also
 pins `MEMO_RECALL_TOP_K=1` and `MEMO_RECALL_TOKEN_BUDGET=160`; the general
 runtime default remains 600 tokens for clients that do not use that hook.
 

--- a/docs/superpowers/plans/2026-08-01-live-terminal-chat.md
+++ b/docs/superpowers/plans/2026-08-01-live-terminal-chat.md
@@ -1,0 +1,199 @@
+# Live Terminal Chat Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add safe, immediate, bidirectional prompt and Return delivery between explicitly registered local Memo agent terminals.
+
+**Architecture:** A focused `TerminalBridge` owns a local SQLite registry and receipts. A separate presenter validates and injects bytes into an exact TTY, while thin CLI and MCP modules expose the same service and the runtime shim performs registration.
+
+**Tech Stack:** Python 3.11+, SQLite, Click, FastMCP/Pydantic, POSIX TTY ioctls, macOS AppleScript fallbacks, pytest.
+
+## Global Constraints
+
+- Only same-UID local character-device TTYs may register or receive input.
+- Every delivery must revalidate PID start marker, TTY association, and foreground process group.
+- Message bodies are UTF-8, at most 16 KiB, and cannot contain terminal control sequences or carriage returns.
+- Duplicate idempotency keys never inject input twice.
+- Tests use isolated `Config` state and pseudo-terminals, never the user's real vault or terminal.
+- New CLI and MCP wiring stays thin and lives in domain modules.
+
+---
+
+### Task 1: Registry, validation, and receipts
+
+**Files:**
+- Create: `src/memo/terminal_live.py`
+- Create: `tests/test_terminal_live.py`
+- Modify: `src/memo/errors.py`
+
+**Interfaces:**
+- Produces: `TerminalBridge(cfg, presenter=None)`, `register(agent, tty, pid, terminal_app, project)`, `list()`, `send(target, message, sender=None, submit=True, message_id=None)`, `enter(target, sender=None, message_id=None)`, and `history(limit=50)`.
+- Produces immutable `TerminalRegistration` and `TerminalReceipt` dataclasses serializable with `dataclasses.asdict`.
+
+- [ ] **Step 1: Write failing registry tests**
+
+```python
+def test_register_persists_same_uid_tty_and_prunes_stale_process(tmp_cfg, pty_agent):
+    bridge = TerminalBridge(tmp_cfg)
+    registration = bridge.register(agent="codex", tty=pty_agent.tty, pid=pty_agent.pid)
+    assert bridge.list()[0].id == registration.id
+    pty_agent.stop()
+    assert bridge.list() == []
+```
+
+- [ ] **Step 2: Run the registry test and confirm it fails because `memo.terminal_live` does not exist**
+
+Run: `uv run --no-sync pytest tests/test_terminal_live.py::test_register_persists_same_uid_tty_and_prunes_stale_process -v`
+
+- [ ] **Step 3: Implement the schema, process probe, same-UID/TTY validation, registration, listing, and stale pruning**
+
+Use SQLite transactions, a random `term-<hex>` id, mode 0600 database file,
+and `ps -p <pid> -o uid=,tty=,lstart=,pgid=,tpgid=,command=` for a portable
+process snapshot. Raise `TerminalValidationError` for rejected targets.
+
+- [ ] **Step 4: Add failing sanitization, foreground, idempotency, and receipt tests**
+
+```python
+def test_send_strips_escape_sequences_and_is_idempotent(registered_bridge, presenter):
+    first = registered_bridge.send("term-a", "hello\x1b[31m!\r", message_id="msg-1")
+    second = registered_bridge.send("term-a", "different", message_id="msg-1")
+    assert presenter.payloads == [b"hello!\r"]
+    assert second.receipt_id == first.receipt_id
+```
+
+- [ ] **Step 5: Implement bounded sanitization, foreground validation, delivery receipts, and idempotency**
+
+The original message body must never appear in exceptions or persisted receipt
+errors. `enter()` calls the presenter with `b"\r"` and no body.
+
+- [ ] **Step 6: Run all terminal bridge tests**
+
+Run: `uv run --no-sync pytest tests/test_terminal_live.py -v`
+
+### Task 2: Real TTY presenter
+
+**Files:**
+- Create: `src/memo/terminal_presenter.py`
+- Create: `tests/test_terminal_presenter.py`
+
+**Interfaces:**
+- Produces: `deliver_input(tty: Path, payload: bytes, *, terminal_app: str) -> str`, returning the transport name.
+- Consumes only an already validated canonical TTY and sanitized payload.
+
+- [ ] **Step 1: Write a failing PTY end-to-end test**
+
+```python
+def test_deliver_input_places_text_and_carriage_return_in_real_pty(pty_reader):
+    transport = deliver_input(pty_reader.tty, b"hello\r", terminal_app="")
+    assert pty_reader.read_exact(6) == b"hello\r"
+    assert transport == "tiocsti"
+```
+
+- [ ] **Step 2: Run the PTY test and confirm it fails because the presenter is missing**
+
+Run: `uv run --no-sync pytest tests/test_terminal_presenter.py::test_deliver_input_places_text_and_carriage_return_in_real_pty -v`
+
+- [ ] **Step 3: Implement bytewise `TIOCSTI` delivery with descriptor cleanup**
+
+Open only the exact path with `O_RDWR|O_NOCTTY`; close it in `finally`; convert
+no bytes because the bridge already supplies the single submit CR.
+
+- [ ] **Step 4: Write failing mocked fallback tests for Terminal, iTerm2, and Ghostty exact-TTY routing**
+
+Each test forces `TIOCSTI` to raise, records the bounded `osascript` argv, and
+asserts that the target TTY and payload are positional arguments rather than
+interpolated script text. The Ghostty test also asserts a separate Return event.
+
+- [ ] **Step 5: Implement bounded `osascript` fallbacks without shell execution**
+
+Use `subprocess.run([...], timeout=5, check=False, capture_output=True,
+text=True)`. Refuse unknown terminal applications when TIOCSTI fails.
+
+- [ ] **Step 6: Run presenter tests on macOS and the bridge tests together**
+
+Run: `uv run --no-sync pytest tests/test_terminal_presenter.py tests/test_terminal_live.py -v`
+
+### Task 3: CLI, MCP, and shim wiring
+
+**Files:**
+- Create: `src/memo/cli_terminal.py`
+- Create: `src/memo/server_terminal.py`
+- Create: `tests/test_cli_terminal.py`
+- Create: `tests/test_server_terminal.py`
+- Modify: `src/memo/cli.py`
+- Modify: `src/memo/server.py`
+- Modify: `src/memo/surface.py`
+- Modify: `src/memo/runtime/shims.py`
+- Modify: related CLI/MCP surface and shim tests when their expected public inventory changes.
+
+**Interfaces:**
+- Produces Click group `terminal_group` and MCP tools `memo_terminal_list`, `memo_terminal_send`, `memo_terminal_enter`.
+- Consumes `TerminalBridge(memory.cfg)` in MCP and `TerminalBridge(Config.from_env())` in CLI.
+
+- [ ] **Step 1: Write failing CLI user-flow tests**
+
+```python
+def test_terminal_send_cli_returns_delivery_receipt(runner, isolated_env, registered_target):
+    result = runner.invoke(cli, ["terminal", "send", "--to", registered_target, "--message", "ping", "--json"], env=isolated_env)
+    assert result.exit_code == 0
+    assert json.loads(result.output)["status"] == "delivered"
+```
+
+- [ ] **Step 2: Implement thin Click commands and register `terminal_group` in `cli.py`**
+
+All domain failures become `click.ClickException`; JSON output uses
+`dataclasses.asdict` and contains no message body.
+
+- [ ] **Step 3: Write failing MCP contract tests**
+
+Call each tool through FastMCP's in-memory client. Assert an agent profile lists
+all three tools, a send returns a receipt, a duplicate returns the same receipt,
+and an invalid target yields structured `status="failed"` without a traceback.
+
+- [ ] **Step 4: Implement `server_terminal.register(server, memory)` and keep the tools on every MCP profile**
+
+`memo_terminal_send` resolves the sender registration from inherited
+`MEMO_AGENT_TTY`, wraps the body in a delimited live-message envelope with a
+reply target, and delegates to `TerminalBridge`.
+
+- [ ] **Step 5: Write a failing executable shim test**
+
+Run an installed shim against a fake downstream agent and fake Memo executable;
+assert registration receives the captured TTY, shell PID, agent, terminal app,
+and project before the downstream `exec`.
+
+- [ ] **Step 6: Wire best-effort registration into the shim and run all focused tests**
+
+Run: `uv run --no-sync pytest tests/test_cli_terminal.py tests/test_server_terminal.py tests/test_runtime_shims.py tests/test_cli_mcp_surface_smoke.py -v`
+
+### Task 4: End-user and repository verification
+
+**Files:**
+- Modify: user docs or command reference only if existing surface tests expose an undocumented command.
+
+**Interfaces:**
+- Consumes the finished CLI/MCP/shim bridge.
+- Produces verification evidence and a controlled receipt from a separate Codex terminal.
+
+- [ ] **Step 1: Run focused tests with warnings promoted to errors**
+
+Run: `uv run --no-sync pytest tests/test_terminal_live.py tests/test_terminal_presenter.py tests/test_cli_terminal.py tests/test_server_terminal.py -W error -v`
+
+- [ ] **Step 2: Run CI order**
+
+Run: `uv run --no-sync ruff check src/ tests/`
+
+Run: `uv run --no-sync mypy src/memo`
+
+Run: `uv run --no-sync pytest -m "not slow" -n auto --timeout=120 --cov=memo --cov-report=term-missing`
+
+- [ ] **Step 3: Install the branch runtime and run a controlled local exchange**
+
+Register a known Codex PID/TTY pair, send a message with `--submit`, obtain its
+reply receipt, and use `memo terminal enter` only against that exact id if the
+terminal is visibly waiting for input.
+
+- [ ] **Step 4: Commit, push, open a PR, wait for every required check, merge to protected `master`, and reinstall from the merged SHA**
+
+Verify `memo doctor --strict-runtime --agent codex --agent claude-code --json`
+reports the package path inside the isolated installed runtime.

--- a/docs/superpowers/specs/2026-08-01-live-terminal-chat-design.md
+++ b/docs/superpowers/specs/2026-08-01-live-terminal-chat-design.md
@@ -1,0 +1,92 @@
+# Live Terminal Chat Design
+
+## Goal
+
+Turn Memo's asynchronous handoff/attention coordination into an optional
+same-machine live channel. A Memo MCP client or CLI user can address one
+explicitly registered agent terminal, place a prompt in its input buffer, and
+submit it as if Return had been pressed. The receiver can reply through the
+same channel without polling a journal.
+
+## Chosen approach
+
+Memo will add a narrow local terminal bridge. This is preferred over reviving
+the closed Memflow/Synapse mesh because it has a smaller trust boundary and
+does not depend on the unsafe migration, remote identity, or distributed
+delivery code from PR #157. It is preferred over polling handoffs because
+polling cannot release a terminal that is already blocked on interactive
+input.
+
+Two alternatives were rejected:
+
+- A background handoff poller remains asynchronous and cannot emulate Return.
+- A network terminal-control service would enlarge the authentication and
+  remote-code-execution boundary beyond the requested same-machine workflow.
+
+## Trust and registration
+
+The operating-system user is the security boundary. A registration contains a
+random terminal id, canonical `/dev/...` TTY, PID, process start marker, agent
+name, terminal application, project directory, and timestamps. The TTY must be
+a character device owned by the current UID, and the PID must belong to that
+UID and be attached to the same TTY. Registrations live in a mode-0600 SQLite
+sidecar under `Config.state_dir`; they are operational state, not durable
+memory.
+
+The Memo agent shim registers itself before `exec`, preserving the PID across
+the exec. Every list/send operation revalidates the PID start marker and TTY,
+and stale registrations are removed. Delivery is refused unless the registered
+agent owns the TTY foreground process group, preventing input from landing in
+a child shell or unrelated command.
+
+## Delivery
+
+`TerminalBridge.send()` accepts an exact terminal id, a UTF-8 message no larger
+than 16 KiB, an optional sender id, an idempotency key, and a submit flag. It
+removes terminal control sequences and forbidden control bytes while
+preserving printable Unicode, tabs, and newlines. Return is never accepted as
+message content; submit appends exactly one carriage return.
+
+The bridge first tries `TIOCSTI`, which writes into the selected terminal's
+input queue without changing focus. On macOS denial it falls back to an exact
+TTY match through Terminal.app, iTerm/iTerm2, or Ghostty AppleScript. Ghostty
+submission is a separate Return event after the target terminal is focused,
+matching the behavior required by raw-mode Codex TUIs.
+
+Each attempt creates a receipt with `delivered`, `failed`, or `duplicate`
+status. A repeated idempotency key returns the original receipt and never types
+the message twice. `enter()` uses the same validation and receipt path but
+delivers only a carriage return.
+
+## User surfaces
+
+The root CLI gains a `terminal` group:
+
+- `memo terminal register --agent codex --tty /dev/ttys003 --pid 123`
+- `memo terminal list --json`
+- `memo terminal send --to <id> --message <text> [--submit/--no-submit]`
+- `memo terminal enter --to <id>`
+- `memo terminal history --json`
+
+The always-on agent MCP profile gains `memo_terminal_list`,
+`memo_terminal_send`, and `memo_terminal_enter`. A live message is wrapped with
+the sender terminal id and a concise instruction explaining how to reply with
+`memo_terminal_send`; the body remains clearly delimited as sender content.
+Handoffs and attention remain available for durable/asynchronous coordination.
+
+## Error behavior
+
+Invalid or stale targets, wrong UID/TTY associations, non-foreground agents,
+oversized messages, control-only messages, and unsupported terminal apps raise
+Memo domain errors. CLI reports a nonzero error without a traceback. MCP tools
+return structured status and safe error text; message bodies are never copied
+into errors or logs.
+
+## Verification
+
+Tests cover registry validation and pruning, sanitization, idempotency,
+foreground refusal, receipt persistence, CLI behavior, MCP schemas, shim
+registration, and macOS fallback selection. A PTY end-to-end test proves text
+and carriage-return delivery through the real input queue without touching a
+user terminal. Final verification follows repository CI order and includes a
+controlled live exchange with a separately registered Codex terminal.

--- a/src/memo/cli.py
+++ b/src/memo/cli.py
@@ -149,6 +149,7 @@ from memo.cli_statusline import install_statusline
 from memo.cli_sync import sync_group
 from memo.cli_synthesize import synthesize_cmd
 from memo.cli_temporal import temporal_group
+from memo.cli_terminal import terminal_group
 from memo.cli_token_gate import token_gate_cmd
 from memo.cli_token_savings import token_savings_cmd
 from memo.cli_tokens import tokens_cmd
@@ -219,6 +220,7 @@ _COMMAND_SECTIONS: list[tuple[str, list[str]]] = [
             "retier",
             "contradict",
             "coordinate",
+            "terminal",
             "invalidate",
             "temporal",
             "compress-context",
@@ -529,6 +531,7 @@ cli.add_command(export_group)
 cli.add_command(collaborative_group)
 cli.add_command(contradict_group)
 cli.add_command(coordinate_group)
+cli.add_command(terminal_group)
 cli.add_command(http_api)
 cli.add_command(startup_banner_cmd)
 cli.add_command(codex_badge_cmd)
@@ -570,6 +573,7 @@ _FIRST_RUN_GATE_SKIP_COMMANDS = {
     "startup-banner",
     "codex-badge",
     "install-shims",
+    "terminal",
 }
 
 

--- a/src/memo/cli_terminal.py
+++ b/src/memo/cli_terminal.py
@@ -1,0 +1,152 @@
+"""`memo terminal` — immediate coordination with registered local agent TTYs."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import click
+
+from memo.config import Config
+from memo.errors import MemoError
+from memo.terminal_live import TerminalBridge
+
+
+def _bridge() -> TerminalBridge:
+    return TerminalBridge(Config.from_env())
+
+
+def _json(value: Any) -> None:
+    click.echo(json.dumps(value, indent=2))
+
+
+def _domain_error(exc: MemoError) -> click.ClickException:
+    return click.ClickException(str(exc))
+
+
+@click.group(name="terminal")
+def terminal_group() -> None:
+    """Chat with or submit input to explicitly registered local agent terminals."""
+
+
+@terminal_group.command(name="register")
+@click.option("--agent", required=True, help="Agent name (for example: codex).")
+@click.option("--tty", required=True, type=click.Path(path_type=Path), help="Exact /dev TTY.")
+@click.option("--pid", required=True, type=click.IntRange(min=2), help="Agent process PID.")
+@click.option("--terminal-app", default="", help="Terminal, iTerm2, or Ghostty.")
+@click.option("--project", default="", help="Project directory associated with this agent.")
+@click.option("--id-only", is_flag=True, hidden=True)
+@click.option("--json", "as_json", is_flag=True, help="Output JSON.")
+def terminal_register(
+    agent: str,
+    tty: Path,
+    pid: int,
+    terminal_app: str,
+    project: str,
+    id_only: bool,
+    as_json: bool,
+) -> None:
+    """Register one local agent process and its exact terminal."""
+    try:
+        registration = _bridge().register(
+            agent=agent,
+            tty=tty,
+            pid=pid,
+            terminal_app=terminal_app,
+            project=project or os.getcwd(),
+        )
+    except MemoError as exc:
+        raise _domain_error(exc) from exc
+    if id_only:
+        click.echo(registration.id)
+    elif as_json:
+        _json(asdict(registration))
+    else:
+        click.echo(f"registered {registration.id} ({registration.agent} {registration.tty})")
+
+
+@terminal_group.command(name="list")
+@click.option("--json", "as_json", is_flag=True, help="Output JSON.")
+def terminal_list(as_json: bool) -> None:
+    """List live registered agent terminals and prune stale entries."""
+    try:
+        registrations = _bridge().list()
+    except MemoError as exc:
+        raise _domain_error(exc) from exc
+    if as_json:
+        _json([asdict(item) for item in registrations])
+        return
+    if not registrations:
+        click.echo("No live registered terminals.")
+        return
+    for item in registrations:
+        click.echo(f"{item.id}\t{item.agent}\t{item.tty}\t{item.project}")
+
+
+@terminal_group.command(name="send")
+@click.option("--to", "target_id", required=True, help="Exact registered terminal id.")
+@click.option("--message", required=True, help="Prompt text to deliver.")
+@click.option("--sender", default="", help="Reply-to terminal id.")
+@click.option("--message-id", default="", help="Optional idempotency key.")
+@click.option("--submit/--no-submit", default=True, help="Press Return after delivery.")
+@click.option("--json", "as_json", is_flag=True, help="Output JSON.")
+def terminal_send(
+    target_id: str,
+    message: str,
+    sender: str,
+    message_id: str,
+    submit: bool,
+    as_json: bool,
+) -> None:
+    """Immediately type a prompt into one registered agent terminal."""
+    try:
+        receipt = _bridge().send(
+            target_id,
+            message,
+            sender=sender or None,
+            message_id=message_id or None,
+            submit=submit,
+        )
+    except MemoError as exc:
+        raise _domain_error(exc) from exc
+    if as_json:
+        _json(asdict(receipt))
+    else:
+        click.echo(f"{receipt.status} {receipt.receipt_id} via {receipt.transport}")
+
+
+@terminal_group.command(name="enter")
+@click.option("--to", "target_id", required=True, help="Exact registered terminal id.")
+@click.option("--sender", default="", help="Origin terminal id.")
+@click.option("--message-id", default="", help="Optional idempotency key.")
+@click.option("--json", "as_json", is_flag=True, help="Output JSON.")
+def terminal_enter(target_id: str, sender: str, message_id: str, as_json: bool) -> None:
+    """Press Return in one registered foreground agent terminal."""
+    try:
+        receipt = _bridge().enter(
+            target_id,
+            sender=sender or None,
+            message_id=message_id or None,
+        )
+    except MemoError as exc:
+        raise _domain_error(exc) from exc
+    if as_json:
+        _json(asdict(receipt))
+    else:
+        click.echo(f"{receipt.status} {receipt.receipt_id} via {receipt.transport}")
+
+
+@terminal_group.command(name="history")
+@click.option("--limit", default=50, type=click.IntRange(min=1, max=500))
+@click.option("--json", "as_json", is_flag=True, help="Output JSON.")
+def terminal_history(limit: int, as_json: bool) -> None:
+    """Show delivery receipts without retaining prompt bodies."""
+    receipts = _bridge().history(limit=limit)
+    if as_json:
+        _json([asdict(item) for item in receipts])
+        return
+    for item in receipts:
+        click.echo(f"{item.created_at}\t{item.status}\t{item.target_id}\t{item.receipt_id}")

--- a/src/memo/errors.py
+++ b/src/memo/errors.py
@@ -73,6 +73,10 @@ class SetupError(MemoError, RuntimeError):
     """Declarative agent setup could not complete safely."""
 
 
+class TerminalValidationError(MemoError, RuntimeError):
+    """A live-terminal target or delivery failed local safety validation."""
+
+
 class StorageError(MemoError, RuntimeError):
     """A storage-layer operation (sqlite / filesystem) failed. Wraps the
     low-level error with operation context so callers don't see bare

--- a/src/memo/runtime/shims.py
+++ b/src/memo/runtime/shims.py
@@ -25,7 +25,7 @@ _SHIM_MARKER = "# memo-shim"
 
 _SHIM_TEMPLATE = """\
 #!/usr/bin/env bash
-# memo-shim v3 — written by `memo install-shims`. Do not edit manually.
+# memo-shim v4 — written by `memo install-shims`. Do not edit manually.
 set -euo pipefail
 _MEMO_BIN_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 _AGENT="$(basename "$0")"
@@ -50,6 +50,18 @@ if [ -z "$_NEXT" ]; then
     exit 127
 fi
 _MEMO="$(command -v memo 2>/dev/null || true)"
+if [ -n "$_MEMO" ] && [ -n "${MEMO_AGENT_TTY:-}" ] && [ "${MEMO_TERMINAL_REGISTRATION_ATTEMPTED:-0}" != "1" ]; then
+    MEMO_TERMINAL_REGISTRATION_ATTEMPTED=1
+    export MEMO_TERMINAL_REGISTRATION_ATTEMPTED
+    MEMO_TERMINAL_ID="$("$_MEMO" terminal register \
+        --agent "$_AGENT" \
+        --tty "$MEMO_AGENT_TTY" \
+        --pid "$$" \
+        --terminal-app "${TERM_PROGRAM:-}" \
+        --project "$PWD" \
+        --id-only 2>/dev/null || true)"
+    [ -n "$MEMO_TERMINAL_ID" ] && export MEMO_TERMINAL_ID
+fi
 if [ -n "$_MEMO" ] && [ "${MEMO_STARTUP_BANNER:-1}" != "0" ] && [ "${MEMO_STARTUP_BANNER_SHOWN:-0}" != "1" ]; then
     MEMO_STARTUP_BANNER_SHOWN=1
     export MEMO_STARTUP_BANNER_SHOWN

--- a/src/memo/server.py
+++ b/src/memo/server.py
@@ -71,6 +71,7 @@ from memo import server_session_patterns as _srv_session_patterns
 from memo import server_sync as _srv_sync
 from memo import server_synthesis as _srv_synthesis
 from memo import server_temporal as _srv_temporal
+from memo import server_terminal as _srv_terminal
 from memo import server_verbatim as _srv_verbatim
 from memo import server_version as _srv_version
 from memo.config import Config
@@ -344,6 +345,7 @@ def _build_server(
     _srv_core_history.register(server, memory)
     _srv_idle_capture.register(server, memory)
     _srv_operational.register(server, memory)
+    _srv_terminal.register(server, memory)
     _srv_resources.register(server, memory)
     _srv_profile.register(server, memory)
     _srv_prompts.register(server, memory)

--- a/src/memo/server_terminal.py
+++ b/src/memo/server_terminal.py
@@ -1,0 +1,105 @@
+"""MCP tools for immediate same-user delivery to registered agent terminals."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import Annotated, Any
+
+from pydantic import Field
+
+from memo.errors import MemoError
+from memo.flags import flag_str
+from memo.server_annotations import READ_ONLY, WRITE, annotated_tool
+from memo.terminal_live import TerminalBridge
+
+
+def _reply_envelope(message: str, sender_id: str) -> str:
+    encoded = json.dumps(message, ensure_ascii=False).replace("<", "\\u003c").replace(
+        ">", "\\u003e"
+    )
+    if not sender_id:
+        return (
+            '<memo-live-message>\n<sender-content encoding="json">\n'
+            f"{encoded}\n"
+            "</sender-content>\n</memo-live-message>"
+        )
+    return (
+        f'<memo-live-message sender="{sender_id}">\n'
+        "Reply live with memo_terminal_send(to="
+        f'"{sender_id}", message="<your reply>").\n'
+        '<sender-content encoding="json">\n'
+        f"{encoded}\n"
+        "</sender-content>\n"
+        "</memo-live-message>"
+    )
+
+
+def _sender_id(bridge: TerminalBridge, requested: str) -> str:
+    if requested.strip():
+        return bridge.registration_id(requested.strip())
+    inherited_tty = flag_str("MEMO_AGENT_TTY").strip()
+    return bridge.registration_id_for_tty(inherited_tty) if inherited_tty else ""
+
+
+def register(server: Any, memory: Any) -> None:
+    """Register live-terminal tools on every MCP surface profile."""
+
+    @annotated_tool(server, **READ_ONLY)
+    def memo_terminal_list() -> dict[str, Any]:
+        """List live local agent terminals that can receive an immediate prompt."""
+        rows = [asdict(item) for item in TerminalBridge(memory.cfg).list()]
+        return {"terminals": rows, "count": len(rows)}
+
+    @annotated_tool(server, **WRITE)
+    def memo_terminal_send(
+        to: Annotated[str, Field(description="Exact terminal id returned by memo_terminal_list.")],
+        message: Annotated[str, Field(description="Prompt or reply to type into the target agent.")],
+        submit: Annotated[
+            bool,
+            Field(description="Press Return after typing so the target agent receives the prompt."),
+        ] = True,
+        message_id: Annotated[
+            str | None,
+            Field(description="Optional idempotency key; retries never type twice."),
+        ] = None,
+        sender: Annotated[
+            str,
+            Field(description="Optional registered reply-to terminal id."),
+        ] = "",
+    ) -> dict[str, Any]:
+        """Immediately type and optionally submit a prompt in one registered terminal."""
+        bridge = TerminalBridge(memory.cfg)
+        try:
+            sender_id = _sender_id(bridge, sender)
+            receipt = bridge.send(
+                to,
+                _reply_envelope(message, sender_id),
+                sender=sender_id or None,
+                submit=submit,
+                message_id=message_id,
+            )
+        except MemoError as exc:
+            return {"status": "failed", "error": str(exc)}
+        return asdict(receipt)
+
+    @annotated_tool(server, **WRITE)
+    def memo_terminal_enter(
+        to: Annotated[str, Field(description="Exact terminal id returned by memo_terminal_list.")],
+        message_id: Annotated[
+            str | None,
+            Field(description="Optional idempotency key; retries never press Return twice."),
+        ] = None,
+        sender: Annotated[
+            str,
+            Field(description="Optional registered origin terminal id."),
+        ] = "",
+    ) -> dict[str, Any]:
+        """Press Return in one registered foreground agent terminal to unblock it."""
+        bridge = TerminalBridge(memory.cfg)
+        try:
+            sender_id = _sender_id(bridge, sender)
+            receipt = bridge.enter(to, sender=sender_id or None, message_id=message_id)
+        except MemoError as exc:
+            return {"status": "failed", "error": str(exc)}
+        return asdict(receipt)

--- a/src/memo/server_terminal.py
+++ b/src/memo/server_terminal.py
@@ -15,8 +15,8 @@ from memo.terminal_live import TerminalBridge
 
 
 def _reply_envelope(message: str, sender_id: str) -> str:
-    encoded = json.dumps(message, ensure_ascii=False).replace("<", "\\u003c").replace(
-        ">", "\\u003e"
+    encoded = (
+        json.dumps(message, ensure_ascii=False).replace("<", "\\u003c").replace(">", "\\u003e")
     )
     if not sender_id:
         return (
@@ -54,7 +54,9 @@ def register(server: Any, memory: Any) -> None:
     @annotated_tool(server, **WRITE)
     def memo_terminal_send(
         to: Annotated[str, Field(description="Exact terminal id returned by memo_terminal_list.")],
-        message: Annotated[str, Field(description="Prompt or reply to type into the target agent.")],
+        message: Annotated[
+            str, Field(description="Prompt or reply to type into the target agent.")
+        ],
         submit: Annotated[
             bool,
             Field(description="Press Return after typing so the target agent receives the prompt."),

--- a/src/memo/surface.py
+++ b/src/memo/surface.py
@@ -36,6 +36,7 @@ CORE_CLI_COMMANDS: frozenset[str] = frozenset(
         "search",
         "update",
         "stats",
+        "terminal",
         "uninstall-watcher",
         "edit",
         "watch",
@@ -94,6 +95,9 @@ AGENT_MCP_TOOLS: frozenset[str] = (
             "memo_pop_notification",
             "memo_profile",
             "memo_start_session",
+            "memo_terminal_enter",
+            "memo_terminal_list",
+            "memo_terminal_send",
             "memo_save_text",
             "memo_version",
             "memo_write_queue_status",
@@ -132,6 +136,9 @@ CORE_MCP_TOOLS: frozenset[str] = (
             "memo_session_get",
             "memo_session_list",
             "memo_stats",
+            "memo_terminal_enter",
+            "memo_terminal_list",
+            "memo_terminal_send",
             "memo_review_due",
             "memo_supersede",
             "memo_unforget",
@@ -183,9 +190,9 @@ def mcp_tools_to_remove() -> frozenset[str]:
 # Per-profile token-cost estimates for the `memo doctor` advisory. Reduced
 # profiles (agent/core/slim) are cheap; only the full/default surface warns.
 _PROFILE_TOKEN_COST: dict[str, tuple[str, str]] = {
-    "agent": ("40", "~4.0k"),
-    "core": ("57", "~5.2k"),
-    "slim": ("57", "~5.2k"),
+    "agent": ("43", "~4.3k"),
+    "core": ("60", "~5.5k"),
+    "slim": ("60", "~5.5k"),
 }
 
 
@@ -194,5 +201,5 @@ def mcp_profile_token_cost(profile: str | None = None) -> tuple[str, str, bool]:
     (or the active profile when ``None``). ``is_reduced`` is False only for the
     full/default surface — the costly one doctor warns about."""
     resolved = profile if profile is not None else mcp_profile()
-    count, cost = _PROFILE_TOKEN_COST.get(resolved, ("161", "~18k"))
+    count, cost = _PROFILE_TOKEN_COST.get(resolved, ("164", "~18.3k"))
     return count, cost, resolved in _PROFILE_TOKEN_COST

--- a/src/memo/terminal_live.py
+++ b/src/memo/terminal_live.py
@@ -592,7 +592,7 @@ class TerminalBridge:
         bounded = max(1, min(limit, 500))
         with self._connect() as conn:
             rows = conn.execute(
-                "SELECT * FROM terminal_receipts ORDER BY created_at DESC, receipt_id DESC LIMIT ?",
+                "SELECT * FROM terminal_receipts ORDER BY rowid DESC LIMIT ?",
                 (bounded,),
             ).fetchall()
         return [self._receipt_from_row(row) for row in rows]

--- a/src/memo/terminal_live.py
+++ b/src/memo/terminal_live.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import builtins
 import os
+import re
 import secrets
 import sqlite3
 import stat
 import subprocess
 import unicodedata
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING
 
 from memo.errors import TerminalValidationError
 
@@ -80,6 +81,8 @@ ProcessProbe = Callable[[int], ProcessSnapshot | None]
 Presenter = Callable[..., str]
 
 _MAX_MESSAGE_BYTES = 16 * 1024
+_MESSAGE_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}\Z")
+_REGISTRATION_ID_RE = re.compile(r"term-[0-9a-f]{16}\Z")
 
 
 def _default_presenter(tty: Path, payload: bytes, *, terminal_app: str) -> str:
@@ -170,6 +173,33 @@ def _command_matches_agent(command: str, agent: str) -> bool:
     )
 
 
+def _consume_csi(message: str, index: int) -> int:
+    while index < len(message) and not ("@" <= message[index] <= "~"):
+        index += 1
+    return index + (index < len(message))
+
+
+def _consume_osc(message: str, index: int) -> int:
+    while index < len(message):
+        if message[index] == "\x07":
+            return index + 1
+        if message[index : index + 2] == "\x1b\\":
+            return index + 2
+        index += 1
+    return index
+
+
+def _consume_escape(message: str, index: int) -> int:
+    index += 1
+    if index >= len(message):
+        return index
+    if message[index] == "[":
+        return _consume_csi(message, index + 1)
+    if message[index] == "]":
+        return _consume_osc(message, index + 1)
+    return index + 1
+
+
 def _strip_terminal_controls(message: str) -> str:
     if len(message.encode("utf-8")) > _MAX_MESSAGE_BYTES:
         raise TerminalValidationError("terminal message exceeds 16 KiB")
@@ -178,26 +208,7 @@ def _strip_terminal_controls(message: str) -> str:
     while i < len(message):
         char = message[i]
         if char == "\x1b":
-            i += 1
-            if i < len(message) and message[i] == "[":
-                i += 1
-                while i < len(message) and not ("@" <= message[i] <= "~"):
-                    i += 1
-                i += i < len(message)
-                continue
-            if i < len(message) and message[i] == "]":
-                i += 1
-                while i < len(message):
-                    if message[i] == "\x07":
-                        i += 1
-                        break
-                    if message[i : i + 2] == "\x1b\\":
-                        i += 2
-                        break
-                    i += 1
-                continue
-            if i < len(message):
-                i += 1
+            i = _consume_escape(message, i)
             continue
         if char in {"\n", "\t"} or unicodedata.category(char) != "Cc":
             result.append(char)
@@ -387,6 +398,18 @@ class TerminalBridge:
                 )
         return live
 
+    def registration_id(self, registration_id: str) -> str:
+        """Return an exact live registration id, or an empty string."""
+        return registration_id if any(item.id == registration_id for item in self.list()) else ""
+
+    def registration_id_for_tty(self, tty: str | Path) -> str:
+        """Resolve a live registration by exact canonical TTY."""
+        try:
+            canonical = str(_canonical_tty(tty))
+        except TerminalValidationError:
+            return ""
+        return next((item.id for item in self.list() if item.tty == canonical), "")
+
     @staticmethod
     def _receipt_from_row(row: sqlite3.Row) -> TerminalReceipt:
         return TerminalReceipt(
@@ -447,8 +470,11 @@ class TerminalBridge:
         kind: str,
     ) -> TerminalReceipt:
         resolved_message_id = (message_id or f"msg-{secrets.token_hex(12)}").strip()
-        if not resolved_message_id:
-            raise TerminalValidationError("terminal message id cannot be empty")
+        if not _MESSAGE_ID_RE.fullmatch(resolved_message_id):
+            raise TerminalValidationError("terminal message id is malformed or too long")
+        sender_id = (sender or "").strip()
+        if sender_id and not _REGISTRATION_ID_RE.fullmatch(sender_id):
+            raise TerminalValidationError("terminal sender id is malformed")
         existing = self._existing_receipt(resolved_message_id)
         if existing is not None:
             return replace(existing, status="duplicate")
@@ -469,7 +495,7 @@ class TerminalBridge:
                         receipt_id,
                         resolved_message_id,
                         target_id,
-                        (sender or "").strip(),
+                        sender_id,
                         kind,
                         now,
                     ),

--- a/src/memo/terminal_live.py
+++ b/src/memo/terminal_live.py
@@ -1,0 +1,554 @@
+"""Registered local terminal sessions for immediate agent-to-agent delivery."""
+
+from __future__ import annotations
+
+import builtins
+import os
+import secrets
+import sqlite3
+import stat
+import subprocess
+import unicodedata
+from collections.abc import Callable
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Iterator
+
+from memo.errors import TerminalValidationError
+
+if TYPE_CHECKING:
+    from memo.config import Config
+
+_AGENTS = frozenset({"blackbox", "claude", "codex", "devin", "gemini", "opencode"})
+_TERMINAL_APPS = {
+    "": "",
+    "terminal": "Terminal",
+    "iterm": "iTerm",
+    "iterm2": "iTerm2",
+    "ghostty": "Ghostty",
+}
+
+
+@dataclass(frozen=True)
+class ProcessSnapshot:
+    """Identity and foreground state of one local process."""
+
+    pid: int
+    uid: int
+    tty: Path
+    started_at: str
+    pgid: int
+    foreground_pgid: int
+    command: str
+
+
+@dataclass(frozen=True)
+class TerminalRegistration:
+    """One explicitly registered agent terminal."""
+
+    id: str
+    tty: str
+    pid: int
+    uid: int
+    agent: str
+    terminal_app: str
+    project: str
+    process_started_at: str
+    created_at: str
+    last_seen_at: str
+
+
+@dataclass(frozen=True)
+class TerminalReceipt:
+    """Outcome of one attempted terminal delivery."""
+
+    receipt_id: str
+    message_id: str
+    target_id: str
+    sender_id: str
+    kind: str
+    status: str
+    transport: str
+    error: str
+    created_at: str
+    delivered_at: str
+
+
+ProcessProbe = Callable[[int], ProcessSnapshot | None]
+Presenter = Callable[..., str]
+
+_MAX_MESSAGE_BYTES = 16 * 1024
+
+
+def _default_presenter(tty: Path, payload: bytes, *, terminal_app: str) -> str:
+    from memo.terminal_presenter import deliver_input
+
+    return deliver_input(tty, payload, terminal_app=terminal_app)
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def _canonical_tty(value: str | Path, *, uid: int | None = None) -> Path:
+    raw = Path(value).expanduser()
+    if not raw.is_absolute():
+        raw = Path("/dev") / raw
+    try:
+        path = raw.resolve(strict=True)
+        info = path.stat()
+    except OSError as exc:
+        raise TerminalValidationError("terminal target is unavailable") from exc
+    if path.parent != Path("/dev") or not stat.S_ISCHR(info.st_mode):
+        raise TerminalValidationError("terminal target is not a local TTY")
+    expected_uid = os.getuid() if uid is None else uid
+    if info.st_uid != expected_uid:
+        raise TerminalValidationError("terminal target belongs to another user")
+    return path
+
+
+def _process_snapshot(pid: int) -> ProcessSnapshot | None:
+    if pid <= 1:
+        return None
+    try:
+        proc = subprocess.run(
+            [
+                "ps",
+                "-p",
+                str(pid),
+                "-o",
+                "uid=",
+                "-o",
+                "tty=",
+                "-o",
+                "lstart=",
+                "-o",
+                "pgid=",
+                "-o",
+                "tpgid=",
+                "-o",
+                "command=",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    parts = proc.stdout.strip().split(maxsplit=9)
+    if len(parts) != 10 or parts[1] in {"?", "??", "-"}:
+        return None
+    try:
+        uid = int(parts[0])
+        pgid = int(parts[7])
+        foreground_pgid = int(parts[8])
+    except ValueError:
+        return None
+    tty = Path(parts[1])
+    if not tty.is_absolute():
+        tty = Path("/dev") / tty
+    return ProcessSnapshot(
+        pid=pid,
+        uid=uid,
+        tty=tty,
+        started_at=" ".join(parts[2:7]),
+        pgid=pgid,
+        foreground_pgid=foreground_pgid,
+        command=parts[9],
+    )
+
+
+def _command_matches_agent(command: str, agent: str) -> bool:
+    lowered = command.lower()
+    return any(part == agent or part.endswith(f"/{agent}") for part in lowered.split()) or (
+        f"/{agent} " in lowered
+    )
+
+
+def _strip_terminal_controls(message: str) -> str:
+    if len(message.encode("utf-8")) > _MAX_MESSAGE_BYTES:
+        raise TerminalValidationError("terminal message exceeds 16 KiB")
+    result: list[str] = []
+    i = 0
+    while i < len(message):
+        char = message[i]
+        if char == "\x1b":
+            i += 1
+            if i < len(message) and message[i] == "[":
+                i += 1
+                while i < len(message) and not ("@" <= message[i] <= "~"):
+                    i += 1
+                i += i < len(message)
+                continue
+            if i < len(message) and message[i] == "]":
+                i += 1
+                while i < len(message):
+                    if message[i] == "\x07":
+                        i += 1
+                        break
+                    if message[i : i + 2] == "\x1b\\":
+                        i += 2
+                        break
+                    i += 1
+                continue
+            if i < len(message):
+                i += 1
+            continue
+        if char in {"\n", "\t"} or unicodedata.category(char) != "Cc":
+            result.append(char)
+        i += 1
+    sanitized = "".join(result)
+    if not sanitized.strip():
+        raise TerminalValidationError("terminal message is empty after sanitization")
+    return sanitized
+
+
+class TerminalBridge:
+    """Persist and revalidate local terminal registrations."""
+
+    def __init__(
+        self,
+        cfg: Config,
+        *,
+        process_probe: ProcessProbe | None = None,
+        presenter: Presenter | None = None,
+    ) -> None:
+        self._path = cfg.state_dir / "terminal_live.db"
+        self._probe = process_probe or _process_snapshot
+        self._present = presenter or _default_presenter
+        self._init_db()
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(self._path, timeout=5)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def _init_db(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS terminal_registrations (
+                    id TEXT PRIMARY KEY,
+                    tty TEXT NOT NULL UNIQUE,
+                    pid INTEGER NOT NULL,
+                    uid INTEGER NOT NULL,
+                    agent TEXT NOT NULL,
+                    terminal_app TEXT NOT NULL,
+                    project TEXT NOT NULL,
+                    process_started_at TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    last_seen_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS terminal_receipts (
+                    receipt_id TEXT PRIMARY KEY,
+                    message_id TEXT NOT NULL UNIQUE,
+                    target_id TEXT NOT NULL,
+                    sender_id TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    transport TEXT NOT NULL,
+                    error TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    delivered_at TEXT NOT NULL
+                )
+                """
+            )
+        self._path.chmod(0o600)
+
+    @staticmethod
+    def _from_row(row: sqlite3.Row) -> TerminalRegistration:
+        return TerminalRegistration(
+            id=str(row["id"]),
+            tty=str(row["tty"]),
+            pid=int(row["pid"]),
+            uid=int(row["uid"]),
+            agent=str(row["agent"]),
+            terminal_app=str(row["terminal_app"]),
+            project=str(row["project"]),
+            process_started_at=str(row["process_started_at"]),
+            created_at=str(row["created_at"]),
+            last_seen_at=str(row["last_seen_at"]),
+        )
+
+    def register(
+        self,
+        *,
+        agent: str,
+        tty: str | Path,
+        pid: int,
+        terminal_app: str = "",
+        project: str | Path = "",
+    ) -> TerminalRegistration:
+        normalized_agent = agent.strip().lower()
+        if normalized_agent not in _AGENTS:
+            raise TerminalValidationError("unsupported agent registration")
+        app_key = terminal_app.strip().lower()
+        if app_key not in _TERMINAL_APPS:
+            raise TerminalValidationError("unsupported terminal application")
+        snapshot = self._probe(pid)
+        if snapshot is None or snapshot.uid != os.getuid():
+            raise TerminalValidationError("agent process is unavailable")
+        canonical_tty = _canonical_tty(tty, uid=snapshot.uid)
+        try:
+            process_tty = _canonical_tty(snapshot.tty, uid=snapshot.uid)
+        except TerminalValidationError as exc:
+            raise TerminalValidationError("agent process has no valid TTY") from exc
+        if process_tty != canonical_tty:
+            raise TerminalValidationError("agent process is attached to a different TTY")
+
+        now = _now()
+        with self._connect() as conn:
+            existing = conn.execute(
+                "SELECT id, created_at FROM terminal_registrations WHERE tty = ?",
+                (str(canonical_tty),),
+            ).fetchone()
+            registration_id = str(existing["id"]) if existing else f"term-{secrets.token_hex(8)}"
+            created_at = str(existing["created_at"]) if existing else now
+            conn.execute(
+                """
+                INSERT INTO terminal_registrations (
+                    id, tty, pid, uid, agent, terminal_app, project,
+                    process_started_at, created_at, last_seen_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(tty) DO UPDATE SET
+                    pid = excluded.pid,
+                    uid = excluded.uid,
+                    agent = excluded.agent,
+                    terminal_app = excluded.terminal_app,
+                    project = excluded.project,
+                    process_started_at = excluded.process_started_at,
+                    last_seen_at = excluded.last_seen_at
+                """,
+                (
+                    registration_id,
+                    str(canonical_tty),
+                    pid,
+                    snapshot.uid,
+                    normalized_agent,
+                    _TERMINAL_APPS[app_key],
+                    str(project),
+                    snapshot.started_at,
+                    created_at,
+                    now,
+                ),
+            )
+            row = conn.execute(
+                "SELECT * FROM terminal_registrations WHERE id = ?",
+                (registration_id,),
+            ).fetchone()
+        if row is None:  # pragma: no cover - guarded by the transaction above
+            raise TerminalValidationError("terminal registration was not persisted")
+        return self._from_row(row)
+
+    def _is_live(self, registration: TerminalRegistration) -> bool:
+        snapshot = self._probe(registration.pid)
+        if snapshot is None or snapshot.uid != registration.uid:
+            return False
+        try:
+            process_tty = _canonical_tty(snapshot.tty, uid=registration.uid)
+        except TerminalValidationError:
+            return False
+        return (
+            str(process_tty) == registration.tty
+            and snapshot.started_at == registration.process_started_at
+            and _command_matches_agent(snapshot.command, registration.agent)
+        )
+
+    def list(self) -> list[TerminalRegistration]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM terminal_registrations ORDER BY created_at, id"
+            ).fetchall()
+            registrations = [self._from_row(row) for row in rows]
+            live = [item for item in registrations if self._is_live(item)]
+            stale_ids = [item.id for item in registrations if item not in live]
+            if stale_ids:
+                conn.executemany(
+                    "DELETE FROM terminal_registrations WHERE id = ?",
+                    [(item,) for item in stale_ids],
+                )
+        return live
+
+    @staticmethod
+    def _receipt_from_row(row: sqlite3.Row) -> TerminalReceipt:
+        return TerminalReceipt(
+            receipt_id=str(row["receipt_id"]),
+            message_id=str(row["message_id"]),
+            target_id=str(row["target_id"]),
+            sender_id=str(row["sender_id"]),
+            kind=str(row["kind"]),
+            status=str(row["status"]),
+            transport=str(row["transport"]),
+            error=str(row["error"]),
+            created_at=str(row["created_at"]),
+            delivered_at=str(row["delivered_at"]),
+        )
+
+    def _existing_receipt(self, message_id: str) -> TerminalReceipt | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM terminal_receipts WHERE message_id = ?",
+                (message_id,),
+            ).fetchone()
+        return self._receipt_from_row(row) if row else None
+
+    def _live_target(self, target_id: str) -> TerminalRegistration:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM terminal_registrations WHERE id = ?",
+                (target_id,),
+            ).fetchone()
+        if row is None:
+            raise TerminalValidationError("registered terminal target was not found")
+        registration = self._from_row(row)
+        snapshot = self._probe(registration.pid)
+        if (
+            snapshot is None
+            or snapshot.uid != registration.uid
+            or snapshot.started_at != registration.process_started_at
+            or not _command_matches_agent(snapshot.command, registration.agent)
+        ):
+            raise TerminalValidationError("registered terminal target is stale")
+        try:
+            process_tty = _canonical_tty(snapshot.tty, uid=registration.uid)
+        except TerminalValidationError as exc:
+            raise TerminalValidationError("registered terminal target is stale") from exc
+        if str(process_tty) != registration.tty:
+            raise TerminalValidationError("registered terminal target changed TTY")
+        if snapshot.pgid != snapshot.foreground_pgid:
+            raise TerminalValidationError("registered agent is not the foreground terminal process")
+        return registration
+
+    def _deliver(
+        self,
+        target_id: str,
+        payload: bytes,
+        *,
+        sender: str | None,
+        message_id: str | None,
+        kind: str,
+    ) -> TerminalReceipt:
+        resolved_message_id = (message_id or f"msg-{secrets.token_hex(12)}").strip()
+        if not resolved_message_id:
+            raise TerminalValidationError("terminal message id cannot be empty")
+        existing = self._existing_receipt(resolved_message_id)
+        if existing is not None:
+            return replace(existing, status="duplicate")
+
+        registration = self._live_target(target_id)
+        now = _now()
+        receipt_id = f"rcpt-{secrets.token_hex(8)}"
+        with self._connect() as conn:
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO terminal_receipts (
+                        receipt_id, message_id, target_id, sender_id, kind,
+                        status, transport, error, created_at, delivered_at
+                    ) VALUES (?, ?, ?, ?, ?, 'pending', '', '', ?, '')
+                    """,
+                    (
+                        receipt_id,
+                        resolved_message_id,
+                        target_id,
+                        (sender or "").strip(),
+                        kind,
+                        now,
+                    ),
+                )
+            except sqlite3.IntegrityError:
+                duplicate = self._existing_receipt(resolved_message_id)
+                if duplicate is None:  # pragma: no cover - defensive race guard
+                    raise TerminalValidationError("terminal receipt collision") from None
+                return replace(duplicate, status="duplicate")
+
+        try:
+            transport = self._present(
+                Path(registration.tty),
+                payload,
+                terminal_app=registration.terminal_app,
+            )
+        except (OSError, RuntimeError) as exc:
+            with self._connect() as conn:
+                conn.execute(
+                    "UPDATE terminal_receipts SET status = 'failed', error = ? "
+                    "WHERE receipt_id = ?",
+                    (type(exc).__name__, receipt_id),
+                )
+            raise TerminalValidationError("terminal delivery failed") from exc
+
+        delivered_at = _now()
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE terminal_receipts SET status = 'delivered', transport = ?, "
+                "delivered_at = ? WHERE receipt_id = ?",
+                (transport, delivered_at, receipt_id),
+            )
+            row = conn.execute(
+                "SELECT * FROM terminal_receipts WHERE receipt_id = ?",
+                (receipt_id,),
+            ).fetchone()
+        if row is None:  # pragma: no cover - guarded by insert above
+            raise TerminalValidationError("terminal receipt was not persisted")
+        return self._receipt_from_row(row)
+
+    def send(
+        self,
+        target_id: str,
+        message: str,
+        *,
+        sender: str | None = None,
+        submit: bool = True,
+        message_id: str | None = None,
+    ) -> TerminalReceipt:
+        sanitized = _strip_terminal_controls(message)
+        payload = sanitized.encode("utf-8") + (b"\r" if submit else b"")
+        return self._deliver(
+            target_id,
+            payload,
+            sender=sender,
+            message_id=message_id,
+            kind="message",
+        )
+
+    def enter(
+        self,
+        target_id: str,
+        *,
+        sender: str | None = None,
+        message_id: str | None = None,
+    ) -> TerminalReceipt:
+        return self._deliver(
+            target_id,
+            b"\r",
+            sender=sender,
+            message_id=message_id,
+            kind="enter",
+        )
+
+    def history(self, *, limit: int = 50) -> builtins.list[TerminalReceipt]:
+        bounded = max(1, min(limit, 500))
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM terminal_receipts ORDER BY created_at DESC, receipt_id DESC LIMIT ?",
+                (bounded,),
+            ).fetchall()
+        return [self._receipt_from_row(row) for row in rows]

--- a/src/memo/terminal_live.py
+++ b/src/memo/terminal_live.py
@@ -95,6 +95,22 @@ def _now() -> str:
     return datetime.now(UTC).isoformat(timespec="seconds")
 
 
+def _is_local_tty_path(path: Path, mode: int) -> bool:
+    return path.is_relative_to(Path("/dev")) and stat.S_ISCHR(mode)
+
+
+def _path_is_tty(path: Path) -> bool:
+    flags = os.O_RDWR | os.O_NONBLOCK | getattr(os, "O_NOCTTY", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        return False
+    try:
+        return os.isatty(fd)
+    finally:
+        os.close(fd)
+
+
 def _canonical_tty(value: str | Path, *, uid: int | None = None) -> Path:
     raw = Path(value).expanduser()
     if not raw.is_absolute():
@@ -104,11 +120,13 @@ def _canonical_tty(value: str | Path, *, uid: int | None = None) -> Path:
         info = path.stat()
     except OSError as exc:
         raise TerminalValidationError("terminal target is unavailable") from exc
-    if path.parent != Path("/dev") or not stat.S_ISCHR(info.st_mode):
+    if not _is_local_tty_path(path, info.st_mode):
         raise TerminalValidationError("terminal target is not a local TTY")
     expected_uid = os.getuid() if uid is None else uid
     if info.st_uid != expected_uid:
         raise TerminalValidationError("terminal target belongs to another user")
+    if not _path_is_tty(path):
+        raise TerminalValidationError("terminal target is not a local TTY")
     return path
 
 

--- a/src/memo/terminal_presenter.py
+++ b/src/memo/terminal_presenter.py
@@ -42,7 +42,7 @@ def _split_payload(payload: bytes) -> tuple[str, bool]:
         raise OSError("terminal payload is not UTF-8") from exc
 
 
-_GHOSTTY_INPUT_SCRIPT = r'''
+_GHOSTTY_INPUT_SCRIPT = r"""
 on run argv
   set targetTty to item 1 of argv
   set promptText to item 2 of argv
@@ -66,15 +66,15 @@ on run argv
   end tell
   return "not found"
 end run
-'''
+"""
 
-_GHOSTTY_ENTER_SCRIPT = r'''
+_GHOSTTY_ENTER_SCRIPT = r"""
 tell application "Ghostty" to activate
 delay 0.35
 tell application "System Events" to key code 36
-'''
+"""
 
-_TERMINAL_INPUT_SCRIPT = r'''
+_TERMINAL_INPUT_SCRIPT = r"""
 on run argv
   set targetTty to item 1 of argv
   set submitPrompt to ((item 2 of argv) is "1")
@@ -115,7 +115,7 @@ on run argv
   end try
   return "ok"
 end run
-'''
+"""
 
 
 def _deliver_ghostty(tty: Path, payload: bytes) -> None:
@@ -139,7 +139,7 @@ def _deliver_terminal(tty: Path, payload: bytes) -> None:
 def _deliver_iterm(tty: Path, payload: bytes, *, app_name: str) -> None:
     body, submit = _split_payload(payload)
     app_literal = json.dumps(app_name)
-    script = f'''
+    script = f"""
 on run argv
   set targetTty to item 1 of argv
   set submitPrompt to ((item 2 of argv) is "1")
@@ -163,7 +163,7 @@ on run argv
   end tell
   return "not found"
 end run
-'''
+"""
     result = _run_osascript(script, str(tty), "1" if submit else "0", body)
     if result.returncode != 0 or result.stdout.strip() != "ok":
         raise OSError(f"{app_name} could not find the registered TTY")

--- a/src/memo/terminal_presenter.py
+++ b/src/memo/terminal_presenter.py
@@ -1,0 +1,190 @@
+"""Low-level, exact-TTY input delivery for registered local terminals."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import subprocess
+import termios
+from pathlib import Path
+
+
+def _deliver_tiocsti(tty: Path, payload: bytes) -> None:
+    request = getattr(termios, "TIOCSTI", None)
+    if request is None:
+        raise OSError("TIOCSTI is unavailable")
+    flags = os.O_RDWR | getattr(os, "O_NOCTTY", 0)
+    fd = os.open(tty, flags)
+    try:
+        for byte in payload:
+            fcntl.ioctl(fd, request, bytes([byte]))
+    finally:
+        os.close(fd)
+
+
+def _run_osascript(script: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["osascript", "-e", script, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+
+def _split_payload(payload: bytes) -> tuple[str, bool]:
+    submit = payload.endswith(b"\r")
+    body = payload[:-1] if submit else payload
+    try:
+        return body.decode("utf-8"), submit
+    except UnicodeDecodeError as exc:  # defensive: bridge always supplies UTF-8
+        raise OSError("terminal payload is not UTF-8") from exc
+
+
+_GHOSTTY_INPUT_SCRIPT = r'''
+on run argv
+  set targetTty to item 1 of argv
+  set promptText to item 2 of argv
+
+  tell application "Ghostty"
+    repeat with candidateWindow in windows
+      repeat with candidateTab in tabs of candidateWindow
+        repeat with candidateTerminal in terminals of candidateTab
+          try
+            set candidateTty to tty of candidateTerminal
+            if candidateTty is targetTty then
+              focus candidateTerminal
+              delay 0.1
+              if promptText is not "" then input text promptText to candidateTerminal
+              return "ok"
+            end if
+          end try
+        end repeat
+      end repeat
+    end repeat
+  end tell
+  return "not found"
+end run
+'''
+
+_GHOSTTY_ENTER_SCRIPT = r'''
+tell application "Ghostty" to activate
+delay 0.35
+tell application "System Events" to key code 36
+'''
+
+_TERMINAL_INPUT_SCRIPT = r'''
+on run argv
+  set targetTty to item 1 of argv
+  set submitPrompt to ((item 2 of argv) is "1")
+  set promptText to item 3 of argv
+  set oldClipboard to ""
+  try
+    set oldClipboard to the clipboard as text
+  end try
+
+  tell application "Terminal"
+    set foundTab to missing value
+    set foundWindow to missing value
+    repeat with candidateWindow in windows
+      repeat with candidateTab in tabs of candidateWindow
+        if tty of candidateTab is targetTty then
+          set foundTab to candidateTab
+          set foundWindow to candidateWindow
+          exit repeat
+        end if
+      end repeat
+      if foundTab is not missing value then exit repeat
+    end repeat
+    if foundTab is missing value then return "not found"
+    set selected tab of foundWindow to foundTab
+    set index of foundWindow to 1
+    activate
+  end tell
+
+  delay 0.1
+  if promptText is not "" then
+    set the clipboard to promptText
+    tell application "System Events" to keystroke "v" using command down
+  end if
+  if submitPrompt then tell application "System Events" to key code 36
+  delay 0.1
+  try
+    set the clipboard to oldClipboard
+  end try
+  return "ok"
+end run
+'''
+
+
+def _deliver_ghostty(tty: Path, payload: bytes) -> None:
+    body, submit = _split_payload(payload)
+    result = _run_osascript(_GHOSTTY_INPUT_SCRIPT, str(tty), body)
+    if result.returncode != 0 or result.stdout.strip() != "ok":
+        raise OSError("Ghostty could not find the registered TTY")
+    if submit:
+        entered = _run_osascript(_GHOSTTY_ENTER_SCRIPT)
+        if entered.returncode != 0:
+            raise OSError("Ghostty could not submit terminal input")
+
+
+def _deliver_terminal(tty: Path, payload: bytes) -> None:
+    body, submit = _split_payload(payload)
+    result = _run_osascript(_TERMINAL_INPUT_SCRIPT, str(tty), "1" if submit else "0", body)
+    if result.returncode != 0 or result.stdout.strip() != "ok":
+        raise OSError("Terminal could not find the registered TTY")
+
+
+def _deliver_iterm(tty: Path, payload: bytes, *, app_name: str) -> None:
+    body, submit = _split_payload(payload)
+    app_literal = json.dumps(app_name)
+    script = f'''
+on run argv
+  set targetTty to item 1 of argv
+  set submitPrompt to ((item 2 of argv) is "1")
+  set promptText to item 3 of argv
+
+  tell application {app_literal}
+    repeat with candidateWindow in windows
+      repeat with candidateTab in tabs of candidateWindow
+        repeat with candidateSession in sessions of candidateTab
+          if tty of candidateSession is targetTty then
+            if submitPrompt then
+              tell candidateSession to write text promptText
+            else
+              tell candidateSession to write text promptText newline false
+            end if
+            return "ok"
+          end if
+        end repeat
+      end repeat
+    end repeat
+  end tell
+  return "not found"
+end run
+'''
+    result = _run_osascript(script, str(tty), "1" if submit else "0", body)
+    if result.returncode != 0 or result.stdout.strip() != "ok":
+        raise OSError(f"{app_name} could not find the registered TTY")
+
+
+def deliver_input(tty: Path, payload: bytes, *, terminal_app: str) -> str:
+    """Deliver sanitized bytes to one validated TTY and return its transport."""
+    try:
+        _deliver_tiocsti(tty, payload)
+        return "tiocsti"
+    except OSError as direct_error:
+        try:
+            if terminal_app == "Ghostty":
+                _deliver_ghostty(tty, payload)
+                return "ghostty-applescript"
+            if terminal_app == "Terminal":
+                _deliver_terminal(tty, payload)
+                return "terminal-applescript"
+            if terminal_app in {"iTerm", "iTerm2"}:
+                _deliver_iterm(tty, payload, app_name=terminal_app)
+                return "iterm-applescript"
+        except OSError as fallback_error:
+            raise OSError("terminal input delivery failed") from fallback_error
+        raise OSError("terminal input injection is unavailable") from direct_error

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -154,6 +154,8 @@ def test_codex_shim_prints_startup_banner_once_for_nested_call(tmp_path) -> None
                 "MEMO_TEST_LOG": str(log_path),
                 "MEMO_CODEX_BADGE": "0",
                 "MEMO_STARTUP_BANNER_SHOWN": "0",
+                "MEMO_AGENT_TTY": "",
+                "TERM_PROGRAM": "ghostty",
             },
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
@@ -166,7 +168,63 @@ def test_codex_shim_prints_startup_banner_once_for_nested_call(tmp_path) -> None
         os.close(master_fd)
 
     assert proc.returncode == 0
-    assert log_path.read_text(encoding="utf-8").splitlines() == ["startup-banner --agent codex"]
+    calls = log_path.read_text(encoding="utf-8").splitlines()
+    assert sum(call.startswith("terminal register --agent codex") for call in calls) == 1
+    assert calls.count("startup-banner --agent codex") == 1
+
+
+def test_shim_registers_exact_terminal_before_agent_exec(tmp_path) -> None:
+    shim_dir = tmp_path / "shim"
+    tools_dir = tmp_path / "tools"
+    real_dir = tmp_path / "real"
+    project = tmp_path / "project"
+    log_path = tmp_path / "order.log"
+    for directory in (tools_dir, real_dir, project):
+        directory.mkdir()
+    memo = tools_dir / "memo"
+    memo.write_text(
+        '#!/usr/bin/env bash\nprintf "memo:%s\\n" "$*" >> "$MEMO_TEST_LOG"\n',
+        encoding="utf-8",
+    )
+    real = real_dir / "codex"
+    real.write_text(
+        '#!/usr/bin/env bash\nprintf "agent:%s\\n" "$MEMO_AGENT_TTY" >> "$MEMO_TEST_LOG"\n',
+        encoding="utf-8",
+    )
+    memo.chmod(0o755)
+    real.chmod(0o755)
+    install_shims(("codex",), shim_dir)
+    master_fd, slave_fd = pty.openpty()
+    tty_path = os.ttyname(slave_fd)
+    try:
+        proc = subprocess.run(
+            [str(shim_dir / "codex")],
+            cwd=project,
+            env={
+                **os.environ,
+                "PATH": os.pathsep.join([str(tools_dir), str(real_dir), os.environ["PATH"]]),
+                "MEMO_TEST_LOG": str(log_path),
+                "MEMO_STARTUP_BANNER": "0",
+                "MEMO_CODEX_BADGE": "0",
+                "MEMO_AGENT_TTY": "",
+                "TERM_PROGRAM": "ghostty",
+            },
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            timeout=5,
+        )
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
+
+    assert proc.returncode == 0
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert lines[0].startswith(
+        f"memo:terminal register --agent codex --tty {tty_path} --pid "
+    )
+    assert f"--terminal-app ghostty --project {project} --id-only" in lines[0]
+    assert lines[1] == f"agent:{tty_path}"
 
 
 def test_codex_badge_uses_memo_notify_protocol(tmp_cfg, tmp_path, monkeypatch) -> None:

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -220,9 +220,7 @@ def test_shim_registers_exact_terminal_before_agent_exec(tmp_path) -> None:
 
     assert proc.returncode == 0
     lines = log_path.read_text(encoding="utf-8").splitlines()
-    assert lines[0].startswith(
-        f"memo:terminal register --agent codex --tty {tty_path} --pid "
-    )
+    assert lines[0].startswith(f"memo:terminal register --agent codex --tty {tty_path} --pid ")
     assert f"--terminal-app ghostty --project {project} --id-only" in lines[0]
     assert lines[1] == f"agent:{tty_path}"
 

--- a/tests/test_cli_mcp_surface_smoke.py
+++ b/tests/test_cli_mcp_surface_smoke.py
@@ -127,15 +127,15 @@ def test_mcp_full_profile_registers_every_decorated_server_tool(
     registered = _mcp_tool_names(tmp_path, monkeypatch, "full")
 
     assert expected <= registered
-    assert len(registered) == 161
+    assert len(registered) == 164
 
 
 @pytest.mark.parametrize(
     ("profile", "expected_count"),
     [
-        ("agent", 40),
-        ("core", 57),
-        ("full", 161),
+        ("agent", 43),
+        ("core", 60),
+        ("full", 164),
     ],
 )
 def test_mcp_profile_tool_counts(

--- a/tests/test_cli_terminal.py
+++ b/tests/test_cli_terminal.py
@@ -1,0 +1,81 @@
+"""End-user CLI surface for live terminal coordination."""
+
+from __future__ import annotations
+
+import json
+import os
+import pty
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from memo.cli import cli
+from memo.terminal_live import ProcessSnapshot, TerminalBridge
+
+
+def _env(tmp_cfg) -> dict[str, str]:
+    return {
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_DATA_DIR": str(tmp_cfg.data_dir),
+        "MEMO_STATE_DIR": str(tmp_cfg.state_dir),
+    }
+
+
+def test_terminal_command_exposes_live_user_workflow(tmp_cfg) -> None:
+    result = CliRunner().invoke(
+        cli,
+        ["terminal", "--help"],
+        env=_env(tmp_cfg),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert all(command in result.output for command in ("register", "list", "send", "enter"))
+
+
+def test_terminal_send_cli_returns_json_receipt(tmp_cfg, monkeypatch) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty_path = Path(os.ttyname(slave_fd))
+    payloads: list[bytes] = []
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty_path,
+            started_at="Sat Aug 1 12:00:00 2026",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="codex",
+        )
+
+    def present(_path: Path, payload: bytes, *, terminal_app: str) -> str:
+        payloads.append(payload)
+        return "test"
+
+    try:
+        bridge = TerminalBridge(tmp_cfg, process_probe=probe, presenter=present)
+        target = bridge.register(agent="codex", tty=tty_path, pid=4242)
+        monkeypatch.setattr("memo.cli_terminal._bridge", lambda: bridge)
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "terminal",
+                "send",
+                "--to",
+                target.id,
+                "--message",
+                "ping",
+                "--message-id",
+                "cli-msg-1",
+                "--json",
+            ],
+            env=_env(tmp_cfg),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["status"] == "delivered"
+        assert payloads == [b"ping\r"]
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)

--- a/tests/test_cli_terminal.py
+++ b/tests/test_cli_terminal.py
@@ -79,3 +79,111 @@ def test_terminal_send_cli_returns_json_receipt(tmp_cfg, monkeypatch) -> None:
     finally:
         os.close(slave_fd)
         os.close(master_fd)
+
+
+def test_terminal_register_list_enter_and_history_cli(tmp_cfg, monkeypatch) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty_path = Path(os.ttyname(slave_fd))
+    payloads: list[bytes] = []
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty_path,
+            started_at="Sat Aug 1 12:00:00 2026",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="codex",
+        )
+
+    def present(_path: Path, payload: bytes, *, terminal_app: str) -> str:
+        payloads.append(payload)
+        return "test"
+
+    try:
+        bridge = TerminalBridge(tmp_cfg, process_probe=probe, presenter=present)
+        monkeypatch.setattr("memo.cli_terminal._bridge", lambda: bridge)
+        runner = CliRunner()
+
+        registered = runner.invoke(
+            cli,
+            [
+                "terminal",
+                "register",
+                "--agent",
+                "codex",
+                "--tty",
+                str(tty_path),
+                "--pid",
+                "4242",
+                "--terminal-app",
+                "Ghostty",
+                "--project",
+                "/tmp/memo",
+                "--json",
+            ],
+            env=_env(tmp_cfg),
+        )
+        assert registered.exit_code == 0, registered.output
+        registration_id = json.loads(registered.output)["id"]
+
+        listed = runner.invoke(cli, ["terminal", "list"], env=_env(tmp_cfg))
+        assert listed.exit_code == 0, listed.output
+        assert f"{registration_id}\tcodex\t{tty_path}\t/tmp/memo" in listed.output
+        listed_json = runner.invoke(cli, ["terminal", "list", "--json"], env=_env(tmp_cfg))
+        assert listed_json.exit_code == 0, listed_json.output
+        assert json.loads(listed_json.output)[0]["id"] == registration_id
+
+        entered = runner.invoke(
+            cli,
+            [
+                "terminal",
+                "enter",
+                "--to",
+                registration_id,
+                "--message-id",
+                "cli-enter-1",
+                "--json",
+            ],
+            env=_env(tmp_cfg),
+        )
+        assert entered.exit_code == 0, entered.output
+        assert json.loads(entered.output)["kind"] == "enter"
+        assert payloads == [b"\r"]
+
+        entered_text = runner.invoke(
+            cli,
+            [
+                "terminal",
+                "enter",
+                "--to",
+                registration_id,
+                "--message-id",
+                "cli-enter-2",
+            ],
+            env=_env(tmp_cfg),
+        )
+        assert entered_text.exit_code == 0, entered_text.output
+        assert "delivered" in entered_text.output
+        assert "via test" in entered_text.output
+        assert payloads == [b"\r", b"\r"]
+
+        history = runner.invoke(cli, ["terminal", "history"], env=_env(tmp_cfg))
+        assert history.exit_code == 0, history.output
+        assert registration_id in history.output
+        assert "delivered" in history.output
+        history_json = runner.invoke(
+            cli,
+            ["terminal", "history", "--limit", "1", "--json"],
+            env=_env(tmp_cfg),
+        )
+        assert history_json.exit_code == 0, history_json.output
+        rows = json.loads(history_json.output)
+        assert len(rows) == 1
+        assert rows[0]["target_id"] == registration_id
+        assert rows[0]["status"] == "delivered"
+        assert rows[0]["message_id"] == "cli-enter-2"
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)

--- a/tests/test_mcp_stdio_end_user.py
+++ b/tests/test_mcp_stdio_end_user.py
@@ -66,7 +66,7 @@ async def test_stdio_process_exposes_full_surface_and_core_crud(tmp_path: Path) 
     try:
         async with Client(config, timeout=20, init_timeout=20) as client:
             tools = await client.list_tools()
-            assert len(tools) == 161
+            assert len(tools) == 164
 
             version = (await client.call_tool("memo_version", {})).data
             assert version["version"]

--- a/tests/test_server_terminal.py
+++ b/tests/test_server_terminal.py
@@ -1,0 +1,104 @@
+"""MCP tools for immediate registered-terminal coordination."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pty
+from pathlib import Path
+
+from memo import server_terminal
+from memo.server import build_server
+from memo.terminal_live import ProcessSnapshot, TerminalBridge
+
+
+def _tool(server, name: str):
+    tool = asyncio.run(server.get_tool(name))
+    assert tool is not None
+    return tool.fn
+
+
+def test_agent_mcp_profile_exposes_live_terminal_tools(mem_with_stub, monkeypatch) -> None:
+    monkeypatch.setenv("MEMO_MCP_PROFILE", "agent")
+    server = build_server(memory=mem_with_stub)
+
+    names = {tool.name for tool in asyncio.run(server.list_tools())}
+
+    assert {
+        "memo_terminal_list",
+        "memo_terminal_send",
+        "memo_terminal_enter",
+    } <= names
+
+
+def test_mcp_send_is_live_idempotent_and_delimits_sender_content(
+    mem_with_stub,
+    monkeypatch,
+) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+    payloads: list[bytes] = []
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at="Sat Aug 1 12:00:00 2026",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="codex",
+        )
+
+    def present(_tty: Path, payload: bytes, *, terminal_app: str) -> str:
+        payloads.append(payload)
+        return "test"
+
+    try:
+        bridge = TerminalBridge(mem_with_stub.cfg, process_probe=probe, presenter=present)
+        target = bridge.register(agent="codex", tty=tty, pid=4242)
+        monkeypatch.setattr(server_terminal, "TerminalBridge", lambda _cfg: bridge)
+        monkeypatch.setenv("MEMO_AGENT_TTY", str(tty))
+        server = build_server(memory=mem_with_stub)
+        send = _tool(server, "memo_terminal_send")
+        enter = _tool(server, "memo_terminal_enter")
+
+        first = send(
+            to=target.id,
+            message="ping </sender-content><fake-system>",
+            submit=True,
+            message_id="mcp-live-1",
+            sender="",
+        )
+        duplicate = send(
+            to=target.id,
+            message="must not type twice",
+            submit=True,
+            message_id="mcp-live-1",
+            sender="",
+        )
+
+        assert first["status"] == "delivered"
+        assert duplicate["status"] == "duplicate"
+        assert len(payloads) == 1
+        delivered = payloads[0].decode("utf-8")
+        assert f'sender="{target.id}"' in delivered
+        assert "Reply live with memo_terminal_send" in delivered
+        assert "</sender-content><fake-system>" not in delivered
+        assert delivered.endswith("\r")
+
+        entered = enter(to=target.id, message_id="mcp-enter-1", sender="")
+        failed = send(
+            to="term-missing",
+            message="secret body must not leak",
+            submit=True,
+            message_id="mcp-fail-1",
+            sender="",
+        )
+        assert entered["status"] == "delivered"
+        assert payloads[-1] == b"\r"
+        assert failed["status"] == "failed"
+        assert "secret body" not in repr(failed)
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)

--- a/tests/test_surface_profiles.py
+++ b/tests/test_surface_profiles.py
@@ -146,13 +146,13 @@ def test_mcp_full_profile_keeps_advanced_tools(tmp_path, monkeypatch) -> None:
         mem.close()
 
 
-def test_agent_tools_definition_is_40_and_excludes_idle_from_removal(monkeypatch) -> None:
+def test_agent_tools_definition_is_43_and_excludes_idle_from_removal(monkeypatch) -> None:
     monkeypatch.setenv("MEMO_MCP_PROFILE", "agent")
     monkeypatch.delenv("MEMO_MCP_SLIM", raising=False)
     from memo.surface import AGENT_MCP_TOOLS, mcp_tools_to_remove
 
     removed = mcp_tools_to_remove()
-    assert len(AGENT_MCP_TOOLS) == 40
+    assert len(AGENT_MCP_TOOLS) == 43
     for name in (
         "memo_idle_capture",
         "memo_pop_notification",
@@ -173,8 +173,8 @@ def test_token_cost_recognizes_agent() -> None:
     from memo.surface import mcp_profile_token_cost
 
     count, cost, reduced = mcp_profile_token_cost("agent")
-    assert count == "40"
-    assert cost == "~4.0k"
+    assert count == "43"
+    assert cost == "~4.3k"
     assert reduced is True
 
 
@@ -183,8 +183,8 @@ def test_token_cost_core_and_slim_are_reduced() -> None:
 
     for profile in ("core", "slim"):
         count, cost, reduced = mcp_profile_token_cost(profile)
-        assert count == "57"
-        assert cost == "~5.2k"
+        assert count == "60"
+        assert cost == "~5.5k"
         assert reduced is True
 
 
@@ -193,8 +193,8 @@ def test_token_cost_full_is_not_reduced() -> None:
 
     for profile in ("full", "default"):
         count, cost, reduced = mcp_profile_token_cost(profile)
-        assert count == "161"
-        assert cost == "~18k"
+        assert count == "164"
+        assert cost == "~18.3k"
         assert reduced is False
 
 
@@ -204,8 +204,8 @@ def test_token_cost_active_default_resolves_to_agent(monkeypatch) -> None:
     from memo.surface import mcp_profile_token_cost
 
     count, cost, reduced = mcp_profile_token_cost()
-    assert count == "40"
-    assert cost == "~4.0k"
+    assert count == "43"
+    assert cost == "~4.3k"
     assert reduced is True
 
 

--- a/tests/test_terminal_live.py
+++ b/tests/test_terminal_live.py
@@ -131,7 +131,14 @@ def test_enter_delivers_only_carriage_return(registered_bridge) -> None:
     assert receipt.status == "delivered"
 
 
-@pytest.mark.parametrize("message", ["", "\x1b[31m\r", "x" * (16 * 1024 + 1)])
+@pytest.mark.parametrize(
+    "message",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("\x1b[31m\r", id="control-only"),
+        pytest.param("x" * (16 * 1024 + 1), id="oversized"),
+    ],
+)
 def test_send_rejects_empty_control_only_and_oversized_messages(
     registered_bridge,
     message: str,
@@ -140,6 +147,17 @@ def test_send_rejects_empty_control_only_and_oversized_messages(
 
     with pytest.raises(TerminalValidationError):
         bridge.send(registration.id, message)
+
+    assert payloads == []
+
+
+def test_send_rejects_unbounded_or_malformed_routing_ids(registered_bridge) -> None:
+    bridge, registration, payloads, _state = registered_bridge
+
+    with pytest.raises(TerminalValidationError, match="message id"):
+        bridge.send(registration.id, "hello", message_id="x" * 129)
+    with pytest.raises(TerminalValidationError, match="sender id"):
+        bridge.send(registration.id, "hello", sender="not a terminal")
 
     assert payloads == []
 

--- a/tests/test_terminal_live.py
+++ b/tests/test_terminal_live.py
@@ -1,0 +1,201 @@
+"""Live terminal registry and delivery behavior."""
+
+from __future__ import annotations
+
+import os
+import pty
+from pathlib import Path
+
+import pytest
+
+from memo.errors import TerminalValidationError
+from memo.terminal_live import ProcessSnapshot, TerminalBridge
+
+
+@pytest.fixture
+def registered_bridge(tmp_cfg):
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+    state = {"alive": True, "foreground_pgid": 4242}
+    payloads: list[tuple[Path, bytes, str]] = []
+
+    def probe(pid: int) -> ProcessSnapshot | None:
+        if not state["alive"]:
+            return None
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at="Sat Aug 1 12:00:00 2026",
+            pgid=pid,
+            foreground_pgid=int(state["foreground_pgid"]),
+            command="codex --dangerously-bypass-approvals-and-sandbox",
+        )
+
+    def presenter(path: Path, payload: bytes, *, terminal_app: str) -> str:
+        payloads.append((path, payload, terminal_app))
+        return "test"
+
+    bridge = TerminalBridge(tmp_cfg, process_probe=probe, presenter=presenter)
+    registration = bridge.register(
+        agent="codex",
+        tty=tty,
+        pid=4242,
+        terminal_app="Ghostty",
+        project="/tmp/memo",
+    )
+    try:
+        yield bridge, registration, payloads, state
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
+
+
+def test_register_persists_same_uid_tty_and_prunes_stale_process(tmp_cfg) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+    alive = True
+
+    def probe(pid: int) -> ProcessSnapshot | None:
+        if not alive:
+            return None
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at="Sat Aug 1 12:00:00 2026",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="codex --dangerously-bypass-approvals-and-sandbox",
+        )
+
+    try:
+        bridge = TerminalBridge(tmp_cfg, process_probe=probe)
+        registration = bridge.register(
+            agent="codex",
+            tty=tty,
+            pid=4242,
+            terminal_app="Ghostty",
+            project="/tmp/memo",
+        )
+
+        assert bridge.list() == [registration]
+        assert registration.tty == str(tty)
+        assert registration.agent == "codex"
+
+        alive = False
+        assert bridge.list() == []
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
+
+
+def test_send_strips_terminal_controls_and_is_idempotent(registered_bridge) -> None:
+    bridge, registration, payloads, _state = registered_bridge
+
+    first = bridge.send(
+        registration.id,
+        "hello\x1b[31m!\x1b[0m\r",
+        message_id="msg-1",
+    )
+    second = bridge.send(
+        registration.id,
+        "different text",
+        message_id="msg-1",
+    )
+
+    assert payloads == [(Path(registration.tty), b"hello!\r", "Ghostty")]
+    assert first.status == "delivered"
+    assert first.transport == "test"
+    assert second.receipt_id == first.receipt_id
+    assert second.status == "duplicate"
+
+
+def test_send_refuses_when_agent_is_not_foreground(registered_bridge) -> None:
+    bridge, registration, payloads, state = registered_bridge
+    state["foreground_pgid"] = 9999
+
+    with pytest.raises(TerminalValidationError, match="foreground"):
+        bridge.send(registration.id, "do not deliver")
+
+    assert payloads == []
+
+
+def test_enter_delivers_only_carriage_return(registered_bridge) -> None:
+    bridge, registration, payloads, _state = registered_bridge
+
+    receipt = bridge.enter(registration.id, message_id="enter-1")
+
+    assert payloads == [(Path(registration.tty), b"\r", "Ghostty")]
+    assert receipt.kind == "enter"
+    assert receipt.status == "delivered"
+
+
+@pytest.mark.parametrize("message", ["", "\x1b[31m\r", "x" * (16 * 1024 + 1)])
+def test_send_rejects_empty_control_only_and_oversized_messages(
+    registered_bridge,
+    message: str,
+) -> None:
+    bridge, registration, payloads, _state = registered_bridge
+
+    with pytest.raises(TerminalValidationError):
+        bridge.send(registration.id, message)
+
+    assert payloads == []
+
+
+def test_failed_delivery_is_receipted_without_message_body(tmp_cfg) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at="Sat Aug 1 12:00:00 2026",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="codex",
+        )
+
+    def fail(_tty: Path, _payload: bytes, *, terminal_app: str) -> str:
+        raise OSError("presenter unavailable")
+
+    try:
+        bridge = TerminalBridge(tmp_cfg, process_probe=probe, presenter=fail)
+        registration = bridge.register(agent="codex", tty=tty, pid=4242)
+
+        with pytest.raises(TerminalValidationError, match="delivery failed"):
+            bridge.send(registration.id, "secret terminal body", message_id="failure-1")
+
+        receipt = bridge.history()[0]
+        assert receipt.status == "failed"
+        assert receipt.error == "OSError"
+        assert "secret terminal body" not in repr(receipt)
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
+
+
+def test_registration_database_is_private(tmp_cfg) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at="Sat Aug 1 12:00:00 2026",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="codex",
+        )
+
+    try:
+        TerminalBridge(tmp_cfg, process_probe=probe, presenter=lambda *_a, **_kw: "test")
+        assert (tmp_cfg.state_dir / "terminal_live.db").stat().st_mode & 0o777 == 0o600
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)

--- a/tests/test_terminal_live.py
+++ b/tests/test_terminal_live.py
@@ -4,12 +4,22 @@ from __future__ import annotations
 
 import os
 import pty
+import stat
 from pathlib import Path
 
 import pytest
 
 from memo.errors import TerminalValidationError
-from memo.terminal_live import ProcessSnapshot, TerminalBridge
+from memo.terminal_live import ProcessSnapshot, TerminalBridge, _is_local_tty_path
+
+
+def test_local_tty_path_accepts_linux_devpts_and_rejects_non_device_paths() -> None:
+    char_mode = stat.S_IFCHR | 0o620
+
+    assert _is_local_tty_path(Path("/dev/pts/7"), char_mode)
+    assert _is_local_tty_path(Path("/dev/ttys000"), char_mode)
+    assert not _is_local_tty_path(Path("/tmp/pts/7"), char_mode)
+    assert not _is_local_tty_path(Path("/dev/pts/7"), stat.S_IFREG | 0o600)
 
 
 @pytest.fixture

--- a/tests/test_terminal_presenter.py
+++ b/tests/test_terminal_presenter.py
@@ -1,0 +1,102 @@
+"""Real and fallback terminal input presentation."""
+
+from __future__ import annotations
+
+import os
+import pty
+from pathlib import Path
+from types import SimpleNamespace
+
+import memo.terminal_presenter as presenter
+
+
+def test_tiocsti_preserves_every_input_byte(monkeypatch) -> None:
+    master_fd, slave_fd = pty.openpty()
+    target = Path(os.ttyname(slave_fd))
+    injected: list[bytes] = []
+    monkeypatch.setattr(presenter.fcntl, "ioctl", lambda _fd, _request, value: injected.append(value))
+    try:
+        transport = presenter.deliver_input(target, b"hello\r", terminal_app="")
+
+        assert injected == [b"h", b"e", b"l", b"l", b"o", b"\r"]
+        assert transport == "tiocsti"
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
+
+
+def test_ghostty_fallback_targets_exact_tty_and_submits_separately(monkeypatch) -> None:
+    calls: list[tuple[str, tuple[str, ...]]] = []
+
+    def deny(_tty: Path, _payload: bytes) -> None:
+        raise PermissionError("kernel denied TIOCSTI")
+
+    def run(script: str, *args: str):
+        calls.append((script, args))
+        return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(presenter, "_deliver_tiocsti", deny)
+    monkeypatch.setattr(presenter, "_run_osascript", run)
+
+    transport = presenter.deliver_input(
+        Path("/dev/ttys003"),
+        b"hello from memo\r",
+        terminal_app="Ghostty",
+    )
+
+    assert transport == "ghostty-applescript"
+    assert calls[0][1] == ("/dev/ttys003", "hello from memo")
+    assert "candidateTty is targetTty" in calls[0][0]
+    assert len(calls) == 2
+    assert "key code 36" in calls[1][0]
+
+
+def test_terminal_app_fallback_passes_payload_as_argv(monkeypatch) -> None:
+    calls: list[tuple[str, tuple[str, ...]]] = []
+    monkeypatch.setattr(
+        presenter,
+        "_deliver_tiocsti",
+        lambda _tty, _payload: (_ for _ in ()).throw(PermissionError()),
+    )
+
+    def run(script: str, *args: str):
+        calls.append((script, args))
+        return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(presenter, "_run_osascript", run)
+
+    transport = presenter.deliver_input(
+        Path("/dev/ttys003"),
+        b"hello 'quoted'\r",
+        terminal_app="Terminal",
+    )
+
+    assert transport == "terminal-applescript"
+    assert calls[0][1] == ("/dev/ttys003", "1", "hello 'quoted'")
+    assert "tty of candidateTab is targetTty" in calls[0][0]
+
+
+def test_iterm_fallback_writes_to_exact_session_without_newline(monkeypatch) -> None:
+    calls: list[tuple[str, tuple[str, ...]]] = []
+    monkeypatch.setattr(
+        presenter,
+        "_deliver_tiocsti",
+        lambda _tty, _payload: (_ for _ in ()).throw(PermissionError()),
+    )
+
+    def run(script: str, *args: str):
+        calls.append((script, args))
+        return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(presenter, "_run_osascript", run)
+
+    transport = presenter.deliver_input(
+        Path("/dev/ttys007"),
+        b"draft only",
+        terminal_app="iTerm2",
+    )
+
+    assert transport == "iterm-applescript"
+    assert calls[0][1] == ("/dev/ttys007", "0", "draft only")
+    assert "tty of candidateSession is targetTty" in calls[0][0]
+    assert "newline false" in calls[0][0]

--- a/tests/test_terminal_presenter.py
+++ b/tests/test_terminal_presenter.py
@@ -14,7 +14,9 @@ def test_tiocsti_preserves_every_input_byte(monkeypatch) -> None:
     master_fd, slave_fd = pty.openpty()
     target = Path(os.ttyname(slave_fd))
     injected: list[bytes] = []
-    monkeypatch.setattr(presenter.fcntl, "ioctl", lambda _fd, _request, value: injected.append(value))
+    monkeypatch.setattr(
+        presenter.fcntl, "ioctl", lambda _fd, _request, value: injected.append(value)
+    )
     try:
         transport = presenter.deliver_input(target, b"hello\r", terminal_app="")
 


### PR DESCRIPTION
## Summary
- add exact-ID local terminal registration and live CLI/MCP message delivery
- support separate remote Return for prompts waiting on human submission
- enforce same-user, PID/start-time, TTY and foreground-process validation with idempotent receipts
- install automatic registration in agent shims and document the new surface

## End-user proof
- delivered a live prompt from `ttys003` to `ttys000` and received a reply through Memo
- delivered a draft with `--no-submit`, then submitted it with a separate `memo terminal enter` receipt

## Verification
- `uv run --no-sync ruff check src/ tests/`
- `uv run --no-sync mypy src/memo`
- `uv run --no-sync python scripts/quality_gate.py`
- `uv run --no-sync pytest -m "not slow" -n auto --timeout=120 --cov=memo --cov-report=term-missing` (6324 passed, 19 skipped)
- `uv run --no-sync pytest -m "slow" --timeout=300 -v` (9 passed)
- focused terminal CLI/MCP/TTY suite with `-W error` (19 passed)
- pre-push recall gate PASS (precision 0.708, noise 0.000)