### PR TITLE
fix: type-check installed mlx-whisper

### DIFF
--- a/src/memo/audio_transcribe.py
+++ b/src/memo/audio_transcribe.py
@@ -38,7 +38,7 @@ def whisper_available() -> bool:
         return _WHISPER_OK
     _WHISPER_CHECKED = True
     try:
-        import mlx_whisper  # type: ignore[import-not-found]  # noqa: F401
+        import mlx_whisper  # type: ignore[import-not-found,import-untyped]  # noqa: F401
 
         _WHISPER_OK = True
     except ImportError as exc:


### PR DESCRIPTION
## Summary
- cover mypy import-untyped for the first deferred mlx_whisper import
- retain import-not-found for dev-only environments where the optional dependency is absent
- avoid the redundant second-line suppression from draft PR #172

## Reproduction
On exact master 24d4f7f63c238bbc3d907f03f5eed1b0d20a8614 with uv sync --frozen --all-extras, mlx-whisper 0.4.3 and mypy 2.3.0 report import-untyped at src/memo/audio_transcribe.py:41. Dev-only sync needs import-not-found instead. Mypy deduplicates the later import, so changing the second line is unnecessary.

## Verification
- ruff check src/ tests/ scripts/
- mypy --no-incremental src/memo (dev-only and all-extras)
- pytest tests/test_audio_transcribe.py -v (5 passed)
- python scripts/quality_gate.py
- deferred-import runtime assertion
- pre-push recall gate (passed)