### PR TITLE
fix: harden live terminal delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
   session-id pagination so consumers can drain histories larger than 1,000
   records without replaying earlier pages.
 
+### Fixed
+
+- Live terminal coordination now recognizes the native `Apple_Terminal` and
+  `iTerm.app` `TERM_PROGRAM` values, rotates a registration id when a new
+  process replaces an agent on the same TTY, and records target-validation
+  failures instead of leaving them outside receipt history.
+- macOS terminal presentation keeps message bodies out of process arguments,
+  converts AppleScript timeouts into failed receipts, submits Ghostty input to
+  the exact terminal without a global-focus race, and no longer uses the
+  clipboard for Terminal.app delivery. A partially successful `TIOCSTI`
+  injection is never replayed through a fallback transport.
+
 ### Changed
 
 - `memo stats --json` now emits `memo.stats.v2`: bounded context activity is

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -387,8 +387,11 @@ are intentionally absent from the default agent profile:
 
 Agent shims installed by `memo install-shims` register their exact local TTY,
 PID, agent name, terminal application, and project. Registrations are scoped to
-the current OS user and revalidated before each delivery. Use the CLI to inspect
-or address them directly:
+the current OS user and revalidated before each delivery. Native
+`TERM_PROGRAM` values such as `Apple_Terminal` and `iTerm.app` are normalized
+to their supported presenters. A new process reusing the same TTY receives a
+new terminal id, so stale callers cannot silently address its replacement. Use
+the CLI to inspect or address registrations directly:
 
 ```bash
 memo terminal list --json
@@ -401,8 +404,18 @@ The equivalent always-on MCP tools are `memo_terminal_list`,
 `memo_terminal_send`, and `memo_terminal_enter`. A live message contains a
 reply-to terminal id so the receiving agent can answer through the same tool.
 `enter` sends only a carriage return and refuses stale, mismatched, or
-non-foreground targets. Handoffs and attention remain the durable asynchronous
-channel; terminal chat is immediate and same-machine only.
+non-foreground targets. Receipt history contains routing and outcome metadata,
+never message bodies; failed target validation and presenter failures are
+recorded as `failed` receipts.
+
+On macOS, Ghostty and iTerm use exact-session application APIs; Terminal.app
+uses its exact tab API for submitted input and avoids clipboard mutation.
+Linux `/dev/pts/N` registration and validation are supported, but delivery on
+a hardened kernel still requires an available exact-session transport:
+generic terminals that deny `TIOCSTI` fail closed and produce a failed receipt
+instead of writing lookalike output that the target process never receives.
+Handoffs and attention remain the durable asynchronous channel; terminal chat
+is immediate and same-machine only.
 
 ## MCP tools
 

--- a/src/memo/audio_transcribe.py
+++ b/src/memo/audio_transcribe.py
@@ -38,7 +38,7 @@ def whisper_available() -> bool:
         return _WHISPER_OK
     _WHISPER_CHECKED = True
     try:
-        import mlx_whisper  # type: ignore[import-not-found]  # noqa: F401
+        import mlx_whisper  # type: ignore[import-not-found,import-untyped]  # noqa: F401
 
         _WHISPER_OK = True
     except ImportError as exc:
@@ -58,7 +58,7 @@ def transcribe_audio(audio_path: Path) -> str:
     if not p.exists() or not p.is_file():
         return ""
     try:
-        import mlx_whisper  # type: ignore[import-not-found]
+        import mlx_whisper  # type: ignore[import-not-found,import-untyped]
 
         from memo.flags import flag_str
 

--- a/src/memo/terminal_live.py
+++ b/src/memo/terminal_live.py
@@ -25,8 +25,10 @@ if TYPE_CHECKING:
 _AGENTS = frozenset({"blackbox", "claude", "codex", "devin", "gemini", "opencode"})
 _TERMINAL_APPS = {
     "": "",
+    "apple_terminal": "Terminal",
     "terminal": "Terminal",
     "iterm": "iTerm",
+    "iterm.app": "iTerm2",
     "iterm2": "iTerm2",
     "ghostty": "Ghostty",
 }
@@ -346,11 +348,21 @@ class TerminalBridge:
         now = _now()
         with self._connect() as conn:
             existing = conn.execute(
-                "SELECT id, created_at FROM terminal_registrations WHERE tty = ?",
+                "SELECT id, pid, uid, agent, process_started_at, created_at "
+                "FROM terminal_registrations WHERE tty = ?",
                 (str(canonical_tty),),
             ).fetchone()
-            registration_id = str(existing["id"]) if existing else f"term-{secrets.token_hex(8)}"
-            created_at = str(existing["created_at"]) if existing else now
+            same_process = bool(
+                existing
+                and int(existing["pid"]) == pid
+                and int(existing["uid"]) == snapshot.uid
+                and str(existing["agent"]) == normalized_agent
+                and str(existing["process_started_at"]) == snapshot.started_at
+            )
+            registration_id = (
+                str(existing["id"]) if same_process else f"term-{secrets.token_hex(8)}"
+            )
+            created_at = str(existing["created_at"]) if same_process else now
             conn.execute(
                 """
                 INSERT INTO terminal_registrations (
@@ -358,12 +370,14 @@ class TerminalBridge:
                     process_started_at, created_at, last_seen_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(tty) DO UPDATE SET
+                    id = excluded.id,
                     pid = excluded.pid,
                     uid = excluded.uid,
                     agent = excluded.agent,
                     terminal_app = excluded.terminal_app,
                     project = excluded.project,
                     process_started_at = excluded.process_started_at,
+                    created_at = excluded.created_at,
                     last_seen_at = excluded.last_seen_at
                 """,
                 (
@@ -493,11 +507,13 @@ class TerminalBridge:
         sender_id = (sender or "").strip()
         if sender_id and not _REGISTRATION_ID_RE.fullmatch(sender_id):
             raise TerminalValidationError("terminal sender id is malformed")
+        resolved_target_id = target_id.strip()
+        if not _REGISTRATION_ID_RE.fullmatch(resolved_target_id):
+            raise TerminalValidationError("terminal target id is malformed")
         existing = self._existing_receipt(resolved_message_id)
         if existing is not None:
             return replace(existing, status="duplicate")
 
-        registration = self._live_target(target_id)
         now = _now()
         receipt_id = f"rcpt-{secrets.token_hex(8)}"
         with self._connect() as conn:
@@ -512,7 +528,7 @@ class TerminalBridge:
                     (
                         receipt_id,
                         resolved_message_id,
-                        target_id,
+                        resolved_target_id,
                         sender_id,
                         kind,
                         now,
@@ -525,12 +541,23 @@ class TerminalBridge:
                 return replace(duplicate, status="duplicate")
 
         try:
+            registration = self._live_target(resolved_target_id)
+        except TerminalValidationError as exc:
+            with self._connect() as conn:
+                conn.execute(
+                    "UPDATE terminal_receipts SET status = 'failed', error = ? "
+                    "WHERE receipt_id = ?",
+                    (str(exc), receipt_id),
+                )
+            raise
+
+        try:
             transport = self._present(
                 Path(registration.tty),
                 payload,
                 terminal_app=registration.terminal_app,
             )
-        except (OSError, RuntimeError) as exc:
+        except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
             with self._connect() as conn:
                 conn.execute(
                     "UPDATE terminal_receipts SET status = 'failed', error = ? "

--- a/src/memo/terminal_presenter.py
+++ b/src/memo/terminal_presenter.py
@@ -9,6 +9,12 @@ import subprocess
 import termios
 from pathlib import Path
 
+_PROMPT_LITERAL_MARKER = "__MEMO_PROMPT_LITERAL__"
+
+
+class _PartialTIOCSTIError(OSError):
+    """TIOCSTI failed after at least one byte reached the target."""
+
 
 def _deliver_tiocsti(tty: Path, payload: bytes) -> None:
     request = getattr(termios, "TIOCSTI", None)
@@ -16,21 +22,48 @@ def _deliver_tiocsti(tty: Path, payload: bytes) -> None:
         raise OSError("TIOCSTI is unavailable")
     flags = os.O_RDWR | getattr(os, "O_NOCTTY", 0)
     fd = os.open(tty, flags)
+    injected = 0
     try:
         for byte in payload:
-            fcntl.ioctl(fd, request, bytes([byte]))
+            try:
+                fcntl.ioctl(fd, request, bytes([byte]))
+            except OSError as exc:
+                if injected:
+                    raise _PartialTIOCSTIError(f"TIOCSTI stopped after {injected} bytes") from exc
+                raise
+            injected += 1
     finally:
         os.close(fd)
 
 
-def _run_osascript(script: str, *args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["osascript", "-e", script, *args],
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=5,
-    )
+def _run_osascript(
+    script: str,
+    *args: str,
+    prompt_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    command = ["osascript", "-e", script, *args]
+    script_input: str | None = None
+    if prompt_text is not None:
+        if script.count(_PROMPT_LITERAL_MARKER) != 1:
+            raise OSError("terminal automation payload marker is invalid")
+        script_input = script.replace(
+            _PROMPT_LITERAL_MARKER,
+            json.dumps(prompt_text, ensure_ascii=False),
+        )
+        command = ["osascript", "-", *args]
+    try:
+        return subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            input=script_input,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise OSError("terminal automation timed out") from exc
+    except OSError as exc:
+        raise OSError("terminal automation could not start") from exc
 
 
 def _split_payload(payload: bytes) -> tuple[str, bool]:
@@ -45,7 +78,8 @@ def _split_payload(payload: bytes) -> tuple[str, bool]:
 _GHOSTTY_INPUT_SCRIPT = r"""
 on run argv
   set targetTty to item 1 of argv
-  set promptText to item 2 of argv
+  set submitPrompt to ((item 2 of argv) is "1")
+  set promptText to __MEMO_PROMPT_LITERAL__
 
   tell application "Ghostty"
     repeat with candidateWindow in windows
@@ -54,9 +88,8 @@ on run argv
           try
             set candidateTty to tty of candidateTerminal
             if candidateTty is targetTty then
-              focus candidateTerminal
-              delay 0.1
               if promptText is not "" then input text promptText to candidateTerminal
+              if submitPrompt then send key "enter" to candidateTerminal
               return "ok"
             end if
           end try
@@ -68,21 +101,11 @@ on run argv
 end run
 """
 
-_GHOSTTY_ENTER_SCRIPT = r"""
-tell application "Ghostty" to activate
-delay 0.35
-tell application "System Events" to key code 36
-"""
-
 _TERMINAL_INPUT_SCRIPT = r"""
 on run argv
   set targetTty to item 1 of argv
   set submitPrompt to ((item 2 of argv) is "1")
-  set promptText to item 3 of argv
-  set oldClipboard to ""
-  try
-    set oldClipboard to the clipboard as text
-  end try
+  set promptText to __MEMO_PROMPT_LITERAL__
 
   tell application "Terminal"
     set foundTab to missing value
@@ -98,6 +121,10 @@ on run argv
       if foundTab is not missing value then exit repeat
     end repeat
     if foundTab is missing value then return "not found"
+    if submitPrompt then
+      do script promptText in foundTab
+      return "ok"
+    end if
     set selected tab of foundWindow to foundTab
     set index of foundWindow to 1
     activate
@@ -105,14 +132,10 @@ on run argv
 
   delay 0.1
   if promptText is not "" then
-    set the clipboard to promptText
-    tell application "System Events" to keystroke "v" using command down
+    tell application "System Events"
+      tell process "Terminal" to keystroke promptText
+    end tell
   end if
-  if submitPrompt then tell application "System Events" to key code 36
-  delay 0.1
-  try
-    set the clipboard to oldClipboard
-  end try
   return "ok"
 end run
 """
@@ -120,18 +143,24 @@ end run
 
 def _deliver_ghostty(tty: Path, payload: bytes) -> None:
     body, submit = _split_payload(payload)
-    result = _run_osascript(_GHOSTTY_INPUT_SCRIPT, str(tty), body)
+    result = _run_osascript(
+        _GHOSTTY_INPUT_SCRIPT,
+        str(tty),
+        "1" if submit else "0",
+        prompt_text=body,
+    )
     if result.returncode != 0 or result.stdout.strip() != "ok":
         raise OSError("Ghostty could not find the registered TTY")
-    if submit:
-        entered = _run_osascript(_GHOSTTY_ENTER_SCRIPT)
-        if entered.returncode != 0:
-            raise OSError("Ghostty could not submit terminal input")
 
 
 def _deliver_terminal(tty: Path, payload: bytes) -> None:
     body, submit = _split_payload(payload)
-    result = _run_osascript(_TERMINAL_INPUT_SCRIPT, str(tty), "1" if submit else "0", body)
+    result = _run_osascript(
+        _TERMINAL_INPUT_SCRIPT,
+        str(tty),
+        "1" if submit else "0",
+        prompt_text=body,
+    )
     if result.returncode != 0 or result.stdout.strip() != "ok":
         raise OSError("Terminal could not find the registered TTY")
 
@@ -143,7 +172,7 @@ def _deliver_iterm(tty: Path, payload: bytes, *, app_name: str) -> None:
 on run argv
   set targetTty to item 1 of argv
   set submitPrompt to ((item 2 of argv) is "1")
-  set promptText to item 3 of argv
+  set promptText to __MEMO_PROMPT_LITERAL__
 
   tell application {app_literal}
     repeat with candidateWindow in windows
@@ -164,7 +193,12 @@ on run argv
   return "not found"
 end run
 """
-    result = _run_osascript(script, str(tty), "1" if submit else "0", body)
+    result = _run_osascript(
+        script,
+        str(tty),
+        "1" if submit else "0",
+        prompt_text=body,
+    )
     if result.returncode != 0 or result.stdout.strip() != "ok":
         raise OSError(f"{app_name} could not find the registered TTY")
 
@@ -174,6 +208,8 @@ def deliver_input(tty: Path, payload: bytes, *, terminal_app: str) -> str:
     try:
         _deliver_tiocsti(tty, payload)
         return "tiocsti"
+    except _PartialTIOCSTIError as partial_error:
+        raise OSError("terminal input delivery was partial; refusing fallback") from partial_error
     except OSError as direct_error:
         try:
             if terminal_app == "Ghostty":
@@ -187,4 +223,6 @@ def deliver_input(tty: Path, payload: bytes, *, terminal_app: str) -> str:
                 return "iterm-applescript"
         except OSError as fallback_error:
             raise OSError("terminal input delivery failed") from fallback_error
-        raise OSError("terminal input injection is unavailable") from direct_error
+        raise OSError(
+            "terminal input injection is unavailable: no exact-session fallback"
+        ) from direct_error

--- a/tests/test_terminal_live.py
+++ b/tests/test_terminal_live.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import pty
 import stat
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -100,6 +101,72 @@ def test_register_persists_same_uid_tty_and_prunes_stale_process(tmp_cfg) -> Non
         os.close(master_fd)
 
 
+@pytest.mark.parametrize(
+    ("reported", "canonical"),
+    [
+        pytest.param("Apple_Terminal", "Terminal", id="apple-terminal"),
+        pytest.param("iTerm.app", "iTerm2", id="iterm-app"),
+    ],
+)
+def test_register_accepts_term_program_aliases(tmp_cfg, reported: str, canonical: str) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at="Sat Aug 1 12:00:00 2026",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="codex",
+        )
+
+    try:
+        registration = TerminalBridge(tmp_cfg, process_probe=probe).register(
+            agent="codex",
+            tty=tty,
+            pid=4242,
+            terminal_app=reported,
+        )
+
+        assert registration.terminal_app == canonical
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
+
+
+def test_replacing_process_on_same_tty_rotates_registration_id(tmp_cfg) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at=f"process-start-{pid}",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="codex",
+        )
+
+    try:
+        bridge = TerminalBridge(tmp_cfg, process_probe=probe)
+        original = bridge.register(agent="codex", tty=tty, pid=4242)
+        refreshed = bridge.register(agent="codex", tty=tty, pid=4242)
+        replacement = bridge.register(agent="codex", tty=tty, pid=4343)
+
+        assert refreshed.id == original.id
+        assert replacement.id != original.id
+        assert bridge.registration_id(original.id) == ""
+        assert bridge.registration_id(replacement.id) == replacement.id
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
+
+
 def test_send_strips_terminal_controls_and_is_idempotent(registered_bridge) -> None:
     bridge, registration, payloads, _state = registered_bridge
 
@@ -128,6 +195,31 @@ def test_send_refuses_when_agent_is_not_foreground(registered_bridge) -> None:
     with pytest.raises(TerminalValidationError, match="foreground"):
         bridge.send(registration.id, "do not deliver")
 
+    assert payloads == []
+
+
+def test_target_validation_failures_are_receipted(registered_bridge) -> None:
+    bridge, registration, payloads, state = registered_bridge
+
+    with pytest.raises(TerminalValidationError, match="not found"):
+        bridge.send(
+            "term-0123456789abcdef",
+            "missing target",
+            message_id="missing-target-1",
+        )
+    state["foreground_pgid"] = 9999
+    with pytest.raises(TerminalValidationError, match="foreground"):
+        bridge.send(registration.id, "background target", message_id="background-target-1")
+
+    history = bridge.history(limit=2)
+    assert [(item.message_id, item.status) for item in history] == [
+        ("background-target-1", "failed"),
+        ("missing-target-1", "failed"),
+    ]
+    assert "foreground" in history[0].error
+    assert "not found" in history[1].error
+    assert "background target" not in repr(history[0])
+    assert "missing target" not in repr(history[1])
     assert payloads == []
 
 
@@ -200,6 +292,40 @@ def test_failed_delivery_is_receipted_without_message_body(tmp_cfg) -> None:
         receipt = bridge.history()[0]
         assert receipt.status == "failed"
         assert receipt.error == "OSError"
+        assert "secret terminal body" not in repr(receipt)
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
+
+
+def test_presenter_timeout_cannot_leave_pending_receipt(tmp_cfg) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at="Sat Aug 1 12:00:00 2026",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="codex",
+        )
+
+    def timeout(_tty: Path, _payload: bytes, *, terminal_app: str) -> str:
+        raise subprocess.TimeoutExpired(["osascript"], timeout=5)
+
+    try:
+        bridge = TerminalBridge(tmp_cfg, process_probe=probe, presenter=timeout)
+        registration = bridge.register(agent="codex", tty=tty, pid=4242)
+
+        with pytest.raises(TerminalValidationError, match="delivery failed"):
+            bridge.send(registration.id, "secret terminal body", message_id="timeout-1")
+
+        receipt = bridge.history()[0]
+        assert receipt.status == "failed"
+        assert receipt.error == "TimeoutExpired"
         assert "secret terminal body" not in repr(receipt)
     finally:
         os.close(slave_fd)

--- a/tests/test_terminal_presenter.py
+++ b/tests/test_terminal_presenter.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import os
 import pty
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 import memo.terminal_presenter as presenter
 
@@ -27,14 +31,14 @@ def test_tiocsti_preserves_every_input_byte(monkeypatch) -> None:
         os.close(master_fd)
 
 
-def test_ghostty_fallback_targets_exact_tty_and_submits_separately(monkeypatch) -> None:
-    calls: list[tuple[str, tuple[str, ...]]] = []
+def test_ghostty_fallback_targets_exact_tty_and_submits_atomically(monkeypatch) -> None:
+    calls: list[tuple[str, tuple[str, ...], dict[str, str]]] = []
 
     def deny(_tty: Path, _payload: bytes) -> None:
         raise PermissionError("kernel denied TIOCSTI")
 
-    def run(script: str, *args: str):
-        calls.append((script, args))
+    def run(script: str, *args: str, **kwargs: str):
+        calls.append((script, args, kwargs))
         return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
 
     monkeypatch.setattr(presenter, "_deliver_tiocsti", deny)
@@ -47,22 +51,24 @@ def test_ghostty_fallback_targets_exact_tty_and_submits_separately(monkeypatch) 
     )
 
     assert transport == "ghostty-applescript"
-    assert calls[0][1] == ("/dev/ttys003", "hello from memo")
+    assert calls[0][1] == ("/dev/ttys003", "1")
+    assert calls[0][2] == {"prompt_text": "hello from memo"}
     assert "candidateTty is targetTty" in calls[0][0]
-    assert len(calls) == 2
-    assert "key code 36" in calls[1][0]
+    assert 'send key "enter" to candidateTerminal' in calls[0][0]
+    assert "System Events" not in calls[0][0]
+    assert len(calls) == 1
 
 
-def test_terminal_app_fallback_passes_payload_as_argv(monkeypatch) -> None:
-    calls: list[tuple[str, tuple[str, ...]]] = []
+def test_terminal_app_fallback_keeps_payload_out_of_argv_and_clipboard(monkeypatch) -> None:
+    calls: list[tuple[str, tuple[str, ...], dict[str, str]]] = []
     monkeypatch.setattr(
         presenter,
         "_deliver_tiocsti",
         lambda _tty, _payload: (_ for _ in ()).throw(PermissionError()),
     )
 
-    def run(script: str, *args: str):
-        calls.append((script, args))
+    def run(script: str, *args: str, **kwargs: str):
+        calls.append((script, args, kwargs))
         return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
 
     monkeypatch.setattr(presenter, "_run_osascript", run)
@@ -74,20 +80,23 @@ def test_terminal_app_fallback_passes_payload_as_argv(monkeypatch) -> None:
     )
 
     assert transport == "terminal-applescript"
-    assert calls[0][1] == ("/dev/ttys003", "1", "hello 'quoted'")
+    assert calls[0][1] == ("/dev/ttys003", "1")
+    assert calls[0][2] == {"prompt_text": "hello 'quoted'"}
     assert "tty of candidateTab is targetTty" in calls[0][0]
+    assert "clipboard" not in calls[0][0].lower()
+    assert "do script promptText in foundTab" in calls[0][0]
 
 
 def test_iterm_fallback_writes_to_exact_session_without_newline(monkeypatch) -> None:
-    calls: list[tuple[str, tuple[str, ...]]] = []
+    calls: list[tuple[str, tuple[str, ...], dict[str, str]]] = []
     monkeypatch.setattr(
         presenter,
         "_deliver_tiocsti",
         lambda _tty, _payload: (_ for _ in ()).throw(PermissionError()),
     )
 
-    def run(script: str, *args: str):
-        calls.append((script, args))
+    def run(script: str, *args: str, **kwargs: str):
+        calls.append((script, args, kwargs))
         return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
 
     monkeypatch.setattr(presenter, "_run_osascript", run)
@@ -99,6 +108,73 @@ def test_iterm_fallback_writes_to_exact_session_without_newline(monkeypatch) -> 
     )
 
     assert transport == "iterm-applescript"
-    assert calls[0][1] == ("/dev/ttys007", "0", "draft only")
+    assert calls[0][1] == ("/dev/ttys007", "0")
+    assert calls[0][2] == {"prompt_text": "draft only"}
     assert "tty of candidateSession is targetTty" in calls[0][0]
     assert "newline false" in calls[0][0]
+
+
+def test_osascript_receives_sensitive_text_over_stdin_not_argv(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def run(command: list[str], **kwargs: object):
+        captured["command"] = command
+        captured.update(kwargs)
+        return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(presenter.subprocess, "run", run)
+    secret = 'secret "prompt"\nwith another line'
+
+    presenter._run_osascript(
+        "on run argv\nset promptText to __MEMO_PROMPT_LITERAL__\nreturn promptText\nend run",
+        "/dev/ttys003",
+        prompt_text=secret,
+    )
+
+    assert all(secret not in part for part in captured["command"])
+    assert json.dumps(secret, ensure_ascii=False) in str(captured["input"])
+    assert "__MEMO_PROMPT_LITERAL__" not in str(captured["input"])
+
+
+def test_osascript_timeout_becomes_safe_oserror(monkeypatch) -> None:
+    def timeout(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(["osascript"], timeout=5)
+
+    monkeypatch.setattr(presenter.subprocess, "run", timeout)
+
+    with pytest.raises(OSError, match="timed out"):
+        presenter._run_osascript('return "ok"')
+
+
+def test_partial_tiocsti_never_replays_payload_through_fallback(monkeypatch) -> None:
+    injected: list[bytes] = []
+    fallbacks: list[bytes] = []
+
+    def inject(_fd: int, _request: int, value: bytes) -> None:
+        if injected:
+            raise PermissionError("kernel denied remaining bytes")
+        injected.append(value)
+
+    monkeypatch.setattr(presenter.fcntl, "ioctl", inject)
+    monkeypatch.setattr(
+        presenter,
+        "_deliver_ghostty",
+        lambda _tty, payload: fallbacks.append(payload),
+    )
+
+    with pytest.raises(OSError, match="partial"):
+        presenter.deliver_input(Path("/dev/null"), b"abc", terminal_app="Ghostty")
+
+    assert injected == [b"a"]
+    assert fallbacks == []
+
+
+def test_missing_platform_fallback_has_actionable_error(monkeypatch) -> None:
+    monkeypatch.setattr(
+        presenter,
+        "_deliver_tiocsti",
+        lambda _tty, _payload: (_ for _ in ()).throw(PermissionError()),
+    )
+
+    with pytest.raises(OSError, match="no exact-session fallback"):
+        presenter.deliver_input(Path("/dev/pts/7"), b"hello\r", terminal_app="")


### PR DESCRIPTION
## Summary
- make Ghostty submit atomic and target the exact terminal object, while keeping prompt data out of process argv
- normalize Terminal/iTerm aliases, rotate terminal IDs on process replacement, and persist failed receipts for validation/delivery errors
- fail closed after partial TIOCSTI injection or when hardened Linux has no exact-session transport
- add regression coverage, document platform behavior, and fix optional mlx-whisper typing under all-extras installs

## Verification
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check src/ tests/ scripts/`
- `uv run --no-sync mypy src/memo`
- `uv run --no-sync python scripts/quality_gate.py`
- `uv run --no-sync pytest -m "not slow" -n auto --timeout=120 --cov=memo --cov-report=term-missing --cov-report=xml` (6388 passed, 1 skipped; 78.73%)
- same non-slow suite with `--resource-hygiene` (6388 passed, 1 skipped)
- `uv run --no-sync pytest -m "slow" --timeout=300 -v` (9 passed)
- diff coverage: 86%
- pre-push recall gate: PASS
- real Ghostty-to-Ghostty submit/ACK confirmed input+Enter reached the exact TTY without stealing focus

## Platform note
Hardened Linux systems that disable TIOCSTI still have no generic safe way to inject input into an arbitrary PTY slave. Delivery now fails closed with a recorded receipt instead of risking replay or an unsafe global fallback.