### PR TITLE
fix: expose safe terminal delivery diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
   the exact terminal without a global-focus race, and no longer uses the
   clipboard for Terminal.app delivery. A partially successful `TIOCSTI`
   injection is never replayed through a fallback transport.
+- Live terminal delivery now reports safe transport failures such as an
+  unresponsive terminal automation endpoint in both the CLI error and receipt,
+  while unexpected exception details remain redacted.
 
 ### Changed
 

--- a/src/memo/errors.py
+++ b/src/memo/errors.py
@@ -77,6 +77,10 @@ class TerminalValidationError(MemoError, RuntimeError):
     """A live-terminal target or delivery failed local safety validation."""
 
 
+class TerminalDeliveryError(MemoError, OSError):
+    """A payload-free terminal transport failure safe to show to callers."""
+
+
 class StorageError(MemoError, RuntimeError):
     """A storage-layer operation (sqlite / filesystem) failed. Wraps the
     low-level error with operation context so callers don't see bare

--- a/src/memo/terminal_live.py
+++ b/src/memo/terminal_live.py
@@ -17,7 +17,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from memo.errors import TerminalValidationError
+from memo.errors import TerminalDeliveryError, TerminalValidationError
 
 if TYPE_CHECKING:
     from memo.config import Config
@@ -558,13 +558,15 @@ class TerminalBridge:
                 terminal_app=registration.terminal_app,
             )
         except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+            safe_error = str(exc) if isinstance(exc, TerminalDeliveryError) else type(exc).__name__
             with self._connect() as conn:
                 conn.execute(
                     "UPDATE terminal_receipts SET status = 'failed', error = ? "
                     "WHERE receipt_id = ?",
-                    (type(exc).__name__, receipt_id),
+                    (safe_error, receipt_id),
                 )
-            raise TerminalValidationError("terminal delivery failed") from exc
+            detail = f": {safe_error}" if isinstance(exc, TerminalDeliveryError) else ""
+            raise TerminalValidationError(f"terminal delivery failed{detail}") from exc
 
         delivered_at = _now()
         with self._connect() as conn:

--- a/src/memo/terminal_presenter.py
+++ b/src/memo/terminal_presenter.py
@@ -9,6 +9,8 @@ import subprocess
 import termios
 from pathlib import Path
 
+from memo.errors import TerminalDeliveryError
+
 _PROMPT_LITERAL_MARKER = "__MEMO_PROMPT_LITERAL__"
 
 
@@ -45,7 +47,7 @@ def _run_osascript(
     script_input: str | None = None
     if prompt_text is not None:
         if script.count(_PROMPT_LITERAL_MARKER) != 1:
-            raise OSError("terminal automation payload marker is invalid")
+            raise TerminalDeliveryError("terminal automation payload marker is invalid")
         script_input = script.replace(
             _PROMPT_LITERAL_MARKER,
             json.dumps(prompt_text, ensure_ascii=False),
@@ -61,9 +63,9 @@ def _run_osascript(
             input=script_input,
         )
     except subprocess.TimeoutExpired as exc:
-        raise OSError("terminal automation timed out") from exc
+        raise TerminalDeliveryError("terminal automation timed out") from exc
     except OSError as exc:
-        raise OSError("terminal automation could not start") from exc
+        raise TerminalDeliveryError("terminal automation could not start") from exc
 
 
 def _split_payload(payload: bytes) -> tuple[str, bool]:
@@ -72,7 +74,7 @@ def _split_payload(payload: bytes) -> tuple[str, bool]:
     try:
         return body.decode("utf-8"), submit
     except UnicodeDecodeError as exc:  # defensive: bridge always supplies UTF-8
-        raise OSError("terminal payload is not UTF-8") from exc
+        raise TerminalDeliveryError("terminal payload is not UTF-8") from exc
 
 
 _GHOSTTY_INPUT_SCRIPT = r"""
@@ -150,7 +152,7 @@ def _deliver_ghostty(tty: Path, payload: bytes) -> None:
         prompt_text=body,
     )
     if result.returncode != 0 or result.stdout.strip() != "ok":
-        raise OSError("Ghostty could not find the registered TTY")
+        raise TerminalDeliveryError("Ghostty could not find the registered TTY")
 
 
 def _deliver_terminal(tty: Path, payload: bytes) -> None:
@@ -162,7 +164,7 @@ def _deliver_terminal(tty: Path, payload: bytes) -> None:
         prompt_text=body,
     )
     if result.returncode != 0 or result.stdout.strip() != "ok":
-        raise OSError("Terminal could not find the registered TTY")
+        raise TerminalDeliveryError("Terminal could not find the registered TTY")
 
 
 def _deliver_iterm(tty: Path, payload: bytes, *, app_name: str) -> None:
@@ -200,7 +202,7 @@ end run
         prompt_text=body,
     )
     if result.returncode != 0 or result.stdout.strip() != "ok":
-        raise OSError(f"{app_name} could not find the registered TTY")
+        raise TerminalDeliveryError(f"{app_name} could not find the registered TTY")
 
 
 def deliver_input(tty: Path, payload: bytes, *, terminal_app: str) -> str:
@@ -209,7 +211,9 @@ def deliver_input(tty: Path, payload: bytes, *, terminal_app: str) -> str:
         _deliver_tiocsti(tty, payload)
         return "tiocsti"
     except _PartialTIOCSTIError as partial_error:
-        raise OSError("terminal input delivery was partial; refusing fallback") from partial_error
+        raise TerminalDeliveryError(
+            "terminal input delivery was partial; refusing fallback"
+        ) from partial_error
     except OSError as direct_error:
         try:
             if terminal_app == "Ghostty":
@@ -221,8 +225,10 @@ def deliver_input(tty: Path, payload: bytes, *, terminal_app: str) -> str:
             if terminal_app in {"iTerm", "iTerm2"}:
                 _deliver_iterm(tty, payload, app_name=terminal_app)
                 return "iterm-applescript"
+        except TerminalDeliveryError:
+            raise
         except OSError as fallback_error:
-            raise OSError("terminal input delivery failed") from fallback_error
-        raise OSError(
+            raise TerminalDeliveryError("terminal input delivery failed") from fallback_error
+        raise TerminalDeliveryError(
             "terminal input injection is unavailable: no exact-session fallback"
         ) from direct_error

--- a/tests/test_terminal_live.py
+++ b/tests/test_terminal_live.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from memo.errors import TerminalValidationError
+from memo.errors import TerminalDeliveryError, TerminalValidationError
 from memo.terminal_live import ProcessSnapshot, TerminalBridge, _is_local_tty_path
 
 
@@ -326,6 +326,47 @@ def test_presenter_timeout_cannot_leave_pending_receipt(tmp_cfg) -> None:
         receipt = bridge.history()[0]
         assert receipt.status == "failed"
         assert receipt.error == "TimeoutExpired"
+        assert "secret terminal body" not in repr(receipt)
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
+
+
+def test_safe_presenter_failure_is_actionable_without_leaking_payload(tmp_cfg) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at="Sat Aug 1 12:00:00 2026",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="codex",
+        )
+
+    def timeout(_tty: Path, _payload: bytes, *, terminal_app: str) -> str:
+        raise TerminalDeliveryError("terminal automation timed out")
+
+    try:
+        bridge = TerminalBridge(tmp_cfg, process_probe=probe, presenter=timeout)
+        registration = bridge.register(agent="codex", tty=tty, pid=4242)
+
+        with pytest.raises(
+            TerminalValidationError,
+            match="delivery failed: terminal automation timed out",
+        ):
+            bridge.send(
+                registration.id,
+                "secret terminal body",
+                message_id="safe-timeout-1",
+            )
+
+        receipt = bridge.history()[0]
+        assert receipt.status == "failed"
+        assert receipt.error == "terminal automation timed out"
         assert "secret terminal body" not in repr(receipt)
     finally:
         os.close(slave_fd)

--- a/tests/test_terminal_presenter.py
+++ b/tests/test_terminal_presenter.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 import pytest
 
 import memo.terminal_presenter as presenter
+from memo.errors import TerminalDeliveryError
 
 
 def test_tiocsti_preserves_every_input_byte(monkeypatch) -> None:
@@ -136,14 +137,104 @@ def test_osascript_receives_sensitive_text_over_stdin_not_argv(monkeypatch) -> N
     assert "__MEMO_PROMPT_LITERAL__" not in str(captured["input"])
 
 
-def test_osascript_timeout_becomes_safe_oserror(monkeypatch) -> None:
+def test_osascript_timeout_becomes_safe_delivery_error(monkeypatch) -> None:
     def timeout(*_args: object, **_kwargs: object) -> None:
         raise subprocess.TimeoutExpired(["osascript"], timeout=5)
 
     monkeypatch.setattr(presenter.subprocess, "run", timeout)
 
-    with pytest.raises(OSError, match="timed out"):
+    with pytest.raises(TerminalDeliveryError, match="timed out"):
         presenter._run_osascript('return "ok"')
+
+
+def test_osascript_rejects_invalid_payload_marker_without_starting(monkeypatch) -> None:
+    started = False
+
+    def run(*_args: object, **_kwargs: object) -> None:
+        nonlocal started
+        started = True
+
+    monkeypatch.setattr(presenter.subprocess, "run", run)
+
+    with pytest.raises(TerminalDeliveryError, match="payload marker is invalid"):
+        presenter._run_osascript('return "ok"', prompt_text="secret")
+
+    assert started is False
+
+
+def test_osascript_start_failure_becomes_safe_delivery_error(monkeypatch) -> None:
+    def missing_binary(*_args: object, **_kwargs: object) -> None:
+        raise FileNotFoundError("private executable path")
+
+    monkeypatch.setattr(presenter.subprocess, "run", missing_binary)
+
+    with pytest.raises(TerminalDeliveryError, match="automation could not start") as exc:
+        presenter._run_osascript('return "ok"')
+
+    assert "private executable path" not in str(exc.value)
+
+
+def test_non_utf8_payload_becomes_safe_delivery_error() -> None:
+    with pytest.raises(TerminalDeliveryError, match="payload is not UTF-8"):
+        presenter._split_payload(b"\xff")
+
+
+@pytest.mark.parametrize(
+    ("terminal_app", "expected_error"),
+    [
+        ("Ghostty", "Ghostty could not find the registered TTY"),
+        ("Terminal", "Terminal could not find the registered TTY"),
+        ("iTerm2", "iTerm2 could not find the registered TTY"),
+    ],
+)
+def test_exact_session_fallback_reports_target_not_found(
+    monkeypatch,
+    terminal_app: str,
+    expected_error: str,
+) -> None:
+    monkeypatch.setattr(
+        presenter,
+        "_deliver_tiocsti",
+        lambda _tty, _payload: (_ for _ in ()).throw(PermissionError()),
+    )
+    monkeypatch.setattr(
+        presenter,
+        "_run_osascript",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0,
+            stdout="not found\n",
+            stderr="",
+        ),
+    )
+
+    with pytest.raises(TerminalDeliveryError, match=expected_error):
+        presenter.deliver_input(
+            Path("/dev/ttys003"),
+            b"secret payload\r",
+            terminal_app=terminal_app,
+        )
+
+
+def test_unexpected_fallback_oserror_is_redacted(monkeypatch) -> None:
+    monkeypatch.setattr(
+        presenter,
+        "_deliver_tiocsti",
+        lambda _tty, _payload: (_ for _ in ()).throw(PermissionError()),
+    )
+    monkeypatch.setattr(
+        presenter,
+        "_deliver_ghostty",
+        lambda _tty, _payload: (_ for _ in ()).throw(OSError("private fallback detail")),
+    )
+
+    with pytest.raises(TerminalDeliveryError, match="terminal input delivery failed") as exc:
+        presenter.deliver_input(
+            Path("/dev/ttys003"),
+            b"secret payload\r",
+            terminal_app="Ghostty",
+        )
+
+    assert "private fallback detail" not in str(exc.value)
 
 
 def test_partial_tiocsti_never_replays_payload_through_fallback(monkeypatch) -> None:
@@ -162,7 +253,7 @@ def test_partial_tiocsti_never_replays_payload_through_fallback(monkeypatch) -> 
         lambda _tty, payload: fallbacks.append(payload),
     )
 
-    with pytest.raises(OSError, match="partial"):
+    with pytest.raises(TerminalDeliveryError, match="partial"):
         presenter.deliver_input(Path("/dev/null"), b"abc", terminal_app="Ghostty")
 
     assert injected == [b"a"]
@@ -176,5 +267,5 @@ def test_missing_platform_fallback_has_actionable_error(monkeypatch) -> None:
         lambda _tty, _payload: (_ for _ in ()).throw(PermissionError()),
     )
 
-    with pytest.raises(OSError, match="no exact-session fallback"):
+    with pytest.raises(TerminalDeliveryError, match="no exact-session fallback"):
         presenter.deliver_input(Path("/dev/pts/7"), b"hello\r", terminal_app="")


### PR DESCRIPTION
## Summary
- classify payload-free terminal transport failures as safe domain errors
- expose actionable automation timeouts in CLI/MCP errors and receipts
- keep arbitrary exception details and message bodies redacted

## Verification
- ruff format --check src/ tests/
- ruff check src/ tests/
- mypy src/memo
- 25 focused terminal tests
- quality gate
- pre-push recall gate

The first full local matrix exhausted host disk in coverage SQLite; a retry reached completion with no lastfailed entries, while a later confirmation was externally SIGTERM-terminated by concurrent test orchestration. GitHub CI is the isolated full-suite authority.