### PR TITLE
fix: accept retired terminal shim state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ### Fixed
 
+- `memo config validate` accepts the retired live-terminal shim variables in
+  agent processes that were already running when the fail-closed upgrade was
+  installed; fresh shims still remove those variables.
 - Live terminal input now fails closed: the CLI and MCP `send`/`enter`
   mutators and automatic shim registration are disabled, and legacy terminal
   registrations are non-deliverable. Read-only diagnostics remain available

--- a/src/memo/flags.py
+++ b/src/memo/flags.py
@@ -282,6 +282,11 @@ def unknown_memo_vars(env: dict[str, str] | None = None) -> list[str]:
         "MEMO_AGENT_TTY",
         "MEMO_CODEX_BADGE_SHOWN",
         "MEMO_STARTUP_BANNER_SHOWN",
+        # Legacy live-terminal shims exported these into already-running agent
+        # sessions.  New shims remove them, but config validation must remain
+        # compatible for the lifetime of a process started before the upgrade.
+        "MEMO_TERMINAL_ID",
+        "MEMO_TERMINAL_REGISTRATION_ATTEMPTED",
         # User-facing banner toggle consumed by the bash shell shim
         # (runtime/shims.py). Env-only: the shim can't see the markdown-config
         # chain, so registering it as a flag would diverge silently.

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -187,6 +187,8 @@ def test_internal_shim_state_vars_not_flagged_unknown() -> None:
         "MEMO_STARTUP_BANNER_SHOWN": "1",
         "MEMO_CODEX_BADGE_SHOWN": "1",
         "MEMO_AGENT_TTY": "/dev/ttys001",
+        "MEMO_TERMINAL_ID": "term-deadbeefdeadbeef",
+        "MEMO_TERMINAL_REGISTRATION_ATTEMPTED": "1",
     }
     assert flags.unknown_memo_vars(env=env) == []
     assert flags.validate(env=env) == []


### PR DESCRIPTION
## Summary
- treat the removed live-terminal shim state variables as owned runtime variables during config validation
- keep fresh shims fail-closed and unsetting both variables
- add a regression for in-place upgrades of already-running agent sessions

## Verification
- 29 tests in tests/test_flags.py pass
- ruff passes
- mypy passes
- end-user memo config validate succeeds with both inherited legacy variables set

Supersedes the transient validation warning discovered after installing #176 from its exact merge SHA.