### PR TITLE
fix: fail closed unsafe terminal input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,18 +20,22 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ### Fixed
 
+- Live terminal input now fails closed: the CLI and MCP `send`/`enter`
+  mutators and automatic shim registration are disabled, and legacy terminal
+  registrations are non-deliverable. Read-only diagnostics remain available
+  while a receiver-bound API with explicit destination authority is designed.
 - Live terminal coordination now recognizes the native `Apple_Terminal` and
   `iTerm.app` `TERM_PROGRAM` values, rotates a registration id when a new
   process replaces an agent on the same TTY, and records target-validation
   failures instead of leaving them outside receipt history.
 - macOS terminal presentation keeps message bodies out of process arguments,
   converts AppleScript timeouts into failed receipts, submits Ghostty input to
-  the exact terminal without a global-focus race, and no longer uses the
-  clipboard for Terminal.app delivery. A partially successful `TIOCSTI`
+  the exact terminal without a global-focus race, and removes unsafe
+  Terminal.app delivery entirely. A partially successful `TIOCSTI`
   injection is never replayed through a fallback transport.
-- Live terminal delivery now reports safe transport failures such as an
-  unresponsive terminal automation endpoint in both the CLI error and receipt,
-  while unexpected exception details remain redacted.
+- The fail-closed internal terminal bridge preserves safe transport diagnostics
+  in receipts while redacting unexpected exception details; no delivery mutator
+  is exposed through CLI or MCP.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ Most memory servers *add* context. memo is built to remove it.
 
 | Profile | Tools | Schema tokens |
 |---|---:|---:|
-| `agent` (default) | 43 | ~4.3k |
-| `core` / `slim` | 60 | ~5.5k |
-| `full` / `default` | 164 | ~18.3k |
+| `agent` (default) | 41 | ~4.1k |
+| `core` / `slim` | 58 | ~5.3k |
+| `full` / `default` | 162 | ~18.1k |
 
-The default MCP surface is 43 tools, not 164: about 74% fewer tool schemas. It exposes **43 tools / ~4.3k schema tokens** versus **164 tools / ~18.3k tokens** on the full surface — overhead paid every session, in every client.
+The default MCP surface is 41 tools, not 162: about 75% fewer tool schemas. It exposes **41 tools / ~4.1k schema tokens** versus **162 tools / ~18.1k tokens** on the full surface — overhead paid every session, in every client.
 
 Ambient recall injects one relevant memory before the model answers. The bundled Claude Code hook caps that injection at ~160 tokens. `memo roi` reads the real grounding and re-ask ledgers, then estimates accumulated savings with disclosed defaults (350 tokens per grounded recall and 900 per avoided re-ask).
 

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -38,7 +38,7 @@
 
   <!-- Title -->
   <text x="40" y="40" class="title">memo — how it fits in your stack</text>
-  <text x="40" y="60" class="sub">Local MCP memory · MLX on Apple Silicon or CPU on Linux · 108 CLI commands · 124 MCP tools</text>
+  <text x="40" y="60" class="sub">Local MCP memory · MLX on Apple Silicon or CPU on Linux · 142 CLI commands · 162 MCP tools (full)</text>
 
   <!-- ============== CLIENTS ROW ============== -->
   <text x="40" y="96" class="section">clients</text>
@@ -66,7 +66,7 @@
 
   <rect x="745" y="112" width="165" height="48" class="box-client box" rx="8" filter="url(#shadow)"/>
   <text x="828" y="133" class="label">your shell</text>
-  <text x="828" y="150" class="meta">memo CLI · 95 commands</text>
+  <text x="828" y="150" class="meta">memo CLI · 142 commands</text>
 
   <!-- arrows down -->
   <line class="arrow" x1="118" y1="160" x2="118" y2="196"/>
@@ -81,12 +81,12 @@
   <rect x="40" y="199" width="880" height="58" class="group-rect" rx="10"/>
 
   <rect x="55" y="207" width="650" height="42" class="box box-blue" rx="8" filter="url(#shadow)"/>
-  <text x="380" y="227" class="label">memo-mcp (FastMCP stdio) — 158 tools in the full profile</text>
-  <text x="380" y="243" class="meta">MEMO_MCP_PROFILE:  agent (30 tools ~3k tokens)  ·  core/slim (50 tools ~4.6k)  ·  full/default (158 tools ~18k)</text>
+  <text x="380" y="227" class="label">memo-mcp (FastMCP stdio) — 162 tools in the full profile</text>
+  <text x="380" y="243" class="meta">MEMO_MCP_PROFILE:  agent (41 tools ~4.1k tokens)  ·  core/slim (58 tools ~5.3k)  ·  full/default (162 tools ~18.1k)</text>
 
   <rect x="720" y="207" width="190" height="42" class="box" rx="8" filter="url(#shadow)"/>
   <text x="815" y="227" class="label">memo CLI</text>
-  <text x="815" y="243" class="meta">95 commands · same API</text>
+  <text x="815" y="243" class="meta">142 commands · same API</text>
 
   <!-- arrows to core -->
   <line class="arrow" x1="380" y1="249" x2="380" y2="285"/>

--- a/docs/how-memo-works.svg
+++ b/docs/how-memo-works.svg
@@ -113,8 +113,8 @@
   <!-- ====================== TOKEN ECONOMY BANNER ====================== -->
   <rect x="40" y="572" width="848" height="104" rx="12" fill="#0f172a"/>
   <text x="64" y="606" font-size="13" font-weight="700" fill="#e2e8f0" letter-spacing="0.06em" style="text-transform:uppercase">Token economy</text>
-  <text x="64" y="636" font-size="15" font-weight="600" fill="#ffffff">Default MCP surface: 30 tools · ~3k tokens   vs   full 158 tools · ~18k tokens</text>
-  <text x="64" y="660" font-size="13" fill="#94a3b8">≈ 90% less schema context per session · recall injects the answer the agent would otherwise re-derive (~160-token budget).</text>
-  <text x="788" y="636" font-size="34" font-weight="800" fill="#38bdf8" text-anchor="middle">90%</text>
+  <text x="64" y="636" font-size="15" font-weight="600" fill="#ffffff">Default MCP surface: 41 tools · ~4.1k tokens   vs   full 162 tools · ~18.1k tokens</text>
+  <text x="64" y="660" font-size="13" fill="#94a3b8">≈ 77% less schema context per session · recall injects the answer the agent would otherwise re-derive (~160-token budget).</text>
+  <text x="788" y="636" font-size="34" font-weight="800" fill="#38bdf8" text-anchor="middle">77%</text>
   <text x="788" y="658" font-size="11" fill="#94a3b8" text-anchor="middle">less context overhead</text>
 </svg>

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -44,7 +44,7 @@ agent-memory projects. For the complete live flag registry, run
   wording of past local transcript turns through a private, lexical-only FTS5
   index that never enters ambient recall.
 - **Fewer tokens, not more.** Recall injects the relevant answer on a bounded
-  budget, and the default MCP surface exposes 43 tools instead of the full 164.
+  budget, and the default MCP surface exposes 41 tools instead of the full 162.
 
 ---
 
@@ -248,12 +248,12 @@ Released wheels include the Claude/Codex/Devin agent assets, so a normal
 checkout, pass `--repo /path/to/memo` to test uncommitted plugin changes.
 
 Tools surface inside the agent as `mcp__memo__memo_*`. Agent installs default to
-a 43-tool surface (`ask`, `context`, `get`, `graph`, `offload`, `rename`, `save`,
+a 41-tool surface (`ask`, `context`, `get`, `graph`, `offload`, `rename`, `save`,
 `search`, `unified_briefing`, `version`, lifecycle, session/capture
 notifications, and Memo-native evidence, operational-continuity, and
-outcome-learning helpers, plus registered-terminal live chat) so
+outcome-learning helpers, plus registered-terminal status) so
 administrative schemas don't consume model context — set
-`MEMO_MCP_PROFILE=core`/`slim` (60 tools) or `full`/`default` (164 tools) only
+`MEMO_MCP_PROFILE=core`/`slim` (58 tools) or `full`/`default` (162 tools) only
 for clients that genuinely need the larger administrative surface.
 
 ### Claude Code
@@ -385,37 +385,25 @@ are intentionally absent from the default agent profile:
 
 ## Live terminal coordination
 
-Agent shims installed by `memo install-shims` register their exact local TTY,
-PID, agent name, terminal application, and project. Registrations are scoped to
-the current OS user and revalidated before each delivery. Native
-`TERM_PROGRAM` values such as `Apple_Terminal` and `iTerm.app` are normalized
-to their supported presenters. A new process reusing the same TTY receives a
-new terminal id, so stale callers cannot silently address its replacement. Use
-the CLI to inspect or address registrations directly:
+Legacy exact-TTY input is disabled fail-closed. TIOCSTI, terminal application
+automation, and tmux can identify a TTY/session but cannot bind the first input
+byte atomically to the registered PID and process birth identity. Agent shims
+therefore capture the local TTY for notifications but do not auto-register an
+input target. Existing registrations are not advertised and are pruned when
+listed.
+
+The CLI retains only read-only inspection and receipt history:
 
 ```bash
 memo terminal list --json
-memo terminal send --to term-0123456789abcdef --message "status?" --submit
-memo terminal enter --to term-0123456789abcdef
 memo terminal history --json
 ```
 
-The equivalent always-on MCP tools are `memo_terminal_list`,
-`memo_terminal_send`, and `memo_terminal_enter`. A live message contains a
-reply-to terminal id so the receiving agent can answer through the same tool.
-`enter` sends only a carriage return and refuses stale, mismatched, or
-non-foreground targets. Receipt history contains routing and outcome metadata,
-never message bodies; failed target validation and presenter failures are
-recorded as `failed` receipts.
-
-On macOS, Ghostty and iTerm use exact-session application APIs; Terminal.app
-uses its exact tab API for submitted input and avoids clipboard mutation.
-Linux `/dev/pts/N` registration and validation are supported, but delivery on
-a hardened kernel still requires an available exact-session transport:
-generic terminals that deny `TIOCSTI` fail closed and produce a failed receipt
-instead of writing lookalike output that the target process never receives.
-Handoffs and attention remain the durable asynchronous channel; terminal chat
-is immediate and same-machine only.
+The read-only `memo_terminal_list` tool remains on every MCP profile and
+honestly returns no deliverable legacy target. `memo_terminal_send` and
+`memo_terminal_enter` are not registered on any MCP profile. The central bridge
+also fails closed until a cooperative or native process-bound receiver exists.
+Use handoffs and attention for durable agent coordination.
 
 ## MCP tools
 
@@ -423,9 +411,9 @@ The live MCP server is profile-gated by `MEMO_MCP_PROFILE`:
 
 | Profile | Tool count | Schema tokens | Use |
 |---|---:|---:|---|
-| `agent` (default) | 43 | ~4.3k | Essential memory, evidence, continuity, lifecycle, live terminal chat, and outcome-learning surface. |
-| `core` / `slim` | 60 | ~5.5k | Agent tools plus CRUD, embeddings, history, sessions, and lint. |
-| `full` / `default` | 164 | ~18.3k | Every advanced domain module and diagnostic tool. |
+| `agent` (default) | 41 | ~4.1k | Essential memory, evidence, continuity, lifecycle, terminal status, and outcome-learning surface. |
+| `core` / `slim` | 58 | ~5.3k | Agent tools plus CRUD, embeddings, history, sessions, and lint. |
+| `full` / `default` | 162 | ~18.1k | Every advanced domain module and diagnostic tool. |
 
 Mutating MCP calls pass through a bounded process-local FIFO by default
 (`MEMO_MCP_WRITE_QUEUE_SIZE=32`); read-only calls bypass it. The
@@ -440,7 +428,7 @@ metadata. Use the full profile's `mem_relation_reviews`, `mem_judge`, and
 `MEMO_RELATION_CANDIDATES_ENABLED=0` and
 `MEMO_RELATION_ANNOTATIONS_ENABLED=0` flags remain rollback controls.
 
-The default `agent` profile exposes exactly 43 tools:
+The default `agent` profile exposes exactly 41 tools:
 
 `memo_ask`, `memo_attention_ack`, `memo_attention_add`, `memo_conflict_open`,
 `memo_conflict_resolve`, `memo_context`, `memo_delete`, `memo_evidence_pack`,
@@ -452,9 +440,8 @@ The default `agent` profile exposes exactly 43 tools:
 `memo_procedure_promote`, `memo_profile`, `memo_rename`, `memo_review_due`,
 `memo_save`, `memo_save_text`, `memo_search`, `memo_signal_list`,
 `memo_signal_remember`, `memo_start_session`,
-`memo_supersede`, `memo_terminal_enter`, `memo_terminal_list`,
-`memo_terminal_send`, `memo_unified_briefing`, `memo_update`, `memo_version`,
-`memo_write_queue_status`.
+`memo_supersede`, `memo_terminal_list`, `memo_unified_briefing`, `memo_update`,
+`memo_version`, `memo_write_queue_status`.
 
 The `core` / `slim` profile adds CRUD/admin-lite tools:
 
@@ -1156,7 +1143,7 @@ plaintext disclosure operations.
 | ingest-daemon | `memo ingest-daemon start` | Serialized repo/batch indexing with dedupe and failure ledger. |
 | maint-daemon | `memo maint-daemon start` | Background cleanup and synthesis. |
 
-### All 141 top-level CLI commands
+### All 142 top-level CLI commands
 
 <details>
 <summary>Complete command inventory</summary>
@@ -1366,8 +1353,8 @@ read-only, `$EDITOR`, and backup restore paths.
 
 ### Token economy
 
-The default MCP profile exposes 43 tools (~4.3k schema tokens), compared with
-164 tools (~18.3k) on the full profile. The bundled Claude Code recall hook also
+The default MCP profile exposes 41 tools (~4.1k schema tokens), compared with
+162 tools (~18.1k) on the full profile. The bundled Claude Code recall hook also
 pins `MEMO_RECALL_TOP_K=1` and `MEMO_RECALL_TOKEN_BUDGET=160`; the general
 runtime default remains 600 tokens for clients that do not use that hook.
 

--- a/docs/superpowers/plans/2026-08-01-live-terminal-chat.md
+++ b/docs/superpowers/plans/2026-08-01-live-terminal-chat.md
@@ -1,5 +1,12 @@
 # Live Terminal Chat Implementation Plan
 
+> **Status (2026-08-02): superseded; do not execute this plan.** The direct
+> terminal-input implementation now fails closed: CLI/MCP `send` and `enter`
+> mutators are removed, automatic registration is disabled, and legacy
+> registrations cannot receive input. The unchecked tasks below are retained
+> only as implementation history. Any replacement requires a receiver-bound
+> API with explicit destination authority and a new reviewed plan.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add safe, immediate, bidirectional prompt and Return delivery between explicitly registered local Memo agent terminals.

--- a/docs/superpowers/specs/2026-08-01-live-terminal-chat-design.md
+++ b/docs/superpowers/specs/2026-08-01-live-terminal-chat-design.md
@@ -1,5 +1,12 @@
 # Live Terminal Chat Design
 
+> **Status (2026-08-02): superseded; not an active product contract.** Memo's
+> direct terminal-input path now fails closed: the CLI and MCP `send`/`enter`
+> mutators are removed, automatic terminal registration is disabled, and
+> legacy registrations are non-deliverable. This document is preserved as the
+> historical design record. Live delivery must not return until a
+> receiver-bound API can prove explicit authority over the destination agent.
+
 ## Goal
 
 Turn Memo's asynchronous handoff/attention coordination into an optional

--- a/src/memo/cli_doctor.py
+++ b/src/memo/cli_doctor.py
@@ -528,8 +528,8 @@ def doctor(
             console.print(
                 f"[yellow]![/yellow] token cost: {_profile_label}  {_tool_count} tools "
                 f"({_tok_cost} tokens/connection)  "
-                "[dim](set MEMO_MCP_PROFILE=agent for 30 tools / ~3k tokens, or "
-                "`memo install-mcp --profile core` for 50 tools / ~4.6k tokens — "
+                "[dim](set MEMO_MCP_PROFILE=agent for 41 tools / ~4.1k tokens, or "
+                "`memo install-mcp --profile core` for 58 tools / ~5.3k tokens — "
                 "for constrained clients)[/dim]"
             )
         try:

--- a/src/memo/cli_install_mcp.py
+++ b/src/memo/cli_install_mcp.py
@@ -276,8 +276,8 @@ def _report(result: dict[str, Any]) -> None:
     "--profile",
     default="",
     type=click.Choice(["", "core", "slim", "default"], case_sensitive=False),
-    help="MCP surface profile. 'core'/'slim' expose 50 tools (~4.6k tokens); "
-    "'default' exposes all 158 tools (~18k tokens). "
+    help="MCP surface profile. 'core'/'slim' expose 58 tools (~5.3k tokens); "
+    "'default' exposes all 162 tools (~18.1k tokens). "
     "Constrained clients (codex, opencode) default to 'core' automatically.",
 )
 def install_mcp(

--- a/src/memo/cli_terminal.py
+++ b/src/memo/cli_terminal.py
@@ -1,11 +1,9 @@
-"""`memo terminal` — immediate coordination with registered local agent TTYs."""
+"""`memo terminal` — diagnostics for disabled legacy terminal input."""
 
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import asdict
-from pathlib import Path
 from typing import Any
 
 import click
@@ -29,49 +27,13 @@ def _domain_error(exc: MemoError) -> click.ClickException:
 
 @click.group(name="terminal")
 def terminal_group() -> None:
-    """Chat with or submit input to explicitly registered local agent terminals."""
-
-
-@terminal_group.command(name="register")
-@click.option("--agent", required=True, help="Agent name (for example: codex).")
-@click.option("--tty", required=True, type=click.Path(path_type=Path), help="Exact /dev TTY.")
-@click.option("--pid", required=True, type=click.IntRange(min=2), help="Agent process PID.")
-@click.option("--terminal-app", default="", help="Terminal, iTerm2, or Ghostty.")
-@click.option("--project", default="", help="Project directory associated with this agent.")
-@click.option("--id-only", is_flag=True, hidden=True)
-@click.option("--json", "as_json", is_flag=True, help="Output JSON.")
-def terminal_register(
-    agent: str,
-    tty: Path,
-    pid: int,
-    terminal_app: str,
-    project: str,
-    id_only: bool,
-    as_json: bool,
-) -> None:
-    """Register one local agent process and its exact terminal."""
-    try:
-        registration = _bridge().register(
-            agent=agent,
-            tty=tty,
-            pid=pid,
-            terminal_app=terminal_app,
-            project=project or os.getcwd(),
-        )
-    except MemoError as exc:
-        raise _domain_error(exc) from exc
-    if id_only:
-        click.echo(registration.id)
-    elif as_json:
-        _json(asdict(registration))
-    else:
-        click.echo(f"registered {registration.id} ({registration.agent} {registration.tty})")
+    """Inspect disabled legacy terminal registrations and receipt history."""
 
 
 @terminal_group.command(name="list")
 @click.option("--json", "as_json", is_flag=True, help="Output JSON.")
 def terminal_list(as_json: bool) -> None:
-    """List live registered agent terminals and prune stale entries."""
+    """List deliverable terminals; empty while legacy TTY input is disabled."""
     try:
         registrations = _bridge().list()
     except MemoError as exc:
@@ -80,63 +42,10 @@ def terminal_list(as_json: bool) -> None:
         _json([asdict(item) for item in registrations])
         return
     if not registrations:
-        click.echo("No live registered terminals.")
+        click.echo("No deliverable registered terminals.")
         return
     for item in registrations:
         click.echo(f"{item.id}\t{item.agent}\t{item.tty}\t{item.project}")
-
-
-@terminal_group.command(name="send")
-@click.option("--to", "target_id", required=True, help="Exact registered terminal id.")
-@click.option("--message", required=True, help="Prompt text to deliver.")
-@click.option("--sender", default="", help="Reply-to terminal id.")
-@click.option("--message-id", default="", help="Optional idempotency key.")
-@click.option("--submit/--no-submit", default=True, help="Press Return after delivery.")
-@click.option("--json", "as_json", is_flag=True, help="Output JSON.")
-def terminal_send(
-    target_id: str,
-    message: str,
-    sender: str,
-    message_id: str,
-    submit: bool,
-    as_json: bool,
-) -> None:
-    """Immediately type a prompt into one registered agent terminal."""
-    try:
-        receipt = _bridge().send(
-            target_id,
-            message,
-            sender=sender or None,
-            message_id=message_id or None,
-            submit=submit,
-        )
-    except MemoError as exc:
-        raise _domain_error(exc) from exc
-    if as_json:
-        _json(asdict(receipt))
-    else:
-        click.echo(f"{receipt.status} {receipt.receipt_id} via {receipt.transport}")
-
-
-@terminal_group.command(name="enter")
-@click.option("--to", "target_id", required=True, help="Exact registered terminal id.")
-@click.option("--sender", default="", help="Origin terminal id.")
-@click.option("--message-id", default="", help="Optional idempotency key.")
-@click.option("--json", "as_json", is_flag=True, help="Output JSON.")
-def terminal_enter(target_id: str, sender: str, message_id: str, as_json: bool) -> None:
-    """Press Return in one registered foreground agent terminal."""
-    try:
-        receipt = _bridge().enter(
-            target_id,
-            sender=sender or None,
-            message_id=message_id or None,
-        )
-    except MemoError as exc:
-        raise _domain_error(exc) from exc
-    if as_json:
-        _json(asdict(receipt))
-    else:
-        click.echo(f"{receipt.status} {receipt.receipt_id} via {receipt.transport}")
 
 
 @terminal_group.command(name="history")

--- a/src/memo/experimental_index.md
+++ b/src/memo/experimental_index.md
@@ -106,6 +106,14 @@ produces compressed backups. No transport or conflict-resolution strategy
 is finalised. This is separate from the stable federation bundle protocol,
 which performs bounded, signed, ACL-scoped exchange without automatic merge.
 
+## terminal_live.py / terminal_presenter.py
+
+Legacy exact-TTY input and presentation internals. Terminal mutation tools are
+not exposed through CLI or any MCP profile, automatic shim registration is
+disabled, and the bridge fails closed. This code remains experimental until a
+receiver-bound transport can atomically prove authority over the destination
+PID and process-start identity before delivering the first byte.
+
 ## versioning.py
 
 Per-memory version history and diff UI. Stores a snapshot of each memory

--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -183,15 +183,15 @@ SPECS: tuple[FlagSpec, ...] = (
         "bool",
         False,
         "mcp",
-        "Expose only the 26 core inline tools (skip domain modules). "
-        "Reduces tool count from ~116 to 26 for local/constrained LLMs.",
+        "Select the 58-tool core MCP surface (skip advanced domain modules) "
+        "for local/constrained LLMs.",
     ),
     _spec(
         "MEMO_MCP_PROFILE",
         "str",
         "agent",
         "mcp",
-        "MCP surface profile: agent (default, 30 tools) | core/slim (stable core) | full/default (all tools).",
+        "MCP surface profile: agent (default, 41 tools) | core/slim (58 stable-core tools) | full/default (162 tools).",
         choices=("agent", "core", "slim", "full", "default"),
     ),
     _spec(

--- a/src/memo/runtime/shims.py
+++ b/src/memo/runtime/shims.py
@@ -30,11 +30,30 @@ set -euo pipefail
 _MEMO_BIN_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 _AGENT="$(basename "$0")"
 # Capture the TTY before the agent changes it, so async hooks can write
-# idle-capture notifications directly to this terminal.
-if [ -z "${MEMO_AGENT_TTY:-}" ] && [ -t 2 ]; then
-    MEMO_AGENT_TTY="$(tty 2>/dev/null || true)"
-    export MEMO_AGENT_TTY
+# idle-capture notifications directly to this terminal. `tty` reads stdin by
+# default, so explicitly bind it to the descriptor that passed `-t`.
+_MEMO_DETECTED_TTY=""
+if [ -t 2 ]; then
+    _MEMO_DETECTED_TTY="$(tty <&2 2>/dev/null || true)"
+elif [ -t 1 ]; then
+    _MEMO_DETECTED_TTY="$(tty <&1 2>/dev/null || true)"
+elif [ -t 0 ]; then
+    _MEMO_DETECTED_TTY="$(tty <&0 2>/dev/null || true)"
 fi
+case "$_MEMO_DETECTED_TTY" in
+    /dev/tty*|/dev/pts/*)
+        if [ "${MEMO_AGENT_TTY:-}" != "$_MEMO_DETECTED_TTY" ]; then
+            unset MEMO_TERMINAL_ID
+        fi
+        MEMO_AGENT_TTY="$_MEMO_DETECTED_TTY"
+        export MEMO_AGENT_TTY
+        ;;
+    *)
+        # A path-shaped inherited value is not evidence that this process still
+        # owns that terminal; it may be stale or already reused.
+        unset MEMO_AGENT_TTY MEMO_TERMINAL_ID
+        ;;
+esac
 _NEXT=""
 IFS=':' read -ra _DIRS <<< "$PATH"
 for _D in "${_DIRS[@]:-}"; do
@@ -50,18 +69,9 @@ if [ -z "$_NEXT" ]; then
     exit 127
 fi
 _MEMO="$(command -v memo 2>/dev/null || true)"
-if [ -n "$_MEMO" ] && [ -n "${MEMO_AGENT_TTY:-}" ] && [ "${MEMO_TERMINAL_REGISTRATION_ATTEMPTED:-0}" != "1" ]; then
-    MEMO_TERMINAL_REGISTRATION_ATTEMPTED=1
-    export MEMO_TERMINAL_REGISTRATION_ATTEMPTED
-    MEMO_TERMINAL_ID="$("$_MEMO" terminal register \
-        --agent "$_AGENT" \
-        --tty "$MEMO_AGENT_TTY" \
-        --pid "$$" \
-        --terminal-app "${TERM_PROGRAM:-}" \
-        --project "$PWD" \
-        --id-only 2>/dev/null || true)"
-    [ -n "$MEMO_TERMINAL_ID" ] && export MEMO_TERMINAL_ID
-fi
+# Legacy TTY input is not process-bound, so shims intentionally do not
+# auto-register a live input target. Keep stale ids out of child processes.
+unset MEMO_TERMINAL_ID MEMO_TERMINAL_REGISTRATION_ATTEMPTED
 if [ -n "$_MEMO" ] && [ "${MEMO_STARTUP_BANNER:-1}" != "0" ] && [ "${MEMO_STARTUP_BANNER_SHOWN:-0}" != "1" ]; then
     MEMO_STARTUP_BANNER_SHOWN=1
     export MEMO_STARTUP_BANNER_SHOWN
@@ -84,7 +94,7 @@ _TTY_MARKER = "# memo-agent-tty"
 # shell env) can still find the active terminal via _read_agent_tty_file().
 _TTY_SNIPPET = (
     "\n{m}\n"
-    '[ -t 1 ] && export MEMO_AGENT_TTY="$(tty 2>/dev/null || true)"'
+    '[ -t 1 ] && export MEMO_AGENT_TTY="$(tty <&1 2>/dev/null || true)"'
     " && printf '%s' \"$MEMO_AGENT_TTY\""
     ' > "${{XDG_DATA_HOME:-$HOME/.local/share}}/memo/agent_tty" 2>/dev/null || true'
     "  {m}\n"

--- a/src/memo/server.py
+++ b/src/memo/server.py
@@ -286,7 +286,7 @@ def _build_server(
     # Stable and advanced domain tool modules register their @server.tool()
     # closures here. Presence on the MCP surface does not by itself mean a
     # feature is part of memo's stable core contract; see experimental_index.md.
-    # Skip when MEMO_MCP_SLIM=1 — reduces 158 tools to the 50-tool core surface
+    # Skip when MEMO_MCP_SLIM=1 — reduces 162 tools to the 58-tool core surface
     # for local/constrained LLMs where tool-definition tokens are expensive.
     from memo.surface import mcp_include_advanced_tools
 

--- a/src/memo/server_terminal.py
+++ b/src/memo/server_terminal.py
@@ -1,107 +1,19 @@
-"""MCP tools for immediate same-user delivery to registered agent terminals."""
+"""Read-only diagnostics for disabled legacy terminal registrations."""
 
 from __future__ import annotations
 
-import json
 from dataclasses import asdict
-from typing import Annotated, Any
+from typing import Any
 
-from pydantic import Field
-
-from memo.errors import MemoError
-from memo.flags import flag_str
-from memo.server_annotations import READ_ONLY, WRITE, annotated_tool
+from memo.server_annotations import READ_ONLY, annotated_tool
 from memo.terminal_live import TerminalBridge
 
 
-def _reply_envelope(message: str, sender_id: str) -> str:
-    encoded = (
-        json.dumps(message, ensure_ascii=False).replace("<", "\\u003c").replace(">", "\\u003e")
-    )
-    if not sender_id:
-        return (
-            '<memo-live-message>\n<sender-content encoding="json">\n'
-            f"{encoded}\n"
-            "</sender-content>\n</memo-live-message>"
-        )
-    return (
-        f'<memo-live-message sender="{sender_id}">\n'
-        "Reply live with memo_terminal_send(to="
-        f'"{sender_id}", message="<your reply>").\n'
-        '<sender-content encoding="json">\n'
-        f"{encoded}\n"
-        "</sender-content>\n"
-        "</memo-live-message>"
-    )
-
-
-def _sender_id(bridge: TerminalBridge, requested: str) -> str:
-    if requested.strip():
-        return bridge.registration_id(requested.strip())
-    inherited_tty = flag_str("MEMO_AGENT_TTY").strip()
-    return bridge.registration_id_for_tty(inherited_tty) if inherited_tty else ""
-
-
 def register(server: Any, memory: Any) -> None:
-    """Register live-terminal tools on every MCP surface profile."""
+    """Register terminal status diagnostics on every MCP surface profile."""
 
     @annotated_tool(server, **READ_ONLY)
     def memo_terminal_list() -> dict[str, Any]:
-        """List live local agent terminals that can receive an immediate prompt."""
+        """List deliverable terminals; empty while legacy TTY input is disabled."""
         rows = [asdict(item) for item in TerminalBridge(memory.cfg).list()]
         return {"terminals": rows, "count": len(rows)}
-
-    @annotated_tool(server, **WRITE)
-    def memo_terminal_send(
-        to: Annotated[str, Field(description="Exact terminal id returned by memo_terminal_list.")],
-        message: Annotated[
-            str, Field(description="Prompt or reply to type into the target agent.")
-        ],
-        submit: Annotated[
-            bool,
-            Field(description="Press Return after typing so the target agent receives the prompt."),
-        ] = True,
-        message_id: Annotated[
-            str | None,
-            Field(description="Optional idempotency key; retries never type twice."),
-        ] = None,
-        sender: Annotated[
-            str,
-            Field(description="Optional registered reply-to terminal id."),
-        ] = "",
-    ) -> dict[str, Any]:
-        """Immediately type and optionally submit a prompt in one registered terminal."""
-        bridge = TerminalBridge(memory.cfg)
-        try:
-            sender_id = _sender_id(bridge, sender)
-            receipt = bridge.send(
-                to,
-                _reply_envelope(message, sender_id),
-                sender=sender_id or None,
-                submit=submit,
-                message_id=message_id,
-            )
-        except MemoError as exc:
-            return {"status": "failed", "error": str(exc)}
-        return asdict(receipt)
-
-    @annotated_tool(server, **WRITE)
-    def memo_terminal_enter(
-        to: Annotated[str, Field(description="Exact terminal id returned by memo_terminal_list.")],
-        message_id: Annotated[
-            str | None,
-            Field(description="Optional idempotency key; retries never press Return twice."),
-        ] = None,
-        sender: Annotated[
-            str,
-            Field(description="Optional registered origin terminal id."),
-        ] = "",
-    ) -> dict[str, Any]:
-        """Press Return in one registered foreground agent terminal to unblock it."""
-        bridge = TerminalBridge(memory.cfg)
-        try:
-            sender_id = _sender_id(bridge, sender)
-            receipt = bridge.enter(to, sender=sender_id or None, message_id=message_id)
-        except MemoError as exc:
-            return {"status": "failed", "error": str(exc)}
-        return asdict(receipt)

--- a/src/memo/surface.py
+++ b/src/memo/surface.py
@@ -95,9 +95,7 @@ AGENT_MCP_TOOLS: frozenset[str] = (
             "memo_pop_notification",
             "memo_profile",
             "memo_start_session",
-            "memo_terminal_enter",
             "memo_terminal_list",
-            "memo_terminal_send",
             "memo_save_text",
             "memo_version",
             "memo_write_queue_status",
@@ -136,9 +134,7 @@ CORE_MCP_TOOLS: frozenset[str] = (
             "memo_session_get",
             "memo_session_list",
             "memo_stats",
-            "memo_terminal_enter",
             "memo_terminal_list",
-            "memo_terminal_send",
             "memo_review_due",
             "memo_supersede",
             "memo_unforget",
@@ -173,7 +169,7 @@ def mcp_include_advanced_tools() -> bool:
 
 
 def mcp_profile() -> str:
-    """Resolve the MCP surface profile, defaulting agent clients to 30 tools."""
+    """Resolve the MCP surface profile, defaulting agent clients to 41 tools."""
     profile = _profile("MEMO_MCP_PROFILE", default="agent", strict=True)
     if flags.flag_bool("MEMO_MCP_SLIM"):
         return "core"
@@ -190,9 +186,9 @@ def mcp_tools_to_remove() -> frozenset[str]:
 # Per-profile token-cost estimates for the `memo doctor` advisory. Reduced
 # profiles (agent/core/slim) are cheap; only the full/default surface warns.
 _PROFILE_TOKEN_COST: dict[str, tuple[str, str]] = {
-    "agent": ("43", "~4.3k"),
-    "core": ("60", "~5.5k"),
-    "slim": ("60", "~5.5k"),
+    "agent": ("41", "~4.1k"),
+    "core": ("58", "~5.3k"),
+    "slim": ("58", "~5.3k"),
 }
 
 
@@ -201,5 +197,5 @@ def mcp_profile_token_cost(profile: str | None = None) -> tuple[str, str, bool]:
     (or the active profile when ``None``). ``is_reduced`` is False only for the
     full/default surface — the costly one doctor warns about."""
     resolved = profile if profile is not None else mcp_profile()
-    count, cost = _PROFILE_TOKEN_COST.get(resolved, ("164", "~18.3k"))
+    count, cost = _PROFILE_TOKEN_COST.get(resolved, ("162", "~18.1k"))
     return count, cost, resolved in _PROFILE_TOKEN_COST

--- a/src/memo/terminal_live.py
+++ b/src/memo/terminal_live.py
@@ -3,19 +3,25 @@
 from __future__ import annotations
 
 import builtins
+import errno
+import fcntl
+import hashlib
+import hmac
 import os
 import re
 import secrets
 import sqlite3
 import stat
 import subprocess
+import sys
+import time
 import unicodedata
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from memo.errors import TerminalDeliveryError, TerminalValidationError
 
@@ -31,6 +37,7 @@ _TERMINAL_APPS = {
     "iterm.app": "iTerm2",
     "iterm2": "iTerm2",
     "ghostty": "Ghostty",
+    "tmux": "tmux",
 }
 
 
@@ -79,18 +86,47 @@ class TerminalReceipt:
     delivered_at: str
 
 
-ProcessProbe = Callable[[int], ProcessSnapshot | None]
+class _ProbeUnknown:
+    """A transient probe failure that is not proof the process exited."""
+
+
+_PROBE_UNKNOWN = _ProbeUnknown()
+ProcessProbe = Callable[[int], ProcessSnapshot | _ProbeUnknown | None]
 Presenter = Callable[..., str]
+TransportProbe = Callable[[Path, str], bool]
+ProcessBindingProbe = Callable[[], bool]
+ReceiptOwnerProbe = Callable[[int, str], bool | None]
+Failpoint = Callable[[str], None]
 
 _MAX_MESSAGE_BYTES = 16 * 1024
+_MAX_FINAL_RECEIPTS = 2_000
+_MAX_RECEIPT_KEYS = 10_000
+_LOCK_BUCKETS = 64
+_LOCK_TIMEOUT_SECONDS = 10.0
+_PENDING_LEASE = timedelta(seconds=30)
+_PROBE_GRACE = timedelta(seconds=30)
 _MESSAGE_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}\Z")
 _REGISTRATION_ID_RE = re.compile(r"term-[0-9a-f]{16}\Z")
+_DELIVERY_TRANSPORTS = frozenset({"ghostty-applescript", "iterm-applescript", "tiocsti", "tmux"})
 
 
 def _default_presenter(tty: Path, payload: bytes, *, terminal_app: str) -> str:
     from memo.terminal_presenter import deliver_input
 
     return deliver_input(tty, payload, terminal_app=terminal_app)
+
+
+def _default_transport_probe(tty: Path, terminal_app: str) -> bool:
+    from memo.terminal_presenter import exact_tty_transport_supported
+
+    return exact_tty_transport_supported(tty, terminal_app)
+
+
+def _default_process_binding_probe() -> bool:
+    # None of the legacy TTY transports binds an input operation atomically to
+    # the registered PID/start identity. Production delivery therefore fails
+    # closed until a cooperative receiver or native process-bound API exists.
+    return False
 
 
 def _now() -> str:
@@ -132,7 +168,101 @@ def _canonical_tty(value: str | Path, *, uid: int | None = None) -> Path:
     return path
 
 
-def _process_snapshot(pid: int) -> ProcessSnapshot | None:
+def _pid_exists(pid: int) -> bool | None:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return None
+    return True
+
+
+def _linux_process_birth_identity(pid: int) -> str:
+    try:
+        stat_line = Path(f"/proc/{pid}/stat").read_text(encoding="ascii")
+    except OSError:
+        return ""
+    closing_paren = stat_line.rfind(")")
+    if closing_paren < 0:
+        return ""
+    fields = stat_line[closing_paren + 2 :].split()
+    # fields[0] is proc stat field 3 (state); starttime is field 22.
+    if len(fields) <= 19 or not fields[19].isdigit():
+        return ""
+    return f"linux-start-ticks:{fields[19]}"
+
+
+def _darwin_process_birth_identity(pid: int) -> str:
+    try:
+        import ctypes
+
+        class ProcBsdInfo(ctypes.Structure):
+            _fields_ = [
+                ("pbi_flags", ctypes.c_uint32),
+                ("pbi_status", ctypes.c_uint32),
+                ("pbi_xstatus", ctypes.c_uint32),
+                ("pbi_pid", ctypes.c_uint32),
+                ("pbi_ppid", ctypes.c_uint32),
+                ("pbi_uid", ctypes.c_uint32),
+                ("pbi_gid", ctypes.c_uint32),
+                ("pbi_ruid", ctypes.c_uint32),
+                ("pbi_rgid", ctypes.c_uint32),
+                ("pbi_svuid", ctypes.c_uint32),
+                ("pbi_svgid", ctypes.c_uint32),
+                ("rfu_1", ctypes.c_uint32),
+                ("pbi_comm", ctypes.c_char * 16),
+                ("pbi_name", ctypes.c_char * 32),
+                ("pbi_nfiles", ctypes.c_uint32),
+                ("pbi_pgid", ctypes.c_uint32),
+                ("pbi_pjobc", ctypes.c_uint32),
+                ("e_tdev", ctypes.c_uint32),
+                ("e_tpgid", ctypes.c_uint32),
+                ("pbi_nice", ctypes.c_int32),
+                ("pbi_start_tvsec", ctypes.c_uint64),
+                ("pbi_start_tvusec", ctypes.c_uint64),
+            ]
+
+        info = ProcBsdInfo()
+        libproc = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+        proc_pidinfo = libproc.proc_pidinfo
+        proc_pidinfo.argtypes = [
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+            ctypes.c_int,
+        ]
+        proc_pidinfo.restype = ctypes.c_int
+        size = ctypes.sizeof(info)
+        if proc_pidinfo(pid, 3, 0, ctypes.byref(info), size) != size:
+            return ""
+        return f"darwin-start:{info.pbi_start_tvsec}:{info.pbi_start_tvusec}"
+    except (AttributeError, OSError, TypeError, ValueError):
+        return ""
+
+
+def _process_birth_identity(pid: int) -> str:
+    if sys.platform.startswith("linux"):
+        return _linux_process_birth_identity(pid)
+    if sys.platform == "darwin":
+        return _darwin_process_birth_identity(pid)
+    return ""
+
+
+def _default_receipt_owner_probe(pid: int, started_at: str) -> bool | None:
+    alive = _pid_exists(pid)
+    if alive is not True:
+        return alive
+    identity = _process_birth_identity(pid)
+    if not identity:
+        return None
+    return hmac.compare_digest(identity, started_at)
+
+
+def _process_snapshot(pid: int) -> ProcessSnapshot | _ProbeUnknown | None:
     if pid <= 1:
         return None
     try:
@@ -160,26 +290,29 @@ def _process_snapshot(pid: int) -> ProcessSnapshot | None:
             timeout=2,
         )
     except (OSError, subprocess.SubprocessError):
-        return None
+        return _PROBE_UNKNOWN
     if proc.returncode != 0 or not proc.stdout.strip():
-        return None
+        return None if _pid_exists(pid) is False else _PROBE_UNKNOWN
     parts = proc.stdout.strip().split(maxsplit=9)
     if len(parts) != 10 or parts[1] in {"?", "??", "-"}:
-        return None
+        return _PROBE_UNKNOWN
     try:
         uid = int(parts[0])
         pgid = int(parts[7])
         foreground_pgid = int(parts[8])
     except ValueError:
-        return None
+        return _PROBE_UNKNOWN
     tty = Path(parts[1])
     if not tty.is_absolute():
         tty = Path("/dev") / tty
+    birth_identity = _process_birth_identity(pid)
+    if not birth_identity:
+        return _PROBE_UNKNOWN
     return ProcessSnapshot(
         pid=pid,
         uid=uid,
         tty=tty,
-        started_at=" ".join(parts[2:7]),
+        started_at=birth_identity,
         pgid=pgid,
         foreground_pgid=foreground_pgid,
         command=parts[9],
@@ -191,6 +324,19 @@ def _command_matches_agent(command: str, agent: str) -> bool:
     return any(part == agent or part.endswith(f"/{agent}") for part in lowered.split()) or (
         f"/{agent} " in lowered
     )
+
+
+def _receipt_fingerprint(
+    target_id: str,
+    sender_id: str,
+    kind: str,
+    payload: bytes,
+) -> str:
+    digest = hashlib.sha256()
+    for part in (target_id.encode(), sender_id.encode(), kind.encode(), payload):
+        digest.update(len(part).to_bytes(8, "big"))
+        digest.update(part)
+    return digest.hexdigest()
 
 
 def _consume_csi(message: str, index: int) -> int:
@@ -220,8 +366,20 @@ def _consume_escape(message: str, index: int) -> int:
     return index + 1
 
 
+def _utf8_bytes(message: str) -> bytes:
+    try:
+        encoded_message = message.encode("utf-8")
+    except UnicodeEncodeError:
+        encoded_message = None
+    if encoded_message is None:
+        # Raise after leaving the codec exception handler so neither the
+        # surrogate-bearing body nor codec offsets survive in exception context.
+        raise TerminalValidationError("terminal message is not valid UTF-8") from None
+    return encoded_message
+
+
 def _strip_terminal_controls(message: str) -> str:
-    if len(message.encode("utf-8")) > _MAX_MESSAGE_BYTES:
+    if len(_utf8_bytes(message)) > _MAX_MESSAGE_BYTES:
         raise TerminalValidationError("terminal message exceeds 16 KiB")
     result: list[str] = []
     i = 0
@@ -230,12 +388,18 @@ def _strip_terminal_controls(message: str) -> str:
         if char == "\x1b":
             i = _consume_escape(message, i)
             continue
-        if char in {"\n", "\t"} or unicodedata.category(char) != "Cc":
+        if char == "\n":
+            result.append(r"\n")
+        elif char == "\t":
+            result.append(r"\t")
+        elif unicodedata.category(char) != "Cc":
             result.append(char)
         i += 1
     sanitized = "".join(result)
     if not sanitized.strip():
         raise TerminalValidationError("terminal message is empty after sanitization")
+    if len(sanitized.encode("utf-8")) > _MAX_MESSAGE_BYTES:
+        raise TerminalValidationError("terminal message exceeds 16 KiB after sanitization")
     return sanitized
 
 
@@ -248,10 +412,19 @@ class TerminalBridge:
         *,
         process_probe: ProcessProbe | None = None,
         presenter: Presenter | None = None,
+        transport_probe: TransportProbe | None = None,
+        process_binding_probe: ProcessBindingProbe | None = None,
+        receipt_owner_probe: ReceiptOwnerProbe | None = None,
+        failpoint: Failpoint | None = None,
     ) -> None:
         self._path = cfg.state_dir / "terminal_live.db"
+        self._lock_dir = cfg.state_dir / "terminal-live-locks"
         self._probe = process_probe or _process_snapshot
         self._present = presenter or _default_presenter
+        self._transport_supported = transport_probe or _default_transport_probe
+        self._process_binding_available = process_binding_probe or _default_process_binding_probe
+        self._receipt_owner_probe = receipt_owner_probe or _default_receipt_owner_probe
+        self._failpoint = failpoint
         self._init_db()
 
     @contextmanager
@@ -269,7 +442,13 @@ class TerminalBridge:
 
     def _init_db(self) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self._lock_dir.chmod(0o700)
         with self._connect() as conn:
+            # Serialize additive migrations across processes. Without an early
+            # write lock, two first-open callers can both observe a missing
+            # column and race the same ALTER TABLE.
+            conn.execute("BEGIN IMMEDIATE")
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS terminal_registrations (
@@ -298,11 +477,172 @@ class TerminalBridge:
                     transport TEXT NOT NULL,
                     error TEXT NOT NULL,
                     created_at TEXT NOT NULL,
-                    delivered_at TEXT NOT NULL
+                    delivered_at TEXT NOT NULL,
+                    fingerprint TEXT NOT NULL DEFAULT '',
+                    owner_pid INTEGER NOT NULL DEFAULT 0,
+                    owner_started_at TEXT NOT NULL DEFAULT ''
                 )
                 """
             )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS terminal_receipt_tombstones (
+                    message_id TEXT PRIMARY KEY,
+                    fingerprint TEXT NOT NULL,
+                    receipt_id TEXT NOT NULL
+                )
+                """
+            )
+            receipt_columns = {
+                str(row["name"]) for row in conn.execute("PRAGMA table_info(terminal_receipts)")
+            }
+            migrations = (
+                ("fingerprint", "TEXT NOT NULL DEFAULT ''"),
+                ("owner_pid", "INTEGER NOT NULL DEFAULT 0"),
+                ("owner_started_at", "TEXT NOT NULL DEFAULT ''"),
+            )
+            for name, declaration in migrations:
+                if name not in receipt_columns:
+                    conn.execute(f"ALTER TABLE terminal_receipts ADD COLUMN {name} {declaration}")
+            conn.execute(
+                "UPDATE terminal_receipts SET status = 'unknown', "
+                "error = 'DeliveryStateUnknown' WHERE status = 'pending' "
+                "AND (owner_pid <= 1 OR owner_started_at = '')"
+            )
+            self._recover_pending_receipts(conn)
+            self._prune_receipts(conn)
         self._path.chmod(0o600)
+
+    def _recover_pending_receipts(self, conn: sqlite3.Connection) -> None:
+        rows = conn.execute(
+            "SELECT receipt_id, owner_pid, owner_started_at, created_at "
+            "FROM terminal_receipts "
+            "WHERE status = 'pending'"
+        ).fetchall()
+        unknown_ids = []
+        for row in rows:
+            owner_active = self._receipt_owner_probe(
+                int(row["owner_pid"]),
+                str(row["owner_started_at"]),
+            )
+            try:
+                created_at = datetime.fromisoformat(str(row["created_at"]))
+                if created_at.tzinfo is None:
+                    created_at = created_at.replace(tzinfo=UTC)
+                lease_expired = datetime.now(UTC) - created_at > _PENDING_LEASE
+            except (TypeError, ValueError):
+                lease_expired = True
+            # An unverifiable owner is not evidence that delivery is active.
+            # The bounded lease also recovers failures that leave the owning
+            # process alive but no longer executing the delivery.
+            if owner_active is not True or lease_expired:
+                unknown_ids.append((str(row["receipt_id"]),))
+        if unknown_ids:
+            conn.executemany(
+                "UPDATE terminal_receipts SET status = 'unknown', "
+                "error = 'DeliveryStateUnknown' WHERE receipt_id = ?",
+                unknown_ids,
+            )
+
+    @staticmethod
+    def _prune_receipts(conn: sqlite3.Connection) -> None:
+        tombstone_limit = max(0, _MAX_RECEIPT_KEYS - _MAX_FINAL_RECEIPTS)
+        tombstone_count = int(
+            conn.execute("SELECT COUNT(*) FROM terminal_receipt_tombstones").fetchone()[0]
+        )
+        available = max(0, tombstone_limit - tombstone_count)
+        if not available:
+            return
+        rows = conn.execute(
+            "SELECT receipt_id, message_id, fingerprint FROM terminal_receipts "
+            "WHERE status IN ('delivered', 'failed') "
+            "ORDER BY rowid DESC LIMIT ? OFFSET ?",
+            (available, _MAX_FINAL_RECEIPTS),
+        ).fetchall()
+        if not rows:
+            return
+        conn.executemany(
+            "INSERT OR IGNORE INTO terminal_receipt_tombstones "
+            "(message_id, fingerprint, receipt_id) VALUES (?, ?, ?)",
+            [
+                (str(row["message_id"]), str(row["fingerprint"]), str(row["receipt_id"]))
+                for row in rows
+            ],
+        )
+        conn.executemany(
+            "DELETE FROM terminal_receipts WHERE receipt_id = ?",
+            [(str(row["receipt_id"]),) for row in rows],
+        )
+
+    @staticmethod
+    def _ensure_receipt_capacity(conn: sqlite3.Connection) -> None:
+        live_count = int(conn.execute("SELECT COUNT(*) FROM terminal_receipts").fetchone()[0])
+        tombstone_count = int(
+            conn.execute("SELECT COUNT(*) FROM terminal_receipt_tombstones").fetchone()[0]
+        )
+        if live_count + tombstone_count >= _MAX_RECEIPT_KEYS:
+            raise TerminalValidationError(
+                "terminal receipt idempotency capacity is exhausted; refusing new delivery"
+            )
+
+    @staticmethod
+    def _lock_key(tty: Path | None) -> str:
+        material = "missing-target"
+        if tty is not None:
+            try:
+                info = tty.stat()
+                material = f"tty:{info.st_dev}:{info.st_rdev}"
+            except OSError:
+                material = f"tty-path:{tty}"
+        # A fixed bucket set bounds persistent lockfiles. Hash collisions only
+        # serialize unrelated terminals; they cannot weaken mutual exclusion.
+        digest = hashlib.sha256(material.encode("utf-8")).digest()
+        bucket = int.from_bytes(digest[:8], "big") % _LOCK_BUCKETS
+        return f"{bucket:02x}"
+
+    @contextmanager
+    def _exclusive_lock(self, tty: Path | None) -> Iterator[None]:
+        lock_path = self._lock_dir / f"{self._lock_key(tty)}.lock"
+        flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(lock_path, flags, 0o600)
+        try:
+            info = os.fstat(fd)
+            if info.st_uid != os.getuid() or not stat.S_ISREG(info.st_mode):
+                raise TerminalValidationError("terminal delivery lock is unsafe")
+            os.fchmod(fd, 0o600)
+            deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+            while True:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except OSError as exc:
+                    if exc.errno not in {errno.EACCES, errno.EAGAIN}:
+                        raise TerminalValidationError(
+                            "terminal delivery lock could not be acquired"
+                        ) from exc
+                    if time.monotonic() >= deadline:
+                        raise TerminalValidationError("terminal delivery lock timed out") from None
+                    time.sleep(0.01)
+            yield
+        finally:
+            with suppress(OSError):
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
+    @contextmanager
+    def _target_lock(self, target_id: str) -> Iterator[None]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT tty FROM terminal_registrations WHERE id = ?",
+                (target_id,),
+            ).fetchone()
+        tty = Path(str(row["tty"])) if row else None
+        with self._exclusive_lock(tty):
+            yield
+
+    def _trip_failpoint(self, name: str) -> None:
+        if self._failpoint is not None:
+            self._failpoint(name)
 
     @staticmethod
     def _from_row(row: sqlite3.Row) -> TerminalRegistration:
@@ -319,6 +659,45 @@ class TerminalBridge:
             last_seen_at=str(row["last_seen_at"]),
         )
 
+    def _validated_registration_target(
+        self,
+        *,
+        agent: str,
+        tty: str | Path,
+        pid: int,
+        terminal_app: str,
+    ) -> tuple[str, str, ProcessSnapshot, Path]:
+        normalized_agent = agent.strip().lower()
+        if normalized_agent not in _AGENTS:
+            raise TerminalValidationError("unsupported agent registration")
+        app_key = terminal_app.strip().lower()
+        if app_key not in _TERMINAL_APPS:
+            raise TerminalValidationError("unsupported terminal application")
+        if not self._process_binding_available():
+            raise TerminalValidationError(
+                "terminal registration is disabled: no process-bound input transport is available"
+            )
+        snapshot = self._probe(pid)
+        if isinstance(snapshot, _ProbeUnknown):
+            raise TerminalValidationError("agent process identity could not be proven")
+        if snapshot is None or snapshot.uid != os.getuid():
+            raise TerminalValidationError("agent process is unavailable")
+        if not _command_matches_agent(snapshot.command, normalized_agent):
+            raise TerminalValidationError("agent process command does not match registration")
+        canonical_tty = _canonical_tty(tty, uid=snapshot.uid)
+        try:
+            process_tty = _canonical_tty(snapshot.tty, uid=snapshot.uid)
+        except TerminalValidationError as exc:
+            raise TerminalValidationError("agent process has no valid TTY") from exc
+        if process_tty != canonical_tty:
+            raise TerminalValidationError("agent process is attached to a different TTY")
+        normalized_app = _TERMINAL_APPS[app_key]
+        if not self._transport_supported(canonical_tty, normalized_app):
+            raise TerminalValidationError(
+                "no safe exact-TTY terminal transport is available for this terminal"
+            )
+        return normalized_agent, normalized_app, snapshot, canonical_tty
+
     def register(
         self,
         *,
@@ -328,25 +707,17 @@ class TerminalBridge:
         terminal_app: str = "",
         project: str | Path = "",
     ) -> TerminalRegistration:
-        normalized_agent = agent.strip().lower()
-        if normalized_agent not in _AGENTS:
-            raise TerminalValidationError("unsupported agent registration")
-        app_key = terminal_app.strip().lower()
-        if app_key not in _TERMINAL_APPS:
-            raise TerminalValidationError("unsupported terminal application")
-        snapshot = self._probe(pid)
-        if snapshot is None or snapshot.uid != os.getuid():
-            raise TerminalValidationError("agent process is unavailable")
-        canonical_tty = _canonical_tty(tty, uid=snapshot.uid)
-        try:
-            process_tty = _canonical_tty(snapshot.tty, uid=snapshot.uid)
-        except TerminalValidationError as exc:
-            raise TerminalValidationError("agent process has no valid TTY") from exc
-        if process_tty != canonical_tty:
-            raise TerminalValidationError("agent process is attached to a different TTY")
+        normalized_agent, normalized_app, snapshot, canonical_tty = (
+            self._validated_registration_target(
+                agent=agent,
+                tty=tty,
+                pid=pid,
+                terminal_app=terminal_app,
+            )
+        )
 
         now = _now()
-        with self._connect() as conn:
+        with self._exclusive_lock(canonical_tty), self._connect() as conn:
             existing = conn.execute(
                 "SELECT id, pid, uid, agent, process_started_at, created_at "
                 "FROM terminal_registrations WHERE tty = ?",
@@ -365,28 +736,28 @@ class TerminalBridge:
             created_at = str(existing["created_at"]) if same_process else now
             conn.execute(
                 """
-                INSERT INTO terminal_registrations (
-                    id, tty, pid, uid, agent, terminal_app, project,
-                    process_started_at, created_at, last_seen_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(tty) DO UPDATE SET
-                    id = excluded.id,
-                    pid = excluded.pid,
-                    uid = excluded.uid,
-                    agent = excluded.agent,
-                    terminal_app = excluded.terminal_app,
-                    project = excluded.project,
-                    process_started_at = excluded.process_started_at,
-                    created_at = excluded.created_at,
-                    last_seen_at = excluded.last_seen_at
-                """,
+                    INSERT INTO terminal_registrations (
+                        id, tty, pid, uid, agent, terminal_app, project,
+                        process_started_at, created_at, last_seen_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(tty) DO UPDATE SET
+                        id = excluded.id,
+                        pid = excluded.pid,
+                        uid = excluded.uid,
+                        agent = excluded.agent,
+                        terminal_app = excluded.terminal_app,
+                        project = excluded.project,
+                        process_started_at = excluded.process_started_at,
+                        created_at = excluded.created_at,
+                        last_seen_at = excluded.last_seen_at
+                    """,
                 (
                     registration_id,
                     str(canonical_tty),
                     pid,
                     snapshot.uid,
                     normalized_agent,
-                    _TERMINAL_APPS[app_key],
+                    normalized_app,
                     str(project),
                     snapshot.started_at,
                     created_at,
@@ -401,28 +772,72 @@ class TerminalBridge:
             raise TerminalValidationError("terminal registration was not persisted")
         return self._from_row(row)
 
-    def _is_live(self, registration: TerminalRegistration) -> bool:
+    def _registration_state(
+        self,
+        registration: TerminalRegistration,
+        *,
+        require_foreground: bool = False,
+    ) -> tuple[Literal["live", "unknown", "stale", "changed", "background"], str]:
         snapshot = self._probe(registration.pid)
-        if snapshot is None or snapshot.uid != registration.uid:
-            return False
+        if isinstance(snapshot, _ProbeUnknown):
+            return "unknown", "process identity probe is temporarily unavailable"
+        if (
+            snapshot is None
+            or snapshot.uid != registration.uid
+            or snapshot.started_at != registration.process_started_at
+            or not _command_matches_agent(snapshot.command, registration.agent)
+        ):
+            return "stale", "registered terminal process is stale"
         try:
             process_tty = _canonical_tty(snapshot.tty, uid=registration.uid)
         except TerminalValidationError:
+            return "stale", "registered terminal process is stale"
+        if str(process_tty) != registration.tty:
+            return "changed", "registered terminal process changed TTY"
+        if require_foreground and snapshot.pgid != snapshot.foreground_pgid:
+            return "background", "registered agent is not the foreground terminal process"
+        return "live", ""
+
+    @staticmethod
+    def _within_probe_grace(registration: TerminalRegistration) -> bool:
+        try:
+            last_seen = datetime.fromisoformat(registration.last_seen_at)
+        except ValueError:
             return False
-        return (
-            str(process_tty) == registration.tty
-            and snapshot.started_at == registration.process_started_at
-            and _command_matches_agent(snapshot.command, registration.agent)
-        )
+        return datetime.now(UTC) - last_seen <= _PROBE_GRACE
 
     def list(self) -> list[TerminalRegistration]:
+        if not self._process_binding_available():
+            with self._connect() as conn:
+                conn.execute("DELETE FROM terminal_registrations")
+            return []
         with self._connect() as conn:
             rows = conn.execute(
                 "SELECT * FROM terminal_registrations ORDER BY created_at, id"
             ).fetchall()
             registrations = [self._from_row(row) for row in rows]
-            live = [item for item in registrations if self._is_live(item)]
-            stale_ids = [item.id for item in registrations if item not in live]
+            live: list[TerminalRegistration] = []
+            stale_ids: list[str] = []
+            refreshed_ids: list[tuple[str, str]] = []
+            now = _now()
+            for item in registrations:
+                if not self._transport_supported(Path(item.tty), item.terminal_app):
+                    stale_ids.append(item.id)
+                    continue
+                state, _reason = self._registration_state(item)
+                if state == "live":
+                    refreshed = replace(item, last_seen_at=now)
+                    live.append(refreshed)
+                    refreshed_ids.append((now, item.id))
+                elif state == "unknown" and self._within_probe_grace(item):
+                    live.append(item)
+                elif state != "unknown":
+                    stale_ids.append(item.id)
+            if refreshed_ids:
+                conn.executemany(
+                    "UPDATE terminal_registrations SET last_seen_at = ? WHERE id = ?",
+                    refreshed_ids,
+                )
             if stale_ids:
                 conn.executemany(
                     "DELETE FROM terminal_registrations WHERE id = ?",
@@ -431,8 +846,8 @@ class TerminalBridge:
         return live
 
     def registration_id(self, registration_id: str) -> str:
-        """Return an exact live registration id, or an empty string."""
-        return registration_id if any(item.id == registration_id for item in self.list()) else ""
+        """Preserve an explicit sender id for core live-validation on delivery."""
+        return registration_id.strip()
 
     def registration_id_for_tty(self, tty: str | Path) -> str:
         """Resolve a live registration by exact canonical TTY."""
@@ -457,116 +872,212 @@ class TerminalBridge:
             delivered_at=str(row["delivered_at"]),
         )
 
-    def _existing_receipt(self, message_id: str) -> TerminalReceipt | None:
-        with self._connect() as conn:
-            row = conn.execute(
-                "SELECT * FROM terminal_receipts WHERE message_id = ?",
+    def _retry_receipt(
+        self,
+        conn: sqlite3.Connection,
+        message_id: str,
+        fingerprint: str,
+    ) -> TerminalReceipt | None:
+        row = conn.execute(
+            "SELECT * FROM terminal_receipts WHERE message_id = ?",
+            (message_id,),
+        ).fetchone()
+        if row is None:
+            tombstone = conn.execute(
+                "SELECT receipt_id, fingerprint FROM terminal_receipt_tombstones "
+                "WHERE message_id = ?",
                 (message_id,),
             ).fetchone()
-        return self._receipt_from_row(row) if row else None
+            if tombstone is None:
+                return None
+            stored_fingerprint = str(tombstone["fingerprint"])
+            if not stored_fingerprint or not hmac.compare_digest(
+                stored_fingerprint,
+                fingerprint,
+            ):
+                raise TerminalValidationError(
+                    "terminal message id conflicts with a different delivery request"
+                )
+            return TerminalReceipt(
+                receipt_id=str(tombstone["receipt_id"]),
+                message_id=message_id,
+                target_id="",
+                sender_id="",
+                kind="",
+                status="duplicate",
+                transport="",
+                error="ReceiptPruned",
+                created_at="",
+                delivered_at="",
+            )
+        stored_fingerprint = str(row["fingerprint"])
+        if not stored_fingerprint or not hmac.compare_digest(stored_fingerprint, fingerprint):
+            raise TerminalValidationError(
+                "terminal message id conflicts with a different delivery request"
+            )
+        receipt = self._receipt_from_row(row)
+        if receipt.status == "pending":
+            # This method runs while holding the target's interprocess lock. A
+            # remaining pending row therefore has no active presenter and is
+            # durably ambiguous; never attempt the body again.
+            conn.execute(
+                "UPDATE terminal_receipts SET status = 'unknown', "
+                "error = 'DeliveryStateUnknown' WHERE receipt_id = ?",
+                (receipt.receipt_id,),
+            )
+            return replace(receipt, status="unknown", error="DeliveryStateUnknown")
+        if receipt.status == "unknown":
+            return receipt
+        return replace(receipt, status="duplicate")
 
-    def _live_target(self, target_id: str) -> TerminalRegistration:
+    def _live_registration(
+        self,
+        registration_id: str,
+        *,
+        role: Literal["target", "sender"],
+        require_foreground: bool,
+    ) -> TerminalRegistration:
+        if not self._process_binding_available():
+            raise TerminalValidationError(
+                "terminal delivery is disabled: no process-bound input transport is available"
+            )
         with self._connect() as conn:
             row = conn.execute(
                 "SELECT * FROM terminal_registrations WHERE id = ?",
-                (target_id,),
+                (registration_id,),
             ).fetchone()
         if row is None:
-            raise TerminalValidationError("registered terminal target was not found")
+            raise TerminalValidationError(f"registered terminal {role} was not found")
         registration = self._from_row(row)
-        snapshot = self._probe(registration.pid)
-        if (
-            snapshot is None
-            or snapshot.uid != registration.uid
-            or snapshot.started_at != registration.process_started_at
-            or not _command_matches_agent(snapshot.command, registration.agent)
-        ):
-            raise TerminalValidationError("registered terminal target is stale")
-        try:
-            process_tty = _canonical_tty(snapshot.tty, uid=registration.uid)
-        except TerminalValidationError as exc:
-            raise TerminalValidationError("registered terminal target is stale") from exc
-        if str(process_tty) != registration.tty:
-            raise TerminalValidationError("registered terminal target changed TTY")
-        if snapshot.pgid != snapshot.foreground_pgid:
-            raise TerminalValidationError("registered agent is not the foreground terminal process")
-        return registration
+        if not self._transport_supported(Path(registration.tty), registration.terminal_app):
+            raise TerminalValidationError(
+                f"registered terminal {role} has no safe exact-TTY transport"
+            )
+        state, reason = self._registration_state(
+            registration,
+            require_foreground=require_foreground,
+        )
+        if state != "live":
+            raise TerminalValidationError(f"registered terminal {role}: {reason}")
+        now = _now()
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE terminal_registrations SET last_seen_at = ? WHERE id = ?",
+                (now, registration.id),
+            )
+        return replace(registration, last_seen_at=now)
 
-    def _deliver(
+    def _live_target(self, target_id: str) -> TerminalRegistration:
+        return self._live_registration(target_id, role="target", require_foreground=True)
+
+    def _live_sender(self, sender_id: str) -> TerminalRegistration:
+        return self._live_registration(sender_id, role="sender", require_foreground=False)
+
+    def _attempt_delivery(
         self,
         target_id: str,
         payload: bytes,
-        *,
-        sender: str | None,
-        message_id: str | None,
-        kind: str,
-    ) -> TerminalReceipt:
-        resolved_message_id = (message_id or f"msg-{secrets.token_hex(12)}").strip()
-        if not _MESSAGE_ID_RE.fullmatch(resolved_message_id):
-            raise TerminalValidationError("terminal message id is malformed or too long")
-        sender_id = (sender or "").strip()
-        if sender_id and not _REGISTRATION_ID_RE.fullmatch(sender_id):
-            raise TerminalValidationError("terminal sender id is malformed")
-        resolved_target_id = target_id.strip()
-        if not _REGISTRATION_ID_RE.fullmatch(resolved_target_id):
-            raise TerminalValidationError("terminal target id is malformed")
-        existing = self._existing_receipt(resolved_message_id)
-        if existing is not None:
-            return replace(existing, status="duplicate")
-
-        now = _now()
-        receipt_id = f"rcpt-{secrets.token_hex(8)}"
-        with self._connect() as conn:
-            try:
-                conn.execute(
-                    """
-                    INSERT INTO terminal_receipts (
-                        receipt_id, message_id, target_id, sender_id, kind,
-                        status, transport, error, created_at, delivered_at
-                    ) VALUES (?, ?, ?, ?, ?, 'pending', '', '', ?, '')
-                    """,
-                    (
-                        receipt_id,
-                        resolved_message_id,
-                        resolved_target_id,
-                        sender_id,
-                        kind,
-                        now,
-                    ),
-                )
-            except sqlite3.IntegrityError:
-                duplicate = self._existing_receipt(resolved_message_id)
-                if duplicate is None:  # pragma: no cover - defensive race guard
-                    raise TerminalValidationError("terminal receipt collision") from None
-                return replace(duplicate, status="duplicate")
-
+        sender_id: str,
+    ) -> tuple[str, str, str]:
+        """Return transport, stable failure code, and body-free public error."""
         try:
-            registration = self._live_target(resolved_target_id)
-        except TerminalValidationError as exc:
-            with self._connect() as conn:
-                conn.execute(
-                    "UPDATE terminal_receipts SET status = 'failed', error = ? "
-                    "WHERE receipt_id = ?",
-                    (str(exc), receipt_id),
-                )
-            raise
-
-        try:
+            registration = self._live_target(target_id)
+            if sender_id:
+                self._live_sender(sender_id)
             transport = self._present(
                 Path(registration.tty),
                 payload,
                 terminal_app=registration.terminal_app,
             )
-        except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
-            safe_error = str(exc) if isinstance(exc, TerminalDeliveryError) else type(exc).__name__
+            if transport not in _DELIVERY_TRANSPORTS:
+                return (
+                    "",
+                    "TerminalValidationError",
+                    "terminal presenter returned an invalid transport",
+                )
+            return transport, "", ""
+        except TerminalValidationError as exc:
+            return "", type(exc).__name__, str(exc)
+        except TerminalDeliveryError as exc:
+            safe_error = str(exc)
+            return "", safe_error, f"terminal delivery failed: {safe_error}"
+        except subprocess.TimeoutExpired:
+            return "", "OSError", "terminal delivery timed out"
+        except OSError as exc:
+            message = (
+                "no safe exact-TTY terminal transport is available"
+                if exc.errno == errno.ENOTSUP
+                else "terminal delivery failed"
+            )
+            return "", type(exc).__name__, message
+        except RuntimeError as exc:
+            return "", type(exc).__name__, "terminal delivery failed"
+
+    def _deliver_locked(
+        self,
+        target_id: str,
+        payload: bytes,
+        *,
+        sender_id: str,
+        message_id: str,
+        kind: str,
+        fingerprint: str,
+    ) -> TerminalReceipt:
+        now = _now()
+        receipt_id = f"rcpt-{secrets.token_hex(8)}"
+        owner_started_at = _process_birth_identity(os.getpid())
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            existing = self._retry_receipt(conn, message_id, fingerprint)
+            if existing is not None:
+                return existing
+            self._ensure_receipt_capacity(conn)
+            inserted = conn.execute(
+                """
+                INSERT OR IGNORE INTO terminal_receipts (
+                    receipt_id, message_id, target_id, sender_id, kind,
+                    status, transport, error, created_at, delivered_at,
+                    fingerprint, owner_pid, owner_started_at
+                ) VALUES (?, ?, ?, ?, ?, 'pending', '', '', ?, '', ?, ?, ?)
+                """,
+                (
+                    receipt_id,
+                    message_id,
+                    target_id,
+                    sender_id,
+                    kind,
+                    now,
+                    fingerprint,
+                    os.getpid(),
+                    owner_started_at,
+                ),
+            )
+            if inserted.rowcount == 0:
+                duplicate = self._retry_receipt(conn, message_id, fingerprint)
+                if duplicate is None:  # pragma: no cover - defensive race guard
+                    raise TerminalValidationError("terminal receipt collision")
+                return duplicate
+
+        self._trip_failpoint("before_presenter")
+        transport, failure_error, failure_message = self._attempt_delivery(
+            target_id,
+            payload,
+            sender_id,
+        )
+        self._trip_failpoint("after_presenter")
+        self._trip_failpoint("before_finalize")
+
+        if failure_error:
             with self._connect() as conn:
                 conn.execute(
                     "UPDATE terminal_receipts SET status = 'failed', error = ? "
                     "WHERE receipt_id = ?",
-                    (safe_error, receipt_id),
+                    (failure_error, receipt_id),
                 )
-            detail = f": {safe_error}" if isinstance(exc, TerminalDeliveryError) else ""
-            raise TerminalValidationError(f"terminal delivery failed{detail}") from exc
+                self._prune_receipts(conn)
+            # Raise after leaving the exception handler so presenter exceptions
+            # cannot retain a body-bearing argv through chained context.
+            raise TerminalValidationError(failure_message)
 
         delivered_at = _now()
         with self._connect() as conn:
@@ -579,9 +1090,45 @@ class TerminalBridge:
                 "SELECT * FROM terminal_receipts WHERE receipt_id = ?",
                 (receipt_id,),
             ).fetchone()
+            self._prune_receipts(conn)
         if row is None:  # pragma: no cover - guarded by insert above
             raise TerminalValidationError("terminal receipt was not persisted")
         return self._receipt_from_row(row)
+
+    def _deliver(
+        self,
+        target_id: str,
+        payload: bytes,
+        *,
+        sender: str | None,
+        message_id: str | None,
+        kind: str,
+    ) -> TerminalReceipt:
+        resolved_target_id = target_id.strip()
+        if not _REGISTRATION_ID_RE.fullmatch(resolved_target_id):
+            raise TerminalValidationError("terminal target id is malformed")
+        resolved_message_id = (message_id or f"msg-{secrets.token_hex(12)}").strip()
+        if not _MESSAGE_ID_RE.fullmatch(resolved_message_id):
+            raise TerminalValidationError("terminal message id is malformed or too long")
+        sender_id = (sender or "").strip()
+        if sender_id and not _REGISTRATION_ID_RE.fullmatch(sender_id):
+            raise TerminalValidationError("terminal sender id is malformed")
+        if not self._process_binding_available():
+            # This is a capability hard fail, not a delivery attempt. Do not
+            # create a misleading pending/failed receipt before rejecting it.
+            raise TerminalValidationError(
+                "terminal delivery is disabled: no process-bound input transport is available"
+            )
+        fingerprint = _receipt_fingerprint(resolved_target_id, sender_id, kind, payload)
+        with self._target_lock(resolved_target_id):
+            return self._deliver_locked(
+                resolved_target_id,
+                payload,
+                sender_id=sender_id,
+                message_id=resolved_message_id,
+                kind=kind,
+                fingerprint=fingerprint,
+            )
 
     def send(
         self,
@@ -620,6 +1167,7 @@ class TerminalBridge:
     def history(self, *, limit: int = 50) -> builtins.list[TerminalReceipt]:
         bounded = max(1, min(limit, 500))
         with self._connect() as conn:
+            self._recover_pending_receipts(conn)
             rows = conn.execute(
                 "SELECT * FROM terminal_receipts ORDER BY rowid DESC LIMIT ?",
                 (bounded,),

--- a/src/memo/terminal_presenter.py
+++ b/src/memo/terminal_presenter.py
@@ -2,40 +2,56 @@
 
 from __future__ import annotations
 
+import errno
 import fcntl
 import json
 import os
+import secrets
 import subprocess
 import termios
+from contextlib import suppress
 from pathlib import Path
 
 from memo.errors import TerminalDeliveryError
 
+_LINUX_TIOCSTI_POLICY = Path("/proc/sys/dev/tty/legacy_tiocsti")
 _PROMPT_LITERAL_MARKER = "__MEMO_PROMPT_LITERAL__"
+_ITERM_BUNDLE_ID = "com.googlecode.iterm2"
 
 
 class _PartialTIOCSTIError(OSError):
-    """TIOCSTI failed after at least one byte reached the target."""
+    """TIOCSTI failed after input may already have reached the terminal."""
 
 
 def _deliver_tiocsti(tty: Path, payload: bytes) -> None:
     request = getattr(termios, "TIOCSTI", None)
     if request is None:
-        raise OSError("TIOCSTI is unavailable")
+        raise OSError(errno.ENOTSUP, "TIOCSTI is unavailable")
     flags = os.O_RDWR | getattr(os, "O_NOCTTY", 0)
     fd = os.open(tty, flags)
-    injected = 0
+    delivered = 0
     try:
         for byte in payload:
             try:
                 fcntl.ioctl(fd, request, bytes([byte]))
             except OSError as exc:
-                if injected:
-                    raise _PartialTIOCSTIError(f"TIOCSTI stopped after {injected} bytes") from exc
+                if delivered:
+                    raise _PartialTIOCSTIError(
+                        errno.EIO,
+                        "TIOCSTI failed after partial input delivery",
+                    ) from exc
                 raise
-            injected += 1
+            delivered += 1
     finally:
-        os.close(fd)
+        try:
+            os.close(fd)
+        except OSError as exc:
+            if delivered:
+                raise _PartialTIOCSTIError(
+                    errno.EIO,
+                    "TTY close failed after input delivery",
+                ) from exc
+            raise
 
 
 def _run_osascript(
@@ -62,10 +78,38 @@ def _run_osascript(
             timeout=5,
             input=script_input,
         )
-    except subprocess.TimeoutExpired as exc:
-        raise TerminalDeliveryError("terminal automation timed out") from exc
-    except OSError as exc:
-        raise TerminalDeliveryError("terminal automation could not start") from exc
+    except subprocess.TimeoutExpired:
+        # Raise outside the exception handler so the TimeoutExpired object (whose
+        # command contains argv, including the prompt) is not retained as context.
+        failure = TerminalDeliveryError(errno.ETIMEDOUT, "terminal automation timed out")
+    except OSError:
+        failure = TerminalDeliveryError(
+            errno.ENOTSUP,
+            "terminal automation could not start",
+        )
+    raise failure
+
+
+def _run_tmux(
+    *args: str,
+    input_bytes: bytes | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    try:
+        return subprocess.run(
+            ["tmux", *args],
+            check=False,
+            capture_output=True,
+            input=input_bytes,
+            timeout=5,
+        )
+    except subprocess.TimeoutExpired:
+        failure = TerminalDeliveryError(errno.ETIMEDOUT, "tmux transport timed out")
+    except OSError:
+        failure = TerminalDeliveryError(
+            errno.ENOTSUP,
+            "tmux exact-TTY input transport is unavailable",
+        )
+    raise failure
 
 
 def _split_payload(payload: bytes) -> tuple[str, bool]:
@@ -73,8 +117,35 @@ def _split_payload(payload: bytes) -> tuple[str, bool]:
     body = payload[:-1] if submit else payload
     try:
         return body.decode("utf-8"), submit
-    except UnicodeDecodeError as exc:  # defensive: bridge always supplies UTF-8
-        raise TerminalDeliveryError("terminal payload is not UTF-8") from exc
+    except UnicodeDecodeError:  # defensive: bridge always supplies UTF-8
+        pass
+    raise TerminalDeliveryError("terminal payload is not UTF-8")
+
+
+def exact_tty_transport_supported(tty: Path, terminal_app: str) -> bool:
+    """Return whether registration can advertise a safe exact-TTY transport.
+
+    macOS terminal integrations target an application-owned TTY object. Linux
+    ``/dev/pts`` registrations require tmux exact-pane delivery or an explicit
+    kernel opt-in to legacy TIOCSTI; an unknown kernel policy fails closed.
+    """
+    # Terminal.app exposes no input API bound to a tab/session object. Global
+    # System Events keystrokes and clipboard paste are focus-racy, so this
+    # presenter is unavailable even to injected/internal capability callers.
+    if terminal_app == "Terminal":
+        return False
+    if not tty.is_relative_to(Path("/dev/pts")):
+        return terminal_app in {"Ghostty", "iTerm", "iTerm2", "tmux"}
+    if terminal_app == "tmux":
+        return True
+    if terminal_app:
+        return False
+    if getattr(termios, "TIOCSTI", None) is None:
+        return False
+    try:
+        return _LINUX_TIOCSTI_POLICY.read_text(encoding="ascii").strip() == "1"
+    except OSError:
+        return False
 
 
 _GHOSTTY_INPUT_SCRIPT = r"""
@@ -103,45 +174,6 @@ on run argv
 end run
 """
 
-_TERMINAL_INPUT_SCRIPT = r"""
-on run argv
-  set targetTty to item 1 of argv
-  set submitPrompt to ((item 2 of argv) is "1")
-  set promptText to __MEMO_PROMPT_LITERAL__
-
-  tell application "Terminal"
-    set foundTab to missing value
-    set foundWindow to missing value
-    repeat with candidateWindow in windows
-      repeat with candidateTab in tabs of candidateWindow
-        if tty of candidateTab is targetTty then
-          set foundTab to candidateTab
-          set foundWindow to candidateWindow
-          exit repeat
-        end if
-      end repeat
-      if foundTab is not missing value then exit repeat
-    end repeat
-    if foundTab is missing value then return "not found"
-    if submitPrompt then
-      do script promptText in foundTab
-      return "ok"
-    end if
-    set selected tab of foundWindow to foundTab
-    set index of foundWindow to 1
-    activate
-  end tell
-
-  delay 0.1
-  if promptText is not "" then
-    tell application "System Events"
-      tell process "Terminal" to keystroke promptText
-    end tell
-  end if
-  return "ok"
-end run
-"""
-
 
 def _deliver_ghostty(tty: Path, payload: bytes) -> None:
     body, submit = _split_payload(payload)
@@ -152,31 +184,21 @@ def _deliver_ghostty(tty: Path, payload: bytes) -> None:
         prompt_text=body,
     )
     if result.returncode != 0 or result.stdout.strip() != "ok":
-        raise TerminalDeliveryError("Ghostty could not find the registered TTY")
-
-
-def _deliver_terminal(tty: Path, payload: bytes) -> None:
-    body, submit = _split_payload(payload)
-    result = _run_osascript(
-        _TERMINAL_INPUT_SCRIPT,
-        str(tty),
-        "1" if submit else "0",
-        prompt_text=body,
-    )
-    if result.returncode != 0 or result.stdout.strip() != "ok":
-        raise TerminalDeliveryError("Terminal could not find the registered TTY")
+        raise TerminalDeliveryError(
+            errno.EIO,
+            "Ghostty could not deliver to the registered TTY",
+        )
 
 
 def _deliver_iterm(tty: Path, payload: bytes, *, app_name: str) -> None:
     body, submit = _split_payload(payload)
-    app_literal = json.dumps(app_name)
     script = f"""
 on run argv
   set targetTty to item 1 of argv
   set submitPrompt to ((item 2 of argv) is "1")
   set promptText to __MEMO_PROMPT_LITERAL__
 
-  tell application {app_literal}
+  tell application id "{_ITERM_BUNDLE_ID}"
     repeat with candidateWindow in windows
       repeat with candidateTab in tabs of candidateWindow
         repeat with candidateSession in sessions of candidateTab
@@ -205,30 +227,94 @@ end run
         raise TerminalDeliveryError(f"{app_name} could not find the registered TTY")
 
 
+def _tmux_target_for_tty(tty: Path) -> str:
+    panes = _run_tmux("list-panes", "-a", "-F", "#{pane_id}\t#{pane_tty}")
+    if panes.returncode != 0:
+        raise TerminalDeliveryError(errno.ENOTSUP, "tmux pane discovery is unavailable")
+    for line in panes.stdout.decode("utf-8", errors="replace").splitlines():
+        pane_id, separator, pane_tty = line.partition("\t")
+        if separator and pane_tty == str(tty):
+            return pane_id
+    raise TerminalDeliveryError(errno.ENOTSUP, "tmux could not find the registered TTY")
+
+
+def _paste_tmux_body(target: str, body: bytes) -> None:
+    buffer_name = f"memo-{os.getpid()}-{secrets.token_hex(8)}"
+    loaded = False
+    try:
+        result = _run_tmux("load-buffer", "-b", buffer_name, "-", input_bytes=body)
+        if result.returncode != 0:
+            raise TerminalDeliveryError(errno.EIO, "tmux could not stage terminal input")
+        loaded = True
+        result = _run_tmux("paste-buffer", "-b", buffer_name, "-d", "-t", target)
+        if result.returncode != 0:
+            raise TerminalDeliveryError(errno.EIO, "tmux could not deliver terminal input")
+        loaded = False
+    finally:
+        if loaded:
+            # Preserve the primary staging/delivery error. A named buffer
+            # cleanup failure must never make a retry look safe.
+            with suppress(OSError):
+                _run_tmux("delete-buffer", "-b", buffer_name)
+
+
+def _deliver_tmux(tty: Path, payload: bytes) -> None:
+    """Deliver via the one tmux pane whose reported TTY exactly matches *tty*."""
+    target = _tmux_target_for_tty(tty)
+    body, submit = _split_payload(payload)
+    if body:
+        _paste_tmux_body(target, body.encode("utf-8"))
+    if submit:
+        result = _run_tmux("send-keys", "-t", target, "Enter")
+        if result.returncode != 0:
+            raise TerminalDeliveryError(errno.EIO, "tmux could not submit terminal input")
+
+
+def _deliver_exact_session(tty: Path, payload: bytes, terminal_app: str) -> str:
+    if terminal_app == "tmux":
+        _deliver_tmux(tty, payload)
+        return "tmux"
+    if terminal_app == "Ghostty":
+        _deliver_ghostty(tty, payload)
+        return "ghostty-applescript"
+    _deliver_iterm(tty, payload, app_name=terminal_app)
+    return "iterm-applescript"
+
+
 def deliver_input(tty: Path, payload: bytes, *, terminal_app: str) -> str:
     """Deliver sanitized bytes to one validated TTY and return its transport."""
-    try:
-        _deliver_tiocsti(tty, payload)
-        return "tiocsti"
-    except _PartialTIOCSTIError as partial_error:
+    if terminal_app == "Terminal":
         raise TerminalDeliveryError(
-            "terminal input delivery was partial; refusing fallback"
-        ) from partial_error
-    except OSError as direct_error:
+            errno.ENOTSUP,
+            "Terminal.app has no safe exact-session input transport",
+        )
+    if terminal_app in {"tmux", "Ghostty", "iTerm", "iTerm2"}:
         try:
-            if terminal_app == "Ghostty":
-                _deliver_ghostty(tty, payload)
-                return "ghostty-applescript"
-            if terminal_app == "Terminal":
-                _deliver_terminal(tty, payload)
-                return "terminal-applescript"
-            if terminal_app in {"iTerm", "iTerm2"}:
-                _deliver_iterm(tty, payload, app_name=terminal_app)
-                return "iterm-applescript"
+            return _deliver_exact_session(tty, payload, terminal_app)
         except TerminalDeliveryError:
             raise
-        except OSError as fallback_error:
-            raise TerminalDeliveryError("terminal input delivery failed") from fallback_error
+        except OSError:
+            # Do not fall back from an exact-session API to a weaker TTY-bound
+            # transport: the exact API may already have delivered part of the body.
+            pass
+        raise TerminalDeliveryError("terminal input delivery failed")
+
+    if tty.is_relative_to(Path("/dev/pts")) and exact_tty_transport_supported(tty, ""):
+        try:
+            _deliver_tiocsti(tty, payload)
+            return "tiocsti"
+        except _PartialTIOCSTIError:
+            # Retrying could duplicate an already-injected prefix.
+            raise
+        except OSError:
+            raise TerminalDeliveryError(
+                errno.ENOTSUP,
+                "no safe exact-TTY Linux input transport is available",
+            ) from None
+
+    if tty.is_relative_to(Path("/dev/pts")):
         raise TerminalDeliveryError(
-            "terminal input injection is unavailable: no exact-session fallback"
-        ) from direct_error
+            errno.ENOTSUP,
+            "no safe exact-TTY Linux input transport is available",
+        )
+    raise TerminalDeliveryError(errno.ENOTSUP, "terminal input injection is unavailable")

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -86,6 +86,8 @@ def test_install_shims_writes_executable_self_contained_script(tmp_cfg, tmp_path
     assert "# memo-shim" in content
     assert 'startup-banner --agent "$_AGENT"' in content
     assert 'codex-badge --agent "$_AGENT"' in content
+    assert "terminal register" not in content
+    assert "tty <&2" in content
     assert "memflow" not in content.lower()
     assert "synapse" not in content.lower()
 
@@ -169,11 +171,11 @@ def test_codex_shim_prints_startup_banner_once_for_nested_call(tmp_path) -> None
 
     assert proc.returncode == 0
     calls = log_path.read_text(encoding="utf-8").splitlines()
-    assert sum(call.startswith("terminal register --agent codex") for call in calls) == 1
+    assert not any(call.startswith("terminal register") for call in calls)
     assert calls.count("startup-banner --agent codex") == 1
 
 
-def test_shim_registers_exact_terminal_before_agent_exec(tmp_path) -> None:
+def test_shim_uses_stderr_tty_with_redirected_stdin_and_clears_stale_id(tmp_path) -> None:
     shim_dir = tmp_path / "shim"
     tools_dir = tmp_path / "tools"
     real_dir = tmp_path / "real"
@@ -188,7 +190,9 @@ def test_shim_registers_exact_terminal_before_agent_exec(tmp_path) -> None:
     )
     real = real_dir / "codex"
     real.write_text(
-        '#!/usr/bin/env bash\nprintf "agent:%s\\n" "$MEMO_AGENT_TTY" >> "$MEMO_TEST_LOG"\n',
+        "#!/usr/bin/env bash\n"
+        'printf "agent:%s:%s\\n" "$MEMO_AGENT_TTY" "${MEMO_TERMINAL_ID:-unset}" '
+        '>> "$MEMO_TEST_LOG"\n',
         encoding="utf-8",
     )
     memo.chmod(0o755)
@@ -206,11 +210,12 @@ def test_shim_registers_exact_terminal_before_agent_exec(tmp_path) -> None:
                 "MEMO_TEST_LOG": str(log_path),
                 "MEMO_STARTUP_BANNER": "0",
                 "MEMO_CODEX_BADGE": "0",
-                "MEMO_AGENT_TTY": "",
+                "MEMO_AGENT_TTY": "/dev/ttys999",
+                "MEMO_TERMINAL_ID": "term-deadbeefdeadbeef",
                 "TERM_PROGRAM": "ghostty",
             },
-            stdin=slave_fd,
-            stdout=slave_fd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
             stderr=slave_fd,
             timeout=5,
         )
@@ -220,9 +225,42 @@ def test_shim_registers_exact_terminal_before_agent_exec(tmp_path) -> None:
 
     assert proc.returncode == 0
     lines = log_path.read_text(encoding="utf-8").splitlines()
-    assert lines[0].startswith(f"memo:terminal register --agent codex --tty {tty_path} --pid ")
-    assert f"--terminal-app ghostty --project {project} --id-only" in lines[0]
-    assert lines[1] == f"agent:{tty_path}"
+    assert lines == [f"agent:{tty_path}:unset"]
+
+
+def test_shim_without_tty_clears_inherited_tty_and_terminal_id(tmp_path) -> None:
+    shim_dir = tmp_path / "shim"
+    real_dir = tmp_path / "real"
+    log_path = tmp_path / "agent.log"
+    real_dir.mkdir()
+    real = real_dir / "codex"
+    real.write_text(
+        "#!/usr/bin/env bash\n"
+        'printf "agent:%s:%s\\n" "${MEMO_AGENT_TTY:-unset}" '
+        '"${MEMO_TERMINAL_ID:-unset}" >> "$MEMO_TEST_LOG"\n',
+        encoding="utf-8",
+    )
+    real.chmod(0o755)
+    install_shims(("codex",), shim_dir)
+
+    proc = subprocess.run(
+        [str(shim_dir / "codex")],
+        env={
+            **os.environ,
+            "PATH": os.pathsep.join([str(real_dir), os.environ["PATH"]]),
+            "MEMO_TEST_LOG": str(log_path),
+            "MEMO_STARTUP_BANNER": "0",
+            "MEMO_CODEX_BADGE": "0",
+            "MEMO_AGENT_TTY": "/dev/ttys999",
+            "MEMO_TERMINAL_ID": "term-deadbeefdeadbeef",
+        },
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        timeout=5,
+    )
+
+    assert proc.returncode == 0
+    assert log_path.read_text(encoding="utf-8").splitlines() == ["agent:unset:unset"]
 
 
 def test_codex_badge_uses_memo_notify_protocol(tmp_cfg, tmp_path, monkeypatch) -> None:

--- a/tests/test_cli_mcp_surface_smoke.py
+++ b/tests/test_cli_mcp_surface_smoke.py
@@ -127,15 +127,15 @@ def test_mcp_full_profile_registers_every_decorated_server_tool(
     registered = _mcp_tool_names(tmp_path, monkeypatch, "full")
 
     assert expected <= registered
-    assert len(registered) == 164
+    assert len(registered) == 162
 
 
 @pytest.mark.parametrize(
     ("profile", "expected_count"),
     [
-        ("agent", 43),
-        ("core", 60),
-        ("full", 164),
+        ("agent", 41),
+        ("core", 58),
+        ("full", 162),
     ],
 )
 def test_mcp_profile_tool_counts(

--- a/tests/test_cli_terminal.py
+++ b/tests/test_cli_terminal.py
@@ -1,16 +1,12 @@
-"""End-user CLI surface for live terminal coordination."""
+"""Read-only CLI diagnostics for disabled legacy terminal coordination."""
 
 from __future__ import annotations
 
 import json
-import os
-import pty
-from pathlib import Path
 
 from click.testing import CliRunner
 
 from memo.cli import cli
-from memo.terminal_live import ProcessSnapshot, TerminalBridge
 
 
 def _env(tmp_cfg) -> dict[str, str]:
@@ -21,7 +17,7 @@ def _env(tmp_cfg) -> dict[str, str]:
     }
 
 
-def test_terminal_command_exposes_live_user_workflow(tmp_cfg) -> None:
+def test_terminal_command_exposes_only_read_only_diagnostics(tmp_cfg) -> None:
     result = CliRunner().invoke(
         cli,
         ["terminal", "--help"],
@@ -29,161 +25,17 @@ def test_terminal_command_exposes_live_user_workflow(tmp_cfg) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert all(command in result.output for command in ("register", "list", "send", "enter"))
+    assert all(command in result.output for command in ("list", "history"))
+    assert all(f"\n  {command}" not in result.output for command in ("register", "send", "enter"))
 
 
-def test_terminal_send_cli_returns_json_receipt(tmp_cfg, monkeypatch) -> None:
-    master_fd, slave_fd = pty.openpty()
-    tty_path = Path(os.ttyname(slave_fd))
-    payloads: list[bytes] = []
+def test_terminal_list_and_history_are_empty_by_default(tmp_cfg) -> None:
+    runner = CliRunner()
 
-    def probe(pid: int) -> ProcessSnapshot:
-        return ProcessSnapshot(
-            pid=pid,
-            uid=os.getuid(),
-            tty=tty_path,
-            started_at="Sat Aug 1 12:00:00 2026",
-            pgid=pid,
-            foreground_pgid=pid,
-            command="codex",
-        )
+    listed = runner.invoke(cli, ["terminal", "list", "--json"], env=_env(tmp_cfg))
+    history = runner.invoke(cli, ["terminal", "history", "--json"], env=_env(tmp_cfg))
 
-    def present(_path: Path, payload: bytes, *, terminal_app: str) -> str:
-        payloads.append(payload)
-        return "test"
-
-    try:
-        bridge = TerminalBridge(tmp_cfg, process_probe=probe, presenter=present)
-        target = bridge.register(agent="codex", tty=tty_path, pid=4242)
-        monkeypatch.setattr("memo.cli_terminal._bridge", lambda: bridge)
-
-        result = CliRunner().invoke(
-            cli,
-            [
-                "terminal",
-                "send",
-                "--to",
-                target.id,
-                "--message",
-                "ping",
-                "--message-id",
-                "cli-msg-1",
-                "--json",
-            ],
-            env=_env(tmp_cfg),
-        )
-
-        assert result.exit_code == 0, result.output
-        assert json.loads(result.output)["status"] == "delivered"
-        assert payloads == [b"ping\r"]
-    finally:
-        os.close(slave_fd)
-        os.close(master_fd)
-
-
-def test_terminal_register_list_enter_and_history_cli(tmp_cfg, monkeypatch) -> None:
-    master_fd, slave_fd = pty.openpty()
-    tty_path = Path(os.ttyname(slave_fd))
-    payloads: list[bytes] = []
-
-    def probe(pid: int) -> ProcessSnapshot:
-        return ProcessSnapshot(
-            pid=pid,
-            uid=os.getuid(),
-            tty=tty_path,
-            started_at="Sat Aug 1 12:00:00 2026",
-            pgid=pid,
-            foreground_pgid=pid,
-            command="codex",
-        )
-
-    def present(_path: Path, payload: bytes, *, terminal_app: str) -> str:
-        payloads.append(payload)
-        return "test"
-
-    try:
-        bridge = TerminalBridge(tmp_cfg, process_probe=probe, presenter=present)
-        monkeypatch.setattr("memo.cli_terminal._bridge", lambda: bridge)
-        runner = CliRunner()
-
-        registered = runner.invoke(
-            cli,
-            [
-                "terminal",
-                "register",
-                "--agent",
-                "codex",
-                "--tty",
-                str(tty_path),
-                "--pid",
-                "4242",
-                "--terminal-app",
-                "Ghostty",
-                "--project",
-                "/tmp/memo",
-                "--json",
-            ],
-            env=_env(tmp_cfg),
-        )
-        assert registered.exit_code == 0, registered.output
-        registration_id = json.loads(registered.output)["id"]
-
-        listed = runner.invoke(cli, ["terminal", "list"], env=_env(tmp_cfg))
-        assert listed.exit_code == 0, listed.output
-        assert f"{registration_id}\tcodex\t{tty_path}\t/tmp/memo" in listed.output
-        listed_json = runner.invoke(cli, ["terminal", "list", "--json"], env=_env(tmp_cfg))
-        assert listed_json.exit_code == 0, listed_json.output
-        assert json.loads(listed_json.output)[0]["id"] == registration_id
-
-        entered = runner.invoke(
-            cli,
-            [
-                "terminal",
-                "enter",
-                "--to",
-                registration_id,
-                "--message-id",
-                "cli-enter-1",
-                "--json",
-            ],
-            env=_env(tmp_cfg),
-        )
-        assert entered.exit_code == 0, entered.output
-        assert json.loads(entered.output)["kind"] == "enter"
-        assert payloads == [b"\r"]
-
-        entered_text = runner.invoke(
-            cli,
-            [
-                "terminal",
-                "enter",
-                "--to",
-                registration_id,
-                "--message-id",
-                "cli-enter-2",
-            ],
-            env=_env(tmp_cfg),
-        )
-        assert entered_text.exit_code == 0, entered_text.output
-        assert "delivered" in entered_text.output
-        assert "via test" in entered_text.output
-        assert payloads == [b"\r", b"\r"]
-
-        history = runner.invoke(cli, ["terminal", "history"], env=_env(tmp_cfg))
-        assert history.exit_code == 0, history.output
-        assert registration_id in history.output
-        assert "delivered" in history.output
-        history_json = runner.invoke(
-            cli,
-            ["terminal", "history", "--limit", "1", "--json"],
-            env=_env(tmp_cfg),
-        )
-        assert history_json.exit_code == 0, history_json.output
-        rows = json.loads(history_json.output)
-        assert len(rows) == 1
-        assert rows[0]["target_id"] == registration_id
-        assert rows[0]["status"] == "delivered"
-        assert rows[0]["message_id"] == "cli-enter-2"
-    finally:
-        os.close(slave_fd)
-        os.close(master_fd)
+    assert listed.exit_code == 0, listed.output
+    assert history.exit_code == 0, history.output
+    assert json.loads(listed.output) == []
+    assert json.loads(history.output) == []

--- a/tests/test_mcp_stdio_end_user.py
+++ b/tests/test_mcp_stdio_end_user.py
@@ -66,7 +66,7 @@ async def test_stdio_process_exposes_full_surface_and_core_crud(tmp_path: Path) 
     try:
         async with Client(config, timeout=20, init_timeout=20) as client:
             tools = await client.list_tools()
-            assert len(tools) == 164
+            assert len(tools) == 162
 
             version = (await client.call_tool("memo_version", {})).data
             assert version["version"]

--- a/tests/test_server_terminal.py
+++ b/tests/test_server_terminal.py
@@ -1,104 +1,29 @@
-"""MCP tools for immediate registered-terminal coordination."""
+"""MCP diagnostics for disabled legacy registered-terminal coordination."""
 
 from __future__ import annotations
 
 import asyncio
-import os
-import pty
-from pathlib import Path
 
-from memo import server_terminal
+import pytest
+
 from memo.server import build_server
-from memo.terminal_live import ProcessSnapshot, TerminalBridge
 
 
-def _tool(server, name: str):
-    tool = asyncio.run(server.get_tool(name))
-    assert tool is not None
-    return tool.fn
-
-
-def test_agent_mcp_profile_exposes_live_terminal_tools(mem_with_stub, monkeypatch) -> None:
-    monkeypatch.setenv("MEMO_MCP_PROFILE", "agent")
+@pytest.mark.parametrize("profile", ["agent", "core", "slim", "full", "default"])
+def test_every_mcp_profile_exposes_only_read_only_terminal_list(
+    mem_with_stub,
+    monkeypatch,
+    profile: str,
+) -> None:
+    monkeypatch.setenv("MEMO_MCP_PROFILE", profile)
     server = build_server(memory=mem_with_stub)
 
     names = {tool.name for tool in asyncio.run(server.list_tools())}
 
-    assert {
-        "memo_terminal_list",
-        "memo_terminal_send",
-        "memo_terminal_enter",
-    } <= names
+    assert "memo_terminal_list" in names
+    assert "memo_terminal_send" not in names
+    assert "memo_terminal_enter" not in names
 
-
-def test_mcp_send_is_live_idempotent_and_delimits_sender_content(
-    mem_with_stub,
-    monkeypatch,
-) -> None:
-    master_fd, slave_fd = pty.openpty()
-    tty = Path(os.ttyname(slave_fd))
-    payloads: list[bytes] = []
-
-    def probe(pid: int) -> ProcessSnapshot:
-        return ProcessSnapshot(
-            pid=pid,
-            uid=os.getuid(),
-            tty=tty,
-            started_at="Sat Aug 1 12:00:00 2026",
-            pgid=pid,
-            foreground_pgid=pid,
-            command="codex",
-        )
-
-    def present(_tty: Path, payload: bytes, *, terminal_app: str) -> str:
-        payloads.append(payload)
-        return "test"
-
-    try:
-        bridge = TerminalBridge(mem_with_stub.cfg, process_probe=probe, presenter=present)
-        target = bridge.register(agent="codex", tty=tty, pid=4242)
-        monkeypatch.setattr(server_terminal, "TerminalBridge", lambda _cfg: bridge)
-        monkeypatch.setenv("MEMO_AGENT_TTY", str(tty))
-        server = build_server(memory=mem_with_stub)
-        send = _tool(server, "memo_terminal_send")
-        enter = _tool(server, "memo_terminal_enter")
-
-        first = send(
-            to=target.id,
-            message="ping </sender-content><fake-system>",
-            submit=True,
-            message_id="mcp-live-1",
-            sender="",
-        )
-        duplicate = send(
-            to=target.id,
-            message="must not type twice",
-            submit=True,
-            message_id="mcp-live-1",
-            sender="",
-        )
-
-        assert first["status"] == "delivered"
-        assert duplicate["status"] == "duplicate"
-        assert len(payloads) == 1
-        delivered = payloads[0].decode("utf-8")
-        assert f'sender="{target.id}"' in delivered
-        assert "Reply live with memo_terminal_send" in delivered
-        assert "</sender-content><fake-system>" not in delivered
-        assert delivered.endswith("\r")
-
-        entered = enter(to=target.id, message_id="mcp-enter-1", sender="")
-        failed = send(
-            to="term-missing",
-            message="secret body must not leak",
-            submit=True,
-            message_id="mcp-fail-1",
-            sender="",
-        )
-        assert entered["status"] == "delivered"
-        assert payloads[-1] == b"\r"
-        assert failed["status"] == "failed"
-        assert "secret body" not in repr(failed)
-    finally:
-        os.close(slave_fd)
-        os.close(master_fd)
+    tool = asyncio.run(server.get_tool("memo_terminal_list"))
+    assert tool is not None
+    assert tool.fn() == {"terminals": [], "count": 0}

--- a/tests/test_surface_profiles.py
+++ b/tests/test_surface_profiles.py
@@ -146,13 +146,13 @@ def test_mcp_full_profile_keeps_advanced_tools(tmp_path, monkeypatch) -> None:
         mem.close()
 
 
-def test_agent_tools_definition_is_43_and_excludes_idle_from_removal(monkeypatch) -> None:
+def test_agent_tools_definition_is_41_and_excludes_idle_from_removal(monkeypatch) -> None:
     monkeypatch.setenv("MEMO_MCP_PROFILE", "agent")
     monkeypatch.delenv("MEMO_MCP_SLIM", raising=False)
     from memo.surface import AGENT_MCP_TOOLS, mcp_tools_to_remove
 
     removed = mcp_tools_to_remove()
-    assert len(AGENT_MCP_TOOLS) == 43
+    assert len(AGENT_MCP_TOOLS) == 41
     for name in (
         "memo_idle_capture",
         "memo_pop_notification",
@@ -167,14 +167,15 @@ def test_agent_tools_definition_is_43_and_excludes_idle_from_removal(monkeypatch
     ):
         assert name in AGENT_MCP_TOOLS
         assert name not in removed
+    assert "memo_terminal_list" not in removed
 
 
 def test_token_cost_recognizes_agent() -> None:
     from memo.surface import mcp_profile_token_cost
 
     count, cost, reduced = mcp_profile_token_cost("agent")
-    assert count == "43"
-    assert cost == "~4.3k"
+    assert count == "41"
+    assert cost == "~4.1k"
     assert reduced is True
 
 
@@ -183,8 +184,8 @@ def test_token_cost_core_and_slim_are_reduced() -> None:
 
     for profile in ("core", "slim"):
         count, cost, reduced = mcp_profile_token_cost(profile)
-        assert count == "60"
-        assert cost == "~5.5k"
+        assert count == "58"
+        assert cost == "~5.3k"
         assert reduced is True
 
 
@@ -193,8 +194,8 @@ def test_token_cost_full_is_not_reduced() -> None:
 
     for profile in ("full", "default"):
         count, cost, reduced = mcp_profile_token_cost(profile)
-        assert count == "164"
-        assert cost == "~18.3k"
+        assert count == "162"
+        assert cost == "~18.1k"
         assert reduced is False
 
 
@@ -204,8 +205,8 @@ def test_token_cost_active_default_resolves_to_agent(monkeypatch) -> None:
     from memo.surface import mcp_profile_token_cost
 
     count, cost, reduced = mcp_profile_token_cost()
-    assert count == "43"
-    assert cost == "~4.3k"
+    assert count == "41"
+    assert cost == "~4.1k"
     assert reduced is True
 
 

--- a/tests/test_terminal_live.py
+++ b/tests/test_terminal_live.py
@@ -2,16 +2,38 @@
 
 from __future__ import annotations
 
+import errno
 import os
 import pty
+import sqlite3
 import stat
 import subprocess
+import sys
+import threading
+import time
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 
+import memo.terminal_live as terminal_live
 from memo.errors import TerminalDeliveryError, TerminalValidationError
-from memo.terminal_live import ProcessSnapshot, TerminalBridge, _is_local_tty_path
+from memo.terminal_live import (
+    _PROBE_UNKNOWN,
+    ProcessSnapshot,
+    TerminalBridge,
+    _darwin_process_birth_identity,
+    _is_local_tty_path,
+    _process_birth_identity,
+)
+
+
+def _allow_transport(_tty: Path, _terminal_app: str) -> bool:
+    return True
+
+
+def _simulate_process_bound_transport() -> bool:
+    return True
 
 
 def test_local_tty_path_accepts_linux_devpts_and_rejects_non_device_paths() -> None:
@@ -27,17 +49,25 @@ def test_local_tty_path_accepts_linux_devpts_and_rejects_non_device_paths() -> N
 def registered_bridge(tmp_cfg):
     master_fd, slave_fd = pty.openpty()
     tty = Path(os.ttyname(slave_fd))
-    state = {"alive": True, "foreground_pgid": 4242}
+    state = {
+        "alive": True,
+        "foreground_pgid": 4242,
+        "tty": tty,
+        "started_at": "Sat Aug 1 12:00:00 2026",
+        "probe_unknown": False,
+    }
     payloads: list[tuple[Path, bytes, str]] = []
 
-    def probe(pid: int) -> ProcessSnapshot | None:
+    def probe(pid: int):
+        if state["probe_unknown"]:
+            return _PROBE_UNKNOWN
         if not state["alive"]:
             return None
         return ProcessSnapshot(
             pid=pid,
             uid=os.getuid(),
-            tty=tty,
-            started_at="Sat Aug 1 12:00:00 2026",
+            tty=Path(state["tty"]),
+            started_at=str(state["started_at"]),
             pgid=pid,
             foreground_pgid=int(state["foreground_pgid"]),
             command="codex --dangerously-bypass-approvals-and-sandbox",
@@ -45,9 +75,15 @@ def registered_bridge(tmp_cfg):
 
     def presenter(path: Path, payload: bytes, *, terminal_app: str) -> str:
         payloads.append((path, payload, terminal_app))
-        return "test"
+        return "ghostty-applescript"
 
-    bridge = TerminalBridge(tmp_cfg, process_probe=probe, presenter=presenter)
+    bridge = TerminalBridge(
+        tmp_cfg,
+        process_probe=probe,
+        presenter=presenter,
+        transport_probe=_allow_transport,
+        process_binding_probe=_simulate_process_bound_transport,
+    )
     registration = bridge.register(
         agent="codex",
         tty=tty,
@@ -81,7 +117,12 @@ def test_register_persists_same_uid_tty_and_prunes_stale_process(tmp_cfg) -> Non
         )
 
     try:
-        bridge = TerminalBridge(tmp_cfg, process_probe=probe)
+        bridge = TerminalBridge(
+            tmp_cfg,
+            process_probe=probe,
+            transport_probe=_allow_transport,
+            process_binding_probe=_simulate_process_bound_transport,
+        )
         registration = bridge.register(
             agent="codex",
             tty=tty,
@@ -102,13 +143,17 @@ def test_register_persists_same_uid_tty_and_prunes_stale_process(tmp_cfg) -> Non
 
 
 @pytest.mark.parametrize(
-    ("reported", "canonical"),
+    ("term_program", "expected"),
     [
         pytest.param("Apple_Terminal", "Terminal", id="apple-terminal"),
         pytest.param("iTerm.app", "iTerm2", id="iterm-app"),
     ],
 )
-def test_register_accepts_term_program_aliases(tmp_cfg, reported: str, canonical: str) -> None:
+def test_register_normalizes_real_term_program_aliases(
+    tmp_cfg,
+    term_program: str,
+    expected: str,
+) -> None:
     master_fd, slave_fd = pty.openpty()
     tty = Path(os.ttyname(slave_fd))
 
@@ -124,20 +169,81 @@ def test_register_accepts_term_program_aliases(tmp_cfg, reported: str, canonical
         )
 
     try:
-        registration = TerminalBridge(tmp_cfg, process_probe=probe).register(
+        registration = TerminalBridge(
+            tmp_cfg,
+            process_probe=probe,
+            transport_probe=_allow_transport,
+            process_binding_probe=_simulate_process_bound_transport,
+        ).register(
             agent="codex",
             tty=tty,
             pid=4242,
-            terminal_app=reported,
+            terminal_app=term_program,
         )
-
-        assert registration.terminal_app == canonical
+        assert registration.terminal_app == expected
     finally:
         os.close(slave_fd)
         os.close(master_fd)
 
 
-def test_replacing_process_on_same_tty_rotates_registration_id(tmp_cfg) -> None:
+def test_reregister_rotates_id_and_created_at_for_new_process(tmp_cfg, monkeypatch) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+    starts = {
+        4242: "Sat Aug 1 12:00:00 2026",
+        4343: "Sat Aug 1 12:01:00 2026",
+    }
+    timestamps = iter(
+        [
+            "2026-08-01T12:00:00+00:00",
+            "2026-08-01T12:01:00+00:00",
+            "2026-08-01T12:02:00+00:00",
+            "2026-08-01T12:03:00+00:00",
+            "2026-08-01T12:04:00+00:00",
+        ]
+    )
+    monkeypatch.setattr(terminal_live, "_now", lambda: next(timestamps))
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at=starts[pid],
+            pgid=pid,
+            foreground_pgid=pid,
+            command="codex",
+        )
+
+    try:
+        bridge = TerminalBridge(
+            tmp_cfg,
+            process_probe=probe,
+            transport_probe=_allow_transport,
+            process_binding_probe=_simulate_process_bound_transport,
+        )
+        first = bridge.register(agent="codex", tty=tty, pid=4242)
+        repeated = bridge.register(agent="codex", tty=tty, pid=4242)
+        second = bridge.register(agent="codex", tty=tty, pid=4343)
+        starts[4343] = "Sat Aug 1 12:02:00 2026"
+        restarted = bridge.register(agent="codex", tty=tty, pid=4343)
+
+        assert repeated.id == first.id
+        assert repeated.created_at == first.created_at
+        assert second.id != first.id
+        assert second.created_at != first.created_at
+        assert restarted.id not in {first.id, second.id}
+        assert restarted.created_at != second.created_at
+        listed = bridge.list()
+        assert len(listed) == 1
+        assert listed[0].id == restarted.id
+        assert listed[0].created_at == restarted.created_at
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
+
+
+def test_register_rejects_agent_name_not_present_in_process_command(tmp_cfg) -> None:
     master_fd, slave_fd = pty.openpty()
     tty = Path(os.ttyname(slave_fd))
 
@@ -146,22 +252,104 @@ def test_replacing_process_on_same_tty_rotates_registration_id(tmp_cfg) -> None:
             pid=pid,
             uid=os.getuid(),
             tty=tty,
-            started_at=f"process-start-{pid}",
+            started_at="native-start:4242:1",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="python unrelated_worker.py",
+        )
+
+    try:
+        bridge = TerminalBridge(
+            tmp_cfg,
+            process_probe=probe,
+            transport_probe=_allow_transport,
+            process_binding_probe=_simulate_process_bound_transport,
+        )
+        with pytest.raises(TerminalValidationError, match="command does not match"):
+            bridge.register(agent="codex", tty=tty, pid=4242)
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
+
+
+def test_register_rejects_terminal_without_safe_exact_tty_capability(tmp_cfg) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at="Sat Aug 1 12:00:00 2026",
             pgid=pid,
             foreground_pgid=pid,
             command="codex",
         )
 
     try:
-        bridge = TerminalBridge(tmp_cfg, process_probe=probe)
-        original = bridge.register(agent="codex", tty=tty, pid=4242)
-        refreshed = bridge.register(agent="codex", tty=tty, pid=4242)
-        replacement = bridge.register(agent="codex", tty=tty, pid=4343)
+        bridge = TerminalBridge(
+            tmp_cfg,
+            process_probe=probe,
+            transport_probe=lambda _tty, _app: False,
+            process_binding_probe=_simulate_process_bound_transport,
+        )
+        with pytest.raises(TerminalValidationError, match="no safe exact-TTY"):
+            bridge.register(agent="codex", tty=tty, pid=4242)
+        assert bridge.list() == []
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
 
-        assert refreshed.id == original.id
-        assert replacement.id != original.id
-        assert bridge.registration_id(original.id) == ""
-        assert bridge.registration_id(replacement.id) == replacement.id
+
+def test_default_process_binding_gate_rejects_registration_and_existing_delivery(tmp_cfg) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+    payloads: list[bytes] = []
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at="native-start:4242:1",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="codex",
+        )
+
+    def present(_tty: Path, payload: bytes, *, terminal_app: str) -> str:
+        payloads.append(payload)
+        return "ghostty-applescript"
+
+    try:
+        enabled = TerminalBridge(
+            tmp_cfg,
+            process_probe=probe,
+            presenter=present,
+            transport_probe=_allow_transport,
+            process_binding_probe=_simulate_process_bound_transport,
+        )
+        registration = enabled.register(agent="codex", tty=tty, pid=4242)
+        disabled = TerminalBridge(
+            tmp_cfg,
+            process_probe=probe,
+            presenter=present,
+            transport_probe=_allow_transport,
+        )
+
+        with pytest.raises(TerminalValidationError, match="process-bound"):
+            disabled.register(agent="codex", tty=tty, pid=4242)
+        with pytest.raises(TerminalValidationError, match="process-bound"):
+            disabled.send(
+                registration.id,
+                "must not reach replacement",
+                message_id="process-swap-blocked",
+            )
+
+        assert payloads == []
+        assert disabled.history() == []
+        assert disabled.list() == []
     finally:
         os.close(slave_fd)
         os.close(master_fd)
@@ -177,15 +365,204 @@ def test_send_strips_terminal_controls_and_is_idempotent(registered_bridge) -> N
     )
     second = bridge.send(
         registration.id,
-        "different text",
+        "hello\x1b[31m!\x1b[0m\r",
         message_id="msg-1",
     )
 
     assert payloads == [(Path(registration.tty), b"hello!\r", "Ghostty")]
     assert first.status == "delivered"
-    assert first.transport == "test"
+    assert first.transport == "ghostty-applescript"
     assert second.receipt_id == first.receipt_id
     assert second.status == "duplicate"
+
+
+def test_send_escapes_line_controls_and_emits_only_requested_return(registered_bridge) -> None:
+    bridge, registration, payloads, _state = registered_bridge
+
+    bridge.send(
+        registration.id,
+        "first\nsecond\tcolumn\rthird",
+        submit=False,
+        message_id="no-submit-controls",
+    )
+    bridge.send(
+        registration.id,
+        "first\nsecond\tcolumn\rthird",
+        submit=True,
+        message_id="submit-controls",
+    )
+
+    draft = payloads[0][1]
+    submitted = payloads[1][1]
+    assert draft == b"first\\nsecond\\tcolumnthird"
+    assert b"\n" not in draft and b"\t" not in draft and b"\r" not in draft
+    assert submitted == draft + b"\r"
+    assert submitted.count(b"\r") == 1
+
+
+@pytest.mark.parametrize("terminal_app", ["", "Ghostty", "Terminal", "iTerm", "iTerm2", "tmux"])
+def test_every_transport_receives_single_line_data_only(
+    registered_bridge,
+    terminal_app: str,
+) -> None:
+    bridge, registration, payloads, _state = registered_bridge
+    updated = bridge.register(
+        agent="codex",
+        tty=registration.tty,
+        pid=registration.pid,
+        terminal_app=terminal_app,
+    )
+
+    bridge.send(
+        updated.id,
+        "line one\nline two\tvalue",
+        message_id=f"transport-controls-{terminal_app or 'tiocsti'}",
+    )
+
+    path, payload, normalized_app = payloads[-1]
+    assert path == Path(registration.tty)
+    assert payload == b"line one\\nline two\\tvalue\r"
+    assert payload.count(b"\r") == 1
+    assert b"\n" not in payload and b"\t" not in payload
+    assert normalized_app in {"", "Ghostty", "Terminal", "iTerm", "iTerm2", "tmux"}
+
+
+@pytest.mark.parametrize("change", ["payload", "target", "sender", "kind"])
+def test_message_id_reuse_with_changed_fingerprint_is_conflict(
+    registered_bridge,
+    change: str,
+) -> None:
+    bridge, registration, payloads, _state = registered_bridge
+    bridge.send(registration.id, "same body", message_id=f"fingerprint-{change}")
+
+    with pytest.raises(TerminalValidationError, match="conflicts"):
+        if change == "payload":
+            bridge.send(registration.id, "different body", message_id="fingerprint-payload")
+        elif change == "target":
+            bridge.send(
+                "term-0000000000000000",
+                "same body",
+                message_id="fingerprint-target",
+            )
+        elif change == "sender":
+            bridge.send(
+                registration.id,
+                "same body",
+                sender=registration.id,
+                message_id="fingerprint-sender",
+            )
+        else:
+            bridge.enter(registration.id, message_id="fingerprint-kind")
+
+    assert len(payloads) == 1
+
+
+def test_forged_live_sender_is_rejected_before_presentation(registered_bridge) -> None:
+    bridge, registration, payloads, _state = registered_bridge
+
+    with pytest.raises(TerminalValidationError, match="sender was not found"):
+        bridge.send(
+            registration.id,
+            "sender must be live",
+            sender="term-0000000000000000",
+            message_id="forged-sender",
+        )
+
+    receipt = bridge.history()[0]
+    assert receipt.status == "failed"
+    assert receipt.sender_id == "term-0000000000000000"
+    assert payloads == []
+
+
+def test_cross_bridge_tty_lock_serializes_messages_and_concurrent_dedupe(tmp_cfg) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+    trace: list[str] = []
+    calls: list[bytes] = []
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at="native-start:4242:1",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="codex",
+        )
+
+    def present(_tty: Path, payload: bytes, *, terminal_app: str) -> str:
+        calls.append(payload)
+        for byte in payload:
+            trace.append(chr(byte))
+            time.sleep(0.002)
+        return "ghostty-applescript"
+
+    try:
+        options = {
+            "process_probe": probe,
+            "presenter": present,
+            "transport_probe": _allow_transport,
+            "process_binding_probe": _simulate_process_bound_transport,
+        }
+        first_bridge = TerminalBridge(tmp_cfg, **options)
+        second_bridge = TerminalBridge(tmp_cfg, **options)
+        registration = first_bridge.register(agent="codex", tty=tty, pid=4242)
+
+        barrier = threading.Barrier(3)
+        errors: list[BaseException] = []
+
+        def send(bridge: TerminalBridge, body: str, message_id: str) -> None:
+            try:
+                barrier.wait()
+                bridge.send(registration.id, body, submit=False, message_id=message_id)
+            except BaseException as exc:  # captured for assertion in the main thread
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=send, args=(first_bridge, "AAAAA", "locked-a")),
+            threading.Thread(target=send, args=(second_bridge, "BBBBB", "locked-b")),
+        ]
+        for thread in threads:
+            thread.start()
+        barrier.wait()
+        for thread in threads:
+            thread.join(timeout=5)
+
+        assert errors == []
+        assert "".join(trace) in {"AAAAABBBBB", "BBBBBAAAAA"}
+
+        calls.clear()
+        trace.clear()
+        barrier = threading.Barrier(3)
+        results = []
+
+        def retry(bridge: TerminalBridge) -> None:
+            barrier.wait()
+            results.append(
+                bridge.send(
+                    registration.id,
+                    "CCCCC",
+                    submit=False,
+                    message_id="locked-dedupe",
+                )
+            )
+
+        threads = [
+            threading.Thread(target=retry, args=(first_bridge,)),
+            threading.Thread(target=retry, args=(second_bridge,)),
+        ]
+        for thread in threads:
+            thread.start()
+        barrier.wait()
+        for thread in threads:
+            thread.join(timeout=5)
+
+        assert calls == [b"CCCCC"]
+        assert {receipt.status for receipt in results} == {"delivered", "duplicate"}
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
 
 
 def test_send_refuses_when_agent_is_not_foreground(registered_bridge) -> None:
@@ -198,29 +575,77 @@ def test_send_refuses_when_agent_is_not_foreground(registered_bridge) -> None:
     assert payloads == []
 
 
-def test_target_validation_failures_are_receipted(registered_bridge) -> None:
-    bridge, registration, payloads, state = registered_bridge
+def test_transient_probe_keeps_registration_during_grace_and_refreshes_last_seen(
+    registered_bridge,
+) -> None:
+    bridge, registration, _payloads, state = registered_bridge
+    state["probe_unknown"] = True
 
-    with pytest.raises(TerminalValidationError, match="not found"):
-        bridge.send(
-            "term-0123456789abcdef",
-            "missing target",
-            message_id="missing-target-1",
+    assert bridge.list() == [registration]
+    with bridge._connect() as conn:
+        old = (datetime.now(UTC) - timedelta(minutes=5)).isoformat(timespec="seconds")
+        conn.execute(
+            "UPDATE terminal_registrations SET last_seen_at = ? WHERE id = ?",
+            (old, registration.id),
         )
-    state["foreground_pgid"] = 9999
-    with pytest.raises(TerminalValidationError, match="foreground"):
-        bridge.send(registration.id, "background target", message_id="background-target-1")
 
-    history = bridge.history(limit=2)
-    assert [(item.message_id, item.status) for item in history] == [
-        ("background-target-1", "failed"),
-        ("missing-target-1", "failed"),
+    assert bridge.list() == []
+    with bridge._connect() as conn:
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM terminal_registrations WHERE id = ?",
+                (registration.id,),
+            ).fetchone()[0]
+            == 1
+        )
+
+    state["probe_unknown"] = False
+    refreshed = bridge.list()
+    assert len(refreshed) == 1
+    assert refreshed[0].last_seen_at != old
+
+
+def test_rejected_targets_are_failed_receipts_without_bodies(registered_bridge) -> None:
+    bridge, registration, payloads, state = registered_bridge
+    other_master_fd, other_slave_fd = pty.openpty()
+    other_tty = Path(os.ttyname(other_slave_fd))
+    attempts = [
+        ("term-0000000000000000", "missing secret", "not found"),
     ]
-    assert "foreground" in history[0].error
-    assert "not found" in history[1].error
-    assert "background target" not in repr(history[0])
-    assert "missing target" not in repr(history[1])
-    assert payloads == []
+    try:
+        for target_id, body, error in attempts:
+            with pytest.raises(TerminalValidationError, match=error):
+                bridge.send(target_id, body, message_id="rejected-missing")
+
+        state["alive"] = False
+        with pytest.raises(TerminalValidationError, match="stale"):
+            bridge.send(registration.id, "stale secret", message_id="rejected-stale")
+
+        state["alive"] = True
+        state["tty"] = other_tty
+        with pytest.raises(TerminalValidationError, match="changed TTY"):
+            bridge.send(registration.id, "changed secret", message_id="rejected-changed")
+
+        state["tty"] = Path(registration.tty)
+        state["foreground_pgid"] = 9999
+        with pytest.raises(TerminalValidationError, match="foreground"):
+            bridge.send(registration.id, "background secret", message_id="rejected-background")
+
+        receipts = bridge.history()
+        assert {receipt.message_id for receipt in receipts} == {
+            "rejected-missing",
+            "rejected-stale",
+            "rejected-changed",
+            "rejected-background",
+        }
+        assert all(receipt.status == "failed" for receipt in receipts)
+        assert all(receipt.error == "TerminalValidationError" for receipt in receipts)
+        assert all(not receipt.delivered_at for receipt in receipts)
+        assert "secret" not in repr(receipts)
+        assert payloads == []
+    finally:
+        os.close(other_slave_fd)
+        os.close(other_master_fd)
 
 
 def test_enter_delivers_only_carriage_return(registered_bridge) -> None:
@@ -239,6 +664,7 @@ def test_enter_delivers_only_carriage_return(registered_bridge) -> None:
         pytest.param("", id="empty"),
         pytest.param("\x1b[31m\r", id="control-only"),
         pytest.param("x" * (16 * 1024 + 1), id="oversized"),
+        pytest.param("\n" * 9_000, id="oversized-after-sanitization"),
     ],
 )
 def test_send_rejects_empty_control_only_and_oversized_messages(
@@ -253,6 +679,18 @@ def test_send_rejects_empty_control_only_and_oversized_messages(
     assert payloads == []
 
 
+def test_send_rejects_surrogate_body_without_retaining_codec_context(registered_bridge) -> None:
+    bridge, registration, payloads, _state = registered_bridge
+
+    with pytest.raises(TerminalValidationError, match="valid UTF-8") as raised:
+        bridge.send(registration.id, "secret\udcffbody")
+
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+    assert "secret" not in repr(raised.value)
+    assert payloads == []
+
+
 def test_send_rejects_unbounded_or_malformed_routing_ids(registered_bridge) -> None:
     bridge, registration, payloads, _state = registered_bridge
 
@@ -260,7 +698,75 @@ def test_send_rejects_unbounded_or_malformed_routing_ids(registered_bridge) -> N
         bridge.send(registration.id, "hello", message_id="x" * 129)
     with pytest.raises(TerminalValidationError, match="sender id"):
         bridge.send(registration.id, "hello", sender="not a terminal")
+    with pytest.raises(TerminalValidationError, match="target id"):
+        bridge.send("not a terminal", "hello")
 
+    assert payloads == []
+
+
+@pytest.mark.parametrize("invalid_transport", ["", "terminal-applescript", "custom"])
+def test_invalid_presenter_transport_is_failed_and_never_retried(
+    registered_bridge,
+    monkeypatch,
+    invalid_transport: str,
+) -> None:
+    bridge, registration, payloads, _state = registered_bridge
+    calls: list[bytes] = []
+
+    def invalid(_tty: Path, payload: bytes, *, terminal_app: str) -> str:
+        calls.append(payload)
+        return invalid_transport
+
+    monkeypatch.setattr(bridge, "_present", invalid)
+
+    with pytest.raises(TerminalValidationError, match="invalid transport"):
+        bridge.send(registration.id, "body", message_id=f"invalid-{invalid_transport or 'empty'}")
+    duplicate = bridge.send(
+        registration.id,
+        "body",
+        message_id=f"invalid-{invalid_transport or 'empty'}",
+    )
+
+    assert duplicate.status == "duplicate"
+    assert bridge.history()[0].status == "failed"
+    assert calls == [b"body\r"]
+    assert payloads == []
+
+
+def test_missing_targets_share_bounded_lock_bucket(registered_bridge) -> None:
+    bridge, _registration, payloads, _state = registered_bridge
+
+    for index in range(100):
+        with pytest.raises(TerminalValidationError, match="not found"):
+            bridge.send(
+                f"term-{index:016x}",
+                "never delivered",
+                message_id=f"missing-lock-{index}",
+            )
+
+    lockfiles = list(bridge._lock_dir.glob("*.lock"))
+    assert len(lockfiles) <= 2
+    assert payloads == []
+
+
+def test_interprocess_lock_wait_is_bounded_before_receipt(
+    registered_bridge,
+    monkeypatch,
+) -> None:
+    bridge, registration, payloads, _state = registered_bridge
+    ticks = iter((0.0, terminal_live._LOCK_TIMEOUT_SECONDS + 1.0))
+
+    def blocked(_fd: int, _operation: int) -> None:
+        raise BlockingIOError(errno.EAGAIN, "busy")
+
+    monkeypatch.setattr(terminal_live.fcntl, "flock", blocked)
+    monkeypatch.setattr(terminal_live.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(terminal_live.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(TerminalValidationError, match="lock timed out"):
+        bridge.send(registration.id, "not attempted", message_id="lock-timeout")
+
+    assert bridge.history() == []
     assert payloads == []
 
 
@@ -283,7 +789,13 @@ def test_failed_delivery_is_receipted_without_message_body(tmp_cfg) -> None:
         raise OSError("presenter unavailable")
 
     try:
-        bridge = TerminalBridge(tmp_cfg, process_probe=probe, presenter=fail)
+        bridge = TerminalBridge(
+            tmp_cfg,
+            process_probe=probe,
+            presenter=fail,
+            transport_probe=_allow_transport,
+            process_binding_probe=_simulate_process_bound_transport,
+        )
         registration = bridge.register(agent="codex", tty=tty, pid=4242)
 
         with pytest.raises(TerminalValidationError, match="delivery failed"):
@@ -298,76 +810,66 @@ def test_failed_delivery_is_receipted_without_message_body(tmp_cfg) -> None:
         os.close(master_fd)
 
 
-def test_presenter_timeout_cannot_leave_pending_receipt(tmp_cfg) -> None:
-    master_fd, slave_fd = pty.openpty()
-    tty = Path(os.ttyname(slave_fd))
+def test_safe_transport_failure_is_preserved_only_in_internal_receipt(registered_bridge) -> None:
+    bridge, registration, payloads, _state = registered_bridge
 
-    def probe(pid: int) -> ProcessSnapshot:
-        return ProcessSnapshot(
-            pid=pid,
-            uid=os.getuid(),
-            tty=tty,
-            started_at="Sat Aug 1 12:00:00 2026",
-            pgid=pid,
-            foreground_pgid=pid,
-            command="codex",
-        )
-
-    def timeout(_tty: Path, _payload: bytes, *, terminal_app: str) -> str:
-        raise subprocess.TimeoutExpired(["osascript"], timeout=5)
-
-    try:
-        bridge = TerminalBridge(tmp_cfg, process_probe=probe, presenter=timeout)
-        registration = bridge.register(agent="codex", tty=tty, pid=4242)
-
-        with pytest.raises(TerminalValidationError, match="delivery failed"):
-            bridge.send(registration.id, "secret terminal body", message_id="timeout-1")
-
-        receipt = bridge.history()[0]
-        assert receipt.status == "failed"
-        assert receipt.error == "TimeoutExpired"
-        assert "secret terminal body" not in repr(receipt)
-    finally:
-        os.close(slave_fd)
-        os.close(master_fd)
-
-
-def test_safe_presenter_failure_is_actionable_without_leaking_payload(tmp_cfg) -> None:
-    master_fd, slave_fd = pty.openpty()
-    tty = Path(os.ttyname(slave_fd))
-
-    def probe(pid: int) -> ProcessSnapshot:
-        return ProcessSnapshot(
-            pid=pid,
-            uid=os.getuid(),
-            tty=tty,
-            started_at="Sat Aug 1 12:00:00 2026",
-            pgid=pid,
-            foreground_pgid=pid,
-            command="codex",
-        )
-
-    def timeout(_tty: Path, _payload: bytes, *, terminal_app: str) -> str:
+    def fail(_tty: Path, _payload: bytes, *, terminal_app: str) -> str:
         raise TerminalDeliveryError("terminal automation timed out")
 
+    bridge._present = fail
+
+    with pytest.raises(TerminalValidationError, match="terminal automation timed out"):
+        bridge.send(registration.id, "secret body", message_id="safe-diagnostic")
+
+    receipt = bridge.history()[0]
+    assert receipt.status == "failed"
+    assert receipt.error == "terminal automation timed out"
+    assert "secret body" not in repr(receipt)
+    assert payloads == []
+
+
+def test_presenter_timeout_is_body_free_and_never_leaves_pending_receipt(tmp_cfg) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at="Sat Aug 1 12:00:00 2026",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="codex",
+        )
+
+    def timeout(_tty: Path, payload: bytes, *, terminal_app: str) -> str:
+        raise subprocess.TimeoutExpired(["osascript", payload.decode()], 5)
+
     try:
-        bridge = TerminalBridge(tmp_cfg, process_probe=probe, presenter=timeout)
+        bridge = TerminalBridge(
+            tmp_cfg,
+            process_probe=probe,
+            presenter=timeout,
+            transport_probe=_allow_transport,
+            process_binding_probe=_simulate_process_bound_transport,
+        )
         registration = bridge.register(agent="codex", tty=tty, pid=4242)
 
-        with pytest.raises(
-            TerminalValidationError,
-            match="delivery failed: terminal automation timed out",
-        ):
+        with pytest.raises(TerminalValidationError, match="timed out") as raised:
             bridge.send(
                 registration.id,
-                "secret terminal body",
-                message_id="safe-timeout-1",
+                "timeout secret body",
+                message_id="timeout-failure",
             )
 
         receipt = bridge.history()[0]
         assert receipt.status == "failed"
-        assert receipt.error == "terminal automation timed out"
-        assert "secret terminal body" not in repr(receipt)
+        assert receipt.error == "OSError"
+        assert receipt.delivered_at == ""
+        assert raised.value.__cause__ is None
+        assert raised.value.__context__ is None
+        assert "timeout secret body" not in repr((raised.value, receipt))
     finally:
         os.close(slave_fd)
         os.close(master_fd)
@@ -389,8 +891,215 @@ def test_registration_database_is_private(tmp_cfg) -> None:
         )
 
     try:
-        TerminalBridge(tmp_cfg, process_probe=probe, presenter=lambda *_a, **_kw: "test")
+        TerminalBridge(
+            tmp_cfg,
+            process_probe=probe,
+            presenter=lambda *_a, **_kw: "ghostty-applescript",
+            transport_probe=_allow_transport,
+            process_binding_probe=_simulate_process_bound_transport,
+        )
         assert (tmp_cfg.state_dir / "terminal_live.db").stat().st_mode & 0o777 == 0o600
     finally:
         os.close(slave_fd)
         os.close(master_fd)
+
+
+@pytest.mark.parametrize(
+    ("stage", "expected_presentations"),
+    [
+        pytest.param("before_presenter", 0, id="before-presenter"),
+        pytest.param("after_presenter", 1, id="after-presenter"),
+        pytest.param("before_finalize", 1, id="before-finalize"),
+    ],
+)
+def test_crash_failpoints_recover_pending_as_unknown_without_redelivery(
+    tmp_cfg,
+    stage: str,
+    expected_presentations: int,
+) -> None:
+    master_fd, slave_fd = pty.openpty()
+    tty = Path(os.ttyname(slave_fd))
+    payloads: list[bytes] = []
+
+    def probe(pid: int) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            pid=pid,
+            uid=os.getuid(),
+            tty=tty,
+            started_at="native-start:4242:1",
+            pgid=pid,
+            foreground_pgid=pid,
+            command="codex",
+        )
+
+    def present(_tty: Path, payload: bytes, *, terminal_app: str) -> str:
+        payloads.append(payload)
+        return "ghostty-applescript"
+
+    def failpoint(name: str) -> None:
+        if name == stage:
+            raise RuntimeError(f"simulated crash at {stage}")
+
+    try:
+        bridge = TerminalBridge(
+            tmp_cfg,
+            process_probe=probe,
+            presenter=present,
+            transport_probe=_allow_transport,
+            process_binding_probe=_simulate_process_bound_transport,
+            failpoint=failpoint,
+        )
+        registration = bridge.register(agent="codex", tty=tty, pid=4242)
+
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            bridge.send(registration.id, "crash body", message_id=f"crash-{stage}")
+
+        assert len(payloads) == expected_presentations
+        assert bridge.history()[0].status == "pending"
+        retry = bridge.send(registration.id, "crash body", message_id=f"crash-{stage}")
+        assert retry.status == "unknown"
+        assert len(payloads) == expected_presentations
+
+        recovered = TerminalBridge(
+            tmp_cfg,
+            process_probe=probe,
+            presenter=present,
+            transport_probe=_allow_transport,
+            process_binding_probe=_simulate_process_bound_transport,
+            receipt_owner_probe=lambda _pid, _started: False,
+        )
+        receipt = recovered.history()[0]
+        assert receipt.status == "unknown"
+        assert receipt.error == "DeliveryStateUnknown"
+        assert not receipt.delivered_at
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
+
+
+def test_receipt_schema_migrates_old_pending_rows_to_unknown(tmp_cfg) -> None:
+    tmp_cfg.state_dir.mkdir(parents=True, exist_ok=True)
+    db = tmp_cfg.state_dir / "terminal_live.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        """
+        CREATE TABLE terminal_receipts (
+            receipt_id TEXT PRIMARY KEY,
+            message_id TEXT NOT NULL UNIQUE,
+            target_id TEXT NOT NULL,
+            sender_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            status TEXT NOT NULL,
+            transport TEXT NOT NULL,
+            error TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            delivered_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO terminal_receipts VALUES "
+        "('rcpt-old', 'msg-old', 'term-old', '', 'message', 'pending', '', '', ?, '')",
+        ((datetime.now(UTC) - timedelta(days=1)).isoformat(),),
+    )
+    conn.commit()
+    conn.close()
+
+    bridge = TerminalBridge(tmp_cfg)
+
+    with bridge._connect() as migrated:
+        columns = {row["name"] for row in migrated.execute("PRAGMA table_info(terminal_receipts)")}
+    assert {"fingerprint", "owner_pid", "owner_started_at"} <= columns
+    receipt = bridge.history()[0]
+    assert receipt.status == "unknown"
+    assert receipt.error == "DeliveryStateUnknown"
+
+
+def test_receipt_retention_bounds_final_rows_and_preserves_ambiguous(tmp_cfg, monkeypatch) -> None:
+    monkeypatch.setattr(terminal_live, "_MAX_FINAL_RECEIPTS", 2)
+    bridge = TerminalBridge(tmp_cfg)
+    now = _now_for_test = datetime.now(UTC).isoformat()
+    with bridge._connect() as conn:
+        for index, status in enumerate(("delivered", "failed", "delivered", "pending", "unknown")):
+            conn.execute(
+                """
+                INSERT INTO terminal_receipts (
+                    receipt_id, message_id, target_id, sender_id, kind, status,
+                    transport, error, created_at, delivered_at, fingerprint,
+                    owner_pid, owner_started_at
+                ) VALUES (?, ?, '', '', 'message', ?, '', '', ?, '', ?, 0, '')
+                """,
+                (f"rcpt-{index}", f"msg-{index}", status, now, f"fingerprint-{index}"),
+            )
+        bridge._prune_receipts(conn)
+        rows = conn.execute("SELECT status FROM terminal_receipts ORDER BY rowid").fetchall()
+        tombstones = conn.execute(
+            "SELECT message_id, fingerprint FROM terminal_receipt_tombstones"
+        ).fetchall()
+
+    statuses = [str(row["status"]) for row in rows]
+    assert statuses.count("delivered") + statuses.count("failed") == 2
+    assert "pending" in statuses
+    assert "unknown" in statuses
+    assert [(str(row["message_id"]), str(row["fingerprint"])) for row in tombstones] == [
+        ("msg-0", "fingerprint-0")
+    ]
+
+
+def test_pruned_receipt_tombstone_prevents_retry_and_conflicting_reuse(
+    registered_bridge,
+    monkeypatch,
+) -> None:
+    bridge, registration, payloads, _state = registered_bridge
+    monkeypatch.setattr(terminal_live, "_MAX_FINAL_RECEIPTS", 2)
+
+    first = bridge.send(registration.id, "first", message_id="pruned-first")
+    bridge.send(registration.id, "second", message_id="pruned-second")
+    bridge.send(registration.id, "third", message_id="pruned-third")
+
+    retry = bridge.send(registration.id, "first", message_id="pruned-first")
+    with pytest.raises(TerminalValidationError, match="conflicts"):
+        bridge.send(registration.id, "changed", message_id="pruned-first")
+
+    assert retry.receipt_id == first.receipt_id
+    assert retry.status == "duplicate"
+    assert retry.error == "ReceiptPruned"
+    assert len(payloads) == 3
+
+
+def test_receipt_key_capacity_fails_closed_but_keeps_tombstone_retries(
+    registered_bridge,
+    monkeypatch,
+) -> None:
+    bridge, registration, payloads, _state = registered_bridge
+    monkeypatch.setattr(terminal_live, "_MAX_FINAL_RECEIPTS", 1)
+    monkeypatch.setattr(terminal_live, "_MAX_RECEIPT_KEYS", 2)
+
+    first = bridge.send(registration.id, "first", message_id="capacity-first")
+    bridge.send(registration.id, "second", message_id="capacity-second")
+
+    with pytest.raises(TerminalValidationError, match="capacity is exhausted"):
+        bridge.send(registration.id, "third", message_id="capacity-third")
+    retry = bridge.send(registration.id, "first", message_id="capacity-first")
+
+    assert retry.receipt_id == first.receipt_id
+    assert retry.status == "duplicate"
+    assert len(payloads) == 2
+    assert {receipt.message_id for receipt in bridge.history()} == {"capacity-second"}
+
+
+def test_native_process_birth_identity_has_subsecond_or_tick_precision() -> None:
+    identity = _process_birth_identity(os.getpid())
+
+    assert identity
+    assert identity.startswith(("linux-start-ticks:", "darwin-start:"))
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="Darwin libproc layout only")
+def test_darwin_process_birth_identity_matches_live_libproc_layout() -> None:
+    identity = _darwin_process_birth_identity(os.getpid())
+    prefix, seconds, microseconds = identity.split(":")
+
+    assert prefix == "darwin-start"
+    assert abs(time.time() - int(seconds)) < 60
+    assert 0 <= int(microseconds) < 1_000_000

--- a/tests/test_terminal_presenter.py
+++ b/tests/test_terminal_presenter.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import pty
 import subprocess
@@ -15,7 +14,7 @@ import memo.terminal_presenter as presenter
 from memo.errors import TerminalDeliveryError
 
 
-def test_tiocsti_preserves_every_input_byte(monkeypatch) -> None:
+def test_low_level_tiocsti_preserves_every_input_byte(monkeypatch) -> None:
     master_fd, slave_fd = pty.openpty()
     target = Path(os.ttyname(slave_fd))
     injected: list[bytes] = []
@@ -23,23 +22,22 @@ def test_tiocsti_preserves_every_input_byte(monkeypatch) -> None:
         presenter.fcntl, "ioctl", lambda _fd, _request, value: injected.append(value)
     )
     try:
-        transport = presenter.deliver_input(target, b"hello\r", terminal_app="")
+        presenter._deliver_tiocsti(target, b"hello\r")
 
         assert injected == [b"h", b"e", b"l", b"l", b"o", b"\r"]
-        assert transport == "tiocsti"
     finally:
         os.close(slave_fd)
         os.close(master_fd)
 
 
-def test_ghostty_fallback_targets_exact_tty_and_submits_atomically(monkeypatch) -> None:
-    calls: list[tuple[str, tuple[str, ...], dict[str, str]]] = []
+def test_ghostty_fallback_targets_and_submits_to_exact_tty_atomically(monkeypatch) -> None:
+    calls: list[tuple[str, tuple[str, ...], str | None]] = []
 
     def deny(_tty: Path, _payload: bytes) -> None:
         raise PermissionError("kernel denied TIOCSTI")
 
-    def run(script: str, *args: str, **kwargs: str):
-        calls.append((script, args, kwargs))
+    def run(script: str, *args: str, prompt_text: str | None = None):
+        calls.append((script, args, prompt_text))
         return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
 
     monkeypatch.setattr(presenter, "_deliver_tiocsti", deny)
@@ -53,51 +51,53 @@ def test_ghostty_fallback_targets_exact_tty_and_submits_atomically(monkeypatch) 
 
     assert transport == "ghostty-applescript"
     assert calls[0][1] == ("/dev/ttys003", "1")
-    assert calls[0][2] == {"prompt_text": "hello from memo"}
+    assert calls[0][2] == "hello from memo"
     assert "candidateTty is targetTty" in calls[0][0]
     assert 'send key "enter" to candidateTerminal' in calls[0][0]
+    assert "focus" not in calls[0][0]
+    assert "activate" not in calls[0][0]
     assert "System Events" not in calls[0][0]
     assert len(calls) == 1
 
 
-def test_terminal_app_fallback_keeps_payload_out_of_argv_and_clipboard(monkeypatch) -> None:
-    calls: list[tuple[str, tuple[str, ...], dict[str, str]]] = []
+@pytest.mark.parametrize("payload", [b"draft only", b"submit\r"])
+def test_terminal_app_always_fails_before_any_global_or_tiocsti_input(
+    monkeypatch,
+    payload: bytes,
+) -> None:
+    calls: list[str] = []
     monkeypatch.setattr(
         presenter,
         "_deliver_tiocsti",
-        lambda _tty, _payload: (_ for _ in ()).throw(PermissionError()),
+        lambda _tty, _payload: calls.append("tiocsti"),
+    )
+    monkeypatch.setattr(
+        presenter,
+        "_run_osascript",
+        lambda *_args, **_kwargs: calls.append("osascript"),
     )
 
-    def run(script: str, *args: str, **kwargs: str):
-        calls.append((script, args, kwargs))
-        return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+    with pytest.raises(OSError, match="no safe exact-session") as raised:
+        presenter.deliver_input(
+            Path("/dev/ttys003"),
+            payload,
+            terminal_app="Terminal",
+        )
 
-    monkeypatch.setattr(presenter, "_run_osascript", run)
-
-    transport = presenter.deliver_input(
-        Path("/dev/ttys003"),
-        b"hello 'quoted'\r",
-        terminal_app="Terminal",
-    )
-
-    assert transport == "terminal-applescript"
-    assert calls[0][1] == ("/dev/ttys003", "1")
-    assert calls[0][2] == {"prompt_text": "hello 'quoted'"}
-    assert "tty of candidateTab is targetTty" in calls[0][0]
-    assert "clipboard" not in calls[0][0].lower()
-    assert "do script promptText in foundTab" in calls[0][0]
+    assert raised.value.errno is not None
+    assert calls == []
 
 
 def test_iterm_fallback_writes_to_exact_session_without_newline(monkeypatch) -> None:
-    calls: list[tuple[str, tuple[str, ...], dict[str, str]]] = []
+    calls: list[tuple[str, tuple[str, ...], str | None]] = []
     monkeypatch.setattr(
         presenter,
         "_deliver_tiocsti",
         lambda _tty, _payload: (_ for _ in ()).throw(PermissionError()),
     )
 
-    def run(script: str, *args: str, **kwargs: str):
-        calls.append((script, args, kwargs))
+    def run(script: str, *args: str, prompt_text: str | None = None):
+        calls.append((script, args, prompt_text))
         return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
 
     monkeypatch.setattr(presenter, "_run_osascript", run)
@@ -110,41 +110,34 @@ def test_iterm_fallback_writes_to_exact_session_without_newline(monkeypatch) -> 
 
     assert transport == "iterm-applescript"
     assert calls[0][1] == ("/dev/ttys007", "0")
-    assert calls[0][2] == {"prompt_text": "draft only"}
+    assert calls[0][2] == "draft only"
+    assert 'tell application id "com.googlecode.iterm2"' in calls[0][0]
     assert "tty of candidateSession is targetTty" in calls[0][0]
     assert "newline false" in calls[0][0]
 
 
-def test_osascript_receives_sensitive_text_over_stdin_not_argv(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+def test_osascript_timeout_is_raised_without_body_bearing_context(monkeypatch) -> None:
+    secret = "secret prompt must not escape"
+    calls: list[tuple[list[str], str | None]] = []
 
-    def run(command: list[str], **kwargs: object):
-        captured["command"] = command
-        captured.update(kwargs)
-        return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
-
-    monkeypatch.setattr(presenter.subprocess, "run", run)
-    secret = 'secret "prompt"\nwith another line'
-
-    presenter._run_osascript(
-        "on run argv\nset promptText to __MEMO_PROMPT_LITERAL__\nreturn promptText\nend run",
-        "/dev/ttys003",
-        prompt_text=secret,
-    )
-
-    assert all(secret not in part for part in captured["command"])
-    assert json.dumps(secret, ensure_ascii=False) in str(captured["input"])
-    assert "__MEMO_PROMPT_LITERAL__" not in str(captured["input"])
-
-
-def test_osascript_timeout_becomes_safe_delivery_error(monkeypatch) -> None:
-    def timeout(*_args: object, **_kwargs: object) -> None:
-        raise subprocess.TimeoutExpired(["osascript"], timeout=5)
+    def timeout(command, **kwargs):
+        calls.append((command, kwargs.get("input")))
+        raise subprocess.TimeoutExpired(command, 5)
 
     monkeypatch.setattr(presenter.subprocess, "run", timeout)
 
-    with pytest.raises(TerminalDeliveryError, match="timed out"):
-        presenter._run_osascript('return "ok"')
+    with pytest.raises(OSError, match="automation timed out") as raised:
+        presenter._run_osascript(
+            f"set promptText to {presenter._PROMPT_LITERAL_MARKER}",
+            "/dev/ttys003",
+            prompt_text=secret,
+        )
+
+    assert secret not in repr(calls[0][0])
+    assert secret in str(calls[0][1])
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+    assert secret not in repr(raised.value)
 
 
 def test_osascript_rejects_invalid_payload_marker_without_starting(monkeypatch) -> None:
@@ -162,110 +155,149 @@ def test_osascript_rejects_invalid_payload_marker_without_starting(monkeypatch) 
     assert started is False
 
 
-def test_osascript_start_failure_becomes_safe_delivery_error(monkeypatch) -> None:
+def test_osascript_start_failure_is_redacted_and_body_free(monkeypatch) -> None:
     def missing_binary(*_args: object, **_kwargs: object) -> None:
         raise FileNotFoundError("private executable path")
 
     monkeypatch.setattr(presenter.subprocess, "run", missing_binary)
 
-    with pytest.raises(TerminalDeliveryError, match="automation could not start") as exc:
+    with pytest.raises(TerminalDeliveryError, match="automation could not start") as raised:
         presenter._run_osascript('return "ok"')
 
-    assert "private executable path" not in str(exc.value)
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+    assert "private executable path" not in str(raised.value)
 
 
-def test_non_utf8_payload_becomes_safe_delivery_error() -> None:
-    with pytest.raises(TerminalDeliveryError, match="payload is not UTF-8"):
-        presenter._split_payload(b"\xff")
+def test_non_utf8_payload_is_redacted_and_body_free() -> None:
+    with pytest.raises(TerminalDeliveryError, match="payload is not UTF-8") as raised:
+        presenter._split_payload(b"secret\xffbody")
+
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+    assert "secret" not in repr(raised.value)
 
 
-@pytest.mark.parametrize(
-    ("terminal_app", "expected_error"),
-    [
-        ("Ghostty", "Ghostty could not find the registered TTY"),
-        ("Terminal", "Terminal could not find the registered TTY"),
-        ("iTerm2", "iTerm2 could not find the registered TTY"),
-    ],
-)
-def test_exact_session_fallback_reports_target_not_found(
-    monkeypatch,
-    terminal_app: str,
-    expected_error: str,
-) -> None:
-    monkeypatch.setattr(
-        presenter,
-        "_deliver_tiocsti",
-        lambda _tty, _payload: (_ for _ in ()).throw(PermissionError()),
-    )
-    monkeypatch.setattr(
-        presenter,
-        "_run_osascript",
-        lambda *_args, **_kwargs: SimpleNamespace(
-            returncode=0,
-            stdout="not found\n",
-            stderr="",
-        ),
-    )
-
-    with pytest.raises(TerminalDeliveryError, match=expected_error):
-        presenter.deliver_input(
-            Path("/dev/ttys003"),
-            b"secret payload\r",
-            terminal_app=terminal_app,
-        )
-
-
-def test_unexpected_fallback_oserror_is_redacted(monkeypatch) -> None:
-    monkeypatch.setattr(
-        presenter,
-        "_deliver_tiocsti",
-        lambda _tty, _payload: (_ for _ in ()).throw(PermissionError()),
-    )
-    monkeypatch.setattr(
-        presenter,
-        "_deliver_ghostty",
-        lambda _tty, _payload: (_ for _ in ()).throw(OSError("private fallback detail")),
-    )
-
-    with pytest.raises(TerminalDeliveryError, match="terminal input delivery failed") as exc:
-        presenter.deliver_input(
-            Path("/dev/ttys003"),
-            b"secret payload\r",
-            terminal_app="Ghostty",
-        )
-
-    assert "private fallback detail" not in str(exc.value)
-
-
-def test_partial_tiocsti_never_replays_payload_through_fallback(monkeypatch) -> None:
+def test_partial_tiocsti_failure_never_falls_back_or_redelivers(monkeypatch) -> None:
+    master_fd, slave_fd = pty.openpty()
+    target = Path(os.ttyname(slave_fd))
     injected: list[bytes] = []
-    fallbacks: list[bytes] = []
 
-    def inject(_fd: int, _request: int, value: bytes) -> None:
-        if injected:
-            raise PermissionError("kernel denied remaining bytes")
+    def partial(_fd, _request, value: bytes) -> None:
         injected.append(value)
+        if len(injected) == 2:
+            raise PermissionError("kernel stopped TIOCSTI")
 
-    monkeypatch.setattr(presenter.fcntl, "ioctl", inject)
-    monkeypatch.setattr(
-        presenter,
-        "_deliver_ghostty",
-        lambda _tty, payload: fallbacks.append(payload),
-    )
+    monkeypatch.setattr(presenter.fcntl, "ioctl", partial)
+    try:
+        with pytest.raises(OSError, match="partial input delivery"):
+            presenter._deliver_tiocsti(target, b"hello\r")
 
-    with pytest.raises(TerminalDeliveryError, match="partial"):
-        presenter.deliver_input(Path("/dev/null"), b"abc", terminal_app="Ghostty")
-
-    assert injected == [b"a"]
-    assert fallbacks == []
+        assert injected == [b"h", b"e"]
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
 
 
-def test_missing_platform_fallback_has_actionable_error(monkeypatch) -> None:
+def test_exact_session_failure_never_falls_back_to_tiocsti(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fail_exact(_tty: Path, _payload: bytes) -> None:
+        calls.append("ghostty")
+        raise OSError("ambiguous exact-session failure")
+
+    monkeypatch.setattr(presenter, "_deliver_ghostty", fail_exact)
     monkeypatch.setattr(
         presenter,
         "_deliver_tiocsti",
-        lambda _tty, _payload: (_ for _ in ()).throw(PermissionError()),
+        lambda _tty, _payload: calls.append("tiocsti"),
     )
 
-    with pytest.raises(TerminalDeliveryError, match="no exact-session fallback"):
-        presenter.deliver_input(Path("/dev/pts/7"), b"hello\r", terminal_app="")
+    with pytest.raises(OSError, match="terminal input delivery failed"):
+        presenter.deliver_input(Path("/dev/ttys003"), b"body\r", terminal_app="Ghostty")
+
+    assert calls == ["ghostty"]
+
+
+def test_tmux_transport_resolves_exact_pane_and_keeps_body_out_of_argv(monkeypatch) -> None:
+    calls: list[tuple[list[str], bytes | None]] = []
+
+    def deny(_tty: Path, _payload: bytes) -> None:
+        raise PermissionError("hardened kernel")
+
+    def run(args, **kwargs):
+        calls.append((args, kwargs.get("input")))
+        stdout = b"%1\t/dev/pts/8\n%2\t/dev/pts/7\n" if "list-panes" in args else b""
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr=b"")
+
+    monkeypatch.setattr(presenter, "_deliver_tiocsti", deny)
+    monkeypatch.setattr(presenter.subprocess, "run", run)
+
+    transport = presenter.deliver_input(
+        Path("/dev/pts/7"),
+        "linux secrét\r".encode(),
+        terminal_app="tmux",
+    )
+
+    assert transport == "tmux"
+    assert calls[0][0] == ["tmux", "list-panes", "-a", "-F", "#{pane_id}\t#{pane_tty}"]
+    assert calls[1][1] == "linux secrét".encode()
+    assert all("linux secrét" not in repr(args) for args, _body in calls)
+    paste_args = next(args for args, _body in calls if "paste-buffer" in args)
+    enter_args = next(args for args, _body in calls if "send-keys" in args)
+    assert paste_args[-2:] == ["-t", "%2"]
+    assert enter_args[-2:] == ["%2", "Enter"]
+
+
+def test_tmux_cleanup_failure_does_not_mask_primary_delivery_error(monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def run(*args: str, input_bytes: bytes | None = None):
+        calls.append(args)
+        if "list-panes" in args:
+            return SimpleNamespace(returncode=0, stdout=b"%2\t/dev/pts/7\n", stderr=b"")
+        if "paste-buffer" in args:
+            return SimpleNamespace(returncode=1, stdout=b"", stderr=b"")
+        if "delete-buffer" in args:
+            raise OSError("cleanup failed")
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(presenter, "_run_tmux", run)
+
+    with pytest.raises(OSError, match="could not deliver terminal input"):
+        presenter._deliver_tmux(Path("/dev/pts/7"), b"body")
+
+    assert any("delete-buffer" in args for args in calls)
+
+
+def test_linux_capability_requires_tmux_or_explicit_kernel_opt_in(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    policy = tmp_path / "legacy_tiocsti"
+    monkeypatch.setattr(presenter, "_LINUX_TIOCSTI_POLICY", policy)
+    monkeypatch.setattr(presenter.termios, "TIOCSTI", 0x5412, raising=False)
+
+    policy.write_text("0\n", encoding="ascii")
+    assert not presenter.exact_tty_transport_supported(Path("/dev/pts/7"), "")
+    assert presenter.exact_tty_transport_supported(Path("/dev/pts/7"), "tmux")
+
+    policy.write_text("1\n", encoding="ascii")
+    assert presenter.exact_tty_transport_supported(Path("/dev/pts/7"), "")
+    assert not presenter.exact_tty_transport_supported(Path("/dev/ttys007"), "")
+    assert not presenter.exact_tty_transport_supported(Path("/dev/ttys007"), "Terminal")
+    assert presenter.exact_tty_transport_supported(Path("/dev/ttys007"), "Ghostty")
+    assert presenter.exact_tty_transport_supported(Path("/dev/ttys007"), "iTerm2")
+
+
+def test_hardened_linux_without_exact_transport_is_rejected_explicitly(monkeypatch) -> None:
+    monkeypatch.setattr(
+        presenter,
+        "_deliver_tiocsti",
+        lambda _tty, _payload: (_ for _ in ()).throw(PermissionError("denied")),
+    )
+
+    with pytest.raises(OSError, match="no safe exact-TTY Linux input transport") as raised:
+        presenter.deliver_input(Path("/dev/pts/7"), b"do not deliver\r", terminal_app="")
+
+    assert raised.value.errno is not None


### PR DESCRIPTION
## Root cause\n\nLegacy terminal delivery validated a PID/start identity and foreground state before injecting into a TTY, but none of the available transports atomically bound that input operation to the validated receiver process. TTY reuse, foreground changes, global-focus automation, and cross-process races could therefore redirect prompt input after validation.\n\n## Production boundary\n\n- Remove CLI register/send/enter; keep list/history diagnostics.\n- Register only memo_terminal_list on every MCP profile.\n- Disable shim auto-registration and clear stale inherited terminal IDs.\n- Make the production bridge capability probe fail closed until a receiver-bound API exists.\n- Remove Terminal.app delivery; constrain Ghostty/iTerm/tmux/Linux presenter paths for internal testable code.\n- Harden validation, UTF-8/control sanitization, process birth identity, per-TTY interprocess locking, SQLite migrations, sender liveness, body-free errors, and crash recovery.\n- Preserve idempotency with bounded durable receipt tombstones; capacity exhaustion refuses new delivery.\n- Mark the legacy implementation experimental/superseded and update exact surface counts.\n\n## Verification\n\n- 6535 passed, 19 skipped with warnings promoted to errors; coverage 78.68%.\n- 587 focused terminal/MCP/shim/surface tests passed.\n- Ruff check and format check passed.\n- Mypy passed on 488 files.\n- Quality budgets passed: complexity 169, exception 174.\n- Recall gate passed: 301 searches, precision@k 0.708 >= 0.697, noise 0.\n- SVG validation and staged/unstaged diff checks passed.\n- Two independent final reviews: 0 findings.\n\nNo public terminal input mutator remains. Re-enabling delivery requires a separate receiver-bound design and review.