### PR TITLE
test: remove terminal last-seen clock race

### DIFF
--- a/tests/test_terminal_live.py
+++ b/tests/test_terminal_live.py
@@ -98,10 +98,18 @@ def registered_bridge(tmp_cfg):
         os.close(master_fd)
 
 
-def test_register_persists_same_uid_tty_and_prunes_stale_process(tmp_cfg) -> None:
+def test_register_persists_same_uid_tty_and_prunes_stale_process(tmp_cfg, monkeypatch) -> None:
     master_fd, slave_fd = pty.openpty()
     tty = Path(os.ttyname(slave_fd))
     alive = True
+    timestamps = iter(
+        [
+            "2026-08-01T12:00:00+00:00",
+            "2026-08-01T12:00:01+00:00",
+            "2026-08-01T12:00:02+00:00",
+        ]
+    )
+    monkeypatch.setattr(terminal_live, "_now", lambda: next(timestamps))
 
     def probe(pid: int) -> ProcessSnapshot | None:
         if not alive:
@@ -131,9 +139,14 @@ def test_register_persists_same_uid_tty_and_prunes_stale_process(tmp_cfg) -> Non
             project="/tmp/memo",
         )
 
-        assert bridge.list() == [registration]
-        assert registration.tty == str(tty)
-        assert registration.agent == "codex"
+        listed = bridge.list()
+        assert len(listed) == 1
+        assert listed[0].id == registration.id
+        assert listed[0].created_at == registration.created_at
+        assert listed[0].last_seen_at == "2026-08-01T12:00:01+00:00"
+        assert listed[0].last_seen_at > registration.last_seen_at
+        assert listed[0].tty == registration.tty == str(tty)
+        assert listed[0].agent == registration.agent == "codex"
 
         alive = False
         assert bridge.list() == []


### PR DESCRIPTION
## Summary

- make the terminal registration persistence test deterministically cross a one-second boundary
- compare stable registration identity separately from the intentionally refreshed `last_seen_at`
- assert that liveness refresh advances the timestamp while stale-process pruning still works

## Root cause

Push CI on master `a041bce821d1f0748768e46ef3fa3d8a25b70ddb` failed once in Python 3.13 because `TerminalBridge.list()` correctly refreshed `last_seen_at` from `11:56:34Z` to `11:56:35Z`, while the test compared the entire dataclass. Runs that stayed within one second passed by accident.

Failed run: https://github.com/jagoff/memo/actions/runs/30746519921

## Verification

- full non-slow local suite with warnings-as-errors: 6535 passed, 19 skipped
- `tests/test_terminal_live.py`: 50 passed
- focused regression: 25 repeated passes with a forced 1-second rollover
- ruff format/check and git diff check pass
- pre-push recall gate: 301/301, precision@k 0.708, noise@k 0.000
- independent review: no findings