### PR TITLE
fix: validate agent command on terminal registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 - Live terminal delivery now reports safe transport failures such as an
   unresponsive terminal automation endpoint in both the CLI error and receipt,
   while unexpected exception details remain redacted.
+- Live terminal registration now rejects a process whose command does not match
+  the declared agent instead of persisting a target that immediately becomes
+  stale.
 
 ### Changed
 

--- a/src/memo/terminal_live.py
+++ b/src/memo/terminal_live.py
@@ -337,6 +337,8 @@ class TerminalBridge:
         snapshot = self._probe(pid)
         if snapshot is None or snapshot.uid != os.getuid():
             raise TerminalValidationError("agent process is unavailable")
+        if not _command_matches_agent(snapshot.command, normalized_agent):
+            raise TerminalValidationError("agent process does not match requested agent")
         canonical_tty = _canonical_tty(tty, uid=snapshot.uid)
         try:
             process_tty = _canonical_tty(snapshot.tty, uid=snapshot.uid)

--- a/tests/test_terminal_live.py
+++ b/tests/test_terminal_live.py
@@ -137,6 +137,33 @@ def test_register_accepts_term_program_aliases(tmp_cfg, reported: str, canonical
         os.close(master_fd)
 
 
+def test_register_rejects_process_that_does_not_match_declared_agent(tmp_cfg) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at="Sat Aug 1 12:00:00 2026",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="zsh -f",
+        )
+
+    try:
+        bridge = TerminalBridge(tmp_cfg, process_probe=probe)
+
+        with pytest.raises(TerminalValidationError, match=r"does not match.*agent"):
+            bridge.register(agent="codex", tty=tty, pid=4242)
+
+        assert bridge.list() == []
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
+
+
 def test_replacing_process_on_same_tty_rotates_registration_id(tmp_cfg) -> None:
     master_fd, slave_fd = pty.openpty()
     tty = Path(os.ttyname(slave_fd))


### PR DESCRIPTION
## Summary
- reject terminal registrations when the probed command does not match the declared agent
- prevent registrations that immediately become stale on list/send
- add a regression for the end-user failure discovered during installed QA

## Verification
- 38 focused terminal tests pass
- Ruff and mypy pass
- changed-line coverage: 100%
- recall pre-push gate: PASS (0.708 precision, 0 noise)