### PR TITLE
feat(dream): learning-loop — measurable, incremental, explainable, reversible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -323,6 +323,7 @@ ignore = [
 ]
 "tests/**" = [
     "S105",  # hardcoded "password"-looking test fixtures (fake tokens)
+    "S106",  # "password"-looking keyword args (e.g. pass_name=) in fixtures
     "S108",  # hardcoded /tmp paths in fixtures (never real temp-file handling)
     "S110",  # try/except/pass in test cleanup
     "SIM117",  # nested `with patch(...)` reads cleaner than one combined with

--- a/src/memo/cli_dream.py
+++ b/src/memo/cli_dream.py
@@ -55,6 +55,12 @@ from memo.cli_dream_passes import (
     _run_validity_extract,
 )
 from memo.config import Config
+from memo.dream_phases import (
+    CHECKPOINT_NAME,
+    DreamCheckpoint,
+    PhaseRecorder,
+    summarize_phases,
+)
 from memo.dream_utils import (
     _corpus_fingerprint,
     _iso_now,
@@ -271,6 +277,12 @@ def dream_cmd() -> None:
     is_flag=True,
     help="Run every pass even if the corpus is unchanged (disable the convergence guard).",
 )
+@click.option(
+    "--resume",
+    is_flag=True,
+    help="Resume an interrupted run: skip phases already committed this cycle "
+    "(no repeated LLM calls / mutations). Restored from the phase checkpoint.",
+)
 def dream_run(
     dry_run: bool,
     as_json: bool,
@@ -285,6 +297,7 @@ def dream_run(
     skip_prewarm: bool,
     skip_presynthesis: bool,
     force: bool,
+    resume: bool,
 ) -> None:
     """Run the full dream pipeline once.
 
@@ -293,8 +306,11 @@ def dream_run(
       memo dream run
     """
     cfg = Config.from_env()
-    tag = "[dim](dry-run)[/dim] " if dry_run else ""
-    console.print(f"{tag}[bold cyan]memo dream[/bold cyan] — starting pipeline...")
+    # Keep --json output pure: the human banner would otherwise land on stdout
+    # ahead of the JSON receipt and break `memo dream run --json | jq`.
+    if not as_json:
+        tag = "[dim](dry-run)[/dim] " if dry_run else ""
+        console.print(f"{tag}[bold cyan]memo dream[/bold cyan] — starting pipeline...")
 
     # Single-owner lock: a second `dream run` (manual, or the com.memo.dream
     # LaunchAgent firing while one is already in flight) would otherwise race on
@@ -315,7 +331,7 @@ def dream_run(
     _prev_fp = read_previous_fingerprint(cfg)
 
     from memo.dream_flags import CODE_DRIFT_FLAG  # import registers the flag spec
-    from memo.flags import flag_bool, flag_int
+    from memo.flags import flag_bool, flag_float, flag_int
 
     _evict_max = flag_int("MEMO_DREAM_EVICT_MAX_COUNT") or 0
     _compress_threshold = flag_int("MEMO_DREAM_COMPRESS_THRESHOLD") or 0
@@ -381,6 +397,8 @@ def dream_run(
     # the last good night and `memo dream status`/doctor report healthy while
     # the 03:00 pipeline is silently dead.
     mem: Any = None
+    _checkpoint: DreamCheckpoint | None = None
+    _pipeline_completed = False
     _pipeline_stack = ExitStack()
     try:
         _pipeline_stack.enter_context(derived_save_scope())
@@ -391,18 +409,81 @@ def dream_run(
         mem = _get_memory(cfg)
         progress.update(step, description="[green]memory loaded ✓[/green]")
 
+        # Fase 1 — per-phase instrumentation + resumable checkpoint. The run
+        # fingerprint is the PREVIOUS completed run's corpus fp: stable across a
+        # crash+restart (a crashed run never rewrites last.json) yet naturally
+        # invalidated once a full run stamps a new corpus_fp. dry-run stays
+        # ephemeral — no checkpoint, no resume.
+        _checkpoint = (
+            None
+            if dry_run
+            else DreamCheckpoint(_state_path(cfg) / CHECKPOINT_NAME, _prev_fp or "cold")
+        )
+        rec = PhaseRecorder(
+            receipt, mem=mem, checkpoint=_checkpoint, resume=resume and not dry_run
+        )
+
+        # Fase 7 — dream conflict-staging. Inside a run with
+        # MEMO_DREAM_STAGING_ENABLED a write-conflict on a dream-minted memory
+        # (e.g. synthesis) parks the candidate in staging instead of losing it;
+        # resume re-applies any parked proposal whose blocking conflict a human
+        # has since resolved (never resolves a conflict itself). Scope-gated so
+        # interactive `memo synthesize` saves are unaffected.
+        if flag_bool("MEMO_DREAM_STAGING_ENABLED") and not dry_run:
+            from memo import dream_staging
+
+            _pipeline_stack.enter_context(dream_staging.dream_staging_scope())
+            try:
+                receipt["staging_resume"] = dream_staging.resume_staged_proposals(cfg, mem)
+            except Exception as exc:
+                receipt["errors"].append(f"staging_resume: {type(exc).__name__}: {exc}")
+
+        # Fase 5 — per-pass incremental skip. When on, a content-derived pass
+        # whose durable-content dependency is unchanged since its last successful
+        # run is skipped (finer than the whole-pipeline convergence guard). Gated
+        # default-off; a skip is recorded in the receipt and is self-healing.
+        from memo import dream_incremental
+
+        _incremental = flag_bool("MEMO_DREAM_INCREMENTAL_ENABLED") and not dry_run
+
         # Orientation — read-only inventory before mutations -----------------
         if not skip_orientation:
-            _run_orientation_phase(mem, receipt, progress, step)
+            rec.timed(
+                "orientation",
+                lambda: _run_orientation_phase(mem, receipt, progress, step),
+                fragment_key="orientation",
+            )
+
+        # Fase 6 — derived-index health check. Gated default-off: when on, scans
+        # for divergence (NULL FTS bodies, orphan vectors/chunks, wrong dims,
+        # MD↔index drift, duplicate HyPE attempts) and repairs ONLY derived
+        # orphans — never a canonical .md. Best-effort, runs before mutations.
+        if flag_bool("MEMO_DREAM_INDEX_REPAIR_ENABLED") and not dry_run:
+            try:
+                from memo.store.index_health import check_index_health
+
+                receipt["index_health"] = check_index_health(cfg, mem, repair=True)
+                _ih_errs = receipt["index_health"].get("errors") or []
+                if _ih_errs:
+                    receipt["errors"].append(
+                        f"index_health: {len(_ih_errs)} sub-check error(s)"
+                    )
+            except Exception as exc:
+                receipt["errors"].append(f"index_health: {type(exc).__name__}: {exc}")
 
         # Phase 0 — Signal gather: mine new transcripts since last dream run --
-        _run_signal_gather_phase(
-            cfg,
-            enabled=not skip_signal_gather and not dry_run,
-            receipt=receipt,
-            progress=progress,
-            overall=overall,
-            step=step,
+        rec.timed(
+            "signal_gather",
+            lambda: _run_signal_gather_phase(
+                cfg,
+                enabled=not skip_signal_gather and not dry_run,
+                receipt=receipt,
+                progress=progress,
+                overall=overall,
+                step=step,
+            ),
+            fragment_key="signal_gathered",
+            resumable=True,
         )
 
         # Convergence guard — if signal-gather added nothing and the corpus
@@ -476,6 +557,47 @@ def dream_run(
             except Exception as exc:
                 receipt["errors"].append(f"tuner: {type(exc).__name__}: {exc}")
                 progress.update(step, description="[tune] recall self-tuner [yellow]warn[/yellow]")
+
+        # Fase 4 — learning-metrics snapshot for the audit trail: the eleven
+        # measures (precision/noise before-after cohort, answerability, grounding
+        # coverage, later-usefulness, correction rate, synthesis acceptance,
+        # created→used, p50/p95 latency) assembled from existing logs. Gated by
+        # the ledger flag (it IS audit data), never re-runs the eval, best-effort.
+        if flag_bool("MEMO_DREAM_LEDGER_ENABLED") and not dry_run:
+            try:
+                from memo import dream_metrics
+                from memo.tuned_overlay import params_version
+
+                _tuner = receipt.get("tuner") or {}
+                receipt["learning_metrics"] = dream_metrics.learning_metrics(
+                    cfg,
+                    mem,
+                    params_version=params_version(cfg.state_dir),
+                    k=5 if (_lmk := flag_int("MEMO_DREAM_TUNE_K")) is None else _lmk,
+                    before=_tuner.get("before"),
+                    after=_tuner.get("after"),
+                )
+            except Exception as exc:
+                receipt["errors"].append(f"learning_metrics: {type(exc).__name__}: {exc}")
+
+        # Fase 8 — shadow mode: measure-only evidence for opt-in phases without
+        # mutating production. Reverts any overlay a shadow-reclassified flag was
+        # auto-graduated into and snapshots the per-flag review rollup. Gated +
+        # best-effort; producers (record_recall_shadow / maybe_shadow) attach as
+        # flags are classified kind="shadow".
+        if flag_bool("MEMO_DREAM_SHADOW_ENABLED") and not dry_run:
+            try:
+                from memo import dream_shadow
+                from memo.dream_flags import GATES
+
+                receipt["shadow_review"] = {
+                    "reclassify_reverted": dream_shadow.migrate_reclassified_overlay(
+                        cfg.state_dir, GATES
+                    ),
+                    "review": dream_shadow.review_rows(cfg.state_dir, GATES),
+                }
+            except Exception as exc:
+                receipt["errors"].append(f"shadow: {type(exc).__name__}: {exc}")
 
         # Curated graph-signal tuner (graph-off plus bounded alpha candidates).
         # Runs after the general pass; both merge the overlay so they coexist.
@@ -826,14 +948,20 @@ def dream_run(
             try:
                 from memo import dream_hype
 
-                receipt["hype"] = dream_hype.run_hype_pass(
-                    cfg,
-                    mem,
-                    questions_per_memory=3
-                    if (_qpm := flag_int("MEMO_HYPE_QUESTIONS_PER_MEMORY")) is None
-                    else _qpm,
-                    night_cap=400 if (_nc := flag_int("MEMO_HYPE_NIGHT_CAP")) is None else _nc,
-                    dry_run=dry_run,
+                receipt["hype"] = rec.timed(
+                    "hype",
+                    lambda: dream_hype.run_hype_pass(
+                        cfg,
+                        mem,
+                        questions_per_memory=3
+                        if (_qpm := flag_int("MEMO_HYPE_QUESTIONS_PER_MEMORY")) is None
+                        else _qpm,
+                        night_cap=400 if (_nc := flag_int("MEMO_HYPE_NIGHT_CAP")) is None else _nc,
+                        budget_s=flag_float("MEMO_DREAM_HYPE_BUDGET_S") or None,
+                        dry_run=dry_run,
+                    ),
+                    fragment_key="hype",
+                    resumable=True,
                 )
                 if receipt["hype"].get("status") == "error":
                     receipt["errors"].append(f"hype: {receipt['hype'].get('error')}")
@@ -1088,7 +1216,11 @@ def dream_run(
             # 1. Contradictions ----------------------------------------------
             progress.update(step, description="[1/6] contradictions — scanning corpus...")
             try:
-                res = _run_contradict(mem, dry_run=dry_run)
+                res = rec.timed(
+                    "contradict",
+                    lambda: _run_contradict(mem, dry_run=dry_run),
+                    resumable=True,
+                )
                 if "error" in res:
                     receipt["errors"].append(f"contradict: {res['error']}")
                 receipt["superseded"] = res.get("superseded", [])
@@ -1123,7 +1255,11 @@ def dream_run(
                 completed=0,
             )
             try:
-                res = _run_consolidate_dups(mem, dry_run=dry_run)
+                res = rec.timed(
+                    "consolidate_dups",
+                    lambda: _run_consolidate_dups(mem, dry_run=dry_run),
+                    resumable=True,
+                )
                 if "error" in res:
                     receipt["errors"].append(f"consolidate: {res['error']}")
                 receipt["merged"] = res.get("merged", [])
@@ -1143,7 +1279,11 @@ def dream_run(
                 step, description="[3/6] stale memories — detecting...", total=None, completed=0
             )
             try:
-                res = _run_stale(mem, dry_run=dry_run)
+                res = rec.timed(
+                    "stale",
+                    lambda: _run_stale(mem, dry_run=dry_run),
+                    resumable=True,
+                )
                 if "error" in res:
                     receipt["errors"].append(f"stale: {res['error']}")
                 for _ae in res.get("errors", []):
@@ -1168,7 +1308,18 @@ def dream_run(
                 completed=0,
             )
             try:
-                res = _run_synthesis(mem, dry_run=dry_run)
+                res = rec.timed(
+                    "synthesis",
+                    lambda: dream_incremental.run_or_skip(
+                        cfg.state_dir,
+                        "synthesis",
+                        dream_incremental.durable_content_fingerprint(mem),
+                        lambda: _run_synthesis(mem, dry_run=dry_run),
+                    )
+                    if _incremental
+                    else _run_synthesis(mem, dry_run=dry_run),
+                    resumable=True,
+                )
                 if "error" in res:
                     receipt["errors"].append(f"synthesize: {res['error']}")
                 receipt["synthesized"] = res.get("synthesized", [])
@@ -1194,7 +1345,18 @@ def dream_run(
                 completed=0,
             )
             try:
-                res = _run_entities(mem, dry_run=dry_run)
+                res = rec.timed(
+                    "entities",
+                    lambda: dream_incremental.run_or_skip(
+                        cfg.state_dir,
+                        "entities",
+                        dream_incremental.durable_content_fingerprint(mem),
+                        lambda: _run_entities(mem, dry_run=dry_run),
+                    )
+                    if _incremental
+                    else _run_entities(mem, dry_run=dry_run),
+                    resumable=True,
+                )
                 if "error" in res:
                     receipt["errors"].append(f"entities: {res['error']}")
                 receipt["entities_extracted"] = res.get("extracted", 0)
@@ -1220,7 +1382,11 @@ def dream_run(
             # pipeline handler and abort every remaining pass (roi/prune/evict/
             # compress/prewarm). Isolate it here like every sibling pass does.
             try:
-                graph_projection = _run_graph_projection(mem, dry_run=dry_run)
+                graph_projection = rec.timed(
+                    "graph_projection",
+                    lambda: _run_graph_projection(mem, dry_run=dry_run),
+                    fragment_key="graph_projection",
+                )
                 receipt["graph_projection"] = graph_projection
                 if graph_projection.get("status") == "error":
                     receipt["errors"].append(f"graph_projection: {graph_projection.get('error')}")
@@ -1242,7 +1408,11 @@ def dream_run(
             # Same isolation rationale as graph projection above: an unexpected
             # error class must not escape and abort every remaining pass.
             try:
-                code_drift = _run_code_drift(mem, dry_run=dry_run)
+                code_drift = rec.timed(
+                    "code_drift",
+                    lambda: _run_code_drift(mem, dry_run=dry_run),
+                    fragment_key="code_drift",
+                )
                 receipt["code_drift"] = code_drift
                 if "error" in code_drift:
                     receipt["errors"].append(f"code_drift: {code_drift['error']}")
@@ -1269,7 +1439,11 @@ def dream_run(
                 completed=0,
             )
             try:
-                res = _run_roi_reconcile(mem, dry_run=dry_run)
+                res = rec.timed(
+                    "roi_reconcile",
+                    lambda: _run_roi_reconcile(mem, dry_run=dry_run),
+                    resumable=True,
+                )
                 if "error" in res:
                     receipt["errors"].append(f"roi_reconcile: {res['error']}")
                 receipt["roi_reconciled"] = res.get("reconciled", 0)
@@ -1296,7 +1470,10 @@ def dream_run(
                 step, description="[7/7] ROI decay — adjusting scores...", total=None, completed=0
             )
             try:
-                res = _run_roi_decay(mem, dry_run=dry_run)
+                res = rec.timed(
+                    "roi_decay",
+                    lambda: _run_roi_decay(mem, dry_run=dry_run),
+                )
                 if "error" in res:
                     receipt["errors"].append(f"roi_decay: {res['error']}")
                 receipt["roi_decayed"] = res.get("decayed", 0)
@@ -1326,12 +1503,15 @@ def dream_run(
 
                 roi_floor = flag_float("MEMO_DREAM_PRUNE_FLOOR") or 0.15
                 min_age = 90 if (_ma := flag_int("MEMO_DREAM_PRUNE_MIN_AGE_DAYS")) is None else _ma
-                pruned = _run_prune_floor(
-                    mem,
-                    roi_floor=roi_floor,
-                    min_age_days=min_age,
-                    dry_run=False,
-                    errors=receipt["errors"],
+                pruned = rec.timed(
+                    "prune_floor",
+                    lambda: _run_prune_floor(
+                        mem,
+                        roi_floor=roi_floor,
+                        min_age_days=min_age,
+                        dry_run=False,
+                        errors=receipt["errors"],
+                    ),
                 )
                 receipt["pruned_floor"] = pruned
                 progress.update(
@@ -1354,8 +1534,11 @@ def dream_run(
                 completed=0,
             )
             try:
-                evicted = _run_eviction(
-                    mem, max_count=_evict_max, dry_run=dry_run, errors=receipt["errors"]
+                evicted = rec.timed(
+                    "eviction",
+                    lambda: _run_eviction(
+                        mem, max_count=_evict_max, dry_run=dry_run, errors=receipt["errors"]
+                    ),
                 )
                 receipt["evicted"] = evicted
                 progress.update(
@@ -1378,7 +1561,10 @@ def dream_run(
                 completed=0,
             )
             try:
-                compressed = _run_compress(mem, threshold=_compress_threshold, dry_run=False)
+                compressed = rec.timed(
+                    "compress",
+                    lambda: _run_compress(mem, threshold=_compress_threshold, dry_run=False),
+                )
                 receipt["compressed"] = compressed
                 progress.update(
                     step,
@@ -1400,7 +1586,11 @@ def dream_run(
                 completed=0,
             )
             try:
-                pw = _run_prewarm_queries(cfg, mem, n=_prewarm_n)
+                pw = rec.timed(
+                    "prewarm",
+                    lambda: _run_prewarm_queries(cfg, mem, n=_prewarm_n),
+                    fragment_key="prewarm",
+                )
                 receipt["prewarm"] = pw
                 progress.update(
                     step,
@@ -1422,7 +1612,11 @@ def dream_run(
                 completed=0,
             )
             try:
-                ps = _run_presynthesis(cfg, mem, top_n=_presynthesis_n, dry_run=dry_run)
+                ps = rec.timed(
+                    "presynthesis",
+                    lambda: _run_presynthesis(cfg, mem, top_n=_presynthesis_n, dry_run=dry_run),
+                    resumable=True,
+                )
                 receipt["presynthesis"] = ps
                 progress.update(
                     step,
@@ -1439,7 +1633,11 @@ def dream_run(
         if flag_bool("MEMO_DREAM_EVAL_ENABLED") and not dry_run:
             progress.update(step, description="[12] harvest labels — mining grounding.log...")
             try:
-                receipt["harvest_labels"] = _run_harvest_labels(cfg)
+                receipt["harvest_labels"] = rec.timed(
+                    "harvest_labels",
+                    lambda: _run_harvest_labels(cfg),
+                    fragment_key="harvest_labels",
+                )
                 _hl = receipt["harvest_labels"]
                 progress.update(
                     step,
@@ -1454,12 +1652,16 @@ def dream_run(
 
             progress.update(step, description="[13] eval recall — retrieval-only eval...")
             try:
-                receipt["eval_recall"] = _run_eval_recall(
-                    cfg,
-                    mem,
-                    max_labels=200
-                    if (_ml := flag_int("MEMO_DREAM_EVAL_MAX_LABELS")) is None
-                    else _ml,
+                receipt["eval_recall"] = rec.timed(
+                    "eval_recall",
+                    lambda: _run_eval_recall(
+                        cfg,
+                        mem,
+                        max_labels=200
+                        if (_ml := flag_int("MEMO_DREAM_EVAL_MAX_LABELS")) is None
+                        else _ml,
+                    ),
+                    fragment_key="eval_recall",
                 )
                 _ev = receipt["eval_recall"]
                 progress.update(
@@ -1476,7 +1678,11 @@ def dream_run(
 
             progress.update(step, description="[14] capture weights — citation-type feedback...")
             try:
-                receipt["capture_weights"] = _run_capture_weights(cfg, mem)
+                receipt["capture_weights"] = rec.timed(
+                    "capture_weights",
+                    lambda: _run_capture_weights(cfg, mem),
+                    fragment_key="capture_weights",
+                )
                 _cw = receipt["capture_weights"]
                 _cw_top = f" · top {_cw['top']}" if _cw.get("top") else ""
                 progress.update(
@@ -1493,17 +1699,52 @@ def dream_run(
 
         # Mark step task complete so spinner stops
         progress.update(step, total=1, completed=1)
+        _pipeline_completed = True
     except Exception as exc:
         # A crash before/around the per-pass guards must not vanish silently:
         # record it and fall through to the receipt write so the failed night
-        # is visible to `memo dream status`/doctor.
+        # is visible to `memo dream status`/doctor. The phase checkpoint is
+        # deliberately NOT cleared here so a `--resume` run can skip the phases
+        # that already committed before the crash.
         receipt["errors"].append(f"pipeline: {type(exc).__name__}: {exc}")
         _log.exception("dream pipeline crashed before completion")
     finally:
         _pipeline_stack.close()
 
+    # Fase 3 — auditable learning ledger: judge prior nights' reversible archives
+    # (close-the-loop) then record tonight's mutations with provenance + rollback
+    # handles. Gated default-off; best-effort so a ledger failure never affects
+    # the receipt or the night. Runs after the finally so it captures whatever
+    # mutations landed even if the pipeline crashed mid-way.
+    if flag_bool("MEMO_DREAM_LEDGER_ENABLED"):
+        try:
+            from memo import dream_ledger
+
+            _resolved = (
+                dream_ledger.resolve_open_actions(
+                    cfg.state_dir, lambda mid: mem.store.get(mid) is not None
+                )
+                if not dry_run
+                else {}
+            )
+            _recorded = dream_ledger.record_from_receipt(cfg.state_dir, receipt, dry_run=dry_run)
+            receipt["ledger"] = {
+                "recorded": _recorded,
+                "resolved": _resolved,
+                "summary": dream_ledger.summarize(cfg.state_dir),
+            }
+        except Exception as exc:
+            receipt["errors"].append(f"ledger: {type(exc).__name__}: {exc}")
+
+    # Fase 1 — roll per-phase records into a compact summary for status/JSON.
+    receipt["phases_summary"] = summarize_phases(receipt)
+
     # Persist receipt + timestamp --------------------------------------------
     if not dry_run:
+        # A fully-completed run has nothing to resume: drop the checkpoint so the
+        # next night starts clean. An interrupted run keeps it for `--resume`.
+        if _pipeline_completed and _checkpoint is not None:
+            _checkpoint.clear()
         try:
             d = _state_path(cfg)
             d.mkdir(parents=True, exist_ok=True)
@@ -1633,6 +1874,162 @@ def dream_status() -> None:
     if data.get("errors"):
         for e in data["errors"]:
             console.print(f"  [yellow]warn:[/yellow] {e}")
+
+
+@dream_cmd.command(name="ledger")
+@click.option("--limit", type=int, default=30, help="Most recent ledger entries to show.")
+@click.option("--open", "open_only", is_flag=True, help="Show only still-open actions (no outcome yet).")
+@click.option("--json", "as_json", is_flag=True, help="Emit the ledger entries/summary as raw JSON.")
+def dream_ledger_cmd(limit: int, open_only: bool, as_json: bool) -> None:
+    """Auditable learning ledger (Fase 3): the chain of dream mutations
+    (supersede/merge/archive) and their later reinforced/rollback outcomes.
+
+    Populated only when ``MEMO_DREAM_LEDGER_ENABLED`` is on for the nightly run.
+    """
+    from memo import dream_ledger
+
+    cfg = Config.from_env()
+    summary = dream_ledger.summarize(cfg.state_dir)
+    rows = (
+        dream_ledger.open_actions(cfg.state_dir, limit=limit)
+        if open_only
+        else dream_ledger.read_ledger(cfg.state_dir, limit=limit)
+    )
+    if as_json:
+        click.echo(json.dumps({"summary": summary, "entries": rows}, indent=2, ensure_ascii=False))
+        return
+    console.print(
+        f"[bold]dream ledger:[/bold] {summary['actions']} actions · {summary['outcomes']} outcomes "
+        f"· {summary['open']} open · {summary['rollback_candidates']} rollback-candidates"
+    )
+    if summary["by_action"]:
+        parts = ", ".join(f"{k}={v}" for k, v in sorted(summary["by_action"].items()))
+        console.print(f"  by action: {parts}")
+    if not rows:
+        console.print("  [dim](no entries — enable MEMO_DREAM_LEDGER_ENABLED for the nightly run)[/dim]")
+        return
+    for r in rows:
+        if r.get("kind") == "outcome":
+            console.print(
+                f"  [dim]{r.get('ts')}[/dim] outcome→{r.get('outcome')} "
+                f"({r.get('verdict')}) for {str(r.get('action_id'))[:8]}"
+            )
+        else:
+            aff = ",".join(str(a)[:8] for a in (r.get("affected_ids") or [])) or "-"
+            console.print(
+                f"  [dim]{r.get('ts')}[/dim] {r.get('action')} [{r.get('pass_name')}] "
+                f"→ {aff}  ({str(r.get('entry_id'))[:8]})"
+            )
+
+
+@dream_cmd.command(name="index-health")
+@click.option("--repair", is_flag=True, help="Delete derived orphans (never touches .md).")
+@click.option("--json", "as_json", is_flag=True, help="Emit the full report as JSON.")
+def dream_index_health_cmd(repair: bool, as_json: bool) -> None:
+    """Fase 6: derived-index health check — detect (and optionally repair)
+    divergence between the Markdown source of truth and the sqlite index.
+    Repair only ever removes derived orphans; canonical .md files are untouched.
+    """
+    from memo.store.index_health import check_index_health
+
+    cfg = Config.from_env()
+    mem = _get_memory(cfg)
+    res = check_index_health(cfg, mem, repair=repair)
+    if as_json:
+        click.echo(json.dumps(res, indent=2, ensure_ascii=False))
+        return
+    console.print(f"[bold]index health:[/bold] {res.get('status')}")
+    for name, v in (res.get("checks") or {}).items():
+        count = v.get("count", 0)
+        style = "green" if count == 0 else "yellow"
+        console.print(f"  {name}: [{style}]{count}[/{style}]")
+    if res.get("repaired"):
+        console.print(f"  [cyan]repaired:[/cyan] {res['repaired']}")
+    for e in res.get("errors") or []:
+        console.print(f"  [red]error:[/red] {e}")
+
+
+@dream_cmd.command(name="staging")
+@click.option("--resume", "do_resume", is_flag=True, help="Re-apply parked proposals whose conflicts are resolved.")
+@click.option("--drop", "drop_id", default=None, help="Drop a staged proposal by id.")
+@click.option("--json", "as_json", is_flag=True, help="Emit as raw JSON.")
+def dream_staging_cmd(do_resume: bool, drop_id: str | None, as_json: bool) -> None:
+    """Fase 7: dream conflict-staging — dream-minted memories parked by a write
+    conflict, awaiting human conflict resolution (MEMO_DREAM_STAGING_ENABLED).
+    """
+    from memo import dream_staging
+
+    cfg = Config.from_env()
+    if drop_id:
+        ok = dream_staging.drop_staged(cfg, drop_id)
+        click.echo(json.dumps({"dropped": ok}) if as_json else (f"dropped {drop_id}" if ok else "not found"))
+        return
+    if do_resume:
+        mem = _get_memory(cfg)
+        res = dream_staging.resume_staged_proposals(cfg, mem)
+        click.echo(json.dumps(res, indent=2) if as_json else f"resumed: {res}")
+        return
+    staged = dream_staging.list_staged(cfg)
+    if as_json:
+        click.echo(json.dumps([p.to_dict() for p in staged], indent=2, ensure_ascii=False))
+        return
+    if not staged:
+        console.print("[dim]no staged proposals (enable MEMO_DREAM_STAGING_ENABLED for the nightly run)[/dim]")
+        return
+    console.print(f"[bold]dream staging:[/bold] {len(staged)} parked proposal(s)")
+    for p in staged:
+        console.print(f"  [bold]{p.proposal_id}[/bold] ({p.kind}) attempts={p.attempts}")
+        console.print(f"    conflict: {p.conflict_summary or '-'}")
+        console.print(f"    resolve:  {dream_staging.resolve_command(p)}")
+
+
+@dream_cmd.command(name="shadow")
+@click.option("--status", "show_status", is_flag=True, help="Per shadow-flag review rollup (default view).")
+@click.option("--promote", "promote_flag", default=None, help="Promote a review-ready shadow flag.")
+@click.option("--reject", "reject_flag", default=None, help="Reject a shadowed flag (needs --reason).")
+@click.option("--reason", default="", help="Reason for --reject.")
+@click.option("--apply", "do_apply", is_flag=True, help="With --promote, persist the config change.")
+@click.option("--force-latency", is_flag=True, help="With --promote, override the latency ceiling.")
+@click.option("--json", "as_json", is_flag=True, help="Emit as raw JSON.")
+def dream_shadow_cmd(
+    show_status: bool,
+    promote_flag: str | None,
+    reject_flag: str | None,
+    reason: str,
+    do_apply: bool,
+    force_latency: bool,
+    as_json: bool,
+) -> None:
+    """Fase 8: shadow mode — measure-only evidence for opt-in phases without
+    mutating production; a human promotes a flag only after enough consecutive
+    clean nights (MEMO_DREAM_SHADOW_ENABLED).
+    """
+    from memo import dream_shadow
+    from memo.dream_flags import GATES
+
+    cfg = Config.from_env()
+    if reject_flag:
+        ok = dream_shadow.reject(cfg, reject_flag, reason or "manual")
+        click.echo(json.dumps({"rejected": ok}) if as_json else f"rejected {reject_flag}: {ok}")
+        return
+    if promote_flag:
+        res = dream_shadow.promote(cfg, promote_flag, force_latency=force_latency, apply=do_apply)
+        click.echo(json.dumps(res, indent=2, ensure_ascii=False) if as_json else str(res))
+        return
+    rows = dream_shadow.review_rows(cfg.state_dir, GATES)
+    if as_json:
+        click.echo(json.dumps(rows, indent=2, ensure_ascii=False))
+        return
+    if not rows:
+        console.print("[dim]no shadow-kind flags declared (classify a gate kind='shadow' to populate)[/dim]")
+        return
+    console.print(f"[bold]dream shadow:[/bold] {len(rows)} shadow flag(s)")
+    for r in rows:
+        ready = "[green]review-ready[/green]" if r["review_ready"] else "[dim]accruing[/dim]"
+        console.print(
+            f"  [bold]{r['flag']}[/bold] {ready}  streak {r['streak']}/{r['review_nights']} "
+            f"· meanΔ {r['mean_delta']} · cost_p50 {r['cost_p50']}ms · {r['last_verdict']}"
+        )
 
 
 @dream_cmd.command(name="timeline")
@@ -1775,7 +2172,7 @@ def dream_hype_cmd(dry_run: bool, reembed: bool, as_json: bool) -> None:
         raise click.UsageError("--dry-run cannot be combined with --reembed")
 
     from memo import dream_hype
-    from memo.flags import flag_int
+    from memo.flags import flag_float, flag_int
 
     cfg = Config.from_env()
     mem = _get_memory(cfg)
@@ -1796,6 +2193,7 @@ def dream_hype_cmd(dry_run: bool, reembed: bool, as_json: bool) -> None:
         if (_qpm := flag_int("MEMO_HYPE_QUESTIONS_PER_MEMORY")) is None
         else _qpm,
         night_cap=400 if (_nc := flag_int("MEMO_HYPE_NIGHT_CAP")) is None else _nc,
+        budget_s=flag_float("MEMO_DREAM_HYPE_BUDGET_S") or None,
         dry_run=dry_run,
     )
     if as_json:

--- a/src/memo/cli_dream_passes.py
+++ b/src/memo/cli_dream_passes.py
@@ -1532,6 +1532,17 @@ def _render_run_summary(receipt: dict[str, Any], dry_run: bool) -> None:
             f"  signal gather:             {sg['files_processed']} files, "
             f"{sg['memories_saved']} saved, {sg.get('skipped_dup', 0)} dup skipped"
         )
+    ps_summary = receipt.get("phases_summary")
+    if ps_summary and ps_summary.get("count"):
+        slow = ps_summary.get("slowest") or {}
+        slow_s = f", slowest {slow.get('phase')} {slow.get('duration_ms')}ms" if slow else ""
+        resumed = ps_summary.get("resumed") or 0
+        resumed_s = f", {resumed} resumed" if resumed else ""
+        console.print(
+            f"  phases:                    {ps_summary['count']} in "
+            f"{ps_summary.get('total_duration_ms', 0)}ms "
+            f"({ps_summary.get('mutations', 0)} mutations{slow_s}{resumed_s})"
+        )
     if receipt["errors"]:
         for e in receipt["errors"]:
             console.print(f"  [yellow]warn:[/yellow] {e}")

--- a/src/memo/dream_flags.py
+++ b/src/memo/dream_flags.py
@@ -49,7 +49,7 @@ _TRUTHY = ("1", "true", "yes", "on")
 # tuner; skipped when the OFF p50 rounds to 0 — stub/tiny corpora).
 FLAG_LATENCY_HEADROOM = 1.25
 
-GateKind = Literal["recall", "tuner", "manual"]
+GateKind = Literal["recall", "tuner", "manual", "shadow"]
 
 # Gates the nightly code-drift pass (`cli_dream_passes._run_code_drift`); the
 # canonical FlagSpec lives in flags_misc.py with the other dream pass flags.
@@ -77,6 +77,9 @@ class GateSpec:
     # Companion env pins required for the ON measurement (and written to the
     # overlay alongside the flag when it graduates).
     extra_flags: tuple[tuple[str, str], ...] = ()
+    # shadow-kind only: which comparable axis dream_shadow measures (e.g.
+    # "latency" / "precision"). Empty for non-shadow gates.
+    shadow_metric: str = ""
 
 
 def _g(
@@ -86,8 +89,11 @@ def _g(
     *,
     mode: str = "vec",
     extra_flags: tuple[tuple[str, str], ...] = (),
+    shadow_metric: str = "",
 ) -> tuple[str, GateSpec]:
-    return flag, GateSpec(flag, kind, reason, mode=mode, extra_flags=extra_flags)
+    return flag, GateSpec(
+        flag, kind, reason, mode=mode, extra_flags=extra_flags, shadow_metric=shadow_metric
+    )
 
 
 # The graduation contract: one entry per dark *_ENABLED flag. Completeness is
@@ -241,6 +247,38 @@ GATES: dict[str, GateSpec] = dict(
         _g("MEMO_DREAM_PROFILE_ENABLED", "manual", "meta: gates profile distillation"),
         _g("MEMO_DREAM_RETAG_GLOBAL_ENABLED", "manual", "meta: gates the retag pass"),
         _g("MEMO_DREAM_CHRONICLE_ENABLED", "manual", "meta: gates the chronicle diary pass"),
+        # --- learning-loop phases (Fase 3-8): observability / safety, human-gated
+        _g(
+            "MEMO_DREAM_LEDGER_ENABLED",
+            "manual",
+            "meta: append-only learning ledger; observability, no recall effect",
+        ),
+        _g(
+            "MEMO_DREAM_INCREMENTAL_ENABLED",
+            "manual",
+            "meta: incremental-maintenance skip; correctness-gated, not recall-measurable",
+        ),
+        _g(
+            "MEMO_DREAM_INDEX_REPAIR_ENABLED",
+            "manual",
+            "meta: derived-index auto-repair; safety decision, human flips",
+        ),
+        _g(
+            "MEMO_DREAM_STAGING_ENABLED",
+            "manual",
+            "meta: write-conflict staging quarantine; workflow decision, human flips",
+        ),
+        _g(
+            "MEMO_DREAM_SHADOW_ENABLED",
+            "manual",
+            "meta: shadow-measure opt-in phases without mutating; human reviews evidence",
+        ),
+        _g(
+            "MEMO_DREAM_TUNE_STRICT_GATE_ENABLED",
+            "manual",
+            "meta: enforce full six-condition tuner graduation_gate; verdict recorded "
+            "as shadow evidence while off, human flips after review",
+        ),
         # MEMO_DREAM_VALIDITY_EXTRACT_ENABLED / MEMO_DREAM_GRADUATION_ENABLED /
         # MEMO_DREAM_FLAG_GRADUATION_ENABLED graduated to default-ON in v4.3.0 —
         # no longer dark flags, so they carry no gate (test_no_graduated_or_stale_gates).
@@ -484,6 +522,14 @@ def run_flag_graduation_pass(
         res["measured"] = candidates
 
         if labels.prompts:
+            # Fase 8 — absolute latency ceiling (the backstop the RELATIVE
+            # headroom gate below cannot provide: when the OFF p50 rounds to 0 the
+            # ratio gate is skipped, so an ON p50 that balloons to seconds on the
+            # recall hook would otherwise graduate).
+            from memo.dream_shadow import latency_ceiling_gate
+
+            _ceil = flag_int("MEMO_FLAG_GRADUATION_LATENCY_CEILING_MS")
+            ceiling_ms = 1500.0 if _ceil is None else float(_ceil)
             curated = _curated_label_set(cfg.state_dir)
             for name in candidates:
                 gate = GATES[name]
@@ -495,6 +541,8 @@ def run_flag_graduation_pass(
                 budget = off.get("latency_ms_p50", 0.0) * FLAG_LATENCY_HEADROOM
                 if win and budget > 0 and on.get("latency_ms_p50", 0.0) > budget:
                     win, verdict["latency_rejected"] = False, True
+                if win and not latency_ceiling_gate(on.get("latency_ms_p50", 0.0), ceiling_ms):
+                    win, verdict["latency_ceiling_rejected"] = False, True
                 if win and curated is not None:
                     c_off = measure_flag(mem, curated, k=k, spec=gate, enabled=False, floor=floor)
                     c_on = measure_flag(mem, curated, k=k, spec=gate, enabled=True, floor=floor)

--- a/src/memo/dream_hype.py
+++ b/src/memo/dream_hype.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json as _json
 import sqlite3
+import time
 from typing import TYPE_CHECKING, Any
 
 from .tiers import DURABLE_TYPES
@@ -68,6 +69,28 @@ def _embed_question(mem: Any, question: str) -> list[float]:
     if flag_bool("MEMO_HYPE_EMBED_RAW"):
         return list(mem.embedder.embed([question])[0])
     return list(mem.embedder.embed_query(question))
+
+
+def _embed_questions(mem: Any, questions: list[str]) -> list[list[float]]:
+    """Batch-embed a memory's HyPE questions in the active variant — one
+    forward pass instead of one call per question.
+
+    Raw variant → document-side `embed(list)` (already batched). Query variant
+    → `embed_queries(list)` when the embedder supports it (keeps the asymmetric
+    prefix INSIDE the embedder — MLX invariant #1), falling back to per-question
+    `embed_query` for embedders without the batch method. `embed`/`embed_queries`
+    take a Sequence[str], never a bare str (MLX invariant #2).
+    """
+    from .flags import flag_bool
+
+    if not questions:
+        return []
+    if flag_bool("MEMO_HYPE_EMBED_RAW"):
+        return [list(v) for v in mem.embedder.embed(list(questions))]
+    batch = getattr(mem.embedder, "embed_queries", None)
+    if callable(batch):
+        return [list(v) for v in batch(list(questions))]
+    return [list(mem.embedder.embed_query(q)) for q in questions]
 
 
 def select_backlog(mem: Any, store: HypeStore, *, cap: int) -> list[dict[str, Any]]:
@@ -177,15 +200,24 @@ def run_hype_pass(
     *,
     questions_per_memory: int = 3,
     night_cap: int = 400,
+    budget_s: float | None = None,
     dry_run: bool = False,
 ) -> dict[str, Any]:
     """One nightly HyPE pass. Never raises — the cli_dream caller records a
     returned ``status="error"`` in ``receipt["errors"]``.
 
-    Per memory: `_llm_questions` → `embed_query` per question (str, one at a
-    time) → `store.replace_for_memory`. A single memory's failure doesn't
-    abort the pass (counted in `errors_items`). Prunes orphans against the
-    live durable id set at the end. `dry_run` only computes the backlog.
+    Per memory: read the input body (FTS → canonical Markdown fallback) →
+    `_llm_questions` → batch-embed the questions in one forward pass
+    (`_embed_questions`) → `store.replace_for_memory`. A single memory's failure
+    doesn't abort the pass (counted in `errors_items`). A memory with no
+    recoverable body is recorded as `missing_source` (not a false empty
+    success) and watermarked so it isn't retried until its body reappears.
+
+    `budget_s` caps wall-clock: when exceeded the loop stops and the untouched
+    tail is reflected in `backlog_remaining` (with `budget_hit=True`). Prunes
+    orphans against the live durable id set at the end. `dry_run` only computes
+    the backlog. The global `night_cap` is never raised — a large backlog is
+    drained incrementally across nights, not in one oversized run.
     """
     res: dict[str, Any] = {
         "status": "skipped",
@@ -193,8 +225,12 @@ def run_hype_pass(
         "memories": 0,
         "pruned": 0,
         "backlog_remaining": 0,
+        "processed": 0,
         "errors_items": 0,
         "empty_items": 0,
+        "missing_source_items": 0,
+        "body_fallback_items": 0,
+        "budget_hit": False,
         "error_samples": [],
     }
     store: HypeStore | None = None
@@ -218,10 +254,25 @@ def run_hype_pass(
             res["backlog_remaining"] = len(backlog)
             return res
 
+        variant = _active_variant()
+        deadline = (time.monotonic() + budget_s) if budget_s and budget_s > 0 else None
         for item in backlog:
+            if deadline is not None and time.monotonic() >= deadline:
+                res["budget_hit"] = True
+                break
+            res["processed"] += 1
             body, used_fallback = _memory_body(mem, item["id"])
+            # A memory with no recoverable body (FTS NULL and empty/absent
+            # canonical Markdown) yields a hollow prompt that the LLM answers
+            # with a spurious empty list. Record it as missing_source (never a
+            # success) and watermark it so it isn't retried until a real body
+            # reappears (body_hash changes) — separate from a genuine "no
+            # useful question" empty.
+            if not body.strip():
+                res["missing_source_items"] += 1
+                store.mark_attempt(item["id"], item["body_hash"], "missing_source")
+                continue
             if used_fallback:
-                res.setdefault("body_fallback_items", 0)
                 res["body_fallback_items"] += 1
             questions = _llm_questions(mem, item["title"], body, n=questions_per_memory)
             # `None` means the LLM timed out/returned malformed output. An
@@ -240,8 +291,7 @@ def run_hype_pass(
                 store.mark_attempt(item["id"], item["body_hash"], "empty")
                 continue
             try:
-                variant = _active_variant()
-                pairs = [(q, _embed_question(mem, q)) for q in questions]
+                pairs = list(zip(questions, _embed_questions(mem, questions), strict=True))
                 inserted = store.replace_for_memory(
                     item["id"],
                     item["body_hash"],
@@ -262,10 +312,12 @@ def run_hype_pass(
                     )
                 continue
 
-        # Honest remaining count: failed items (counted in errors_items) were
-        # never written to the store, so they're still pending — the cheap
-        # proxy is len(backlog) minus the ones that succeeded (res["memories"]).
-        res["backlog_remaining"] = res["errors_items"]
+        # Honest remaining count: failed items (errors_items) were never
+        # written, and any tail skipped by the wall-clock budget is untouched —
+        # both are still pending. (missing_source/empty items ARE watermarked,
+        # so they are NOT pending.)
+        unprocessed = len(backlog) - res["processed"]
+        res["backlog_remaining"] = res["errors_items"] + unprocessed
 
         live_ids = {
             mid
@@ -273,11 +325,7 @@ def run_hype_pass(
             if (row := mem.store.get(mid)) is not None and row.get("type") in DURABLE_TYPES
         }
         res["pruned"] = store.prune_orphans(live_ids)
-        res["status"] = (
-            "all_items_failed"
-            if res["errors_items"] == len(backlog) and backlog and res["empty_items"] == 0
-            else "done"
-        )
+        res["status"] = _hype_status(res, len(backlog))
     except Exception as exc:  # surfaced via receipt["errors"], never silent
         res["status"] = "error"
         res["error"] = f"{type(exc).__name__}: {exc}"
@@ -285,6 +333,26 @@ def run_hype_pass(
         if store is not None:
             store.close()
     return res
+
+
+def _hype_status(res: dict[str, Any], backlog_size: int) -> str:
+    """Terminal status for a completed (non-dry, non-raising) HyPE pass.
+
+    ``all_items_failed`` only when EVERY processed item hit an LLM/store error
+    with nothing else to show for the run — a night whose items were legitimately
+    empty, missing a body, or partly succeeded (or was cut short by the budget)
+    is ``done``, not a failure.
+    """
+    if (
+        backlog_size
+        and res["processed"] > 0
+        and res["errors_items"] == res["processed"]
+        and res["empty_items"] == 0
+        and res["missing_source_items"] == 0
+        and not res["budget_hit"]
+    ):
+        return "all_items_failed"
+    return "done"
 
 
 def run_hype_reembed(cfg: Any, mem: Any) -> dict[str, Any]:

--- a/src/memo/dream_incremental.py
+++ b/src/memo/dream_incremental.py
@@ -1,0 +1,131 @@
+"""Fase 5 — per-pass incremental skip for the nightly dream pipeline.
+
+The global convergence guard (``dream_utils.check_convergence``) skips the WHOLE
+pipeline when the corpus fingerprint is unchanged. This module is the finer
+grain: even when the corpus DID change somewhere, a content-derived pass whose
+OWN dependency signal is unchanged since its last successful run can skip
+re-deriving over the full corpus.
+
+Each pass records a *dependency fingerprint* on success (``record_success``);
+the next night skips it iff that fingerprint still matches (``should_skip``). The
+dependency for the content-derived passes (entities / cross-cluster synthesis) is
+the durable-memory content signal (``durable_content_fingerprint`` —
+``(durable_count, max_updated)`` over durable types, mirroring
+``dream_utils._corpus_fingerprint`` but scoped to durable content). Access-only
+churn (ROI/decay) does not move it, so a night that only touched the access log
+skips the content passes.
+
+A skip is a pure optimization and always safe:
+
+* **gated** default-off (``MEMO_DREAM_INCREMENTAL_ENABLED``),
+* **reversible** (delete ``state_dir/dream/incremental.json`` or flip the flag),
+* **self-healing** (any dependency change re-triggers the pass next night),
+* **explainable** (the skip is recorded in the receipt with the fingerprint).
+
+MLX-free: one cheap sqlite aggregate. Never raises into the pipeline.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+_log = logging.getLogger(__name__)
+
+STATE_FILE = "incremental.json"
+
+
+def _path(state_dir: Path) -> Path:
+    return Path(state_dir) / "dream" / STATE_FILE
+
+
+def durable_content_fingerprint(mem: Any) -> str | None:
+    """``"<durable_count>:<max_updated>"`` over durable-tier rows — a cheap
+    change-signal for content-derived passes. Any durable add/edit/delete moves
+    it; access-only changes (ROI/decay) do not. ``None`` on any store error
+    (caller then treats the pass as not-skippable — fail safe = run)."""
+    try:
+        from .tiers import DURABLE_TYPES
+
+        # placeholders is only "?,?,..." (len == number of durable types); the
+        # values are bound parameters, so this is not an injection vector.
+        placeholders = ",".join("?" * len(DURABLE_TYPES))
+        row = mem.store._conn.execute(
+            f"SELECT COUNT(*), COALESCE(MAX(updated), '') FROM meta WHERE type IN ({placeholders})",  # noqa: S608
+            tuple(DURABLE_TYPES),
+        ).fetchone()
+        return f"{row[0]}:{row[1]}"
+    except Exception as exc:  # defensive: a fingerprint failure must never skip
+        _log.debug("dream_incremental: durable fingerprint failed: %s", exc)
+        return None
+
+
+def _load(state_dir: Path) -> dict[str, Any]:
+    try:
+        doc = json.loads(_path(state_dir).read_text(encoding="utf-8"))
+        return doc if isinstance(doc, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def should_skip(state_dir: Path, pass_name: str, fingerprint: str | None) -> bool:
+    """True iff ``pass_name`` last succeeded on exactly this ``fingerprint``.
+
+    A ``None`` fingerprint (store error) is never skippable — fail safe by
+    running the pass. Unknown pass / mismatch → not skippable → run + re-stamp.
+    """
+    if fingerprint is None:
+        return False
+    return str(_load(state_dir).get(pass_name) or "") == fingerprint
+
+
+def record_success(state_dir: Path, pass_name: str, fingerprint: str | None) -> None:
+    """Stamp ``pass_name``'s dependency fingerprint after a successful run.
+
+    A ``None`` fingerprint clears any stored value (so the pass re-runs next
+    night rather than being wrongly skipped). Best-effort — never raises."""
+    try:
+        state = _load(state_dir)
+        if fingerprint is None:
+            state.pop(pass_name, None)
+        else:
+            state[pass_name] = fingerprint
+        p = _path(state_dir)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    except OSError as exc:
+        _log.debug("dream_incremental: record_success failed for %s: %s", pass_name, exc)
+
+
+def clear(state_dir: Path) -> None:
+    """Forget every per-pass fingerprint (next run re-derives everything)."""
+    with contextlib.suppress(OSError):
+        _path(state_dir).unlink()
+
+
+def run_or_skip(
+    state_dir: Path,
+    pass_name: str,
+    fingerprint: str | None,
+    runner: Any,
+) -> dict[str, Any]:
+    """Run ``runner()`` unless ``pass_name``'s dependency is unchanged.
+
+    On skip returns ``{"status": "skipped_incremental", "fingerprint": fp}``
+    without invoking ``runner``. On run, invokes ``runner()``, and — only if the
+    result did not error (no ``error`` key / ``status`` != ``"error"``) — stamps
+    the fingerprint so the next unchanged night skips it. Returns the runner's
+    own result dict verbatim on run. Never raises: a fingerprint failure just
+    means the pass runs (fail safe)."""
+    if should_skip(state_dir, pass_name, fingerprint):
+        return {"status": "skipped_incremental", "fingerprint": fingerprint}
+    result = runner()
+    errored = isinstance(result, dict) and (
+        "error" in result or result.get("status") == "error"
+    )
+    if not errored:
+        record_success(state_dir, pass_name, fingerprint)
+    return result if isinstance(result, dict) else {"result": result}

--- a/src/memo/dream_ledger.py
+++ b/src/memo/dream_ledger.py
@@ -1,0 +1,477 @@
+"""Auditable learning ledger for the nightly dream pipeline.
+
+Every ``memo dream run`` night mutates the corpus (supersede / merge / archive /
+synthesize / tune / graduate / prune / evict / dead-archive / code-drift), but
+the only durable trail today is the flat receipt (``state_dir/dream/last.json``,
+overwritten every night) plus the tuner-only proof loop
+(``dream_tune_online.py`` — ``tune_pending.json`` + ``tune_ledger.jsonl``, the
+"act now, judge later" pattern this module generalizes).
+
+This module is the general version of that pattern: an append-only JSONL ledger
+that chains the full learning loop for *any* dream action ::
+
+    source_signal -> candidate_memory -> proposed_action -> evidence
+      -> confidence -> applied_change -> later_outcome -> rollback_or_reinforcement
+
+Two event kinds live in one append-only file (``state_dir/dream/ledger.jsonl``):
+
+* ``kind="action"``  — full provenance up to the applied change (written when a
+  mutating pass acts). ``entry_id`` is the action id later events reference.
+* ``kind="outcome"`` — the later outcome + rollback/reinforcement verdict,
+  referencing a prior action's ``entry_id`` via ``action_id`` (written by a
+  later night that judges the action).
+
+MLX-free: pure JSONL I/O over ``state_dir/dream/`` (mirrors
+``dream_tune_online.py``). Every public function is best-effort and NEVER raises
+into the pipeline — a ledger failure must never abort a dream night. The whole
+feature is gated by ``MEMO_DREAM_LEDGER_ENABLED`` at the call sites; this module
+does not read the flag itself so it stays pure and unit-testable.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from collections.abc import Callable, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_log = logging.getLogger(__name__)
+
+LEDGER_FILE = "ledger.jsonl"
+
+_ACTION = "action"
+_OUTCOME = "outcome"
+
+
+def _dream_dir(state_dir: Path) -> Path:
+    return Path(state_dir) / "dream"
+
+
+def ledger_path(state_dir: Path) -> Path:
+    """Path of the append-only learning ledger under ``state_dir/dream/``."""
+    return _dream_dir(state_dir) / LEDGER_FILE
+
+
+def _now_iso(now: datetime | None = None) -> str:
+    return (now or datetime.now(UTC)).isoformat(timespec="seconds")
+
+
+def _coerce_confidence(value: Any) -> float | None:
+    # bool is an int subclass; a stray True/False is not a confidence.
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _append(state_dir: Path, entry: dict[str, Any]) -> bool:
+    """Append one JSONL line. Best-effort: logs and returns False on failure."""
+    try:
+        path = ledger_path(state_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(entry, ensure_ascii=False) + "\n"
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+        return True
+    except (OSError, TypeError, ValueError) as exc:
+        _log.warning("dream_ledger: failed to append %s entry: %s", entry.get("kind"), exc)
+        return False
+
+
+def _read_all(state_dir: Path) -> list[dict[str, Any]]:
+    """All ledger entries oldest->newest, skipping blank/corrupt lines.
+
+    Missing file -> ``[]``. Non-dict JSON lines are dropped.
+    """
+    try:
+        lines = ledger_path(state_dir).read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    out: list[dict[str, Any]] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            obj = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            out.append(obj)
+    return out
+
+
+def read_ledger(state_dir: Path, *, limit: int = 50) -> list[dict[str, Any]]:
+    """The last ``limit`` ledger entries (any kind), oldest->newest."""
+    entries = _read_all(state_dir)
+    if limit >= 0:
+        return entries[-limit:]
+    return entries
+
+
+def record_action(
+    state_dir: Path,
+    *,
+    action: str,
+    pass_name: str | None = None,
+    source_signal: Any = None,
+    candidate_ids: Sequence[str] | None = None,
+    evidence: dict[str, Any] | None = None,
+    confidence: float | None = None,
+    affected_ids: Sequence[str] | None = None,
+    applied: bool = True,
+    reversal: dict[str, Any] | None = None,
+    params_version: str | None = None,
+    dry_run: bool = False,
+    now: datetime | None = None,
+) -> str | None:
+    """Record one dream action with its full provenance up to the applied change.
+
+    Returns the new ``action_id`` (a uuid hex, referenced by a later
+    :func:`resolve_action`) or ``None`` when nothing was written — i.e. on
+    ``dry_run`` (matches every mutating pass), on invalid input, or on an I/O
+    failure. Never raises.
+
+    ``action`` is the action class (``supersede``/``merge``/``archive_stale``/
+    ``synthesize``/``tune``/``graduate``/``prune``/``evict``/``dead_archive``/
+    ``code_drift`` ...). ``applied`` distinguishes a mutation that actually
+    landed from one merely recorded for review (held/competing/flagged).
+    ``reversal`` carries the rollback handle, e.g.
+    ``{"type": "inactive_md", "handle": "inactive/<id>.md"}``.
+    """
+    if not isinstance(action, str) or not action.strip():
+        _log.warning("dream_ledger: record_action skipped — invalid action %r", action)
+        return None
+    if dry_run:
+        return None
+
+    entry_id = uuid.uuid4().hex
+    entry: dict[str, Any] = {
+        "entry_id": entry_id,
+        "ts": _now_iso(now),
+        "kind": _ACTION,
+        "action": action.strip(),
+        "pass_name": pass_name,
+        "source_signal": source_signal,
+        "candidate_ids": list(candidate_ids) if candidate_ids else [],
+        "evidence": evidence or {},
+        "confidence": _coerce_confidence(confidence),
+        "affected_ids": list(affected_ids) if affected_ids else [],
+        "applied": bool(applied),
+        "dry_run": False,
+        "reversal": reversal,
+        "params_version": params_version,
+    }
+    if _append(state_dir, entry):
+        return entry_id
+    return None
+
+
+def resolve_action(
+    state_dir: Path,
+    action_id: str,
+    *,
+    outcome: str,
+    verdict: str | None = None,
+    evidence: dict[str, Any] | None = None,
+    delta: float | None = None,
+    now: datetime | None = None,
+) -> str | None:
+    """Attach a later outcome + rollback/reinforcement verdict to a prior action.
+
+    Appends a new ``kind="outcome"`` event referencing ``action_id`` (the ledger
+    is append-only; the original action line is never rewritten). Returns the new
+    outcome ``entry_id`` or ``None`` when nothing was written — on invalid input,
+    on an unknown ``action_id`` (no matching action in the ledger), or on I/O
+    failure. Never raises.
+
+    ``outcome`` is the observed later_outcome (e.g. ``reinforced`` /
+    ``rollback_candidate`` / ``confirmed`` / ``reverted`` / ``neutral``);
+    ``verdict`` optionally records the rollback-or-reinforcement decision
+    separately. ``delta`` carries the realized change that justified the verdict.
+    """
+    if not isinstance(action_id, str) or not action_id.strip():
+        _log.warning("dream_ledger: resolve_action skipped — invalid action_id %r", action_id)
+        return None
+    if not isinstance(outcome, str) or not outcome.strip():
+        _log.warning("dream_ledger: resolve_action skipped — invalid outcome %r", outcome)
+        return None
+    if not _action_exists(state_dir, action_id):
+        _log.warning("dream_ledger: resolve_action skipped — unknown action_id %r", action_id)
+        return None
+
+    entry_id = uuid.uuid4().hex
+    entry: dict[str, Any] = {
+        "entry_id": entry_id,
+        "ts": _now_iso(now),
+        "kind": _OUTCOME,
+        "action_id": action_id,
+        "outcome": outcome.strip(),
+        "verdict": verdict,
+        "evidence": evidence or {},
+        "delta": delta,
+    }
+    if _append(state_dir, entry):
+        return entry_id
+    return None
+
+
+def _action_exists(state_dir: Path, action_id: str) -> bool:
+    for entry in _read_all(state_dir):
+        if entry.get("kind") == _ACTION and entry.get("entry_id") == action_id:
+            return True
+    return False
+
+
+def recent_actions(
+    state_dir: Path,
+    *,
+    limit: int = 50,
+    action: str | None = None,
+    phase: str | None = None,
+) -> list[dict[str, Any]]:
+    """Recent action events, newest-first, optionally filtered.
+
+    ``action`` filters on the action class; ``phase`` filters on ``pass_name``
+    (the dream pass that produced the action).
+    """
+    rows = [e for e in _read_all(state_dir) if e.get("kind") == _ACTION]
+    if action is not None:
+        rows = [e for e in rows if e.get("action") == action]
+    if phase is not None:
+        rows = [e for e in rows if e.get("pass_name") == phase]
+    rows.reverse()
+    if limit >= 0:
+        return rows[:limit]
+    return rows
+
+
+def open_actions(state_dir: Path, *, limit: int = 500) -> list[dict[str, Any]]:
+    """Action events with no matching outcome event yet, oldest-first.
+
+    These are the actions a later night's resolution pass still has to judge.
+    """
+    entries = _read_all(state_dir)
+    resolved = {e.get("action_id") for e in entries if e.get("kind") == _OUTCOME}
+    unresolved = [
+        e
+        for e in entries
+        if e.get("kind") == _ACTION and e.get("entry_id") not in resolved
+    ]
+    if limit >= 0:
+        return unresolved[:limit]
+    return unresolved
+
+
+def get_action(state_dir: Path, action_id: str) -> dict[str, Any] | None:
+    """The action entry for ``action_id`` folded with its latest outcome event.
+
+    Returns the action dict plus an ``"outcome"`` key (the latest matching
+    outcome event, or ``None`` if still open). ``None`` if the action is unknown.
+    """
+    action: dict[str, Any] | None = None
+    outcome: dict[str, Any] | None = None
+    for entry in _read_all(state_dir):
+        kind = entry.get("kind")
+        if kind == _ACTION and entry.get("entry_id") == action_id:
+            action = entry
+        elif kind == _OUTCOME and entry.get("action_id") == action_id:
+            outcome = entry
+    if action is None:
+        return None
+    return {**action, "outcome": outcome}
+
+
+def _inactive_reversal(memory_id: str) -> dict[str, Any]:
+    """Rollback handle for an archived memory (moved to ``inactive/<id>.md``)."""
+    return {"type": "inactive_md", "handle": f"inactive/{memory_id}.md"}
+
+
+def record_from_receipt(
+    state_dir: Path, receipt: dict[str, Any], *, dry_run: bool = False
+) -> dict[str, int]:
+    """Record one ledger action per concrete, id-bearing mutation in ``receipt``.
+
+    Maps the completed dream receipt's mutating fragments (contradict-supersede,
+    consolidate-merge, archive-stale, evolve, synthesize) into the append-only
+    learning ledger with each action's provenance, evidence, and rollback handle.
+    Coarser than per-decision instrumentation but honest: every reversible corpus
+    mutation of a night gets one auditable chain entry. Returns a per-action
+    count. ``dry_run`` records nothing (matches every mutating pass). Never
+    raises — a ledger failure must not abort the night.
+    """
+    counts: dict[str, int] = {}
+    if dry_run:
+        return counts
+
+    def _bump(kind: str) -> None:
+        counts[kind] = counts.get(kind, 0) + 1
+
+    contradict = receipt.get("contradict") or {}
+    for item in contradict.get("superseded", []) or []:
+        older = str(item.get("older") or "")
+        if not older:
+            continue
+        if record_action(
+            state_dir,
+            action="supersede",
+            pass_name="contradict",  # noqa: S106 - dream pass name, not a secret
+            source_signal={"pair_id": item.get("pair_id")},
+            candidate_ids=[older],
+            affected_ids=[older],
+            evidence={"relationship": "contradiction"},
+            confidence=0.9,
+            reversal=_inactive_reversal(older),
+        ):
+            _bump("supersede")
+    for pair_id in contradict.get("evolved", []) or []:
+        if record_action(
+            state_dir,
+            action="evolve",
+            pass_name="contradict",  # noqa: S106 - dream pass name, not a secret
+            source_signal={"pair_id": pair_id},
+            evidence={"relationship": "evolution"},
+            reversal={"type": "confidence_restore"},
+        ):
+            _bump("evolve")
+
+    consolidate = receipt.get("consolidate_dups") or {}
+    for item in consolidate.get("merged", []) or []:
+        archived = [str(a) for a in (item.get("archived_ids") or []) if str(a)]
+        if not archived:
+            continue
+        if record_action(
+            state_dir,
+            action="merge",
+            pass_name="consolidate_dups",  # noqa: S106 - dream pass name, not a secret
+            candidate_ids=archived,
+            affected_ids=archived,
+            evidence={"merged_id": item.get("merged_id"), "archived": len(archived)},
+            reversal={"type": "inactive_md_multi", "handles": [f"inactive/{a}.md" for a in archived]},
+        ):
+            _bump("merge")
+
+    stale = receipt.get("stale") or {}
+    for item in stale.get("archived", []) or []:
+        mid = str(item.get("id") or "")
+        if not mid:
+            continue
+        if record_action(
+            state_dir,
+            action="archive_stale",
+            pass_name="stale",  # noqa: S106 - dream pass name, not a secret
+            candidate_ids=[mid],
+            affected_ids=[mid],
+            evidence={"days_since_update": item.get("days")},
+            reversal=_inactive_reversal(mid),
+        ):
+            _bump("archive_stale")
+
+    return counts
+
+
+def resolve_open_actions(
+    state_dir: Path,
+    is_live: Callable[[str], bool],
+    *,
+    min_age_hours: float = 20.0,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Close the loop on prior nights' reversible archives (later_outcome).
+
+    For each still-open ``supersede`` / ``archive_stale`` / ``merge`` action older
+    than ``min_age_hours`` (so tonight's own actions are never judged tonight),
+    checks whether an affected (archived) memory came back to life
+    (``is_live(id)`` — e.g. a human un-archived it). A resurrected memory means
+    the archive was wrong → ``rollback_candidate``/``reopened``; a memory that
+    stayed archived is ``reinforced``. Returns ``{reinforced, rollback_candidate,
+    skipped}``. ``is_live`` is injected so this stays MLX-free and unit-testable.
+    Never raises.
+    """
+    cutoff = (now or datetime.now(UTC))
+    out = {"reinforced": 0, "rollback_candidate": 0, "skipped": 0}
+    reversible = {"supersede", "archive_stale", "merge"}
+    for action in open_actions(state_dir):
+        if action.get("action") not in reversible:
+            continue
+        ts = _parse_ts(action.get("ts"))
+        if ts is None or (cutoff - ts).total_seconds() < min_age_hours * 3600.0:
+            out["skipped"] += 1
+            continue
+        affected = [str(a) for a in (action.get("affected_ids") or []) if str(a)]
+        try:
+            resurrected = any(is_live(a) for a in affected)
+        except Exception as exc:  # defensive: liveness probe must not abort
+            _log.debug("dream_ledger: liveness probe failed: %s", exc)
+            out["skipped"] += 1
+            continue
+        if resurrected:
+            resolve_action(
+                state_dir,
+                str(action.get("entry_id")),
+                outcome="rollback_candidate",
+                verdict="reopened",
+                evidence={"resurrected": [a for a in affected if _safe_live(is_live, a)]},
+                now=now,
+            )
+            out["rollback_candidate"] += 1
+        else:
+            resolve_action(
+                state_dir,
+                str(action.get("entry_id")),
+                outcome="reinforced",
+                verdict="held",
+                now=now,
+            )
+            out["reinforced"] += 1
+    return out
+
+
+def _safe_live(is_live: Callable[[str], bool], memory_id: str) -> bool:
+    try:
+        return bool(is_live(memory_id))
+    except Exception:
+        return False
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+def summarize(state_dir: Path) -> dict[str, Any]:
+    """A one-glance summary for ``memo dream status`` / ``memo dream ledger``.
+
+    Counts total actions/outcomes, still-open actions, rollback candidates, and a
+    per-action-class breakdown.
+    """
+    entries = _read_all(state_dir)
+    actions = [e for e in entries if e.get("kind") == _ACTION]
+    outcomes = [e for e in entries if e.get("kind") == _OUTCOME]
+    resolved = {e.get("action_id") for e in outcomes}
+    open_count = sum(1 for a in actions if a.get("entry_id") not in resolved)
+    rollback = sum(
+        1
+        for o in outcomes
+        if "rollback" in str(o.get("verdict") or "") or "rollback" in str(o.get("outcome") or "")
+    )
+    by_action: dict[str, int] = {}
+    for a in actions:
+        key = str(a.get("action", "?"))
+        by_action[key] = by_action.get(key, 0) + 1
+    return {
+        "actions": len(actions),
+        "outcomes": len(outcomes),
+        "open": open_count,
+        "rollback_candidates": rollback,
+        "by_action": by_action,
+    }

--- a/src/memo/dream_metrics.py
+++ b/src/memo/dream_metrics.py
@@ -1,0 +1,360 @@
+"""Fase-4 learning metrics + the tuner graduation gate.
+
+Two responsibilities, both nightly-only and MLX-free:
+
+1. **Pure gate functions** (:func:`graduation_gate` + the sub-gates) the
+   recall self-tuner calls before it applies a knob change. Today
+   ``dream_tune.run_tuning_pass`` gates a change on only three of the six
+   required conditions (offline improvement, curated no-regression, rank-knob
+   latency headroom). :func:`graduation_gate` folds ALL six into one verdict:
+   precision improves by ``>= min_margin``, noise not up, latency within both a
+   headroom ratio and an absolute hook budget, a minimum label-sample count,
+   plus the two structural invariants (experiment recorded, rollback exists).
+   The functions are pure — the caller reads the flags and threads the
+   thresholds in — so they never touch the store, the flags, or MLX.
+
+2. **Read-only :func:`learning_metrics`** — assembles the eleven learning
+   metrics from their existing sources (eval before/after, grounded_rate,
+   the online cohort, the verdict log, consolidate-reuse, outcome utilities,
+   recall-latency percentiles) into one snapshot the tuner receipt/ledger can
+   record for before/after-by-cohort auditability. It NEVER re-runs the eval
+   (it reuses the ``before``/``after`` the tuner already measured) and NEVER
+   raises — every sub-failure lands in the returned ``errors`` list, mirroring
+   the dream passes.
+
+MLX-free: only reads jsonl logs + ``store.list_recent``; never calls
+``embed()`` / ``chat()``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+# Float comparison slack — mirrors dream_tune._regressed's 1e-9 tolerance so
+# the gate never trips on representation noise.
+_EPS = 1e-9
+
+# verdict.classify_reaction vocabulary that counts as a bad outcome.
+_NEGATIVE_VERDICTS = frozenset({"negative", "correction"})
+
+
+# --- pure gate functions -----------------------------------------------------
+
+
+def min_labels_gate(n_labels: int, min_labels: int) -> bool:
+    """Enough labeled samples to trust the offline apply (statistical floor)."""
+    return n_labels >= min_labels
+
+
+def margin_gate(prec_before: float, prec_after: float, min_margin: float) -> bool:
+    """precision@k improved by at least ``min_margin`` (0.0 = any non-regression).
+
+    Deadband: ``min_margin > 0`` rejects trivial +epsilon churn on the overlay.
+    """
+    return prec_after >= prec_before + min_margin - _EPS
+
+
+def noise_gate(noise_before: float, noise_after: float) -> bool:
+    """noise@k did not rise."""
+    return noise_after <= noise_before + _EPS
+
+
+def latency_gate(
+    latency_before: float,
+    latency_after: float,
+    *,
+    headroom: float,
+    hook_budget_ms: float,
+) -> bool:
+    """Candidate latency respects BOTH the headroom ratio and the absolute budget.
+
+    - Absolute: ``latency_after <= hook_budget_ms`` (protects the 5s recall-hook
+      budget) — always enforced.
+    - Ratio: ``latency_after <= headroom * latency_before`` — skipped when the
+      baseline p50 rounds to 0.0 (stub/tiny corpora have no meaningful ratio).
+    """
+    if latency_after > hook_budget_ms + _EPS:
+        return False
+    if round(latency_before, 1) <= 0.0:
+        return True
+    return latency_after <= headroom * latency_before + _EPS
+
+
+def graduation_gate(
+    before: dict[str, float],
+    after: dict[str, float],
+    *,
+    n_labels: int,
+    latency_before: float,
+    latency_after: float,
+    min_labels: int,
+    latency_headroom: float,
+    hook_budget_ms: float,
+    min_margin: float,
+    experiment_recorded: bool = True,
+    rollback_exists: bool = True,
+) -> dict[str, Any]:
+    """Hard pre-apply gate enforcing all six graduation conditions.
+
+    ``before``/``after`` are the ``{"precision_at_k", "noise_at_k", ...}`` dicts
+    the tuner already measured (``gate_metrics``). Returns a structured verdict
+    ``{"ok": bool, "reasons": [...]}`` — ``ok`` is True only when every
+    condition holds; ``reasons`` names each condition that failed. Pure and
+    total: never reads flags, never touches the store, never raises.
+    """
+    reasons: list[str] = []
+
+    prec_b = _as_float(before.get("precision_at_k"))
+    prec_a = _as_float(after.get("precision_at_k"))
+    noise_b = _as_float(before.get("noise_at_k"))
+    noise_a = _as_float(after.get("noise_at_k"))
+
+    # 1. minimum sample count
+    if not min_labels_gate(n_labels, min_labels):
+        reasons.append(f"insufficient_labels: n_labels={n_labels} < min={min_labels}")
+    # 2. precision improves by >= min_margin
+    if not margin_gate(prec_b, prec_a, min_margin):
+        reasons.append(
+            f"precision_not_improved: after={prec_a:.4f} < before={prec_b:.4f} + margin={min_margin}"
+        )
+    # 3. noise not up
+    if not noise_gate(noise_b, noise_a):
+        reasons.append(f"noise_regressed: after={noise_a:.4f} > before={noise_b:.4f}")
+    # 4. latency budget (headroom ratio AND absolute hook budget)
+    if not latency_gate(
+        latency_before, latency_after, headroom=latency_headroom, hook_budget_ms=hook_budget_ms
+    ):
+        if latency_after > hook_budget_ms + _EPS:
+            reasons.append(
+                f"latency_over_budget: p50={latency_after:.1f}ms > {hook_budget_ms:.0f}ms"
+            )
+        else:
+            reasons.append(
+                f"latency_regressed: p50={latency_after:.1f}ms > "
+                f"{latency_headroom:g}x baseline {latency_before:.1f}ms"
+            )
+    # 5. experiment recorded (structural invariant the caller guarantees)
+    if not experiment_recorded:
+        reasons.append("experiment_not_recorded")
+    # 6. rollback exists (structural invariant the caller guarantees)
+    if not rollback_exists:
+        reasons.append("rollback_missing")
+
+    return {"ok": not reasons, "reasons": reasons}
+
+
+def tune_gate_thresholds() -> dict[str, Any]:
+    """The four graduation thresholds, read from the flag registry.
+
+    Convenience for the tuner call site — keeps every ``MEMO_DREAM_TUNE_*``
+    read in one place so ``graduation_gate`` stays pure. Returns kwargs ready to
+    splat into :func:`graduation_gate` (``min_labels``, ``latency_headroom``,
+    ``hook_budget_ms``, ``min_margin``).
+    """
+    from memo.flags import flag_float, flag_int
+
+    min_labels = flag_int("MEMO_DREAM_TUNE_MIN_LABELS")
+    headroom = flag_float("MEMO_DREAM_TUNE_LATENCY_HEADROOM")
+    budget = flag_float("MEMO_DREAM_TUNE_HOOK_BUDGET_MS")
+    margin = flag_float("MEMO_DREAM_TUNE_MIN_MARGIN")
+    return {
+        "min_labels": 12 if min_labels is None else min_labels,
+        "latency_headroom": 1.25 if headroom is None else headroom,
+        "hook_budget_ms": 3000.0 if budget is None else budget,
+        "min_margin": 0.0 if margin is None else margin,
+    }
+
+
+# --- pure learning-metric helpers --------------------------------------------
+
+
+def correction_rate(verdict_rows: list[dict[str, Any]]) -> tuple[float | None, int]:
+    """(fraction of next-turn verdicts that were negative/correction, sample).
+
+    ``(None, 0)`` when no verdicts are present — a rate over zero turns is not
+    meaningful, so it is reported as absent rather than 0.0.
+    """
+    verdicts = [str(r.get("verdict")) for r in verdict_rows if r.get("verdict")]
+    total = len(verdicts)
+    if total == 0:
+        return None, 0
+    bad = sum(1 for v in verdicts if v in _NEGATIVE_VERDICTS)
+    return bad / total, total
+
+
+def created_used_ratio(grounded_total: int, surfaced_total: int) -> float | None:
+    """created->used: grounded observations / surfaced observations.
+
+    ``None`` when nothing was surfaced (no denominator).
+    """
+    if surfaced_total <= 0:
+        return None
+    return grounded_total / surfaced_total
+
+
+# --- learning-metrics snapshot -----------------------------------------------
+
+
+def learning_metrics(
+    cfg: Any,
+    mem: Any,
+    *,
+    params_version: str,
+    k: int = 5,
+    before: dict[str, float] | None = None,
+    after: dict[str, float] | None = None,
+) -> dict[str, Any]:
+    """Read-only snapshot of the eleven learning metrics from existing sources.
+
+    Reuses the ``before``/``after`` the tuner already measured (does NOT re-run
+    ``evaluate``). Every metric is computed defensively: a missing log or a
+    failing source yields ``None`` for that key and a note in ``errors`` —
+    the function never raises. Runs only inside ``memo dream run`` (nightly).
+    """
+    errors: list[str] = []
+    state_dir = Path(cfg.state_dir)
+    headline = after or before or {}
+
+    metrics: dict[str, Any] = {
+        "params_version": params_version,
+        "k": k,
+        # 1-2. precision@k / noise@k — from the tuner's own measurement.
+        "precision_at_k": _num(headline.get("precision_at_k")),
+        "noise_at_k": _num(headline.get("noise_at_k")),
+    }
+    if before is not None:
+        metrics["precision_before"] = _num(before.get("precision_at_k"))
+        metrics["noise_before"] = _num(before.get("noise_at_k"))
+    if after is not None:
+        metrics["precision_after"] = _num(after.get("precision_at_k"))
+        metrics["noise_after"] = _num(after.get("noise_at_k"))
+
+    # 3-4. answerability + grounding coverage — from grounded_rate.
+    grounded = _safe(errors, "grounded_rate", lambda: _grounded_rate(state_dir), {})
+    # answerability is a log-derived proxy (answer_rate_knowledge), NOT the
+    # eval's pack-answerability (which is unimplemented) — labelled as such.
+    metrics["answerability"] = _num(grounded.get("answer_rate_knowledge"))
+    metrics["answerability_note"] = "proxy: answer_rate_knowledge (log-derived, not pack)"
+    metrics["grounding_coverage"] = _num(grounded.get("measurement_coverage"))
+    metrics["grounded_rate"] = _num(grounded.get("grounded_rate"))
+
+    # 5. later_usefulness — realized grounded fraction of the live cohort.
+    lu_frac, lu_n = _safe(
+        errors, "later_usefulness", lambda: _online_fraction(state_dir, params_version), (None, 0)
+    )
+    metrics["later_usefulness"] = _num(lu_frac) if lu_n else None
+    metrics["later_usefulness_cohort"] = int(lu_n or 0)
+
+    # 6. correction_rate — from the next-turn verdict log.
+    cr_rate, cr_n = _safe(
+        errors, "correction_rate", lambda: correction_rate(_verdict_rows(state_dir)), (None, 0)
+    )
+    metrics["correction_rate"] = _num(cr_rate)
+    metrics["correction_sample"] = int(cr_n or 0)
+
+    # 7. synthesis_acceptance — reuse fraction of consolidate's synthesis memos.
+    metrics["synthesis_acceptance"] = _num(
+        _safe(errors, "synthesis_acceptance", lambda: _reuse_fraction(mem), None)
+    )
+
+    # 8. created->used — grounded / surfaced over the outcome window.
+    metrics["created_used_ratio"] = _num(
+        _safe(errors, "created_used_ratio", lambda: _created_used(state_dir), None)
+    )
+
+    # 9-10. p50 / p95 recall latency — p95 lives ONLY here.
+    p50, p95 = _safe(errors, "latency", lambda: _latency_percentiles(state_dir), (None, None))
+    metrics["latency_p50_ms"] = p50
+    metrics["latency_p95_ms"] = p95
+
+    # 11. reopened_contradiction_rate — no faithful durable source today; the
+    # reopen transition is not stamped, so expose None rather than fabricate.
+    metrics["reopened_contradiction_rate"] = None
+    metrics["reopened_contradiction_note"] = "needs_event_stamp: reopen() nulls resolved_at"
+
+    metrics["errors"] = errors
+    return metrics
+
+
+# --- source adapters (thin, defensive) ---------------------------------------
+
+
+def _grounded_rate(state_dir: Path) -> dict[str, Any]:
+    from memo import dashboard_metrics
+
+    return dashboard_metrics.grounded_rate(state_dir)
+
+
+def _online_fraction(state_dir: Path, params_version: str) -> tuple[float, int]:
+    from memo import dream_tune_online
+
+    return dream_tune_online.online_fraction(state_dir, params_version)
+
+
+def _verdict_rows(state_dir: Path) -> list[dict[str, Any]]:
+    from memo.dashboard_logs import read_verdict_log
+
+    return read_verdict_log(state_dir)
+
+
+def _reuse_fraction(mem: Any) -> float | None:
+    from memo import dream_reuse
+
+    return dream_reuse.consolidated_reuse(mem).get("reuse_fraction")
+
+
+def _created_used(state_dir: Path) -> float | None:
+    from memo import outcome
+
+    u = outcome.compute_utilities(state_dir)
+    return created_used_ratio(int((u.get("surfaced_total", 0) and u.get("grounded_total", 0)) or 0), int(u.get("surfaced_total", 0) or 0))
+
+
+def _latency_percentiles(state_dir: Path) -> tuple[float | None, float | None]:
+    """p50/p95 of the dominant recall path (most-sampled) from recall_metrics."""
+    from memo import recall_metrics
+
+    summary = recall_metrics.summarize(state_dir)
+    if not summary:
+        return None, None
+    # Dominant path = most samples; name breaks ties deterministically.
+    path = max(summary, key=lambda p: (int(summary[p].get("count", 0)), p))
+    row = summary[path]
+    return _num(row.get("p50")), _num(row.get("p95"))
+
+
+# --- small utilities ---------------------------------------------------------
+
+
+def _safe[T](errors: list[str], name: str, fn: Callable[[], T], default: Any) -> T:
+    """Run ``fn``; on any failure record it and return ``default`` (never raise).
+
+    ``default`` is typed ``Any`` (not ``T``) so the type variable binds to the
+    callable's return alone — a literal fallback like ``{}`` / ``(None, 0)`` must
+    not narrow ``T`` below what ``fn`` actually yields.
+    """
+    try:
+        return fn()
+    except Exception as exc:  # defensive: a broken source must not kill the snapshot
+        errors.append(f"{name}: {type(exc).__name__}: {exc}")
+        return default
+
+
+def _num(value: Any) -> float | None:
+    """Coerce a numeric metric to float; None for bool/None/non-numeric."""
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _as_float(value: Any) -> float:
+    """Coerce a gate input to float; 0.0 for None/non-numeric (defensive)."""
+    if isinstance(value, bool) or value is None:
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    return 0.0

--- a/src/memo/dream_phases.py
+++ b/src/memo/dream_phases.py
@@ -1,0 +1,416 @@
+"""Per-phase instrumentation + resumable checkpoints for `memo dream run`.
+
+This is the observability keystone of the dream learning loop. Every dream
+phase records a structured, timed receipt fragment so the pipeline stops being
+an opaque batch job and becomes a measurable ``signal -> change -> result``
+sequence:
+
+    {
+      "phase": "hype", "status": "done", "duration_ms": 1234,
+      "input_count": 50, "changed_count": 12, "skipped_count": 38,
+      "mutations": 36, "errors": [], "warnings": [],
+      "quality_before": {}, "quality_after": {},
+      "in_fingerprint": "...", "out_fingerprint": "..."
+    }
+
+Design constraints (kept deliberately small to stay surgical over the large,
+concurrently-edited ``cli_dream.py``):
+
+* ``PhaseRecorder`` uses an explicit ``begin()/end()`` pair — two lines per
+  pass, no re-indentation of the existing bespoke ``try/except`` bodies.
+* Counts are *inferred* from the pass result fragment (``receipt[key]``) via
+  common maintenance keys, so passes need no hand-annotation; a pass may still
+  override any field on the handle for precision.
+* ``end()`` never raises: instrumentation must not be able to break a pass.
+* ``DreamCheckpoint`` persists after every phase, so an interrupted run leaves a
+  partial, readable receipt on disk and a ``--resume`` run can skip phases whose
+  LLM calls / mutations already committed. The run fingerprint is the *previous*
+  completed run's corpus fingerprint — stable across a crash+restart cycle
+  (a crashed run never rewrites ``last.json``), and naturally invalidated once a
+  full run completes and stamps a new ``corpus_fp``.
+
+Markdown stays the source of truth; this module only reads the derived index
+(``_corpus_fingerprint``) and writes a JSON sidecar under ``state_dir/dream/``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging as _logging
+import time
+from contextlib import suppress
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from memo.dream_utils import _corpus_fingerprint
+
+_log = _logging.getLogger(__name__)
+
+CHECKPOINT_VERSION = 1
+CHECKPOINT_NAME = "checkpoint.json"
+
+_UNSET = object()
+
+# Result-fragment keys that count as "inputs seen" and "mutations made". Passes
+# return heterogeneous dicts; these cover the maintenance vocabulary so the
+# recorder can infer counts without every call site annotating them by hand.
+_INPUT_KEYS = ("scanned", "processed", "considered", "candidates", "examined", "seen")
+_MUTATION_KEYS = (
+    "saved",
+    "updated",
+    "written",
+    "promoted",
+    "merged",
+    "archived",
+    "superseded",
+    "captured",
+    "synthesized",
+    "extracted",
+    "reconciled",
+    "decayed",
+    "pruned",
+    "evicted",
+    "compressed",
+    "retagged",
+    "indexed",
+    "applied",
+    "remapped",
+)
+
+
+def _now_ms() -> float:
+    """Monotonic millisecond clock for durations (never walks backwards)."""
+    return time.perf_counter() * 1000.0
+
+
+def _coerce_count(value: Any) -> int:
+    """Best-effort count from a fragment value: len() of a list, int of a number."""
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, list):
+        return len(value)
+    return 0
+
+
+def _infer_counts(fragment: Any) -> tuple[int, int]:
+    """Infer (input_count, mutations) from a pass result fragment.
+
+    Returns (0, 0) for anything that isn't a dict so unannotated / opaque passes
+    degrade quietly rather than raising inside instrumentation.
+    """
+    if not isinstance(fragment, dict):
+        return 0, 0
+    inputs = max((_coerce_count(fragment.get(k)) for k in _INPUT_KEYS), default=0)
+    mutations = sum(_coerce_count(fragment.get(k)) for k in _MUTATION_KEYS)
+    return inputs, mutations
+
+
+@dataclass
+class PhaseHandle:
+    """Mutable handle a pass body may populate for precise metrics.
+
+    All fields are optional; anything left unset is inferred at ``end()`` from
+    the pass result fragment. ``restored`` is set by ``PhaseRecorder.restore()``
+    so the pass body can cheaply skip its work on a ``--resume`` run.
+    """
+
+    name: str
+    fragment_key: str | None = None
+    input_count: int | None = None
+    changed_count: int | None = None
+    skipped_count: int = 0
+    mutations: int | None = None
+    warnings: list[str] = field(default_factory=list)
+    quality_before: dict[str, Any] = field(default_factory=dict)
+    quality_after: dict[str, Any] = field(default_factory=dict)
+    status: str | None = None
+    restored: bool = False
+    # internal bookkeeping
+    _t0: float = 0.0
+    _err_before: int = 0
+    _in_fp: str | None = None
+    _track_fp: bool = False
+    _closed: bool = False
+    _fragment: Any = _UNSET
+
+
+class DreamCheckpoint:
+    """Resumable, idempotent phase ledger under ``state_dir/dream/checkpoint.json``.
+
+    Keyed on ``run_fingerprint`` so a *new* run (different previous-corpus fp)
+    starts clean while an interrupted run with the same fp can resume from its
+    last completed phase.
+    """
+
+    def __init__(self, path: Path, run_fingerprint: str) -> None:
+        self.path = path
+        self.run_fingerprint = run_fingerprint
+        self._done: dict[str, dict[str, Any]] = {}
+        self._loaded_fp: str | None = None
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return
+        if not isinstance(data, dict):
+            return
+        self._loaded_fp = data.get("run_fingerprint")
+        done = data.get("done")
+        if isinstance(done, dict):
+            self._done = done
+
+    def resumable(self) -> bool:
+        """True when an on-disk checkpoint matches this run and has content."""
+        return self._loaded_fp == self.run_fingerprint and bool(self._done)
+
+    def is_done(self, name: str) -> bool:
+        return self.resumable() and name in self._done
+
+    def phase_record(self, name: str) -> dict[str, Any] | None:
+        entry = self._done.get(name) if self.is_done(name) else None
+        return entry.get("phase") if entry else None
+
+    def fragment(self, name: str) -> Any:
+        entry = self._done.get(name) if self.is_done(name) else None
+        return entry.get("fragment") if entry else None
+
+    def record(self, name: str, phase_record: dict[str, Any], fragment: Any = None) -> None:
+        """Persist one completed phase. Instrumentation must never crash a run, so
+        a write failure is logged and swallowed (the in-memory receipt is intact)."""
+        self._done[name] = {"phase": phase_record, "fragment": fragment}
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "version": CHECKPOINT_VERSION,
+                "run_fingerprint": self.run_fingerprint,
+                "ts": time.time(),
+                "done": self._done,
+            }
+            self.path.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+        except (OSError, TypeError, ValueError) as exc:
+            _log.warning("dream checkpoint write failed for %s: %s", name, exc)
+
+    def clear(self) -> None:
+        """Drop the checkpoint after a fully successful run."""
+        self._done = {}
+        with suppress(OSError):
+            self.path.unlink()
+
+
+class PhaseRecorder:
+    """Records a structured, timed record per dream phase into ``receipt['phases']``.
+
+    Usage (no re-indentation of existing pass bodies)::
+
+        _ph = rec.begin("hype", fragment_key="hype")
+        if rec.restore(_ph):          # --resume hit: skip work, restore fragment
+            ...                        # (optional) light restore-path branch
+        else:
+            ... run the pass, set receipt["hype"] = ... ...
+        rec.end(_ph)
+
+    ``end()`` is idempotent and never raises.
+    """
+
+    def __init__(
+        self,
+        receipt: dict[str, Any],
+        *,
+        mem: Any = None,
+        checkpoint: DreamCheckpoint | None = None,
+        resume: bool = False,
+    ) -> None:
+        self.receipt = receipt
+        self.mem = mem
+        self.checkpoint = checkpoint
+        self.resume = resume
+        receipt.setdefault("phases", [])
+
+    # -- lifecycle --------------------------------------------------------
+
+    def begin(
+        self,
+        name: str,
+        *,
+        fragment_key: str | None = None,
+        input_count: int | None = None,
+        track_fp: bool | None = None,
+    ) -> PhaseHandle:
+        """Open a phase. ``track_fp`` snapshots the corpus fingerprint before/after
+        (cheap COUNT+MAX query) to detect real mutations; defaults on when a
+        ``mem`` is available. Pass ``track_fp=False`` for pure-read passes."""
+        h = PhaseHandle(name=name, fragment_key=fragment_key, input_count=input_count)
+        h._t0 = _now_ms()
+        h._err_before = len(self.receipt.get("errors", []))
+        h._track_fp = self.mem is not None if track_fp is None else track_fp
+        if h._track_fp:
+            h._in_fp = _corpus_fingerprint(self.mem)
+        return h
+
+    def restore(self, handle: PhaseHandle) -> bool:
+        """On a ``--resume`` run, if this phase already completed, append its cached
+        record (flagged ``resumed``), restore its result fragment into the receipt,
+        and return True so the caller skips the (LLM/mutation) work. Else False."""
+        if not (self.resume and self.checkpoint and self.checkpoint.is_done(handle.name)):
+            return False
+        record = self.checkpoint.phase_record(handle.name)
+        fragment = self.checkpoint.fragment(handle.name)
+        if handle.fragment_key and fragment is not None:
+            self.receipt[handle.fragment_key] = fragment
+        if isinstance(record, dict):
+            self.receipt["phases"].append({**record, "resumed": True})
+        handle.restored = True
+        handle._closed = True
+        return True
+
+    def end(self, handle: PhaseHandle, *, fragment: Any = _UNSET) -> dict[str, Any] | None:
+        """Close a phase: compute duration/status/counts, append the structured
+        record, and checkpoint it. No-op if already closed (e.g. after restore).
+
+        ``fragment`` explicitly supplies the pass result for count inference —
+        used by ``timed()`` where the result is not yet assigned to the receipt."""
+        if handle._closed:
+            return None
+        handle._closed = True
+        if fragment is not _UNSET:
+            handle._fragment = fragment
+        try:
+            return self._finalize(handle)
+        except Exception as exc:  # instrumentation must never break a run
+            _log.warning("dream phase recorder failed for %s: %s", handle.name, exc)
+            return None
+
+    def timed(
+        self,
+        name: str,
+        thunk: Any,
+        *,
+        fragment_key: str | None = None,
+        resumable: bool = False,
+    ) -> Any:
+        """Run ``thunk()`` under phase instrumentation, returning its result.
+
+        One-line call-site wrapper (no re-indentation of the surrounding
+        ``try/except``)::
+
+            receipt["hype"] = rec.timed("hype", lambda: run_hype_pass(...),
+                                        fragment_key="hype", resumable=True)
+
+        On a ``--resume`` run where this phase already committed, the cached
+        result fragment is returned WITHOUT calling ``thunk`` (no repeated LLM
+        calls / mutations). Counts are inferred from the returned fragment.
+        """
+        ph = self.begin(name, fragment_key=fragment_key)
+        if resumable and self.resume and self.checkpoint and self.checkpoint.is_done(name):
+            record = self.checkpoint.phase_record(name)
+            fragment = self.checkpoint.fragment(name)
+            if isinstance(record, dict):
+                self.receipt["phases"].append({**record, "resumed": True})
+            ph.restored = True
+            ph._closed = True
+            return fragment
+        result: Any = None
+        raised: BaseException | None = None
+        try:
+            result = thunk()
+            return result
+        except BaseException as exc:
+            raised = exc
+            raise
+        finally:
+            # A pass that raised appends to receipt["errors"] in ITS OWN except
+            # block, which runs AFTER this finally — so mark the failure here or
+            # the crashed phase would record status="done".
+            if raised is not None:
+                ph.status = "error"
+                ph.warnings.append(f"{type(raised).__name__}: {raised}")
+            # A helper-style pass returns None and mutates receipt[key] directly;
+            # fall back to the receipt fragment so counts still infer. A pass that
+            # returns its dict result uses that directly.
+            self.end(ph, fragment=result if result is not None else _UNSET)
+
+    # -- internals --------------------------------------------------------
+
+    def _finalize(self, h: PhaseHandle) -> dict[str, Any]:
+        duration_ms = round(_now_ms() - h._t0, 1)
+        new_errors = list(self.receipt.get("errors", [])[h._err_before :])
+
+        if h._fragment is not _UNSET:
+            fragment = h._fragment
+        elif h.fragment_key:
+            fragment = self.receipt.get(h.fragment_key)
+        else:
+            fragment = None
+        inferred_inputs, inferred_mutations = _infer_counts(fragment)
+
+        out_fp = _corpus_fingerprint(self.mem) if h._track_fp and self.mem is not None else None
+        fp_changed = h._in_fp is not None and out_fp is not None and h._in_fp != out_fp
+
+        input_count = h.input_count if h.input_count is not None else inferred_inputs
+        mutations = h.mutations if h.mutations is not None else inferred_mutations
+        if h.changed_count is not None:
+            changed_count = h.changed_count
+        elif mutations:
+            changed_count = mutations
+        else:
+            changed_count = 1 if fp_changed else 0
+
+        # Status derivation: an explicit override wins; otherwise a pass whose
+        # result fragment reports status=="error", or that appended to
+        # receipt["errors"], is an error — matching the existing convention.
+        status = h.status
+        if status is None:
+            frag_status = fragment.get("status") if isinstance(fragment, dict) else None
+            status = "error" if frag_status == "error" or new_errors else "done"
+
+        record: dict[str, Any] = {
+            "phase": h.name,
+            "status": status,
+            "duration_ms": duration_ms,
+            "input_count": input_count,
+            "changed_count": changed_count,
+            "skipped_count": h.skipped_count,
+            "mutations": mutations,
+            "errors": new_errors,
+            "warnings": list(h.warnings),
+            "quality_before": dict(h.quality_before),
+            "quality_after": dict(h.quality_after),
+            "in_fingerprint": h._in_fp,
+            "out_fingerprint": out_fp,
+        }
+        if h.fragment_key:
+            record["fragment_key"] = h.fragment_key
+        self.receipt["phases"].append(record)
+        if self.checkpoint is not None:
+            self.checkpoint.record(h.name, record, fragment)
+        return record
+
+
+def summarize_phases(receipt: dict[str, Any]) -> dict[str, Any]:
+    """Roll ``receipt['phases']`` into a compact summary for status/JSON output."""
+    phases = receipt.get("phases") or []
+    total_ms = round(sum(float(p.get("duration_ms", 0.0)) for p in phases), 1)
+    slowest = max(
+        phases,
+        key=lambda p: float(p.get("duration_ms", 0.0)),
+        default=None,
+    )
+    return {
+        "count": len(phases),
+        "total_duration_ms": total_ms,
+        "mutations": sum(int(p.get("mutations", 0) or 0) for p in phases),
+        "errors": sum(len(p.get("errors", []) or []) for p in phases),
+        "resumed": sum(1 for p in phases if p.get("resumed")),
+        "slowest": (
+            {"phase": slowest["phase"], "duration_ms": slowest["duration_ms"]}
+            if slowest
+            else None
+        ),
+    }

--- a/src/memo/dream_shadow.py
+++ b/src/memo/dream_shadow.py
@@ -1,0 +1,549 @@
+"""dream_shadow — measure-only ("shadow") evaluation of opt-in dream phases.
+
+Generalises the single-flag ``ask_gaps.py`` shadow pattern ("report-only: log
+what it WOULD do; a human flips the flag after review") into a reusable harness
+for every ``shadow``-kind gate (see ``dream_flags.GATES``). A shadow phase runs
+in *measure-only* mode: we compute what it WOULD change and its cost into a
+durable, comparable ledger **without mutating production** (no overlay write, no
+markdown-config write, no corpus/index change). Evidence accrues per night; a
+human promotes a flag only after ``MEMO_SHADOW_REVIEW_NIGHTS`` of consecutive
+clean nights (:func:`promote`). Auto-graduation is deliberately never reached.
+
+Two measurement entry points:
+
+- :func:`record_recall_shadow` — for recall-measurable shadow flags (e.g. the
+  graph-ranking signal). The caller supplies the offline ON/OFF eval metrics
+  (measured non-invasively through ``measure_flag``'s ``flag_overrides`` env-pin
+  seam, which restores the env); we derive the comparable axis
+  (Δprecision / −Δnoise) and cost (ON p50) and append.
+- :func:`maybe_shadow` — for pass-behavior shadow flags (phases whose impact is
+  not recall-eval-measurable). Runs the pass's ``runner(dry_run=True)`` — which
+  MUST be side-effect-free — records the declared ``shadow_metric`` plus wall
+  cost, and asserts non-mutation via the corpus fingerprint + overlay version.
+
+Also home to :func:`latency_ceiling_gate` (the absolute p50 guard used by
+auto-graduation and shadow promotion — defence against the graph-signal
+~6272ms-vs-48ms recall-hook latency catastrophe that the *relative* headroom
+gate cannot catch) and :func:`migrate_reclassified_overlay` (one-time cleanup
+that un-graduates a shadow-reclassified flag the flag-graduation pass had
+previously auto-set in the overlay).
+
+Best-effort throughout: every public helper swallows and degrades rather than
+raising into the nightly pipeline. No MLX imports.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Callable
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+from memo.flags import flag_bool, flag_int
+
+_log = logging.getLogger(__name__)
+
+_SHADOW_DIR = "shadow"
+_LEDGER = "shadow_ledger.jsonl"
+_STATE = "shadow_state.json"
+_LEDGER_CAP = 2000
+_LEDGER_SIZE_LIMIT = 2_000_000
+
+# Verdicts that count as a "clean" night for the consecutive-clean review streak.
+_CLEAN = frozenset({"win", "neutral", "clean"})
+# Observation kinds (as opposed to lifecycle "event" rows) in the ledger.
+_OBS_KINDS = frozenset({"recall", "pass"})
+
+
+# --- flag accessors -------------------------------------------------------------
+
+
+def _review_nights() -> int:
+    v = flag_int("MEMO_SHADOW_REVIEW_NIGHTS")
+    return 5 if v is None else max(1, v)
+
+
+def _latency_ceiling() -> float:
+    v = flag_int("MEMO_FLAG_GRADUATION_LATENCY_CEILING_MS")
+    return 1500.0 if v is None else float(v)
+
+
+def _shadow_enabled() -> bool:
+    return flag_bool("MEMO_DREAM_SHADOW_ENABLED")
+
+
+# --- pure gate ------------------------------------------------------------------
+
+
+def latency_ceiling_gate(measured_ms: float, ceiling_ms: float) -> bool:
+    """True when ``measured_ms`` is within the absolute latency ceiling (i.e. it
+    is safe to graduate on latency grounds).
+
+    A non-positive ``ceiling_ms`` disables the gate (always passes) — matching
+    the ``ceil > 0`` guard the auto-graduation win loop applies. This is the
+    absolute backstop the relative headroom ratio cannot provide: a flag whose
+    p50 balloons from ~48ms to ~6272ms on the recall hook passes any relative
+    check against an equally-slow OFF baseline but must never graduate.
+    """
+    if ceiling_ms <= 0:
+        return True
+    return measured_ms <= ceiling_ms
+
+
+# --- paths + io -----------------------------------------------------------------
+
+
+def _shadow_root(state_dir: Path) -> Path:
+    return Path(state_dir) / "dream" / _SHADOW_DIR
+
+
+def _ledger_path(state_dir: Path) -> Path:
+    return _shadow_root(state_dir) / _LEDGER
+
+
+def _state_path(state_dir: Path) -> Path:
+    return _shadow_root(state_dir) / _STATE
+
+
+def _append_ledger(state_dir: Path, entry: dict[str, Any]) -> None:
+    from memo.dashboard_logs import _write_jsonl_entry
+
+    row = {"ts": datetime.now(UTC).isoformat(timespec="seconds"), **entry}
+    _write_jsonl_entry(
+        _ledger_path(state_dir), row, cap=_LEDGER_CAP, size_limit=_LEDGER_SIZE_LIMIT
+    )
+
+
+def read_observations(
+    state_dir: Path, *, flag: str | None = None, limit: int = _LEDGER_CAP
+) -> list[dict[str, Any]]:
+    """Ledger observation rows (kind ``recall``/``pass``), oldest first, optionally
+    filtered to one ``flag``. Lifecycle ``event`` rows are excluded."""
+    from memo.dashboard_logs import _read_jsonl
+
+    rows = _read_jsonl(_ledger_path(state_dir), limit=limit)
+    out = [r for r in rows if r.get("kind") in _OBS_KINDS]
+    if flag is not None:
+        out = [r for r in out if r.get("flag") == flag]
+    return out
+
+
+def _load_state(state_dir: Path) -> dict[str, Any]:
+    try:
+        doc = json.loads(_state_path(state_dir).read_text(encoding="utf-8"))
+        return doc if isinstance(doc, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_state(state_dir: Path, state: dict[str, Any]) -> None:
+    p = _state_path(state_dir)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+
+# --- small pure helpers ---------------------------------------------------------
+
+
+def _today() -> str:
+    return date.today().isoformat()
+
+
+def _p50(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    s = sorted(values)
+    mid = len(s) // 2
+    if len(s) % 2:
+        return round(float(s[mid]), 1)
+    return round((float(s[mid - 1]) + float(s[mid])) / 2.0, 1)
+
+
+def _recall_verdict(delta_precision: float, delta_noise: float) -> str:
+    """win / lose / neutral on the (Δprecision, −Δnoise) comparable axis."""
+    if delta_precision > 0 or (delta_precision == 0 and delta_noise < 0):
+        return "win"
+    if delta_precision < 0 or (delta_precision == 0 and delta_noise > 0):
+        return "lose"
+    return "neutral"
+
+
+def _num(value: Any) -> float | None:
+    return float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+
+
+# --- gate lookups (deferred; dream_flags imports this module) --------------------
+
+
+def _gate(flag: str) -> Any:
+    try:
+        from memo.dream_flags import GATES
+
+        return GATES.get(flag)
+    except Exception as exc:  # pragma: no cover - import guard
+        _log.debug("dream_shadow: gate lookup failed for %s: %s", flag, exc)
+        return None
+
+
+def _is_shadow_flag(flag: str) -> bool:
+    return getattr(_gate(flag), "kind", "") == "shadow"
+
+
+def _shadow_metric(flag: str) -> str:
+    return str(getattr(_gate(flag), "shadow_metric", "") or "")
+
+
+def _is_latency_metric(metric: str) -> bool:
+    return "latency" in metric.lower()
+
+
+def _env_to_path() -> dict[str, str]:
+    """Inverse of ``catalog.path_to_env`` — env-var name -> dotted config key."""
+    try:
+        from memo.tui.config.catalog import path_to_env
+
+        return {env: path for path, env in path_to_env().items()}
+    except Exception as exc:
+        _log.debug("dream_shadow: path_to_env inverse failed: %s", exc)
+        return {}
+
+
+def _fingerprint(mem: Any) -> str | None:
+    if mem is None:
+        return None
+    try:
+        from memo.dream_utils import _corpus_fingerprint
+
+        return _corpus_fingerprint(mem)
+    except Exception as exc:
+        _log.debug("dream_shadow: corpus fingerprint failed: %s", exc)
+        return None
+
+
+def _human_or_live(cfg: Any, flag: str) -> bool:
+    """A flag the human already pinned (env/config) or that is live in the
+    overlay is out of the shadow pool — we only shadow dark, unpinned flags."""
+    try:
+        from memo.dream_flags import human_owned
+        from memo.tuned_overlay import read_overlay
+
+        if human_owned(flag):
+            return True
+        return bool(read_overlay(cfg.state_dir).get(flag))
+    except Exception as exc:
+        _log.debug("dream_shadow: ownership check failed for %s: %s", flag, exc)
+        return False
+
+
+# --- recording ------------------------------------------------------------------
+
+
+def _bump_state(state_dir: Path, obs: dict[str, Any]) -> None:
+    """Update the per-flag rollup: total nights + the consecutive-clean streak.
+
+    Idempotent within a night — a re-measurement of the same ``night`` updates
+    the last verdict but never double-counts nights or the streak."""
+    state = _load_state(state_dir)
+    flags = state.setdefault("flags", {})
+    flag = obs["flag"]
+    entry = flags.setdefault(flag, {"first_night": obs["night"], "nights": 0, "streak": 0})
+    clean = obs.get("verdict") in _CLEAN
+    if obs["night"] != entry.get("last_night"):
+        entry["nights"] = int(entry.get("nights", 0)) + 1
+        entry["streak"] = int(entry.get("streak", 0)) + 1 if clean else 0
+        entry["last_night"] = obs["night"]
+    entry["last_verdict"] = obs.get("verdict")
+    _save_state(state_dir, state)
+
+
+def _record(state_dir: Path, obs: dict[str, Any]) -> None:
+    _append_ledger(state_dir, obs)
+    _bump_state(state_dir, obs)
+
+
+def record_recall_shadow(
+    state_dir: Path,
+    *,
+    flag: str,
+    off: dict[str, float],
+    on: dict[str, float],
+    night: str | None = None,
+) -> dict[str, Any] | None:
+    """Record one recall-shadow observation from precomputed ON/OFF eval metrics.
+
+    Comparable axis: Δprecision (primary) and Δnoise (tiebreak, lower better);
+    cost is the ON p50. Never mutates anything but the shadow ledger/state.
+    Returns the observation fragment (for the caller's ``receipt['shadow']``)."""
+    try:
+        d_prec = round(float(on.get("precision_at_k", 0.0)) - float(off.get("precision_at_k", 0.0)), 4)
+        d_noise = round(float(on.get("noise_at_k", 0.0)) - float(off.get("noise_at_k", 0.0)), 4)
+        cost_ms = round(float(on.get("latency_ms_p50", 0.0)), 1)
+        obs: dict[str, Any] = {
+            "kind": "recall",
+            "flag": flag,
+            "night": night or _today(),
+            "delta": d_prec,
+            "delta_precision": d_prec,
+            "delta_noise": d_noise,
+            "cost_ms": cost_ms,
+            "off": dict(off),
+            "on": dict(on),
+            "verdict": _recall_verdict(d_prec, d_noise),
+        }
+        _record(state_dir, obs)
+        return obs
+    except Exception as exc:
+        _log.debug("dream_shadow: record_recall_shadow failed for %s: %s", flag, exc)
+        return None
+
+
+def maybe_shadow(
+    cfg: Any,
+    mem: Any,
+    *,
+    flag: str,
+    runner: Callable[..., dict[str, Any] | None],
+    receipt: dict[str, Any],
+    metric: str,
+    baseline_getter: Callable[[Any, Any], Any] | None = None,
+    night: str | None = None,
+) -> dict[str, Any] | None:
+    """Shadow-measure a pass-behavior flag: run ``runner(dry_run=True)`` and
+    record its declared ``metric`` + wall cost WITHOUT mutating production.
+
+    Gate: ``MEMO_DREAM_SHADOW_ENABLED`` on, ``flag`` is shadow-kind, and the
+    human has not pinned/graduated it. ``runner(dry_run=True)`` MUST be
+    side-effect-free; non-mutation is asserted via the corpus fingerprint +
+    overlay ``params_version`` — a run that moved either is recorded as a
+    ``lose`` (leak). Stashes the fragment under ``receipt['shadow'][flag]``.
+    Best-effort: returns None (and records nothing) when gated off or on error.
+    """
+    try:
+        if not _shadow_enabled() or not _is_shadow_flag(flag) or _human_or_live(cfg, flag):
+            return None
+        from memo.tuned_overlay import params_version
+
+        fp_before = _fingerprint(mem)
+        ver_before = params_version(cfg.state_dir)
+        t0 = time.perf_counter()
+        fragment = runner(dry_run=True) or {}
+        cost_ms = round((time.perf_counter() - t0) * 1000.0, 1)
+        fp_after = _fingerprint(mem)
+        ver_after = params_version(cfg.state_dir)
+        mutated = (fp_before is not None and fp_before != fp_after) or (ver_before != ver_after)
+
+        value = fragment.get(metric) if isinstance(fragment, dict) else None
+        baseline: Any = None
+        if baseline_getter is not None:
+            try:
+                baseline = baseline_getter(cfg, mem)
+            except Exception as exc:
+                _log.debug("dream_shadow: baseline_getter failed for %s: %s", flag, exc)
+                baseline = None
+        v_num, b_num = _num(value), _num(baseline)
+        if v_num is not None and b_num is not None:
+            delta: float | None = round(v_num - b_num, 4)
+        else:
+            delta = v_num
+        obs: dict[str, Any] = {
+            "kind": "pass",
+            "flag": flag,
+            "night": night or _today(),
+            "metric": metric,
+            "value": value,
+            "baseline": baseline,
+            "delta": delta,
+            "cost_ms": cost_ms,
+            "mutated": bool(mutated),
+            "verdict": "lose" if mutated else "clean",
+        }
+        _record(cfg.state_dir, obs)
+        receipt.setdefault("shadow", {})[flag] = obs
+        return obs
+    except Exception as exc:
+        _log.debug("dream_shadow: maybe_shadow failed for %s: %s", flag, exc)
+        return None
+
+
+# --- review / summary -----------------------------------------------------------
+
+
+def shadow_summary(state_dir: Path, flag: str) -> dict[str, Any]:
+    """Per-flag review rollup: nights of evidence, consecutive-clean streak, mean
+    Δ, cost p50, last verdict, and whether the flag is review-ready (enough
+    consecutive-clean nights and no decision yet)."""
+    obs = read_observations(state_dir, flag=flag)
+    entry = _load_state(state_dir).get("flags", {}).get(flag, {})
+    review_nights = _review_nights()
+    deltas = [d for d in (_num(o.get("delta")) for o in obs) if d is not None]
+    costs = [c for c in (_num(o.get("cost_ms")) for o in obs) if c is not None]
+    nights = int(entry.get("nights", 0))
+    streak = int(entry.get("streak", 0))
+    decision = entry.get("decision")
+    return {
+        "flag": flag,
+        "kind": getattr(_gate(flag), "kind", ""),
+        "metric": _shadow_metric(flag),
+        "nights": nights,
+        "streak": streak,
+        "review_nights": review_nights,
+        "mean_delta": round(sum(deltas) / len(deltas), 4) if deltas else 0.0,
+        "cost_p50": _p50(costs),
+        "last_verdict": entry.get("last_verdict"),
+        "decision": decision,
+        "review_ready": decision is None and streak >= review_nights,
+    }
+
+
+def review_rows(state_dir: Path, gates: dict[str, Any]) -> list[dict[str, Any]]:
+    """One :func:`shadow_summary` per shadow-kind gate — the ``memo dream shadow
+    --status`` table source. Pure over the passed ``gates`` mapping."""
+    shadow_flags = sorted(
+        name for name, g in gates.items() if getattr(g, "kind", "") == "shadow"
+    )
+    return [shadow_summary(state_dir, name) for name in shadow_flags]
+
+
+# --- decisions ------------------------------------------------------------------
+
+
+def _mark_decision(state_dir: Path, flag: str, decision: str, *, reason: str = "") -> None:
+    state = _load_state(state_dir)
+    entry = state.setdefault("flags", {}).setdefault(flag, {})
+    entry["decision"] = decision
+    entry["decision_reason"] = reason
+    entry["decided_at"] = _today()
+    _save_state(state_dir, state)
+
+
+def migrate_reclassified_overlay(state_dir: Path, gates: dict[str, Any]) -> list[str]:
+    """One-time cleanup: strip any shadow-kind flag the flag-graduation pass had
+    auto-set in the overlay (``_meta.set_by == 'dream-flag-graduation'``).
+
+    Scoped to that provenance so it never fights the graph-weight tuner's own
+    online-revert (``set_by == 'dream-curated-graph'``) — an overlay last written
+    by any other writer is left entirely alone. Each removal is logged to the
+    ledger as ``auto_reverted_on_reclassify``. Returns the removed flag names.
+    """
+    try:
+        from memo.tuned_overlay import _scalar_params, read_overlay, write_overlay
+
+        doc = read_overlay(state_dir)
+        if not doc:
+            return []
+        set_by = str((doc.get("_meta") or {}).get("set_by") or "")
+        if set_by != "dream-flag-graduation":
+            return []
+        shadow_flags = {name for name, g in gates.items() if getattr(g, "kind", "") == "shadow"}
+        params = _scalar_params(doc)
+        removed = [name for name in params if name in shadow_flags]
+        if not removed:
+            return []
+        for name in removed:
+            params.pop(name, None)
+        write_overlay(state_dir, params, {"set_by": "dream-shadow-reclassify"})
+        for name in removed:
+            _append_ledger(
+                state_dir,
+                {"kind": "event", "event": "auto_reverted_on_reclassify", "flag": name},
+            )
+        return removed
+    except Exception as exc:
+        _log.debug("dream_shadow: overlay reclassify migration failed: %s", exc)
+        return []
+
+
+def promote(
+    cfg: Any, flag: str, *, force_latency: bool = False, apply: bool = False
+) -> dict[str, Any]:
+    """Human graduation of a review-ready shadow flag (never automatic).
+
+    Refuses unless the flag is review-ready. For a latency-metric shadow flag,
+    refuses when the recorded cost p50 exceeds ``MEMO_FLAG_GRADUATION_LATENCY_CEILING_MS``
+    unless ``force_latency`` — the offline p50 is a LOWER bound on the real
+    recall-hook cost, so a passing offline ceiling is not proof of hook safety.
+    With ``apply=False`` (default) nothing is written: returns the exact ``memo
+    config set`` command (or an ``export`` fallback when the flag has no markdown
+    key). With ``apply=True`` persists via ``config_md.set_value`` and marks the
+    decision. Best-effort: returns a result dict with ``ok``/``error``.
+    """
+    result: dict[str, Any] = {"flag": flag, "ok": False, "applied": False}
+    try:
+        summary = shadow_summary(cfg.state_dir, flag)
+        if not summary["review_ready"]:
+            result["error"] = (
+                f"not review-ready: {summary['streak']}/{summary['review_nights']} "
+                "consecutive-clean nights"
+            )
+            return result
+
+        metric = _shadow_metric(flag)
+        if _is_latency_metric(metric):
+            ceiling = _latency_ceiling()
+            cost_p50 = float(summary["cost_p50"])
+            if not force_latency and not latency_ceiling_gate(cost_p50, ceiling):
+                result["error"] = (
+                    f"latency p50 {cost_p50}ms exceeds ceiling {ceiling}ms; the offline "
+                    "eval is a lower bound on the recall-hook cost — confirm "
+                    "hook-faithfully or pass force_latency"
+                )
+                return result
+
+        path = _env_to_path().get(flag)
+        if path is None:
+            # Pure meta flag with no markdown-config surface: instruct via env.
+            result["instruction"] = f"export {flag}=1"
+            if apply:
+                result["error"] = "no markdown-config key; set via env/overlay, cannot config-set"
+                return result
+            result["ok"] = True
+            return result
+
+        result["path"] = path
+        if not apply:
+            result["command"] = f"memo config set {path} true"
+            result["ok"] = True
+            return result
+
+        from memo.config_md import set_value
+
+        set_value(path, "true")
+        _mark_decision(cfg.state_dir, flag, "promoted", reason=f"config set {path}=true")
+        result["ok"] = True
+        result["applied"] = True
+        return result
+    except Exception as exc:
+        _log.debug("dream_shadow: promote failed for %s: %s", flag, exc)
+        result["error"] = f"{type(exc).__name__}: {exc}"
+        return result
+
+
+def reject(cfg: Any, flag: str, reason: str) -> bool:
+    """Record a human rejection of a shadowed flag and mark its decision so it
+    drops out of the review-ready pool. Best-effort; returns success."""
+    try:
+        _append_ledger(
+            cfg.state_dir,
+            {"kind": "event", "event": "rejected", "flag": flag, "reason": reason[:200]},
+        )
+        _mark_decision(cfg.state_dir, flag, "rejected", reason=reason[:200])
+        return True
+    except Exception as exc:
+        _log.debug("dream_shadow: reject failed for %s: %s", flag, exc)
+        return False
+
+
+__all__ = [
+    "latency_ceiling_gate",
+    "maybe_shadow",
+    "migrate_reclassified_overlay",
+    "promote",
+    "read_observations",
+    "record_recall_shadow",
+    "reject",
+    "review_rows",
+    "shadow_summary",
+]

--- a/src/memo/dream_staging.py
+++ b/src/memo/dream_staging.py
@@ -1,0 +1,418 @@
+"""Dream conflict-staging: park a blocked dream-minted memory instead of losing it.
+
+Every dream pass that mints a durable memory calls ``mem.save(...)``, which runs
+the native write policy and raises :class:`memo.errors.WriteRefused` when an
+active ``freeze_write`` conflict matches the write's topic. Historically each
+save site swallowed that in a broad ``except`` and lost the LLM-generated
+candidate — no conflict id, no evidence, no way to re-apply once the human
+resolved the conflict.
+
+This module is the seam that fixes it, gated default-OFF behind
+``MEMO_DREAM_STAGING_ENABLED``:
+
+- :func:`staged_save` wraps ``mem.save``. Outside a dream pipeline run (or with
+  the flag off) it is a pure pass-through — ``WriteRefused`` propagates exactly
+  as before. Inside a dream run with the flag on, a ``WriteRefused`` (and only a
+  ``WriteRefused``) parks the full proposal + conflict evidence in machine-local
+  dream state and returns ``None``; every other error re-raises so callers'
+  ``save_failed`` path is preserved.
+- :func:`resume_staged_proposals` re-applies a parked proposal on a later run
+  once the blocking conflict is resolved (human-only, via
+  ``memo operational conflict resolve``) or auto-cleared (subject memory
+  deleted). It never resolves a conflict itself.
+
+The staging store is ``state_dir/dream/staging.json`` — derived, machine-local
+dream state like ``last.json``. It is NOT a memory: no ``.md``, no ``id:``
+frontmatter, never in the vault, never exported over git sync. Markdown remains
+the source of truth.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import hashlib
+import json
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from memo.atomic_io import atomic_write_text
+from memo.errors import MemoError, WriteRefused
+from memo.flags import flag_bool, flag_int
+from memo.util import utc_now_iso
+
+if TYPE_CHECKING:
+    from memo.config import Config
+    from memo.memory import Memory
+    from memo.memory.record import MemoryRecord
+
+_SCHEMA = "memo.dream_staging.v1"
+_STAGING_FLAG = "MEMO_DREAM_STAGING_ENABLED"
+_STAGING_MAX_FLAG = "MEMO_DREAM_STAGING_MAX"
+_DEFAULT_MAX = 200
+
+# Extra-frontmatter keys a pass may carry a stable provenance hash under. Used
+# to make the proposal id deterministic across nights so the same blocked
+# candidate dedups instead of piling up.
+_PROVENANCE_KEYS = ("synthesis_sources_hash", "sources_hash", "provenance_hash")
+
+
+@dataclass(frozen=True)
+class StagedProposal:
+    """One dream-minted candidate parked because a write conflict blocked it.
+
+    ``save_kwargs`` is replayed verbatim into ``mem.save`` on resume, so it holds
+    exactly the keyword arguments the pass passed to :func:`staged_save`
+    (content/title/type_/tags/extra/...).
+    """
+
+    proposal_id: str
+    kind: str
+    save_kwargs: dict[str, Any]
+    source_ids: tuple[str, ...]
+    conflict_ids: tuple[str, ...]
+    conflict_summary: str
+    evidence_uris: tuple[str, ...]
+    staged_at: str
+    state: str = "staged"  # "staged" | "applied" | "dropped"
+    attempts: int = 1
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "proposal_id": self.proposal_id,
+            "kind": self.kind,
+            "save_kwargs": dict(self.save_kwargs),
+            "source_ids": list(self.source_ids),
+            "conflict_ids": list(self.conflict_ids),
+            "conflict_summary": self.conflict_summary,
+            "evidence_uris": list(self.evidence_uris),
+            "staged_at": self.staged_at,
+            "state": self.state,
+            "attempts": self.attempts,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StagedProposal:
+        return cls(
+            proposal_id=str(data["proposal_id"]),
+            kind=str(data.get("kind") or ""),
+            save_kwargs=dict(data.get("save_kwargs") or {}),
+            source_ids=tuple(str(s) for s in (data.get("source_ids") or ())),
+            conflict_ids=tuple(str(c) for c in (data.get("conflict_ids") or ())),
+            conflict_summary=str(data.get("conflict_summary") or ""),
+            evidence_uris=tuple(str(u) for u in (data.get("evidence_uris") or ())),
+            staged_at=str(data.get("staged_at") or ""),
+            state=str(data.get("state") or "staged"),
+            attempts=int(data.get("attempts") or 1),
+            metadata=dict(data.get("metadata") or {}),
+        )
+
+
+# --- scope -----------------------------------------------------------------
+# staged_save only diverts to staging inside a dream pipeline run. Interactive
+# `memo synthesize` / presynthesis saves (which call the same public Memory
+# methods) must never silently disappear into staging, so the seam is gated on
+# this contextvar in addition to the flag.
+_STAGING_SCOPE: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "memo_dream_staging_scope", default=False
+)
+
+
+@contextmanager
+def dream_staging_scope() -> Iterator[None]:
+    """Mark the current context as a dream pipeline run for :func:`staged_save`."""
+    token = _STAGING_SCOPE.set(True)
+    try:
+        yield
+    finally:
+        _STAGING_SCOPE.reset(token)
+
+
+def _staging_active() -> bool:
+    return _STAGING_SCOPE.get() and flag_bool(_STAGING_FLAG)
+
+
+# --- persistence -----------------------------------------------------------
+def _staging_path(cfg: Config) -> Path:
+    return cfg.state_dir / "dream" / "staging.json"
+
+
+def _load(cfg: Config) -> list[StagedProposal]:
+    path = _staging_path(cfg)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    proposals = raw.get("proposals") if isinstance(raw, dict) else None
+    if not isinstance(proposals, list):
+        return []
+    out: list[StagedProposal] = []
+    for item in proposals:
+        if not isinstance(item, dict):
+            continue
+        try:
+            out.append(StagedProposal.from_dict(item))
+        except (KeyError, TypeError, ValueError):
+            continue
+    return out
+
+
+def _save(cfg: Config, proposals: Sequence[StagedProposal]) -> None:
+    payload = {"schema": _SCHEMA, "proposals": [p.to_dict() for p in proposals]}
+    atomic_write_text(
+        _staging_path(cfg),
+        json.dumps(payload, ensure_ascii=False, indent=2),
+    )
+
+
+# --- helpers ---------------------------------------------------------------
+def _provenance_hash(save_kwargs: dict[str, Any], source_ids: Sequence[str]) -> str:
+    """A stable 16-hex fingerprint for a proposal.
+
+    Prefers a pass-supplied provenance hash (so the id matches the pass's own
+    dedup), else falls back to ``sha256(sorted(source_ids) + title)``.
+    """
+    extra = save_kwargs.get("extra")
+    if isinstance(extra, dict):
+        for key in _PROVENANCE_KEYS:
+            val = str(extra.get(key) or "").strip()
+            if val:
+                return val[:16]
+    title = str(save_kwargs.get("title") or "")
+    basis = "\x00".join(sorted(str(s) for s in source_ids)) + "\x00" + title
+    return hashlib.sha256(basis.encode("utf-8")).hexdigest()[:16]
+
+
+def _capture_conflict(
+    mem: Memory, conflict: dict[str, Any]
+) -> tuple[list[str], str, list[str]]:
+    """Extract (conflict_ids, summary, evidence_uris) for a WriteRefused.
+
+    The WriteRefused only carries the first blocking conflict id + reason. We
+    enrich it by matching that id against the live operational conflict rows to
+    pull the row's summary, evidence uris, and subject memory ids. Best-effort:
+    evidence enrichment must never fail the primary staging write, so a read
+    failure degrades to the WriteRefused's own summary.
+    """
+    cid = str(conflict.get("conflict_id") or "").strip()
+    summary = str(conflict.get("summary") or "").strip()
+    conflict_ids = [cid] if cid else []
+    evidence: list[str] = []
+    try:
+        rows = mem.operational.active_conflicts()
+    except Exception:
+        rows = []
+    for row in rows:
+        if str(row.get("id") or "") != cid:
+            continue
+        summary = str(row.get("summary") or summary).strip()
+        evidence = [str(u) for u in (row.get("evidence_uris") or ()) if str(u).strip()]
+        meta = row.get("metadata") or {}
+        member_ids = [str(m) for m in (meta.get("memory_ids") or ()) if str(m).strip()]
+        if not evidence and member_ids:
+            evidence = [f"memo://memoria/{m}" for m in member_ids]
+        break
+    return conflict_ids, summary, evidence
+
+
+def _enforce_cap(
+    proposals: list[StagedProposal], max_staged: int
+) -> list[StagedProposal]:
+    """Drop the oldest ``staged`` proposals beyond the cap (list order = age)."""
+    if max_staged <= 0:
+        return proposals
+    staged_idx = [i for i, p in enumerate(proposals) if p.state == "staged"]
+    excess = len(staged_idx) - max_staged
+    if excess <= 0:
+        return proposals
+    drop = set(staged_idx[:excess])
+    return [p for i, p in enumerate(proposals) if i not in drop]
+
+
+# --- public API ------------------------------------------------------------
+def stage_proposal(
+    cfg: Config,
+    mem: Memory,
+    *,
+    kind: str,
+    save_kwargs: dict[str, Any],
+    source_ids: Sequence[str],
+    conflict: dict[str, Any],
+) -> StagedProposal:
+    """Park a blocked candidate (idempotent by deterministic proposal id).
+
+    Staging the same proposal again bumps ``attempts`` and refreshes the
+    captured conflict rather than creating a duplicate. Enforces
+    ``MEMO_DREAM_STAGING_MAX`` by dropping the oldest staged proposals.
+    """
+    ids = [str(s) for s in source_ids]
+    proposal_id = f"dream-{kind}-{_provenance_hash(save_kwargs, ids)}"
+    conflict_ids, summary, evidence = _capture_conflict(mem, conflict)
+
+    proposals = _load(cfg)
+    existing = next((p for p in proposals if p.proposal_id == proposal_id), None)
+    if existing is not None:
+        updated = replace(
+            existing,
+            save_kwargs=dict(save_kwargs),
+            source_ids=tuple(ids),
+            conflict_ids=tuple(conflict_ids) or existing.conflict_ids,
+            conflict_summary=summary or existing.conflict_summary,
+            evidence_uris=tuple(evidence) or existing.evidence_uris,
+            state="staged",
+            attempts=existing.attempts + 1,
+        )
+        proposals = [updated if p.proposal_id == proposal_id else p for p in proposals]
+        _save(cfg, proposals)
+        return updated
+
+    proposal = StagedProposal(
+        proposal_id=proposal_id,
+        kind=str(kind),
+        save_kwargs=dict(save_kwargs),
+        source_ids=tuple(ids),
+        conflict_ids=tuple(conflict_ids),
+        conflict_summary=summary,
+        evidence_uris=tuple(evidence),
+        staged_at=utc_now_iso(),
+    )
+    proposals.append(proposal)
+    max_staged = flag_int(_STAGING_MAX_FLAG) or _DEFAULT_MAX
+    proposals = _enforce_cap(proposals, max_staged)
+    _save(cfg, proposals)
+    return proposal
+
+
+def staged_save(
+    mem: Memory,
+    cfg: Config,
+    *,
+    kind: str,
+    source_ids: Sequence[str],
+    **save_kwargs: Any,
+) -> MemoryRecord | None:
+    """``mem.save`` with dream conflict-staging.
+
+    Outside a dream run or with the flag off, this is exactly ``mem.save`` and
+    ``WriteRefused`` propagates as before. Inside a dream run with the flag on, a
+    ``WriteRefused`` (and only that) parks the proposal and returns ``None``;
+    every other exception re-raises so callers' ``save_failed`` path is intact.
+    """
+    if not _staging_active():
+        return mem.save(**save_kwargs)
+    try:
+        return mem.save(**save_kwargs)
+    except WriteRefused as exc:
+        stage_proposal(
+            cfg,
+            mem,
+            kind=kind,
+            save_kwargs=save_kwargs,
+            source_ids=source_ids,
+            conflict=exc.conflict,
+        )
+        return None
+
+
+def resume_staged_proposals(cfg: Config, mem: Memory) -> dict[str, Any]:
+    """Re-apply parked proposals whose blocking conflicts are gone.
+
+    A proposal is unblocked when none of its ``conflict_ids`` are still active.
+    Resolution stays human-only (or auto-clear on subject delete) — this never
+    resolves a conflict. Replay runs OUTSIDE the staging scope so a still-blocked
+    proposal re-stages (bumping attempts) rather than being lost. Returns
+    ``{applied, still_blocked, errors, total_open}``.
+    """
+    proposals = _load(cfg)
+    try:
+        active_ids = {str(r.get("id") or "") for r in mem.operational.active_conflicts()}
+    except Exception:
+        active_ids = set()
+
+    applied: list[str] = []
+    errors: list[str] = []
+    still_blocked = 0
+    remaining: list[StagedProposal] = []
+
+    token = _STAGING_SCOPE.set(False)
+    try:
+        for proposal in proposals:
+            if proposal.state != "staged":
+                continue  # applied/dropped entries are pruned on rewrite
+            if any(cid in active_ids for cid in proposal.conflict_ids):
+                still_blocked += 1
+                remaining.append(proposal)
+                continue
+            try:
+                mem.save(**proposal.save_kwargs)
+            except WriteRefused as exc:
+                # A different / remaining conflict still blocks: re-stage with
+                # the new blocker's evidence so the next resume targets it.
+                still_blocked += 1
+                cids, summ, evid = _capture_conflict(mem, exc.conflict)
+                remaining.append(
+                    replace(
+                        proposal,
+                        conflict_ids=tuple(cids) or proposal.conflict_ids,
+                        conflict_summary=summ or proposal.conflict_summary,
+                        evidence_uris=tuple(evid) or proposal.evidence_uris,
+                        attempts=proposal.attempts + 1,
+                    )
+                )
+                continue
+            except MemoError as exc:
+                errors.append(f"{proposal.proposal_id}: {type(exc).__name__}: {exc}")
+                remaining.append(proposal)  # keep for a later retry
+                continue
+            applied.append(proposal.proposal_id)  # pruned (not carried forward)
+    finally:
+        _STAGING_SCOPE.reset(token)
+
+    _save(cfg, remaining)
+    return {
+        "applied": applied,
+        "still_blocked": still_blocked,
+        "errors": errors,
+        "total_open": sum(1 for p in remaining if p.state == "staged"),
+    }
+
+
+def list_staged(cfg: Config) -> list[StagedProposal]:
+    """All currently-staged (awaiting-resolution) proposals."""
+    return [p for p in _load(cfg) if p.state == "staged"]
+
+
+def drop_staged(cfg: Config, proposal_id: str) -> bool:
+    """Remove a staged proposal by id. Returns True if one was removed."""
+    proposals = _load(cfg)
+    kept = [p for p in proposals if p.proposal_id != proposal_id]
+    if len(kept) == len(proposals):
+        return False
+    _save(cfg, kept)
+    return True
+
+
+def resolve_command(proposal: StagedProposal) -> str:
+    """The exact human CLI command to resolve the proposal's blocking conflict.
+
+    Mirrors the read-only MCP ``memo_conflict_resolve`` contract: conflict
+    resolution is human-only via the CLI, never performed by staging.
+    """
+    cid = proposal.conflict_ids[0] if proposal.conflict_ids else "<conflict-id>"
+    return f"memo operational conflict resolve {cid} '<resolution>' --actor <human>"
+
+
+__all__ = [
+    "StagedProposal",
+    "dream_staging_scope",
+    "drop_staged",
+    "list_staged",
+    "resolve_command",
+    "resume_staged_proposals",
+    "stage_proposal",
+    "staged_save",
+]

--- a/src/memo/dream_tune.py
+++ b/src/memo/dream_tune.py
@@ -484,6 +484,33 @@ def run_tuning_pass(
             knob_results[knob]["verdict"] = "would_apply"
             return res
 
+        # Fase 4 — full six-condition graduation gate on the selected winner.
+        # Always COMPUTED and recorded (shadow evidence: what the strict gate
+        # would decide tonight); only ENFORCED when MEMO_DREAM_TUNE_STRICT_GATE_ENABLED
+        # is graduated on. Best-effort: a gate-computation failure never blocks
+        # the tuner's existing (already-gated) apply path.
+        try:
+            from memo import dream_metrics
+            from memo.flags import flag_bool
+
+            grad = dream_metrics.graduation_gate(
+                w_before,
+                w_after,
+                n_labels=int(res.get("n_labels", 0)),
+                latency_before=float(w_before.get("latency_ms_p50", 0.0)),
+                latency_after=float(w_after.get("latency_ms_p50", 0.0)),
+                experiment_recorded=True,  # record_pending below IS the experiment
+                rollback_exists=True,  # overlay + saved knob baseline are the rollback
+                **dream_metrics.tune_gate_thresholds(),
+            )
+            res["graduation_gate"] = grad
+            if flag_bool("MEMO_DREAM_TUNE_STRICT_GATE_ENABLED") and not grad["ok"]:
+                res["status"] = "gate_rejected"
+                knob_results[knob]["verdict"] = "gate_rejected"
+                return res
+        except Exception as exc:  # gate is advisory unless graduated; never fatal
+            res["graduation_gate_error"] = f"{type(exc).__name__}: {exc}"
+
         # Merge, don't clobber: preserve every param a prior pass set (float
         # knobs AND the retrieval pass's bool/str levers) so the tuners coexist.
         version_before = params_version(cfg.state_dir)

--- a/src/memo/embedder.py
+++ b/src/memo/embedder.py
@@ -384,6 +384,41 @@ class MLXEmbedder(EmbedderBase):  # see memo.embed_base for the shared contract
 
         return result
 
+    def embed_queries(self, queries: Sequence[str]) -> list[list[float]]:
+        """Batch variant of :meth:`embed_query`: one forward pass for many
+        queries, sharing the asymmetric-retrieval prefix and the LRU cache.
+
+        Preserves the query-only prefix invariant (the prefix is applied HERE,
+        never by callers) and the empty-string guard (→ zero vector). Cached
+        queries are served without a forward pass; only the misses are batched.
+        """
+        stripped = [(q or "").strip() for q in queries]
+        results: list[list[float] | None] = [None] * len(stripped)
+        miss_text: list[str] = []
+        miss_idx: list[int] = []
+        for i, q in enumerate(stripped):
+            if not q:
+                results[i] = [0.0] * self.expected_dims
+                continue
+            if self._query_cache is not None:
+                cached = self._query_cache.get(
+                    f"{self._model_identity()}:{self.expected_dims}:{q}"
+                )
+                if cached is not None:
+                    results[i] = cached
+                    continue
+            miss_idx.append(i)
+            miss_text.append(q)
+        if miss_text:
+            vecs = self.embed([_QUERY_INSTRUCTION_PREFIX + q for q in miss_text])
+            for j, i in enumerate(miss_idx):
+                results[i] = vecs[j]
+                if self._query_cache is not None:
+                    self._query_cache.put(
+                        f"{self._model_identity()}:{self.expected_dims}:{miss_text[j]}", vecs[j]
+                    )
+        return [r if r is not None else [0.0] * self.expected_dims for r in results]
+
     def unload(self) -> None:  # type: ignore[no-redef]
         """Drop the model + tokenizer + query cache; clear the MLX cache. Idempotent."""
         with self._load_lock:

--- a/src/memo/flags_ingest.py
+++ b/src/memo/flags_ingest.py
@@ -304,6 +304,16 @@ SPECS: tuple[FlagSpec, ...] = (
         "Per-memory local LLM timeout for nightly HyPE generation; long enough for a cold model load.",
         min_val=1.0,
     ),
+    _spec(
+        "MEMO_DREAM_HYPE_BUDGET_S",
+        "float",
+        0.0,
+        "ingest",
+        "Wall-clock budget (seconds) for the nightly HyPE pass; the untouched "
+        "backlog tail carries to the next night (backlog_remaining). 0 disables "
+        "the budget (drain the whole night_cap).",
+        min_val=0.0,
+    ),
     # verbatim turn-level index (Total Recall F1)
     _spec(
         "MEMO_VERBATIM_INDEX",

--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -25,6 +25,123 @@ SPECS: tuple[FlagSpec, ...] = (
         "Maximum title/tag vector views generated per nightly run.",
         min_val=1,
     ),
+    # --- dream learning-loop phases (Fase 3-8): all default-off, opt-in -------
+    _spec(
+        "MEMO_DREAM_LEDGER_ENABLED",
+        "bool",
+        False,
+        "dream",
+        "Record an auditable learning-ledger entry (signal→action→evidence→"
+        "confidence→applied_change→outcome→rollback) for every mutating dream "
+        "action. Read-only append log; does not change what dream does.",
+    ),
+    _spec(
+        "MEMO_DREAM_INCREMENTAL_ENABLED",
+        "bool",
+        False,
+        "dream",
+        "Skip heavy maintenance passes for corpus regions whose cluster / "
+        "watermark fingerprint is unchanged since the last run (entities, "
+        "consolidate, graph, synthesis). Derived-index only; Markdown unchanged.",
+    ),
+    _spec(
+        "MEMO_DREAM_INDEX_REPAIR_ENABLED",
+        "bool",
+        False,
+        "dream",
+        "Allow the index health check to auto-repair DERIVED indexes only "
+        "(orphan vec/fts rows, stale caches); Markdown stays the source of "
+        "truth and is never modified. Off = report-only.",
+    ),
+    _spec(
+        "MEMO_DREAM_STAGING_ENABLED",
+        "bool",
+        False,
+        "dream",
+        "Route a dream-minted memory that hits a write conflict into a staging "
+        "quarantine (with conflict id + evidence) instead of losing it, so a "
+        "human can resolve and re-apply later.",
+    ),
+    _spec(
+        "MEMO_DREAM_STAGING_MAX",
+        "int",
+        200,
+        "dream",
+        "Maximum staged proposals retained; oldest are dropped past this cap.",
+        min_val=1,
+    ),
+    _spec(
+        "MEMO_DREAM_SHADOW_ENABLED",
+        "bool",
+        False,
+        "dream",
+        "Shadow mode: measure the impact of opt-in dream phases and emit a "
+        "comparable receipt WITHOUT changing production behavior. Graduation "
+        "stays a human decision after reviewing the shadow evidence.",
+    ),
+    _spec(
+        "MEMO_SHADOW_REVIEW_NIGHTS",
+        "int",
+        5,
+        "dream",
+        "Consecutive shadow nights of evidence required before a human may "
+        "graduate a shadowed phase.",
+        min_val=1,
+    ),
+    _spec(
+        "MEMO_FLAG_GRADUATION_LATENCY_CEILING_MS",
+        "int",
+        1500,
+        "dream",
+        "Absolute recall-hook latency ceiling (ms) a dark flag must respect to "
+        "graduate; guards against graph-signal-style latency regressions.",
+        min_val=0,
+    ),
+    _spec(
+        "MEMO_DREAM_TUNE_MIN_LABELS",
+        "int",
+        12,
+        "dream",
+        "Minimum labeled samples the tuner needs before it may graduate a "
+        "config change (statistical-floor gate; too few labels = no graduation).",
+        min_val=1,
+    ),
+    _spec(
+        "MEMO_DREAM_TUNE_LATENCY_HEADROOM",
+        "float",
+        1.25,
+        "dream",
+        "Maximum ratio of post-change recall latency to baseline the tuner "
+        "tolerates before rejecting a candidate config.",
+        min_val=1.0,
+    ),
+    _spec(
+        "MEMO_DREAM_TUNE_HOOK_BUDGET_MS",
+        "float",
+        3000.0,
+        "dream",
+        "Recall-hook latency budget (ms) the tuner's latency gate enforces.",
+        min_val=0.0,
+    ),
+    _spec(
+        "MEMO_DREAM_TUNE_MIN_MARGIN",
+        "float",
+        0.0,
+        "dream",
+        "Minimum precision improvement margin required for the tuner to "
+        "graduate a config change (0.0 = any strict improvement qualifies).",
+        min_val=0.0,
+    ),
+    _spec(
+        "MEMO_DREAM_TUNE_STRICT_GATE_ENABLED",
+        "bool",
+        False,
+        "dream",
+        "Enforce the full six-condition graduation_gate (min labels, precision "
+        "margin, noise, absolute+relative latency, experiment+rollback) before "
+        "the tuner applies a change. Default off: the verdict is still RECORDED "
+        "every night (shadow evidence) but not enforced until graduated.",
+    ),
     # feedback boosting
     _spec(
         "MEMO_FEEDBACK_DISABLED",

--- a/src/memo/memory/consolidate_ops.py
+++ b/src/memo/memory/consolidate_ops.py
@@ -766,7 +766,19 @@ class _ConsolidateOpsMixin(_MemoryBase):
                 and not dry_run
             ):
                 try:
-                    rec = self.save(
+                    # Fase 7 — inside a dream run with MEMO_DREAM_STAGING_ENABLED,
+                    # a write-conflict (WriteRefused) parks the candidate in dream
+                    # staging (returns None) instead of losing it; every other
+                    # error re-raises into the except below. Outside a dream run
+                    # (or flag off) this is exactly self.save, so interactive
+                    # `memo synthesize` keeps raising as before.
+                    from memo.dream_staging import staged_save
+
+                    rec = staged_save(
+                        self,
+                        self.cfg,
+                        kind="synthesis",
+                        source_ids=source_ids,
                         content=body,
                         title=title,
                         type_="synthesis",
@@ -778,10 +790,13 @@ class _ConsolidateOpsMixin(_MemoryBase):
                             "synthesis_confidence": confidence,
                         },
                     )
-                    result["saved"] = True
-                    result["id"] = rec.id
-                    existing_hashes.add(sources_hash)
-                    saved += 1
+                    if rec is not None:
+                        result["saved"] = True
+                        result["id"] = rec.id
+                        existing_hashes.add(sources_hash)
+                        saved += 1
+                    else:
+                        result["staged"] = True  # parked pending conflict resolution
                 except Exception as exc:
                     _log.warning("synthesize: save failed: %s", exc)
 

--- a/src/memo/store/hype_store.py
+++ b/src/memo/store/hype_store.py
@@ -280,7 +280,7 @@ class HypeStore(_ConnectionMixin):
             "SELECT body_hash, status FROM hype_attempts WHERE memory_id = ?",
             (memory_id,),
         ).fetchone()
-        if attempt and str(attempt["status"]) in {"indexed", "empty"}:
+        if attempt and str(attempt["status"]) in {"indexed", "empty", "missing_source"}:
             return str(attempt["body_hash"])
         return None
 

--- a/src/memo/store/index_health.py
+++ b/src/memo/store/index_health.py
@@ -1,0 +1,379 @@
+"""Index-health diagnostic for the derived sqlite index.
+
+memo's canonical store is the Markdown corpus; ``memvec.db`` (``meta`` +
+sqlite-vec ``vec`` + FTS5 ``fts``, plus derived HyPE sidecars and the
+``repo_embedding_cache``) is a **rebuildable index** over it. Over time the
+two can drift — a hand-edit in Obsidian, an interrupted delete, a model swap.
+
+``check_index_health`` is a pure, MLX-free SQL diagnostic: it DETECTS those
+divergences and, only under ``repair=True``, removes genuinely *derived*
+orphans (a vector or index row whose canonical memory is gone). It NEVER
+touches a ``.md`` file and never deletes a memory whose ``.md`` still exists —
+the source of truth is always safe.
+
+Best-effort by construction: no sub-check may raise. A failed check records its
+error in ``errors`` and the diagnostic continues (dream-pass style).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+# Cap every sample list so a badly-diverged store can't return a huge payload.
+_SAMPLE_CAP = 10
+
+# Checks that are purely informational — their non-zero count is expected on a
+# healthy store (the embed cache holds rows) and must NOT flip status to "issues".
+_INFORMATIONAL = frozenset({"stale_caches"})
+
+
+def _summary(items: list[Any]) -> dict[str, Any]:
+    """Uniform ``{count, sample}`` view over a list of offenders."""
+    return {"count": len(items), "sample": items[:_SAMPLE_CAP]}
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND name = ?",
+        (name,),
+    ).fetchone()
+    return row is not None
+
+
+def _resolve_md(cfg: Any, rel_path: str) -> Path | None:
+    """Resolve a store ``path`` to an existing canonical ``.md`` file, or None.
+
+    Mirrors ``Memory._resolve_existing``: try ``memory_dir`` (current layout),
+    then ``vault_path`` (legacy). A path with a ``#`` fragment (``...#chunk-N``)
+    is a derived chunk with no standalone file. Store rows are untrusted, so an
+    absolute path or one escaping the root is rejected rather than followed.
+    """
+    if not rel_path or "#" in rel_path:
+        return None
+    parts = Path(rel_path).parts
+    if Path(rel_path).is_absolute() or ".." in parts:
+        return None
+    candidate = cfg.memory_dir / rel_path
+    if candidate.is_file():
+        return candidate
+    vault = getattr(cfg, "vault_path", None)
+    if vault is not None:
+        legacy = Path(vault) / rel_path
+        if legacy.is_file():
+            return legacy
+    return None
+
+
+def _chunk_parent_id(extra_json: str | None, path: str) -> str | None:
+    """Best-effort parent id for a chunk row: ``extra.parent_id`` if present,
+    else None (the caller falls back to matching the base path)."""
+    if not extra_json:
+        return None
+    try:
+        import json
+
+        extra = json.loads(extra_json)
+    except (ValueError, TypeError):
+        return None
+    parent = extra.get("parent_id") if isinstance(extra, dict) else None
+    return str(parent) if parent else None
+
+
+def check_index_health(cfg: Any, mem: Any, *, repair: bool = False) -> dict[str, Any]:
+    """Diagnose (and optionally repair) divergence in the derived sqlite index.
+
+    Returns ``{"status", "checks", "repaired", "errors"}`` where ``status`` is
+    ``"ok"`` (clean), ``"issues"`` (divergence found or a sub-check errored) or
+    ``"error"`` (the store could not be opened at all). ``repair=True`` only
+    ever deletes derived orphans (vectors / chunk index rows / HyPE-attempt
+    rows whose canonical memory is gone); it never modifies a ``.md`` file.
+    """
+    checks: dict[str, dict[str, Any]] = {}
+    repaired: dict[str, int] = {}
+    errors: list[str] = []
+
+    try:
+        store = mem.store
+        conn = store.connection
+    except Exception as exc:  # store unavailable — nothing to diagnose
+        return {
+            "status": "error",
+            "checks": {},
+            "repaired": {},
+            "errors": [f"store unavailable: {exc}"],
+        }
+
+    # -- 1. FTS bodies NULL/empty (or missing) while the memory row exists ----
+    try:
+        rows = conn.execute(
+            "SELECT m.id AS id, m.path AS path FROM meta m "
+            "LEFT JOIN fts f ON f.id = m.id "
+            "WHERE f.id IS NULL OR f.body IS NULL OR TRIM(f.body) = ''"
+        ).fetchall()
+        checks["fts_missing_body"] = _summary(
+            [{"id": str(r["id"]), "path": str(r["path"])} for r in rows]
+        )
+    except Exception as exc:
+        errors.append(f"fts_missing_body: {exc}")
+
+    # -- 2. Durable memories with a missing canonical Markdown file ------------
+    #     Detect only: a "missing" file may just be an unmounted vault, so we
+    #     never delete the index row (it may be the last searchable copy).
+    try:
+        from memo.tiers import DURABLE_TYPES
+
+        durable = sorted(DURABLE_TYPES)
+        placeholders = ",".join("?" for _ in durable)
+        rows = conn.execute(
+            f"SELECT id, path FROM meta WHERE type IN ({placeholders})",  # noqa: S608
+            durable,
+        ).fetchall()
+        offenders: list[dict[str, Any]] = [
+            {"id": str(r["id"]), "path": str(r["path"])}
+            for r in rows
+            if "#" not in str(r["path"]) and _resolve_md(cfg, str(r["path"])) is None
+        ]
+        checks["missing_markdown"] = _summary(offenders)
+    except Exception as exc:
+        errors.append(f"missing_markdown: {exc}")
+
+    # -- 3. Orphan chunk rows whose parent memory is gone ---------------------
+    try:
+        live = conn.execute("SELECT id, path FROM meta").fetchall()
+        live_ids = {str(r["id"]) for r in live}
+        live_paths = {str(r["path"]) for r in live}
+        chunk_rows = conn.execute(
+            "SELECT id, path, extra_json FROM meta WHERE path LIKE '%#chunk-%'"
+        ).fetchall()
+        offenders = []
+        for r in chunk_rows:
+            path = str(r["path"])
+            parent = _chunk_parent_id(r["extra_json"], path)
+            if parent is not None:
+                gone = parent not in live_ids
+            else:
+                gone = path.split("#", 1)[0] not in live_paths
+            if gone:
+                offenders.append({"id": str(r["id"]), "path": path})
+        checks["orphan_chunks"] = _summary(offenders)
+        if repair and offenders:
+            with store._tx() as cx:
+                for o in offenders:
+                    cx.execute("DELETE FROM meta WHERE id = ?", (o["id"],))
+                    cx.execute("DELETE FROM vec WHERE id = ?", (o["id"],))
+                    cx.execute("DELETE FROM fts WHERE id = ?", (o["id"],))
+            repaired["orphan_chunks"] = len(offenders)
+    except Exception as exc:
+        errors.append(f"orphan_chunks: {exc}")
+
+    # -- 4. Orphan vectors (vec rows with no matching meta row) ----------------
+    try:
+        ids = [
+            str(r["id"])
+            for r in conn.execute(
+                "SELECT id FROM vec WHERE id NOT IN (SELECT id FROM meta)"
+            ).fetchall()
+        ]
+        checks["orphan_vectors"] = _summary(ids)
+        if repair and ids:
+            with store._tx() as cx:
+                for vid in ids:
+                    cx.execute("DELETE FROM vec WHERE id = ?", (vid,))
+            repaired["orphan_vectors"] = len(ids)
+    except Exception as exc:
+        errors.append(f"orphan_vectors: {exc}")
+
+    # -- 5. Memories with a meta row but no vector ----------------------------
+    #     Rows explicitly stamped `_memo_embed_pending` are a tracked transient
+    #     state (model still downloading), not a divergence — excluded.
+    try:
+        rows = conn.execute(
+            "SELECT id, path FROM meta WHERE id NOT IN (SELECT id FROM vec) "
+            "AND COALESCE(json_extract(extra_json, '$._memo_embed_pending'), 0) = 0"
+        ).fetchall()
+        checks["missing_vector"] = _summary(
+            [{"id": str(r["id"]), "path": str(r["path"])} for r in rows]
+        )
+    except Exception as exc:
+        errors.append(f"missing_vector: {exc}")
+
+    # -- 6. Vectors whose stored dimension != cfg.embedder_dims ---------------
+    #     vec0 enforces a uniform column width, so this is a table-level fact.
+    try:
+        stored_dims = store._vec_table_dims("vec")
+        expected = int(cfg.embedder_dims)
+        if stored_dims is not None and stored_dims != expected:
+            affected = conn.execute("SELECT COUNT(*) AS n FROM vec").fetchone()
+            checks["wrong_dims"] = {
+                "count": int(affected["n"]) if affected else 0,
+                "sample": [{"stored_dims": stored_dims, "expected_dims": expected}],
+            }
+        else:
+            checks["wrong_dims"] = _summary([])
+    except Exception as exc:
+        errors.append(f"wrong_dims: {exc}")
+
+    # -- 7. Stored embedder-model tag inconsistent with the configured model --
+    try:
+        stored_model: str | None = None
+        if _table_exists(conn, "schema_meta"):
+            row = conn.execute(
+                "SELECT value FROM schema_meta WHERE key = 'embedder_model'"
+            ).fetchone()
+            stored_model = str(row["value"]) if row and row["value"] else None
+        # Compare against the STORE's configured model (it carries the same
+        # ``@revision`` suffix the vectors were stamped with), not the bare
+        # ``cfg.embedder_model`` — otherwise the revision suffix false-positives.
+        configured = str(getattr(store, "embedder_model", "") or "").strip()
+        mismatch = bool(
+            stored_model
+            and configured
+            and "stub" not in configured.lower()
+            and stored_model != configured
+        )
+        if mismatch:
+            affected = conn.execute("SELECT COUNT(*) AS n FROM meta").fetchone()
+            checks["model_mismatch"] = {
+                "count": int(affected["n"]) if affected else 0,
+                "sample": [{"stored_model": stored_model, "configured_model": configured}],
+            }
+        else:
+            checks["model_mismatch"] = _summary([])
+    except Exception as exc:
+        errors.append(f"model_mismatch: {exc}")
+
+    # -- 8. MD/SQLite divergence (disk body_hash != indexed body_hash) --------
+    #     Reproduces the exact index-time hash (sanitize -> sha256_short) so an
+    #     unmodified file never false-positives; a hand-edit in Obsidian does.
+    try:
+        import frontmatter
+
+        from memo.redact import sanitize_memory_input
+        from memo.tiers import DURABLE_TYPES
+        from memo.util import sha256_short
+
+        # Store is a foundation layer: read the flag via a relative deferred
+        # import (matches queries.py/store.py — avoids the module-level memo.flags
+        # dependency the architecture-boundary guard forbids).
+        from ..flags import flag_bool
+
+        entropy = flag_bool("MEMO_REDACT_ENTROPY")
+        durable = sorted(DURABLE_TYPES)
+        placeholders = ",".join("?" for _ in durable)
+        rows = conn.execute(
+            f"SELECT id, path, body_hash FROM meta WHERE type IN ({placeholders})",  # noqa: S608
+            durable,
+        ).fetchall()
+        offenders = []
+        for r in rows:
+            path = str(r["path"])
+            if "#" in path:
+                continue
+            md_path = _resolve_md(cfg, path)
+            if md_path is None:
+                continue  # missing file is reported by check #2, not here
+            try:
+                text = md_path.read_text(encoding="utf-8")
+                body = frontmatter.loads(text).content or ""
+            except (OSError, UnicodeDecodeError, ValueError):
+                continue
+            clean = sanitize_memory_input(
+                content=body, entropy=entropy, allow_empty_content=True
+            ).content
+            indexed_hash = str(r["body_hash"]) if r["body_hash"] is not None else ""
+            if sha256_short(clean) != indexed_hash:
+                offenders.append({"id": str(r["id"]), "path": path})
+        checks["md_divergence"] = _summary(offenders)
+    except Exception as exc:
+        errors.append(f"md_divergence: {exc}")
+
+    # -- 9. Duplicate HyPE attempts (should be exactly one per memory) --------
+    try:
+        if _table_exists(conn, "hype_attempts"):
+            rows = conn.execute(
+                "SELECT memory_id, COUNT(*) AS n FROM hype_attempts "
+                "GROUP BY memory_id HAVING COUNT(*) > 1"
+            ).fetchall()
+            offenders = [
+                {"memory_id": str(r["memory_id"]), "count": int(r["n"])} for r in rows
+            ]
+            checks["duplicate_hype_attempts"] = _summary(offenders)
+            if repair and offenders:
+                removed = 0
+                with store._tx() as cx:
+                    for o in offenders:
+                        cur = cx.execute(
+                            "DELETE FROM hype_attempts WHERE memory_id = ? AND rowid NOT IN "
+                            "(SELECT MIN(rowid) FROM hype_attempts WHERE memory_id = ?)",
+                            (o["memory_id"], o["memory_id"]),
+                        )
+                        removed += cur.rowcount
+                if removed:
+                    repaired["duplicate_hype_attempts"] = removed
+        else:
+            checks["duplicate_hype_attempts"] = _summary([])
+    except Exception as exc:
+        errors.append(f"duplicate_hype_attempts: {exc}")
+
+    # -- 10. Orphan HyPE attempts (memory_id no longer in meta) ---------------
+    try:
+        if _table_exists(conn, "hype_attempts"):
+            ids = [
+                str(r["memory_id"])
+                for r in conn.execute(
+                    "SELECT memory_id FROM hype_attempts "
+                    "WHERE memory_id NOT IN (SELECT id FROM meta)"
+                ).fetchall()
+            ]
+            checks["orphan_hype_attempts"] = _summary(ids)
+            if repair and ids:
+                with store._tx() as cx:
+                    for mid in ids:
+                        cx.execute("DELETE FROM hype_attempts WHERE memory_id = ?", (mid,))
+                repaired["orphan_hype_attempts"] = len(ids)
+        else:
+            checks["orphan_hype_attempts"] = _summary([])
+    except Exception as exc:
+        errors.append(f"orphan_hype_attempts: {exc}")
+
+    # -- 11. Stale caches (informational: embed-cache size vs live corpus) ----
+    try:
+        if _table_exists(conn, "repo_embedding_cache"):
+            cache_rows = conn.execute(
+                "SELECT COUNT(*) AS n FROM repo_embedding_cache"
+            ).fetchone()
+            live_mem = conn.execute("SELECT COUNT(*) AS n FROM meta").fetchone()
+            by_model = conn.execute(
+                "SELECT model, dims, COUNT(*) AS n FROM repo_embedding_cache "
+                "GROUP BY model, dims"
+            ).fetchall()
+            sample: list[Any] = [
+                {
+                    "cache_rows": int(cache_rows["n"]) if cache_rows else 0,
+                    "live_memories": int(live_mem["n"]) if live_mem else 0,
+                }
+            ]
+            sample.extend(
+                {"model": str(r["model"]), "dims": int(r["dims"]), "rows": int(r["n"])}
+                for r in by_model
+            )
+            checks["stale_caches"] = {
+                "count": int(cache_rows["n"]) if cache_rows else 0,
+                "sample": sample[:_SAMPLE_CAP],
+            }
+        else:
+            checks["stale_caches"] = _summary([])
+    except Exception as exc:
+        errors.append(f"stale_caches: {exc}")
+
+    problem_count = sum(
+        v["count"] for name, v in checks.items() if name not in _INFORMATIONAL
+    )
+    status = "issues" if problem_count > 0 or errors else "ok"
+
+    return {"status": status, "checks": checks, "repaired": repaired, "errors": errors}
+
+
+__all__ = ["check_index_health"]

--- a/tests/test_dream_flags.py
+++ b/tests/test_dream_flags.py
@@ -121,6 +121,23 @@ def test_win_streak_graduates_flag_to_overlay(tmp_cfg, monkeypatch):
     assert entry["baseline"]["precision_at_k"] == 0.8
 
 
+def test_absolute_latency_ceiling_blocks_win_when_relative_gate_skipped(tmp_cfg, monkeypatch):
+    """Fase 8: when OFF p50 rounds to 0 the RELATIVE headroom gate is skipped, so
+    a candidate whose ON p50 balloons to seconds would otherwise win. The
+    absolute latency-ceiling backstop must reject it (no streak, no graduate)."""
+    _mini_registry(monkeypatch)
+    # precision improves, but ON latency 6000ms >> ceiling; OFF p50 == 0 so the
+    # relative headroom gate (budget = 0) does not fire — only the ceiling can.
+    _stub_measure(monkeypatch, on=_metrics(0.9, p50=6000.0), off=_metrics(0.4, p50=0.0))
+    monkeypatch.setenv("MEMO_FLAG_GRADUATION_LATENCY_CEILING_MS", "1500")
+
+    res = df.run_flag_graduation_pass(tmp_cfg, mem=None, today=TODAY)
+    verdict = res["flags"][_FLAG]
+    assert verdict["verdict"] == "lose"
+    assert verdict.get("latency_ceiling_rejected") is True
+    assert df.load_state(tmp_cfg.state_dir)["flags"][_FLAG]["streak"] == 0
+
+
 def test_lose_resets_streak(tmp_cfg, monkeypatch):
     _mini_registry(monkeypatch)
     _stub_measure(monkeypatch, on=_metrics(0.8), off=_metrics(0.4))

--- a/tests/test_dream_hype.py
+++ b/tests/test_dream_hype.py
@@ -405,6 +405,76 @@ def test_run_hype_pass_all_items_failed_status(tmp_path, monkeypatch):
     assert res["memories"] == 0
 
 
+def test_run_hype_pass_missing_source_not_counted_as_empty(tmp_path, monkeypatch):
+    """A memory with no recoverable body (FTS NULL and empty canonical) must be
+    recorded as missing_source — never a false 'empty' success — and never sent
+    to the LLM. It is watermarked so a second run skips it."""
+    memories = {"id1": {"type": "decision", "body_hash": "h1", "title": "T", "_body": ""}}
+    mem = _FakeMem(memories, state_dir=tmp_path)
+    cfg = _FakeCfg(tmp_path / "memvec.db")
+
+    llm_called: list[int] = []
+    monkeypatch.setattr(
+        dh, "_llm_questions", lambda *a, **k: llm_called.append(1) or ["q?"]
+    )
+
+    res = dh.run_hype_pass(cfg, mem, dry_run=False)
+    assert res["status"] == "done"
+    assert res["missing_source_items"] == 1
+    assert res["empty_items"] == 0
+    assert res["memories"] == 0
+    assert not llm_called  # never sent a hollow prompt to the model
+
+    # Second run: the missing_source attempt is a watermark, so no re-attempt.
+    second = dh.run_hype_pass(cfg, mem, dry_run=False)
+    assert second["status"] == "skipped"
+
+
+def test_run_hype_pass_budget_stops_and_carries_remaining(tmp_path, monkeypatch):
+    """The wall-clock budget stops the loop early; the untouched tail is
+    reflected in backlog_remaining with budget_hit=True (status stays 'done')."""
+    memories = {
+        "id1": _mem_row(body_hash="h1", title="A"),
+        "id2": _mem_row(body_hash="h2", title="B"),
+        "id3": _mem_row(body_hash="h3", title="C"),
+    }
+    mem = _FakeMem(memories, state_dir=tmp_path)
+    cfg = _FakeCfg(tmp_path / "memvec.db")
+    monkeypatch.setattr(dh, "_llm_questions", lambda mem, title, body, *, n: ["q1?"])
+    # deadline calc -> 100 (deadline=110); iter1 check -> 100 (<110, process);
+    # iter2 check -> 200 (>=110, break).
+    clock = iter([100.0, 100.0, 200.0, 200.0, 200.0])
+    monkeypatch.setattr(dh.time, "monotonic", lambda: next(clock))
+
+    res = dh.run_hype_pass(cfg, mem, night_cap=400, budget_s=10.0, dry_run=False)
+    assert res["status"] == "done"
+    assert res["budget_hit"] is True
+    assert res["processed"] == 1
+    assert res["memories"] == 1
+    assert res["backlog_remaining"] == 2  # two untouched items still pending
+
+
+def test_embed_questions_uses_batch_when_embedder_supports_it():
+    """Query-variant HyPE embeds all of a memory's questions in one forward pass
+    via embed_queries when available (no per-question embed_query calls)."""
+
+    class _BatchEmbedder(_FakeEmbedder):
+        def __init__(self):
+            super().__init__()
+            self.batch_calls: list[list[str]] = []
+
+        def embed_queries(self, qs):
+            self.batch_calls.append(list(qs))
+            return [self._fn(q) for q in qs]
+
+    mem = _FakeMem({})
+    mem.embedder = _BatchEmbedder()  # type: ignore[assignment]
+    out = dh._embed_questions(mem, ["alpha?", "beta?"])
+    assert len(out) == 2
+    assert mem.embedder.batch_calls == [["alpha?", "beta?"]]
+    assert mem.embedder.query_calls == []
+
+
 def test_run_hype_pass_prunes_orphans(tmp_path, monkeypatch):
     """A memory indexed previously but no longer live gets pruned at pass end."""
     cfg = _FakeCfg(tmp_path / "memvec.db")

--- a/tests/test_dream_incremental.py
+++ b/tests/test_dream_incremental.py
@@ -1,0 +1,101 @@
+"""Fase 5 — per-pass incremental skip (dependency-fingerprint gating).
+
+Hermetic: fingerprint state is a small JSON sidecar under a tmp_path/dream/; the
+durable-content fingerprint reads one sqlite aggregate through a fake store.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from memo import dream_incremental as inc
+
+
+class _FakeConn:
+    def __init__(self, row):
+        self._row = row
+
+    def execute(self, _sql, _params=None):
+        return self
+
+    def fetchone(self):
+        return self._row
+
+
+class _FakeStore:
+    def __init__(self, row):
+        self._conn = _FakeConn(row)
+
+
+class _FakeMem:
+    def __init__(self, row):
+        self.store = _FakeStore(row)
+
+
+def test_durable_content_fingerprint_shape():
+    mem = _FakeMem((3, "2026-01-01T00:00:00"))
+    assert inc.durable_content_fingerprint(mem) == "3:2026-01-01T00:00:00"
+
+
+def test_durable_content_fingerprint_none_on_store_error():
+    class _Boom:
+        class store:
+            class _conn:
+                @staticmethod
+                def execute(*_a, **_k):
+                    raise RuntimeError("db gone")
+
+    assert inc.durable_content_fingerprint(_Boom()) is None
+
+
+def test_should_skip_only_on_exact_match(tmp_path: Path):
+    assert inc.should_skip(tmp_path, "entities", "abc") is False  # nothing stored
+    inc.record_success(tmp_path, "entities", "abc")
+    assert inc.should_skip(tmp_path, "entities", "abc") is True
+    assert inc.should_skip(tmp_path, "entities", "def") is False  # dependency moved
+    assert inc.should_skip(tmp_path, "synthesis", "abc") is False  # per-pass keyed
+
+
+def test_none_fingerprint_never_skips_and_clears(tmp_path: Path):
+    inc.record_success(tmp_path, "entities", "abc")
+    assert inc.should_skip(tmp_path, "entities", None) is False  # fail safe = run
+    inc.record_success(tmp_path, "entities", None)  # clears the stored value
+    assert inc.should_skip(tmp_path, "entities", "abc") is False
+
+
+def test_run_or_skip_runs_then_skips_on_unchanged(tmp_path: Path):
+    calls = []
+
+    def runner():
+        calls.append(1)
+        return {"status": "done", "extracted": 5}
+
+    r1 = inc.run_or_skip(tmp_path, "entities", "fp1", runner)
+    assert r1["extracted"] == 5
+    assert len(calls) == 1
+
+    r2 = inc.run_or_skip(tmp_path, "entities", "fp1", runner)
+    assert r2["status"] == "skipped_incremental"
+    assert r2["fingerprint"] == "fp1"
+    assert len(calls) == 1  # runner NOT called again
+
+    r3 = inc.run_or_skip(tmp_path, "entities", "fp2", runner)  # dependency changed
+    assert r3["status"] == "done"
+    assert len(calls) == 2
+
+
+def test_run_or_skip_does_not_stamp_on_error(tmp_path: Path):
+    def failing():
+        return {"status": "error", "error": "boom"}
+
+    inc.run_or_skip(tmp_path, "entities", "fp1", failing)
+    # errored run must NOT be recorded → next run re-runs, not skips
+    assert inc.should_skip(tmp_path, "entities", "fp1") is False
+
+
+def test_clear_forgets_everything(tmp_path: Path):
+    inc.record_success(tmp_path, "entities", "abc")
+    inc.record_success(tmp_path, "synthesis", "xyz")
+    inc.clear(tmp_path)
+    assert inc.should_skip(tmp_path, "entities", "abc") is False
+    assert inc.should_skip(tmp_path, "synthesis", "xyz") is False

--- a/tests/test_dream_ledger.py
+++ b/tests/test_dream_ledger.py
@@ -1,0 +1,367 @@
+"""Tests for the append-only dream learning ledger.
+
+``memo.dream_ledger`` is pure JSONL I/O over ``state_dir/dream/`` — MLX-free,
+flag-free, and best-effort (never raises into the pipeline). Every test here is
+hermetic: it only touches ``tmp_path``. The module reads no ``MEMO_*`` flags and
+needs no ``Config``, so no env/flag setup is required.
+"""
+
+from __future__ import annotations
+
+import json
+import string
+from pathlib import Path
+
+from memo import dream_ledger as mod
+
+
+def _is_hex_id(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 32
+        and all(c in string.hexdigits for c in value)
+    )
+
+
+# --- record_action -------------------------------------------------------
+
+
+def test_record_action_returns_hex_id_and_writes_entry(tmp_path: Path) -> None:
+    action_id = mod.record_action(tmp_path, action="supersede", pass_name="contradict")
+
+    assert _is_hex_id(action_id)
+    entries = mod._read_all(tmp_path)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["entry_id"] == action_id
+    assert entry["kind"] == "action"
+    assert entry["action"] == "supersede"
+    assert entry["pass_name"] == "contradict"
+    assert entry["dry_run"] is False
+
+
+def test_record_action_strips_action_and_defaults_collections(tmp_path: Path) -> None:
+    action_id = mod.record_action(tmp_path, action="  merge  ")
+    entry = mod.get_action(tmp_path, action_id)  # type: ignore[arg-type]
+
+    assert entry is not None
+    assert entry["action"] == "merge"
+    assert entry["candidate_ids"] == []
+    assert entry["affected_ids"] == []
+    assert entry["evidence"] == {}
+
+
+def test_record_action_none_on_dry_run_and_writes_nothing(tmp_path: Path) -> None:
+    result = mod.record_action(tmp_path, action="archive_stale", dry_run=True)
+
+    assert result is None
+    assert mod._read_all(tmp_path) == []
+
+
+def test_record_action_none_on_empty_action(tmp_path: Path) -> None:
+    assert mod.record_action(tmp_path, action="") is None
+    assert mod.record_action(tmp_path, action="   ") is None
+    assert mod._read_all(tmp_path) == []
+
+
+def test_record_action_none_on_non_string_action(tmp_path: Path) -> None:
+    assert mod.record_action(tmp_path, action=123) is None  # type: ignore[arg-type]
+    assert mod.record_action(tmp_path, action=None) is None  # type: ignore[arg-type]
+
+
+def test_record_action_coerces_confidence(tmp_path: Path) -> None:
+    aid_ok = mod.record_action(tmp_path, action="tune", confidence=0.9)
+    aid_bool = mod.record_action(tmp_path, action="tune", confidence=True)  # type: ignore[arg-type]
+
+    a_ok = mod.get_action(tmp_path, aid_ok)  # type: ignore[arg-type]
+    a_bool = mod.get_action(tmp_path, aid_bool)  # type: ignore[arg-type]
+    assert a_ok is not None and a_ok["confidence"] == 0.9
+    # bool is an int subclass but is not a valid confidence -> None
+    assert a_bool is not None and a_bool["confidence"] is None
+
+
+# --- best-effort append (never raises) -----------------------------------
+
+
+def test_record_action_best_effort_none_on_unserializable_payload(tmp_path: Path) -> None:
+    # A non-JSON-serializable source_signal makes json.dumps raise TypeError,
+    # which _append must swallow -> record_action returns None, no exception.
+    result = mod.record_action(tmp_path, action="synthesize", source_signal=object())
+
+    assert result is None
+    assert mod._read_all(tmp_path) == []
+
+
+def test_append_returns_false_and_never_raises_on_io_error(tmp_path: Path) -> None:
+    # Collide the ledger file path with a directory so open("a") raises
+    # IsADirectoryError (an OSError). _append must catch it and return False.
+    path = mod.ledger_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.mkdir()
+
+    assert mod._append(tmp_path, {"kind": "action"}) is False
+
+
+# --- resolve_action ------------------------------------------------------
+
+
+def test_resolve_action_chains_outcome_to_known_action(tmp_path: Path) -> None:
+    action_id = mod.record_action(tmp_path, action="tune")
+    outcome_id = mod.resolve_action(
+        tmp_path, action_id, outcome="reinforced", verdict="keep", delta=0.05
+    )  # type: ignore[arg-type]
+
+    assert _is_hex_id(outcome_id)
+    entries = mod._read_all(tmp_path)
+    assert len(entries) == 2
+    outcome_entry = entries[1]
+    assert outcome_entry["kind"] == "outcome"
+    assert outcome_entry["action_id"] == action_id
+    assert outcome_entry["outcome"] == "reinforced"
+    assert outcome_entry["verdict"] == "keep"
+    assert outcome_entry["delta"] == 0.05
+
+
+def test_resolve_action_none_on_unknown_action_id(tmp_path: Path) -> None:
+    # No matching action in the ledger -> nothing written.
+    result = mod.resolve_action(tmp_path, "deadbeef" * 4, outcome="reverted")
+
+    assert result is None
+    assert mod._read_all(tmp_path) == []
+
+
+def test_resolve_action_none_on_invalid_input(tmp_path: Path) -> None:
+    action_id = mod.record_action(tmp_path, action="prune")
+
+    assert mod.resolve_action(tmp_path, "", outcome="ok") is None
+    assert mod.resolve_action(tmp_path, action_id, outcome="") is None  # type: ignore[arg-type]
+    assert mod.resolve_action(tmp_path, action_id, outcome="   ") is None  # type: ignore[arg-type]
+    # only the action was ever written
+    assert len(mod._read_all(tmp_path)) == 1
+
+
+# --- open_actions --------------------------------------------------------
+
+
+def test_open_actions_excludes_resolved(tmp_path: Path) -> None:
+    a1 = mod.record_action(tmp_path, action="supersede")
+    a2 = mod.record_action(tmp_path, action="merge")
+    mod.resolve_action(tmp_path, a1, outcome="confirmed")  # type: ignore[arg-type]
+
+    open_ids = [e["entry_id"] for e in mod.open_actions(tmp_path)]
+    assert open_ids == [a2]  # oldest-first, only the unresolved action
+
+
+def test_open_actions_empty_when_all_resolved(tmp_path: Path) -> None:
+    a1 = mod.record_action(tmp_path, action="evict")
+    mod.resolve_action(tmp_path, a1, outcome="neutral")  # type: ignore[arg-type]
+
+    assert mod.open_actions(tmp_path) == []
+
+
+# --- get_action ----------------------------------------------------------
+
+
+def test_get_action_folds_latest_outcome(tmp_path: Path) -> None:
+    action_id = mod.record_action(tmp_path, action="graduate")
+    mod.resolve_action(tmp_path, action_id, outcome="neutral")  # type: ignore[arg-type]
+    mod.resolve_action(tmp_path, action_id, outcome="rollback_candidate")  # type: ignore[arg-type]
+
+    folded = mod.get_action(tmp_path, action_id)  # type: ignore[arg-type]
+    assert folded is not None
+    assert folded["action"] == "graduate"
+    assert folded["outcome"] is not None
+    # latest outcome in file order wins
+    assert folded["outcome"]["outcome"] == "rollback_candidate"
+
+
+def test_get_action_open_action_has_none_outcome(tmp_path: Path) -> None:
+    action_id = mod.record_action(tmp_path, action="compress")
+
+    folded = mod.get_action(tmp_path, action_id)  # type: ignore[arg-type]
+    assert folded is not None
+    assert folded["outcome"] is None
+
+
+def test_get_action_unknown_returns_none(tmp_path: Path) -> None:
+    mod.record_action(tmp_path, action="prune")
+    assert mod.get_action(tmp_path, "cafe" * 8) is None
+
+
+# --- summarize -----------------------------------------------------------
+
+
+def test_summarize_counts_open_and_rollback_candidates(tmp_path: Path) -> None:
+    a1 = mod.record_action(tmp_path, action="supersede")
+    a2 = mod.record_action(tmp_path, action="supersede")
+    mod.record_action(tmp_path, action="merge")  # a3, left open
+    mod.record_action(tmp_path, action="archive_stale")  # a4, left open
+
+    mod.resolve_action(tmp_path, a1, outcome="reinforced")  # type: ignore[arg-type]
+    mod.resolve_action(tmp_path, a2, outcome="rollback_candidate")  # type: ignore[arg-type]
+
+    s = mod.summarize(tmp_path)
+    assert s["actions"] == 4
+    assert s["outcomes"] == 2
+    assert s["open"] == 2
+    assert s["rollback_candidates"] == 1
+    assert s["by_action"] == {"supersede": 2, "merge": 1, "archive_stale": 1}
+
+
+def test_summarize_rollback_detected_via_verdict(tmp_path: Path) -> None:
+    a1 = mod.record_action(tmp_path, action="tune")
+    # "rollback" lives in the verdict, not the outcome, and must still count.
+    mod.resolve_action(tmp_path, a1, outcome="reverted", verdict="rollback")  # type: ignore[arg-type]
+
+    assert mod.summarize(tmp_path)["rollback_candidates"] == 1
+
+
+def test_summarize_empty_ledger(tmp_path: Path) -> None:
+    s = mod.summarize(tmp_path)
+    assert s == {
+        "actions": 0,
+        "outcomes": 0,
+        "open": 0,
+        "rollback_candidates": 0,
+        "by_action": {},
+    }
+
+
+# --- _read_all (robust parsing) ------------------------------------------
+
+
+def test_read_all_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert mod._read_all(tmp_path) == []
+
+
+def test_read_all_skips_blank_and_corrupt_and_non_dict_lines(tmp_path: Path) -> None:
+    path = mod.ledger_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"entry_id": "a", "kind": "action", "action": "x"}),
+                "",  # blank
+                "   ",  # whitespace only
+                "not valid json at all",  # corrupt
+                json.dumps([1, 2, 3]),  # valid JSON, non-dict
+                json.dumps("a bare string"),  # valid JSON, non-dict
+                "123",  # valid JSON int, non-dict
+                json.dumps({"entry_id": "b", "kind": "outcome", "action_id": "a"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    entries = mod._read_all(tmp_path)
+    assert len(entries) == 2
+    assert [e["entry_id"] for e in entries] == ["a", "b"]
+    assert all(isinstance(e, dict) for e in entries)
+
+
+# --- read_ledger / recent_actions (thin wrappers) ------------------------
+
+
+def test_read_ledger_returns_last_n_oldest_first(tmp_path: Path) -> None:
+    ids = [mod.record_action(tmp_path, action=f"a{i}") for i in range(5)]
+
+    last_two = mod.read_ledger(tmp_path, limit=2)
+    assert [e["entry_id"] for e in last_two] == ids[-2:]
+
+
+def test_recent_actions_newest_first_with_filters(tmp_path: Path) -> None:
+    mod.record_action(tmp_path, action="merge", pass_name="consolidate")
+    a2 = mod.record_action(tmp_path, action="supersede", pass_name="contradict")
+    a3 = mod.record_action(tmp_path, action="supersede", pass_name="contradict")
+
+    by_action = mod.recent_actions(tmp_path, action="supersede")
+    assert [e["entry_id"] for e in by_action] == [a3, a2]  # newest-first
+
+    by_phase = mod.recent_actions(tmp_path, phase="consolidate")
+    assert [e["action"] for e in by_phase] == ["merge"]
+
+
+# --- record_from_receipt (Fase 3 receipt mapping) ------------------------
+
+
+def _receipt_with_mutations() -> dict:
+    return {
+        "contradict": {
+            "superseded": [{"pair_id": 11, "older": "aaaa1111"}],
+            "evolved": [22],
+        },
+        "consolidate_dups": {
+            "merged": [{"merged_id": "mmmm0000", "archived_ids": ["bbbb2222", "cccc3333"]}]
+        },
+        "stale": {"archived": [{"id": "dddd4444", "days": 400}]},
+    }
+
+
+def test_record_from_receipt_maps_each_mutation_to_an_action(tmp_path: Path) -> None:
+    counts = mod.record_from_receipt(tmp_path, _receipt_with_mutations())
+    assert counts == {"supersede": 1, "evolve": 1, "merge": 1, "archive_stale": 1}
+
+    actions = [e for e in mod.read_ledger(tmp_path, limit=100) if e.get("kind") == "action"]
+    by_action = {a["action"] for a in actions}
+    assert by_action == {"supersede", "evolve", "merge", "archive_stale"}
+
+    supersede = next(a for a in actions if a["action"] == "supersede")
+    assert supersede["affected_ids"] == ["aaaa1111"]
+    assert supersede["reversal"] == {"type": "inactive_md", "handle": "inactive/aaaa1111.md"}
+    assert supersede["confidence"] == 0.9
+
+    merge = next(a for a in actions if a["action"] == "merge")
+    assert merge["affected_ids"] == ["bbbb2222", "cccc3333"]
+
+
+def test_record_from_receipt_dry_run_writes_nothing(tmp_path: Path) -> None:
+    counts = mod.record_from_receipt(tmp_path, _receipt_with_mutations(), dry_run=True)
+    assert counts == {}
+    assert mod.read_ledger(tmp_path, limit=100) == []
+
+
+def test_record_from_receipt_skips_empty_and_idless_fragments(tmp_path: Path) -> None:
+    receipt = {"contradict": {"superseded": [{"pair_id": 1, "older": ""}]}, "stale": {}}
+    assert mod.record_from_receipt(tmp_path, receipt) == {}
+
+
+# --- resolve_open_actions (close-the-loop) -------------------------------
+
+
+def test_resolve_open_actions_reinforces_still_archived(tmp_path: Path) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    old = datetime(2020, 1, 1, tzinfo=UTC)
+    mod.record_action(
+        tmp_path, action="archive_stale", affected_ids=["gone9999"], now=old
+    )
+    # Nothing came back to life -> reinforced.
+    out = mod.resolve_open_actions(tmp_path, lambda _mid: False, now=old + timedelta(days=1))
+    assert out["reinforced"] == 1
+    assert out["rollback_candidate"] == 0
+    assert mod.open_actions(tmp_path) == []  # now resolved
+
+
+def test_resolve_open_actions_flags_resurrected_as_rollback(tmp_path: Path) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    old = datetime(2020, 1, 1, tzinfo=UTC)
+    aid = mod.record_action(
+        tmp_path, action="supersede", affected_ids=["back0001"], now=old
+    )
+    out = mod.resolve_open_actions(tmp_path, lambda mid: mid == "back0001", now=old + timedelta(days=1))
+    assert out["rollback_candidate"] == 1
+    folded = mod.get_action(tmp_path, str(aid))
+    assert folded["outcome"]["outcome"] == "rollback_candidate"
+    assert folded["outcome"]["verdict"] == "reopened"
+
+
+def test_resolve_open_actions_skips_actions_younger_than_min_age(tmp_path: Path) -> None:
+    from datetime import UTC, datetime
+
+    now = datetime(2020, 1, 1, 12, 0, tzinfo=UTC)
+    mod.record_action(tmp_path, action="archive_stale", affected_ids=["x"], now=now)
+    # Same night: too young to judge.
+    out = mod.resolve_open_actions(tmp_path, lambda _m: False, now=now, min_age_hours=20.0)
+    assert out == {"reinforced": 0, "rollback_candidate": 0, "skipped": 1}
+    assert len(mod.open_actions(tmp_path)) == 1

--- a/tests/test_dream_metrics.py
+++ b/tests/test_dream_metrics.py
@@ -1,0 +1,293 @@
+"""Unit tests for the pure gate functions + learning-metric helpers in
+``memo.dream_metrics``.
+
+Scope is the fully-deterministic surface: the pre-apply graduation gate and its
+sub-gates, plus the two pure learning-metric helpers. ``learning_metrics``
+reaches many live subsystems, so it is exercised only for its total contract
+(returns a dict with an ``errors`` list, never raises) on a minimal fake
+cfg/mem. Every test is hermetic — no MLX, no network, no vault, temp dirs only.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from memo import dream_metrics as mod
+
+# --- min_labels_gate ---------------------------------------------------------
+
+
+def test_min_labels_gate_passes_when_at_or_above_floor() -> None:
+    assert mod.min_labels_gate(12, 12) is True  # equal is enough
+    assert mod.min_labels_gate(20, 12) is True
+
+
+def test_min_labels_gate_fails_below_floor() -> None:
+    assert mod.min_labels_gate(11, 12) is False
+    assert mod.min_labels_gate(0, 1) is False
+
+
+# --- margin_gate -------------------------------------------------------------
+
+
+def test_margin_gate_zero_margin_accepts_non_regression() -> None:
+    # min_margin=0.0 -> any non-regression passes (equality included).
+    assert mod.margin_gate(0.5, 0.5, 0.0) is True
+    assert mod.margin_gate(0.5, 0.6, 0.0) is True
+
+
+def test_margin_gate_zero_margin_rejects_regression() -> None:
+    assert mod.margin_gate(0.5, 0.49, 0.0) is False
+
+
+def test_margin_gate_deadband_rejects_trivial_epsilon_churn() -> None:
+    # With min_margin>0, an unchanged (or barely-nudged) precision is rejected.
+    assert mod.margin_gate(0.5, 0.5, 0.02) is False
+    assert mod.margin_gate(0.5, 0.515, 0.02) is False
+
+
+def test_margin_gate_deadband_accepts_real_improvement() -> None:
+    assert mod.margin_gate(0.5, 0.53, 0.02) is True
+    # Exactly at the deadband boundary passes (within _EPS).
+    assert mod.margin_gate(0.5, 0.52, 0.02) is True
+
+
+# --- noise_gate --------------------------------------------------------------
+
+
+def test_noise_gate_accepts_flat_or_decreasing_noise() -> None:
+    assert mod.noise_gate(0.1, 0.1) is True  # unchanged
+    assert mod.noise_gate(0.1, 0.05) is True  # improved
+
+
+def test_noise_gate_rejects_increased_noise() -> None:
+    assert mod.noise_gate(0.1, 0.2) is False
+
+
+def test_noise_gate_tolerates_epsilon_representation_noise() -> None:
+    # A rise strictly inside _EPS is not a real regression.
+    assert mod.noise_gate(0.1, 0.1 + 1e-10) is True
+
+
+# --- latency_gate ------------------------------------------------------------
+
+
+def test_latency_gate_passes_within_both_ratio_and_budget() -> None:
+    assert (
+        mod.latency_gate(100.0, 120.0, headroom=1.25, hook_budget_ms=3000.0) is True
+    )
+
+
+def test_latency_gate_rejects_over_absolute_budget() -> None:
+    # Ratio would pass (baseline huge) but the absolute hook budget is blown.
+    assert (
+        mod.latency_gate(100.0, 4000.0, headroom=1000.0, hook_budget_ms=3000.0)
+        is False
+    )
+
+
+def test_latency_gate_rejects_ratio_regression_within_budget() -> None:
+    # Under the absolute budget, but 200ms > 1.25 * 100ms baseline.
+    assert (
+        mod.latency_gate(100.0, 200.0, headroom=1.25, hook_budget_ms=3000.0) is False
+    )
+
+
+def test_latency_gate_skips_ratio_when_baseline_rounds_to_zero() -> None:
+    # round(0.04, 1) == 0.0 -> the ratio is meaningless and skipped; only the
+    # absolute budget matters, so a large-but-under-budget latency passes.
+    assert (
+        mod.latency_gate(0.04, 500.0, headroom=1.25, hook_budget_ms=3000.0) is True
+    )
+
+
+def test_latency_gate_enforces_budget_even_when_ratio_skipped() -> None:
+    # Zero-ish baseline skips the ratio, but the absolute budget still bites.
+    assert (
+        mod.latency_gate(0.04, 4000.0, headroom=1.25, hook_budget_ms=3000.0)
+        is False
+    )
+
+
+def test_latency_gate_boundary_at_exact_budget_passes() -> None:
+    assert (
+        mod.latency_gate(100.0, 3000.0, headroom=100.0, hook_budget_ms=3000.0)
+        is True
+    )
+
+
+# --- graduation_gate ---------------------------------------------------------
+
+
+def _grad_kwargs(**overrides: Any) -> dict[str, Any]:
+    """A fully-passing kwargs baseline for graduation_gate; override to break one."""
+    kwargs: dict[str, Any] = {
+        "before": {"precision_at_k": 0.5, "noise_at_k": 0.1},
+        "after": {"precision_at_k": 0.6, "noise_at_k": 0.1},
+        "n_labels": 20,
+        "latency_before": 100.0,
+        "latency_after": 110.0,
+        "min_labels": 12,
+        "latency_headroom": 1.25,
+        "hook_budget_ms": 3000.0,
+        "min_margin": 0.0,
+        "experiment_recorded": True,
+        "rollback_exists": True,
+    }
+    kwargs.update(overrides)
+    before = kwargs.pop("before")
+    after = kwargs.pop("after")
+    return {"before": before, "after": after, **kwargs}
+
+
+def test_graduation_gate_all_conditions_pass() -> None:
+    kw = _grad_kwargs()
+    verdict = mod.graduation_gate(kw.pop("before"), kw.pop("after"), **kw)
+    assert verdict["ok"] is True
+    assert verdict["reasons"] == []
+
+
+def test_graduation_gate_fails_on_insufficient_labels() -> None:
+    kw = _grad_kwargs(n_labels=5)
+    verdict = mod.graduation_gate(kw.pop("before"), kw.pop("after"), **kw)
+    assert verdict["ok"] is False
+    assert any("insufficient_labels" in r for r in verdict["reasons"])
+
+
+def test_graduation_gate_fails_on_precision_not_improved() -> None:
+    kw = _grad_kwargs(after={"precision_at_k": 0.4, "noise_at_k": 0.1})
+    verdict = mod.graduation_gate(kw.pop("before"), kw.pop("after"), **kw)
+    assert verdict["ok"] is False
+    assert any("precision_not_improved" in r for r in verdict["reasons"])
+
+
+def test_graduation_gate_fails_on_noise_regressed() -> None:
+    kw = _grad_kwargs(after={"precision_at_k": 0.6, "noise_at_k": 0.3})
+    verdict = mod.graduation_gate(kw.pop("before"), kw.pop("after"), **kw)
+    assert verdict["ok"] is False
+    assert any("noise_regressed" in r for r in verdict["reasons"])
+
+
+def test_graduation_gate_fails_on_latency_over_budget() -> None:
+    kw = _grad_kwargs(latency_after=4000.0)
+    verdict = mod.graduation_gate(kw.pop("before"), kw.pop("after"), **kw)
+    assert verdict["ok"] is False
+    assert any("latency_over_budget" in r for r in verdict["reasons"])
+
+
+def test_graduation_gate_fails_on_latency_ratio_regression() -> None:
+    # Under the absolute budget but well over the headroom ratio.
+    kw = _grad_kwargs(latency_after=200.0)
+    verdict = mod.graduation_gate(kw.pop("before"), kw.pop("after"), **kw)
+    assert verdict["ok"] is False
+    assert any("latency_regressed" in r for r in verdict["reasons"])
+
+
+def test_graduation_gate_fails_when_experiment_not_recorded() -> None:
+    kw = _grad_kwargs(experiment_recorded=False)
+    verdict = mod.graduation_gate(kw.pop("before"), kw.pop("after"), **kw)
+    assert verdict["ok"] is False
+    assert "experiment_not_recorded" in verdict["reasons"]
+
+
+def test_graduation_gate_fails_when_rollback_missing() -> None:
+    kw = _grad_kwargs(rollback_exists=False)
+    verdict = mod.graduation_gate(kw.pop("before"), kw.pop("after"), **kw)
+    assert verdict["ok"] is False
+    assert "rollback_missing" in verdict["reasons"]
+
+
+def test_graduation_gate_accumulates_every_failure_reason() -> None:
+    kw = _grad_kwargs(
+        after={"precision_at_k": 0.4, "noise_at_k": 0.3},
+        n_labels=1,
+        latency_after=4000.0,
+        experiment_recorded=False,
+        rollback_exists=False,
+    )
+    verdict = mod.graduation_gate(kw.pop("before"), kw.pop("after"), **kw)
+    assert verdict["ok"] is False
+    reasons = " ".join(verdict["reasons"])
+    for token in (
+        "insufficient_labels",
+        "precision_not_improved",
+        "noise_regressed",
+        "latency_over_budget",
+        "experiment_not_recorded",
+        "rollback_missing",
+    ):
+        assert token in reasons
+
+
+# --- correction_rate ---------------------------------------------------------
+
+
+def test_correction_rate_empty_returns_none_zero() -> None:
+    assert mod.correction_rate([]) == (None, 0)
+
+
+def test_correction_rate_ignores_rows_without_a_verdict() -> None:
+    # Falsy/absent verdicts are filtered out; over zero real verdicts -> None.
+    assert mod.correction_rate([{"foo": 1}, {"verdict": ""}, {"verdict": None}]) == (
+        None,
+        0,
+    )
+
+
+def test_correction_rate_counts_negative_and_correction_as_bad() -> None:
+    rows = [
+        {"verdict": "negative"},
+        {"verdict": "positive"},
+        {"verdict": "correction"},
+        {"verdict": "neutral"},
+    ]
+    rate, sample = mod.correction_rate(rows)
+    assert rate == 0.5
+    assert sample == 4
+
+
+def test_correction_rate_all_positive_is_zero() -> None:
+    rate, sample = mod.correction_rate([{"verdict": "positive"}, {"verdict": "neutral"}])
+    assert rate == 0.0
+    assert sample == 2
+
+
+def test_correction_rate_all_bad_is_one() -> None:
+    rate, sample = mod.correction_rate(
+        [{"verdict": "negative"}, {"verdict": "correction"}]
+    )
+    assert rate == 1.0
+    assert sample == 2
+
+
+# --- created_used_ratio ------------------------------------------------------
+
+
+def test_created_used_ratio_none_when_nothing_surfaced() -> None:
+    assert mod.created_used_ratio(5, 0) is None
+    assert mod.created_used_ratio(5, -1) is None
+
+
+def test_created_used_ratio_computes_fraction() -> None:
+    assert mod.created_used_ratio(5, 10) == 0.5
+    assert mod.created_used_ratio(0, 10) == 0.0
+
+
+# --- learning_metrics (contract only) ----------------------------------------
+
+
+def test_learning_metrics_returns_dict_with_errors_list_and_never_raises(
+    tmp_path: Any,
+) -> None:
+    # Minimal fake cfg/mem against an empty temp state dir: every source is
+    # wrapped in _safe, so the snapshot must come back as a dict carrying an
+    # ``errors`` list rather than raising.
+    cfg = SimpleNamespace(state_dir=tmp_path)
+    mem = SimpleNamespace()
+    result = mod.learning_metrics(cfg, mem, params_version="test-v0", k=5)
+
+    assert isinstance(result, dict)
+    assert isinstance(result["errors"], list)
+    assert result["params_version"] == "test-v0"
+    assert result["k"] == 5

--- a/tests/test_dream_phases.py
+++ b/tests/test_dream_phases.py
@@ -1,0 +1,302 @@
+"""Tests for the dream per-phase instrumentation + checkpoint harness."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from memo.dream_phases import (
+    DreamCheckpoint,
+    PhaseRecorder,
+    _coerce_count,
+    _infer_counts,
+    summarize_phases,
+)
+
+
+class _FakeConn:
+    def __init__(self, count: int, ts: str) -> None:
+        self._count = count
+        self._ts = ts
+
+    def execute(self, _sql: str) -> _FakeConn:
+        return self
+
+    def fetchone(self) -> tuple[int, str]:
+        return (self._count, self._ts)
+
+
+class _FakeStore:
+    def __init__(self, count: int, ts: str) -> None:
+        self._conn = _FakeConn(count, ts)
+
+
+class _FakeMem:
+    """Minimal stand-in exposing what ``_corpus_fingerprint`` reads."""
+
+    def __init__(self, count: int, ts: str) -> None:
+        self.store = _FakeStore(count, ts)
+
+    def set_fp(self, count: int, ts: str) -> None:
+        self.store = _FakeStore(count, ts)
+
+
+def test_coerce_count_handles_lists_ints_and_bools() -> None:
+    assert _coerce_count([1, 2, 3]) == 3
+    assert _coerce_count(7) == 7
+    assert _coerce_count(True) == 1
+    assert _coerce_count("nope") == 0
+    assert _coerce_count(None) == 0
+
+
+def test_infer_counts_reads_maintenance_vocabulary() -> None:
+    frag = {"scanned": 50, "merged": [1, 2], "archived": 3}
+    inputs, mutations = _infer_counts(frag)
+    assert inputs == 50
+    assert mutations == 5  # len([1,2]) + 3
+
+
+def test_infer_counts_non_dict_is_zero() -> None:
+    assert _infer_counts(None) == (0, 0)
+    assert _infer_counts([1, 2]) == (0, 0)
+
+
+def test_recorder_builds_structured_record() -> None:
+    receipt: dict[str, Any] = {"errors": []}
+    rec = PhaseRecorder(receipt)
+    ph = rec.begin("hype", fragment_key="hype")
+    receipt["hype"] = {"scanned": 50, "saved": [1, 2, 3]}
+    ph.skipped_count = 47
+    rec.end(ph)
+
+    assert len(receipt["phases"]) == 1
+    r = receipt["phases"][0]
+    # spec-mandated fields all present
+    for key in (
+        "phase",
+        "status",
+        "duration_ms",
+        "input_count",
+        "changed_count",
+        "skipped_count",
+        "mutations",
+        "errors",
+        "warnings",
+        "quality_before",
+        "quality_after",
+        "in_fingerprint",
+        "out_fingerprint",
+    ):
+        assert key in r
+    assert r["phase"] == "hype"
+    assert r["status"] == "done"
+    assert r["input_count"] == 50
+    assert r["mutations"] == 3
+    assert r["changed_count"] == 3
+    assert r["skipped_count"] == 47
+    assert r["duration_ms"] >= 0.0
+
+
+def test_recorder_error_status_from_receipt_errors_delta() -> None:
+    receipt: dict[str, Any] = {"errors": []}
+    rec = PhaseRecorder(receipt)
+    ph = rec.begin("contradict")
+    receipt["errors"].append("contradict: boom")
+    rec.end(ph)
+    r = receipt["phases"][0]
+    assert r["status"] == "error"
+    assert r["errors"] == ["contradict: boom"]
+
+
+def test_recorder_error_status_from_fragment_status() -> None:
+    receipt: dict[str, Any] = {"errors": []}
+    rec = PhaseRecorder(receipt)
+    ph = rec.begin("tuner", fragment_key="tuner")
+    receipt["tuner"] = {"status": "error", "error": "nope"}
+    rec.end(ph)
+    assert receipt["phases"][0]["status"] == "error"
+
+
+def test_recorder_fingerprint_change_detection() -> None:
+    mem = _FakeMem(10, "2026-08-02T00:00:00")
+    receipt: dict[str, Any] = {"errors": []}
+    rec = PhaseRecorder(receipt, mem=mem)
+    ph = rec.begin("consolidate")
+    mem.set_fp(9, "2026-08-02T01:00:00")  # a merge dropped a row
+    rec.end(ph)
+    r = receipt["phases"][0]
+    assert r["in_fingerprint"] == "10:2026-08-02T00:00:00"
+    assert r["out_fingerprint"] == "9:2026-08-02T01:00:00"
+    assert r["changed_count"] == 1  # fp moved => at least one change
+
+
+def test_recorder_end_is_idempotent_and_safe() -> None:
+    receipt: dict[str, Any] = {"errors": []}
+    rec = PhaseRecorder(receipt)
+    ph = rec.begin("x")
+    rec.end(ph)
+    rec.end(ph)  # second call must not append a duplicate
+    assert len(receipt["phases"]) == 1
+
+
+def test_explicit_status_override_wins() -> None:
+    receipt: dict[str, Any] = {"errors": []}
+    rec = PhaseRecorder(receipt)
+    ph = rec.begin("skippy")
+    ph.status = "skipped"
+    rec.end(ph)
+    assert receipt["phases"][0]["status"] == "skipped"
+
+
+def test_checkpoint_persist_and_reload(tmp_path: Any) -> None:
+    path = tmp_path / "dream" / "checkpoint.json"
+    ck = DreamCheckpoint(path, run_fingerprint="fp-a")
+    ck.record("hype", {"phase": "hype", "status": "done"}, {"saved": [1]})
+    assert path.exists()
+
+    reloaded = DreamCheckpoint(path, run_fingerprint="fp-a")
+    assert reloaded.resumable() is True
+    assert reloaded.is_done("hype") is True
+    assert reloaded.fragment("hype") == {"saved": [1]}
+    assert reloaded.phase_record("hype")["status"] == "done"
+
+
+def test_checkpoint_fingerprint_mismatch_not_resumable(tmp_path: Any) -> None:
+    path = tmp_path / "checkpoint.json"
+    DreamCheckpoint(path, "fp-a").record("hype", {"phase": "hype"}, None)
+    # a new run with a different previous-corpus fingerprint must start clean
+    fresh = DreamCheckpoint(path, run_fingerprint="fp-b")
+    assert fresh.resumable() is False
+    assert fresh.is_done("hype") is False
+
+
+def test_checkpoint_clear_removes_file(tmp_path: Any) -> None:
+    path = tmp_path / "checkpoint.json"
+    ck = DreamCheckpoint(path, "fp-a")
+    ck.record("hype", {"phase": "hype"}, None)
+    ck.clear()
+    assert not path.exists()
+    assert ck.resumable() is False
+
+
+def test_checkpoint_corrupt_file_is_ignored(tmp_path: Any) -> None:
+    path = tmp_path / "checkpoint.json"
+    path.write_text("{ not json", encoding="utf-8")
+    ck = DreamCheckpoint(path, "fp-a")
+    assert ck.resumable() is False  # unreadable => fresh, no crash
+
+
+def test_resume_restores_fragment_and_skips_work(tmp_path: Any) -> None:
+    path = tmp_path / "checkpoint.json"
+    ck = DreamCheckpoint(path, "fp-a")
+    ck.record("hype", {"phase": "hype", "status": "done", "mutations": 3}, {"saved": [1, 2, 3]})
+
+    receipt: dict[str, Any] = {"errors": []}
+    rec = PhaseRecorder(receipt, checkpoint=DreamCheckpoint(path, "fp-a"), resume=True)
+    ph = rec.begin("hype", fragment_key="hype")
+    ran = False
+    if rec.restore(ph):
+        pass  # skipped
+    else:
+        ran = True
+    rec.end(ph)
+
+    assert ran is False  # work was skipped
+    assert receipt["hype"] == {"saved": [1, 2, 3]}  # fragment restored
+    assert receipt["phases"][0]["resumed"] is True
+    assert ph.restored is True
+
+
+def test_resume_off_does_not_skip(tmp_path: Any) -> None:
+    path = tmp_path / "checkpoint.json"
+    ck = DreamCheckpoint(path, "fp-a")
+    ck.record("hype", {"phase": "hype"}, {"saved": [1]})
+    receipt: dict[str, Any] = {"errors": []}
+    # resume=False (default nightly behavior): never skip
+    rec = PhaseRecorder(receipt, checkpoint=DreamCheckpoint(path, "fp-a"), resume=False)
+    ph = rec.begin("hype", fragment_key="hype")
+    assert rec.restore(ph) is False
+
+
+def test_checkpoint_written_after_each_phase(tmp_path: Any) -> None:
+    path = tmp_path / "checkpoint.json"
+    receipt: dict[str, Any] = {"errors": []}
+    ck = DreamCheckpoint(path, "fp-a")
+    rec = PhaseRecorder(receipt, checkpoint=ck)
+    rec.end(rec.begin("a"))
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert "a" in data["done"]  # partial receipt survives an interruption here
+
+
+def test_timed_runs_thunk_and_records() -> None:
+    receipt: dict[str, Any] = {"errors": []}
+    rec = PhaseRecorder(receipt)
+    calls: list[int] = []
+
+    def _run() -> dict[str, Any]:
+        calls.append(1)
+        return {"scanned": 5, "saved": [1, 2]}
+
+    receipt["hype"] = rec.timed("hype", _run, fragment_key="hype")
+    assert calls == [1]
+    assert receipt["hype"] == {"scanned": 5, "saved": [1, 2]}
+    r = receipt["phases"][0]
+    assert r["phase"] == "hype"
+    assert r["input_count"] == 5
+    assert r["mutations"] == 2
+
+
+def test_timed_error_fragment_marks_error() -> None:
+    receipt: dict[str, Any] = {"errors": []}
+    rec = PhaseRecorder(receipt)
+    receipt["t"] = rec.timed("t", lambda: {"status": "error"}, fragment_key="t")
+    assert receipt["phases"][0]["status"] == "error"
+
+
+def test_timed_exception_records_error_and_propagates(tmp_path: Any) -> None:
+    receipt: dict[str, Any] = {"errors": []}
+    rec = PhaseRecorder(receipt)
+
+    def _boom() -> dict[str, Any]:
+        raise RuntimeError("kaboom")
+
+    try:
+        rec.timed("boom", _boom)
+    except RuntimeError:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("timed must propagate the pass exception")
+    # a phase record is still emitted for the crashed pass
+    assert receipt["phases"][0]["phase"] == "boom"
+
+
+def test_timed_resumable_skips_thunk_and_returns_cached(tmp_path: Any) -> None:
+    path = tmp_path / "checkpoint.json"
+    ck = DreamCheckpoint(path, "fp-a")
+    ck.record("hype", {"phase": "hype", "status": "done"}, {"saved": [1, 2, 3]})
+
+    receipt: dict[str, Any] = {"errors": []}
+    rec = PhaseRecorder(receipt, checkpoint=DreamCheckpoint(path, "fp-a"), resume=True)
+    calls: list[int] = []
+    frag = rec.timed(
+        "hype", lambda: calls.append(1) or {"saved": []}, fragment_key="hype", resumable=True
+    )
+    assert calls == []  # thunk never ran
+    assert frag == {"saved": [1, 2, 3]}  # cached fragment returned
+    assert receipt["phases"][0]["resumed"] is True
+
+
+def test_summarize_phases() -> None:
+    receipt = {
+        "phases": [
+            {"phase": "a", "duration_ms": 10.0, "mutations": 2, "errors": []},
+            {"phase": "b", "duration_ms": 40.0, "mutations": 0, "errors": ["x"], "resumed": True},
+        ]
+    }
+    s = summarize_phases(receipt)
+    assert s["count"] == 2
+    assert s["total_duration_ms"] == 50.0
+    assert s["mutations"] == 2
+    assert s["errors"] == 1
+    assert s["resumed"] == 1
+    assert s["slowest"]["phase"] == "b"

--- a/tests/test_dream_shadow.py
+++ b/tests/test_dream_shadow.py
@@ -1,0 +1,279 @@
+"""Tests for dream_shadow — measure-only ("shadow") evaluation of opt-in dream phases.
+
+Targets the pure / fully-deterministic surface: the latency ceiling gate, the
+recall verdict axis, observation recording + the consecutive-clean streak, the
+review-ready rollup, and the human promote/reject decisions. Hermetic: temp
+state dirs only, no MLX, no network, no vault. Gate-kind lookups are stubbed via
+``mod._gate`` and the markdown-key inverse via ``mod._env_to_path``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from memo import dream_shadow as mod
+
+# --- helpers --------------------------------------------------------------------
+
+_OFF = {"precision_at_k": 0.5, "noise_at_k": 0.2, "latency_ms_p50": 40.0}
+_WIN_ON = {"precision_at_k": 0.7, "noise_at_k": 0.1, "latency_ms_p50": 50.0}
+_LOSE_ON = {"precision_at_k": 0.3, "noise_at_k": 0.3, "latency_ms_p50": 50.0}
+
+
+class _StubGate:
+    """Minimal stand-in for a ``dream_flags`` GateSpec (kind + shadow_metric)."""
+
+    def __init__(self, kind: str = "shadow", shadow_metric: str = "") -> None:
+        self.kind = kind
+        self.shadow_metric = shadow_metric
+
+
+def _cfg(state_dir: Path) -> SimpleNamespace:
+    return SimpleNamespace(state_dir=state_dir)
+
+
+def _seed_nights(state_dir: Path, flag: str, nights: list[str], on: dict) -> None:
+    for night in nights:
+        mod.record_recall_shadow(state_dir, flag=flag, off=_OFF, on=on, night=night)
+
+
+# --- latency_ceiling_gate -------------------------------------------------------
+
+
+def test_latency_ceiling_gate_disabled_when_ceiling_non_positive() -> None:
+    # A non-positive ceiling disables the gate: always passes, however slow.
+    assert mod.latency_ceiling_gate(99_999.0, 0) is True
+    assert mod.latency_ceiling_gate(99_999.0, -1.0) is True
+
+
+def test_latency_ceiling_gate_passes_when_within_ceiling() -> None:
+    assert mod.latency_ceiling_gate(48.0, 1500.0) is True
+    assert mod.latency_ceiling_gate(1500.0, 1500.0) is True  # boundary: equal passes
+
+
+def test_latency_ceiling_gate_fails_when_over_ceiling() -> None:
+    assert mod.latency_ceiling_gate(6272.0, 1500.0) is False
+
+
+# --- _recall_verdict ------------------------------------------------------------
+
+
+def test_recall_verdict_win_on_precision_gain() -> None:
+    assert mod._recall_verdict(0.1, 0.0) == "win"
+    # positive Δprecision wins even when noise also rises
+    assert mod._recall_verdict(0.1, 0.5) == "win"
+
+
+def test_recall_verdict_win_on_noise_drop_at_flat_precision() -> None:
+    assert mod._recall_verdict(0.0, -0.1) == "win"
+
+
+def test_recall_verdict_lose_on_precision_drop() -> None:
+    assert mod._recall_verdict(-0.1, -0.5) == "lose"
+
+
+def test_recall_verdict_lose_on_noise_rise_at_flat_precision() -> None:
+    assert mod._recall_verdict(0.0, 0.1) == "lose"
+
+
+def test_recall_verdict_neutral_when_both_flat() -> None:
+    assert mod._recall_verdict(0.0, 0.0) == "neutral"
+
+
+# --- record_recall_shadow -------------------------------------------------------
+
+
+def test_record_recall_shadow_appends_observation(tmp_path: Path) -> None:
+    obs = mod.record_recall_shadow(
+        tmp_path, flag="MEMO_X", off=_OFF, on=_WIN_ON, night="2026-08-01"
+    )
+    assert obs is not None
+    assert obs["kind"] == "recall"
+    assert obs["flag"] == "MEMO_X"
+    assert obs["night"] == "2026-08-01"
+    assert obs["delta_precision"] == 0.2  # 0.7 - 0.5
+    assert obs["delta_noise"] == -0.1  # 0.1 - 0.2
+    assert obs["cost_ms"] == 50.0  # ON p50
+    assert obs["verdict"] == "win"
+
+    rows = mod.read_observations(tmp_path, flag="MEMO_X")
+    assert len(rows) == 1
+    assert rows[0]["night"] == "2026-08-01"
+
+
+def test_streak_increments_over_consecutive_clean_nights(tmp_path: Path) -> None:
+    _seed_nights(tmp_path, "MEMO_X", ["d1", "d2", "d3"], _WIN_ON)
+    entry = mod._load_state(tmp_path)["flags"]["MEMO_X"]
+    assert entry["nights"] == 3
+    assert entry["streak"] == 3
+    assert entry["last_verdict"] == "win"
+
+
+def test_non_clean_night_resets_streak(tmp_path: Path) -> None:
+    _seed_nights(tmp_path, "MEMO_X", ["d1", "d2"], _WIN_ON)
+    mod.record_recall_shadow(tmp_path, flag="MEMO_X", off=_OFF, on=_LOSE_ON, night="d3")
+    entry = mod._load_state(tmp_path)["flags"]["MEMO_X"]
+    assert entry["nights"] == 3  # nights keep counting
+    assert entry["streak"] == 0  # a lose resets the consecutive-clean streak
+    assert entry["last_verdict"] == "lose"
+
+
+def test_neutral_verdict_counts_as_clean_night(tmp_path: Path) -> None:
+    same = {"precision_at_k": 0.5, "noise_at_k": 0.2}
+    obs = mod.record_recall_shadow(
+        tmp_path,
+        flag="MEMO_X",
+        off={**same, "latency_ms_p50": 40.0},
+        on={**same, "latency_ms_p50": 50.0},
+        night="d1",
+    )
+    assert obs is not None and obs["verdict"] == "neutral"
+    assert mod._load_state(tmp_path)["flags"]["MEMO_X"]["streak"] == 1
+
+
+def test_same_night_remeasurement_is_idempotent_for_state(tmp_path: Path) -> None:
+    mod.record_recall_shadow(tmp_path, flag="MEMO_X", off=_OFF, on=_WIN_ON, night="d1")
+    mod.record_recall_shadow(tmp_path, flag="MEMO_X", off=_OFF, on=_WIN_ON, night="d1")
+    entry = mod._load_state(tmp_path)["flags"]["MEMO_X"]
+    assert entry["nights"] == 1  # same night never double-counts
+    assert entry["streak"] == 1
+
+
+# --- read_observations ----------------------------------------------------------
+
+
+def test_read_observations_filters_by_flag(tmp_path: Path) -> None:
+    mod.record_recall_shadow(tmp_path, flag="MEMO_A", off=_OFF, on=_WIN_ON, night="d1")
+    mod.record_recall_shadow(tmp_path, flag="MEMO_B", off=_OFF, on=_WIN_ON, night="d1")
+    a_rows = mod.read_observations(tmp_path, flag="MEMO_A")
+    assert len(a_rows) == 1 and a_rows[0]["flag"] == "MEMO_A"
+    assert len(mod.read_observations(tmp_path)) == 2
+
+
+def test_read_observations_excludes_event_rows(tmp_path: Path) -> None:
+    mod.record_recall_shadow(tmp_path, flag="MEMO_X", off=_OFF, on=_WIN_ON, night="d1")
+    mod.reject(_cfg(tmp_path), "MEMO_X", "nope")  # appends a lifecycle "event" row
+    rows = mod.read_observations(tmp_path)
+    assert len(rows) == 1  # the event row is excluded
+    assert rows[0]["kind"] == "recall"
+    assert all(r["kind"] in ("recall", "pass") for r in rows)
+
+
+# --- shadow_summary / review-ready ----------------------------------------------
+
+
+def test_shadow_summary_not_review_ready_before_enough_nights(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("MEMO_SHADOW_REVIEW_NIGHTS", "3")
+    _seed_nights(tmp_path, "MEMO_X", ["d1", "d2"], _WIN_ON)
+    summary = mod.shadow_summary(tmp_path, "MEMO_X")
+    assert summary["streak"] == 2
+    assert summary["review_nights"] == 3
+    assert summary["review_ready"] is False
+
+
+def test_shadow_summary_review_ready_after_enough_clean_nights(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("MEMO_SHADOW_REVIEW_NIGHTS", "3")
+    _seed_nights(tmp_path, "MEMO_X", ["d1", "d2", "d3"], _WIN_ON)
+    summary = mod.shadow_summary(tmp_path, "MEMO_X")
+    assert summary["streak"] == 3
+    assert summary["review_ready"] is True
+
+
+def test_shadow_summary_not_review_ready_after_decision(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("MEMO_SHADOW_REVIEW_NIGHTS", "3")
+    _seed_nights(tmp_path, "MEMO_X", ["d1", "d2", "d3"], _WIN_ON)
+    assert mod.shadow_summary(tmp_path, "MEMO_X")["review_ready"] is True
+    mod.reject(_cfg(tmp_path), "MEMO_X", "not worth it")
+    summary = mod.shadow_summary(tmp_path, "MEMO_X")
+    assert summary["decision"] == "rejected"
+    assert summary["review_ready"] is False  # a decision drops it out of the pool
+
+
+# --- promote --------------------------------------------------------------------
+
+
+def test_promote_refuses_when_not_review_ready(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("MEMO_SHADOW_REVIEW_NIGHTS", "3")
+    _seed_nights(tmp_path, "MEMO_X", ["d1"], _WIN_ON)  # only 1 clean night
+    result = mod.promote(_cfg(tmp_path), "MEMO_X")
+    assert result["ok"] is False
+    assert result["applied"] is False
+    assert "not review-ready" in result["error"]
+
+
+def test_promote_returns_config_set_command_when_review_ready(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("MEMO_SHADOW_REVIEW_NIGHTS", "3")
+    monkeypatch.setattr(mod, "_gate", lambda f: _StubGate(shadow_metric="precision"))
+    monkeypatch.setattr(mod, "_env_to_path", lambda: {"MEMO_X": "recall.graph_boost"})
+    _seed_nights(tmp_path, "MEMO_X", ["d1", "d2", "d3"], _WIN_ON)
+
+    result = mod.promote(_cfg(tmp_path), "MEMO_X", apply=False)
+    assert result["ok"] is True
+    assert result["applied"] is False  # apply=False writes nothing
+    assert result["path"] == "recall.graph_boost"
+    assert result["command"] == "memo config set recall.graph_boost true"
+
+
+def test_promote_export_fallback_when_no_markdown_key(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("MEMO_SHADOW_REVIEW_NIGHTS", "2")
+    monkeypatch.setattr(mod, "_gate", lambda f: _StubGate(shadow_metric="precision"))
+    monkeypatch.setattr(mod, "_env_to_path", lambda: {})  # no markdown-config surface
+    _seed_nights(tmp_path, "MEMO_X", ["d1", "d2"], _WIN_ON)
+
+    result = mod.promote(_cfg(tmp_path), "MEMO_X")
+    assert result["ok"] is True
+    assert result["instruction"] == "export MEMO_X=1"
+    assert "command" not in result
+
+
+def test_promote_refuses_latency_metric_over_ceiling(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("MEMO_SHADOW_REVIEW_NIGHTS", "3")
+    monkeypatch.setenv("MEMO_FLAG_GRADUATION_LATENCY_CEILING_MS", "100")
+    monkeypatch.setattr(mod, "_gate", lambda f: _StubGate(shadow_metric="latency_ms"))
+    monkeypatch.setattr(mod, "_env_to_path", lambda: {"MEMO_X": "recall.graph_boost"})
+    slow_on = {"precision_at_k": 0.7, "noise_at_k": 0.1, "latency_ms_p50": 6000.0}
+    _seed_nights(tmp_path, "MEMO_X", ["d1", "d2", "d3"], slow_on)
+
+    result = mod.promote(_cfg(tmp_path), "MEMO_X")
+    assert result["ok"] is False
+    assert "exceeds ceiling" in result["error"]
+
+
+def test_promote_latency_over_ceiling_passes_with_force(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("MEMO_SHADOW_REVIEW_NIGHTS", "3")
+    monkeypatch.setenv("MEMO_FLAG_GRADUATION_LATENCY_CEILING_MS", "100")
+    monkeypatch.setattr(mod, "_gate", lambda f: _StubGate(shadow_metric="latency_ms"))
+    monkeypatch.setattr(mod, "_env_to_path", lambda: {"MEMO_X": "recall.graph_boost"})
+    slow_on = {"precision_at_k": 0.7, "noise_at_k": 0.1, "latency_ms_p50": 6000.0}
+    _seed_nights(tmp_path, "MEMO_X", ["d1", "d2", "d3"], slow_on)
+
+    result = mod.promote(_cfg(tmp_path), "MEMO_X", force_latency=True)
+    assert result["ok"] is True
+    assert result["command"] == "memo config set recall.graph_boost true"
+
+
+# --- reject ---------------------------------------------------------------------
+
+
+def test_reject_marks_decision(tmp_path: Path) -> None:
+    assert mod.reject(_cfg(tmp_path), "MEMO_X", "too slow") is True
+    entry = mod._load_state(tmp_path)["flags"]["MEMO_X"]
+    assert entry["decision"] == "rejected"
+    assert entry["decision_reason"] == "too slow"
+    # reject records a lifecycle event, never an observation row
+    assert mod.read_observations(tmp_path, flag="MEMO_X") == []

--- a/tests/test_dream_staging.py
+++ b/tests/test_dream_staging.py
@@ -1,0 +1,393 @@
+"""Tests for dream conflict-staging (`memo.dream_staging`).
+
+Hermetic unit tests over the deterministic surface: no MLX, no network, no
+real vault — every test builds an isolated `Config` (the `tmp_cfg` fixture) and
+drives a fake `Memory` whose `.save` and `.operational.active_conflicts()` are
+scripted. Flags are set via `monkeypatch.setenv` (memo flag resolution reads
+env first).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from memo import dream_staging as mod
+from memo.errors import StorageError, WriteRefused
+
+STAGING_FLAG = "MEMO_DREAM_STAGING_ENABLED"
+STAGING_MAX_FLAG = "MEMO_DREAM_STAGING_MAX"
+
+
+# --- fakes -----------------------------------------------------------------
+class FakeOperational:
+    """`mem.operational` double: `active_conflicts()` returns scripted rows."""
+
+    def __init__(self, rows: Any = ()) -> None:
+        self._rows = rows  # list, or callable -> list, or callable that raises
+
+    def active_conflicts(self) -> list[dict[str, Any]]:
+        rows = self._rows() if callable(self._rows) else self._rows
+        return [dict(r) for r in rows]
+
+
+class FakeMemory:
+    """Minimal `Memory` stand-in for `staged_save` / `resume_staged_proposals`."""
+
+    def __init__(self, *, save: Any = None, conflict_rows: Any = ()) -> None:
+        self._save = save
+        self.save_calls: list[dict[str, Any]] = []
+        self.operational = FakeOperational(conflict_rows)
+
+    def save(self, **kwargs: Any) -> Any:
+        self.save_calls.append(dict(kwargs))
+        if self._save is None:
+            return {"id": "saved", "kwargs": dict(kwargs)}
+        return self._save(**kwargs)
+
+
+def _refuse(conflict: dict[str, Any]):
+    def _raise(**_kwargs: Any) -> Any:
+        raise WriteRefused(conflict)
+
+    return _raise
+
+
+def _raise_storage(**_kwargs: Any) -> Any:
+    raise StorageError("disk on fire")
+
+
+def _stage_one(cfg, mem, *, kind="synthesis", title="T", source_ids=("a", "b"),
+               conflict=None, extra=None):
+    """Helper: stage a single proposal directly via `stage_proposal`."""
+    save_kwargs: dict[str, Any] = {"content": "body", "title": title, "type_": "synthesis"}
+    if extra is not None:
+        save_kwargs["extra"] = extra
+    return mod.stage_proposal(
+        cfg,
+        mem,
+        kind=kind,
+        save_kwargs=save_kwargs,
+        source_ids=list(source_ids),
+        conflict=conflict or {"conflict_id": "c1", "summary": "topic frozen"},
+    )
+
+
+# --- staged_save: scope / flag gating --------------------------------------
+def test_staged_save_flag_off_is_passthrough_and_propagates_refused(tmp_cfg, monkeypatch):
+    monkeypatch.setenv(STAGING_FLAG, "0")
+    mem = FakeMemory(save=_refuse({"conflict_id": "c1", "summary": "frozen"}))
+
+    with mod.dream_staging_scope():
+        with pytest.raises(WriteRefused):
+            mod.staged_save(
+                mem, tmp_cfg, kind="synthesis", source_ids=["a"],
+                content="body", title="T", type_="synthesis",
+            )
+    # Passthrough: nothing was parked.
+    assert mod.list_staged(tmp_cfg) == []
+
+
+def test_staged_save_outside_scope_is_passthrough_and_propagates_refused(tmp_cfg, monkeypatch):
+    monkeypatch.setenv(STAGING_FLAG, "1")  # flag on, but NOT inside a dream scope
+    mem = FakeMemory(save=_refuse({"conflict_id": "c1", "summary": "frozen"}))
+
+    with pytest.raises(WriteRefused):
+        mod.staged_save(
+            mem, tmp_cfg, kind="synthesis", source_ids=["a"],
+            content="body", title="T", type_="synthesis",
+        )
+    assert mod.list_staged(tmp_cfg) == []
+
+
+def test_staged_save_inside_scope_parks_refused_and_returns_none(tmp_cfg, monkeypatch):
+    monkeypatch.setenv(STAGING_FLAG, "1")
+    mem = FakeMemory(save=_refuse({"conflict_id": "c1", "summary": "topic frozen"}))
+
+    with mod.dream_staging_scope():
+        result = mod.staged_save(
+            mem, tmp_cfg, kind="synthesis", source_ids=["a", "b"],
+            content="body", title="T", type_="synthesis",
+        )
+
+    assert result is None
+    staged = mod.list_staged(tmp_cfg)
+    assert len(staged) == 1
+    p = staged[0]
+    assert p.proposal_id.startswith("dream-synthesis-")
+    assert p.save_kwargs == {"content": "body", "title": "T", "type_": "synthesis"}
+    assert p.source_ids == ("a", "b")
+    assert p.conflict_ids == ("c1",)
+    assert p.conflict_summary == "topic frozen"
+    assert p.attempts == 1
+    assert p.state == "staged"
+
+
+def test_staged_save_reraises_non_refused_error(tmp_cfg, monkeypatch):
+    monkeypatch.setenv(STAGING_FLAG, "1")
+    mem = FakeMemory(save=_raise_storage)
+
+    with mod.dream_staging_scope():
+        with pytest.raises(StorageError):
+            mod.staged_save(
+                mem, tmp_cfg, kind="synthesis", source_ids=["a"],
+                content="body", title="T", type_="synthesis",
+            )
+    # Only WriteRefused parks; every other error re-raises and stages nothing.
+    assert mod.list_staged(tmp_cfg) == []
+
+
+def test_staged_save_success_returns_record_and_stages_nothing(tmp_cfg, monkeypatch):
+    monkeypatch.setenv(STAGING_FLAG, "1")
+    mem = FakeMemory()  # default save returns a sentinel record
+
+    with mod.dream_staging_scope():
+        result = mod.staged_save(
+            mem, tmp_cfg, kind="synthesis", source_ids=["a"],
+            content="body", title="T", type_="synthesis",
+        )
+
+    assert result is not None
+    assert result["id"] == "saved"
+    assert mod.list_staged(tmp_cfg) == []
+
+
+# --- stage_proposal: idempotency + provenance ------------------------------
+def test_stage_proposal_is_idempotent_by_proposal_id(tmp_cfg):
+    mem = FakeMemory()
+    first = _stage_one(tmp_cfg, mem, title="Same")
+    second = _stage_one(tmp_cfg, mem, title="Same")
+
+    assert first.proposal_id == second.proposal_id
+    staged = mod.list_staged(tmp_cfg)
+    assert len(staged) == 1  # no duplicate
+    assert staged[0].attempts == 2  # re-stage bumped attempts
+
+
+def test_stage_proposal_distinct_titles_produce_distinct_ids(tmp_cfg):
+    mem = FakeMemory()
+    p1 = _stage_one(tmp_cfg, mem, title="Title one")
+    p2 = _stage_one(tmp_cfg, mem, title="Title two")
+
+    assert p1.proposal_id != p2.proposal_id
+    assert len(mod.list_staged(tmp_cfg)) == 2
+
+
+def test_stage_proposal_provenance_hash_from_extra_drives_id(tmp_cfg):
+    mem = FakeMemory()
+    # Same provenance hash but different titles => same deterministic id.
+    p1 = _stage_one(tmp_cfg, mem, title="One", extra={"synthesis_sources_hash": "abc123def456"})
+    p2 = _stage_one(tmp_cfg, mem, title="Two", extra={"synthesis_sources_hash": "abc123def456"})
+
+    assert p1.proposal_id == "dream-synthesis-abc123def456"
+    assert p2.proposal_id == p1.proposal_id
+    assert len(mod.list_staged(tmp_cfg)) == 1
+
+
+# --- conflict enrichment ----------------------------------------------------
+def test_stage_proposal_enriches_conflict_from_active_rows(tmp_cfg):
+    rows = [
+        {
+            "id": "c1",
+            "summary": "enriched summary",
+            "evidence_uris": ["memo://evidence/1"],
+            "metadata": {"memory_ids": ["m1", "m2"]},
+        }
+    ]
+    mem = FakeMemory(conflict_rows=rows)
+    p = _stage_one(tmp_cfg, mem, conflict={"conflict_id": "c1", "summary": "raw"})
+
+    assert p.conflict_ids == ("c1",)
+    assert p.conflict_summary == "enriched summary"
+    assert p.evidence_uris == ("memo://evidence/1",)
+
+
+def test_stage_proposal_evidence_falls_back_to_member_memory_ids(tmp_cfg):
+    rows = [{"id": "c1", "summary": "s", "metadata": {"memory_ids": ["m1", "m2"]}}]
+    mem = FakeMemory(conflict_rows=rows)
+    p = _stage_one(tmp_cfg, mem, conflict={"conflict_id": "c1", "summary": "raw"})
+
+    assert p.evidence_uris == ("memo://memoria/m1", "memo://memoria/m2")
+
+
+def test_stage_proposal_degrades_when_active_conflicts_raises(tmp_cfg):
+    def _boom():
+        raise RuntimeError("conflicts read failed")
+
+    mem = FakeMemory(conflict_rows=_boom)
+    p = _stage_one(tmp_cfg, mem, conflict={"conflict_id": "c1", "summary": "raw summary"})
+
+    # Best-effort enrichment: degrades to the WriteRefused's own summary.
+    assert p.conflict_ids == ("c1",)
+    assert p.conflict_summary == "raw summary"
+    assert p.evidence_uris == ()
+
+
+# --- cap enforcement --------------------------------------------------------
+def test_enforce_cap_drops_oldest_staged():
+    proposals = [
+        mod.StagedProposal(f"p{i}", "synthesis", {}, (), (), "", (), "t")
+        for i in range(4)
+    ]
+    kept = mod._enforce_cap(proposals, 2)
+
+    kept_ids = [p.proposal_id for p in kept]
+    assert kept_ids == ["p2", "p3"]  # two oldest (p0, p1) dropped
+
+
+def test_enforce_cap_ignores_non_staged_when_counting():
+    proposals = [
+        mod.StagedProposal("a", "k", {}, (), (), "", (), "t", state="applied"),
+        mod.StagedProposal("b", "k", {}, (), (), "", (), "t", state="staged"),
+        mod.StagedProposal("c", "k", {}, (), (), "", (), "t", state="staged"),
+    ]
+    kept = mod._enforce_cap(proposals, 1)
+    # Only staged entries count toward the cap; the applied one stays.
+    kept_ids = sorted(p.proposal_id for p in kept)
+    assert "a" in kept_ids
+    assert "c" in kept_ids
+    assert "b" not in kept_ids  # oldest staged dropped
+
+
+def test_stage_proposal_enforces_cap_via_flag(tmp_cfg, monkeypatch):
+    monkeypatch.setenv(STAGING_MAX_FLAG, "2")
+    mem = FakeMemory()
+    _stage_one(tmp_cfg, mem, title="one")
+    _stage_one(tmp_cfg, mem, title="two")
+    _stage_one(tmp_cfg, mem, title="three")
+
+    staged = mod.list_staged(tmp_cfg)
+    assert len(staged) == 2
+    titles = {p.save_kwargs["title"] for p in staged}
+    assert titles == {"two", "three"}  # oldest ("one") dropped
+
+
+# --- resume ----------------------------------------------------------------
+def test_resume_applies_unblocked_proposal(tmp_cfg):
+    stager = FakeMemory()
+    _stage_one(tmp_cfg, stager, title="unblock me")
+
+    # Later run: conflict resolved (no active conflicts), save now succeeds.
+    resumer = FakeMemory(conflict_rows=[])
+    result = mod.resume_staged_proposals(tmp_cfg, resumer)
+
+    assert len(result["applied"]) == 1
+    assert result["still_blocked"] == 0
+    assert result["total_open"] == 0
+    assert mod.list_staged(tmp_cfg) == []
+    assert len(resumer.save_calls) == 1
+
+
+def test_resume_keeps_still_blocked_proposal(tmp_cfg):
+    stager = FakeMemory()
+    _stage_one(tmp_cfg, stager, title="blocked", conflict={"conflict_id": "c1", "summary": "s"})
+
+    # The blocking conflict is still active.
+    resumer = FakeMemory(conflict_rows=[{"id": "c1", "summary": "s"}])
+    result = mod.resume_staged_proposals(tmp_cfg, resumer)
+
+    assert result["applied"] == []
+    assert result["still_blocked"] == 1
+    assert result["total_open"] == 1
+    assert len(resumer.save_calls) == 0  # blocked proposal is not re-saved
+    assert len(mod.list_staged(tmp_cfg)) == 1
+
+
+def test_resume_restages_when_a_new_conflict_blocks(tmp_cfg):
+    stager = FakeMemory()
+    _stage_one(tmp_cfg, stager, title="restage", conflict={"conflict_id": "c1", "summary": "old"})
+
+    # Original conflict gone (empty active list) but save hits a *new* blocker.
+    resumer = FakeMemory(
+        save=_refuse({"conflict_id": "c2", "summary": "new block"}),
+        conflict_rows=[],
+    )
+    result = mod.resume_staged_proposals(tmp_cfg, resumer)
+
+    assert result["applied"] == []
+    assert result["still_blocked"] == 1
+    assert result["total_open"] == 1
+    staged = mod.list_staged(tmp_cfg)
+    assert len(staged) == 1
+    assert staged[0].conflict_ids == ("c2",)  # re-pointed at the new blocker
+    assert staged[0].attempts == 2  # bumped on re-stage
+
+
+def test_resume_records_error_and_keeps_on_memoerror(tmp_cfg):
+    stager = FakeMemory()
+    _stage_one(tmp_cfg, stager, title="erring", conflict={"conflict_id": "c1", "summary": "s"})
+
+    resumer = FakeMemory(save=_raise_storage, conflict_rows=[])
+    result = mod.resume_staged_proposals(tmp_cfg, resumer)
+
+    assert result["applied"] == []
+    assert len(result["errors"]) == 1
+    assert "StorageError" in result["errors"][0]
+    assert result["total_open"] == 1  # kept for a later retry
+    assert len(mod.list_staged(tmp_cfg)) == 1
+
+
+def test_resume_runs_outside_scope_and_restores_contextvar(tmp_cfg, monkeypatch):
+    monkeypatch.setenv(STAGING_FLAG, "1")
+    stager = FakeMemory()
+    _stage_one(tmp_cfg, stager, title="unblock", conflict={"conflict_id": "c1", "summary": "s"})
+
+    resumer = FakeMemory(conflict_rows=[])
+    with mod.dream_staging_scope():
+        assert mod._STAGING_SCOPE.get() is True
+        result = mod.resume_staged_proposals(tmp_cfg, resumer)
+        # Replay resets the scope internally, then restores it on exit.
+        assert mod._STAGING_SCOPE.get() is True
+
+    assert len(result["applied"]) == 1
+    assert mod.list_staged(tmp_cfg) == []
+
+
+# --- list / drop / resolve_command -----------------------------------------
+def test_list_staged_on_fresh_cfg_is_empty(tmp_cfg):
+    assert mod.list_staged(tmp_cfg) == []
+
+
+def test_drop_staged_removes_by_id_and_reports(tmp_cfg):
+    mem = FakeMemory()
+    p = _stage_one(tmp_cfg, mem, title="dropme")
+
+    assert mod.drop_staged(tmp_cfg, p.proposal_id) is True
+    assert mod.list_staged(tmp_cfg) == []
+    # Dropping again reports no removal.
+    assert mod.drop_staged(tmp_cfg, p.proposal_id) is False
+
+
+def test_resolve_command_uses_first_conflict_id():
+    p = mod.StagedProposal(
+        "dream-x-abc", "x", {}, (), ("conf-42",), "", (), "2026-01-01T00:00:00Z"
+    )
+    cmd = mod.resolve_command(p)
+    assert "conf-42" in cmd
+    assert cmd.startswith("memo operational conflict resolve conf-42")
+
+
+def test_resolve_command_placeholder_without_conflict_ids():
+    p = mod.StagedProposal("dream-x-abc", "x", {}, (), (), "", (), "2026-01-01T00:00:00Z")
+    cmd = mod.resolve_command(p)
+    assert "<conflict-id>" in cmd
+
+
+# --- serialization round-trip ----------------------------------------------
+def test_staged_proposal_round_trip_is_stable():
+    p = mod.StagedProposal(
+        proposal_id="dream-synthesis-deadbeef",
+        kind="synthesis",
+        save_kwargs={"content": "body", "title": "T"},
+        source_ids=("a", "b"),
+        conflict_ids=("c1",),
+        conflict_summary="frozen",
+        evidence_uris=("memo://x",),
+        staged_at="2026-01-01T00:00:00Z",
+        state="staged",
+        attempts=3,
+        metadata={"k": "v"},
+    )
+    restored = mod.StagedProposal.from_dict(p.to_dict())
+    assert restored == p

--- a/tests/test_dream_tune_strict_gate.py
+++ b/tests/test_dream_tune_strict_gate.py
@@ -1,0 +1,97 @@
+"""Fase 4 — the tuner's six-condition graduation gate is recorded always and
+enforced only behind MEMO_DREAM_TUNE_STRICT_GATE_ENABLED (default off).
+
+The gate verdict must appear in the receipt every night (shadow evidence), but
+an un-graduated (default-off) gate must NEVER change the tuner's existing apply
+decision. Once the flag is on, a failing gate blocks the apply.
+
+The apply path is reached via the MMR rank knob (same clean, non-leaky stubbing
+as test_dream_tune_knobs — module-attr patches only, no global flag_float
+monkeypatch, which leaks across tests).
+"""
+
+from __future__ import annotations
+
+from memo import dream_metrics
+from memo import dream_tune as dt
+from memo.eval_recall import LabelSet, Prompt
+
+_MMR = "MEMO_RECALL_MMR_LAMBDA"
+
+
+class _StubMem:
+    def search(self, query, limit, mode="vec", exclude_types=None, exclude_tags=None):
+        return []
+
+
+def _cfg(tmp_path):
+    from memo.config import Config
+
+    return Config.from_env()
+
+
+def _metrics(prec, noise=0.0, lat=10.0):
+    return {"precision_at_k": prec, "noise_at_k": noise, "latency_ms_p50": lat}
+
+
+def _one_label():
+    return LabelSet(prompts=[Prompt("q", relevant=True, expect_ids=["aaaa1111"])]), True
+
+
+def _reach_apply(monkeypatch, tmp_path):
+    """Stub the search so exactly the MMR knob improves — the tuner reaches the
+    apply path where the Fase-4 graduation gate sits. All patches are on the dt
+    module (reverted per-test) — no global flag_float monkeypatch."""
+    monkeypatch.setenv("MEMO_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(dt, "build_labels", lambda cfg, **k: _one_label())
+    monkeypatch.setattr(dt, "load_baseline", lambda sd: None)
+    monkeypatch.setattr(
+        dt, "search_min_sim", lambda *a, **k: (0.5, _metrics(0.2), _metrics(0.2))
+    )
+
+    def _fake_search(mem, labels, *, k, floor, knob, current, grid, max_evals):
+        if knob == _MMR:
+            return 0.5, _metrics(0.2), _metrics(0.4), []
+        return current, _metrics(0.2), _metrics(0.2), []
+
+    monkeypatch.setattr(dt, "search_rank_knob", _fake_search)
+    monkeypatch.setattr(dt, "curated_gate", lambda *a, **k: {"ok": True})
+
+
+def test_gate_recorded_but_not_enforced_when_flag_off(tmp_path, monkeypatch):
+    _reach_apply(monkeypatch, tmp_path)
+    # Even a FAILING gate must not block the apply while the flag is off.
+    monkeypatch.setattr(
+        dream_metrics, "graduation_gate", lambda *a, **k: {"ok": False, "reasons": ["stub"]}
+    )
+    monkeypatch.delenv("MEMO_DREAM_TUNE_STRICT_GATE_ENABLED", raising=False)
+
+    res = dt.run_tuning_pass(_cfg(tmp_path), _StubMem(), k=5)
+    assert res["status"] == "applied"  # existing behavior preserved
+    assert res["applied_knob"] == _MMR
+    assert res["graduation_gate"] == {"ok": False, "reasons": ["stub"]}  # recorded
+
+
+def test_gate_enforced_blocks_apply_when_flag_on(tmp_path, monkeypatch):
+    _reach_apply(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        dream_metrics,
+        "graduation_gate",
+        lambda *a, **k: {"ok": False, "reasons": ["insufficient_labels"]},
+    )
+    monkeypatch.setenv("MEMO_DREAM_TUNE_STRICT_GATE_ENABLED", "1")
+
+    res = dt.run_tuning_pass(_cfg(tmp_path), _StubMem(), k=5)
+    assert res["status"] == "gate_rejected"
+    assert res["graduation_gate"]["reasons"] == ["insufficient_labels"]
+    assert dt.read_overlay(tmp_path) == {}  # nothing applied
+
+
+def test_gate_ok_applies_when_flag_on(tmp_path, monkeypatch):
+    _reach_apply(monkeypatch, tmp_path)
+    monkeypatch.setattr(dream_metrics, "graduation_gate", lambda *a, **k: {"ok": True, "reasons": []})
+    monkeypatch.setenv("MEMO_DREAM_TUNE_STRICT_GATE_ENABLED", "1")
+
+    res = dt.run_tuning_pass(_cfg(tmp_path), _StubMem(), k=5)
+    assert res["status"] == "applied"
+    assert res["graduation_gate"] == {"ok": True, "reasons": []}

--- a/tests/test_index_health.py
+++ b/tests/test_index_health.py
@@ -1,0 +1,156 @@
+"""Hermetic tests for the derived-index health diagnostic.
+
+Every test builds a real isolated ``Memory`` (via the ``mock_memory`` fixture,
+which stubs the embedder) so the SQL-level checks run against a genuine
+``memvec.db`` round-trip. The developer's real vault is never touched.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+
+from memo.sqlite_compat import import_sqlite_vec
+from memo.store.index_health import check_index_health
+
+_serialize_float32 = import_sqlite_vec().serialize_float32
+
+
+def _unit_vector(dims: int) -> list[float]:
+    vec = [0.0] * dims
+    vec[0] = 1.0
+    return vec
+
+
+def _insert_orphan_vector(mem, vec_id: str) -> None:
+    """Insert a vec row with no matching meta row (a derived orphan)."""
+    store = mem.store
+    bind = store._vec_bind_new()
+    with store._tx() as cx:
+        cx.execute(
+            f"INSERT INTO vec (id, embedding, type) VALUES (?, {bind}, ?)",  # noqa: S608
+            (vec_id, _serialize_float32(_unit_vector(store.dims)), "note"),
+        )
+
+
+def test_clean_store_reports_ok(mock_memory):
+    # Arrange: a store with two well-formed memories.
+    mock_memory.save(content="prod db is postgres", title="DB choice", type_="fact")
+    mock_memory.save(content="deploy runs at 03:00", title="Deploy window", type_="note")
+
+    # Act
+    result = check_index_health(mock_memory.cfg, mock_memory)
+
+    # Assert: no divergence, and the informational check is still present.
+    assert result["status"] == "ok"
+    assert result["errors"] == []
+    for name in ("orphan_vectors", "fts_missing_body", "missing_markdown", "md_divergence"):
+        assert result["checks"][name]["count"] == 0
+    assert "stale_caches" in result["checks"]
+
+
+def test_orphan_vector_detected_and_repaired(mock_memory):
+    # Arrange: one real memory + one injected orphan vector.
+    rec = mock_memory.save(content="a durable fact", title="Fact", type_="fact")
+    md_path = mock_memory.cfg.memory_dir / rec.path
+    assert md_path.is_file()
+    _insert_orphan_vector(mock_memory, "deadbeefdeadbeef")
+
+    # Act: detect only.
+    detected = check_index_health(mock_memory.cfg, mock_memory)
+
+    # Assert: the orphan is flagged and status escalates.
+    assert detected["status"] == "issues"
+    orphan = detected["checks"]["orphan_vectors"]
+    assert orphan["count"] == 1
+    assert "deadbeefdeadbeef" in orphan["sample"]
+    assert detected["repaired"] == {}
+
+    # Act: repair.
+    repaired = check_index_health(mock_memory.cfg, mock_memory, repair=True)
+
+    # Assert: derived orphan removed, canonical .md untouched.
+    assert repaired["repaired"].get("orphan_vectors") == 1
+    assert md_path.is_file()
+    after = check_index_health(mock_memory.cfg, mock_memory)
+    assert after["checks"]["orphan_vectors"]["count"] == 0
+
+
+def test_null_fts_body_detected(mock_memory):
+    # Arrange: blank out an indexed FTS body under the memory row.
+    rec = mock_memory.save(content="has a real body", title="Body", type_="note")
+    with mock_memory.store._tx() as cx:
+        cx.execute("UPDATE fts SET body = '' WHERE id = ?", (rec.id,))
+
+    # Act
+    result = check_index_health(mock_memory.cfg, mock_memory)
+
+    # Assert
+    check = result["checks"]["fts_missing_body"]
+    assert check["count"] >= 1
+    assert any(entry["id"] == rec.id for entry in check["sample"])
+
+
+def test_missing_markdown_detected_but_not_repaired(mock_memory):
+    # Arrange: delete the canonical .md on disk, leaving the index row.
+    rec = mock_memory.save(content="canonical body", title="Canonical", type_="fact")
+    md_path = mock_memory.cfg.memory_dir / rec.path
+    md_path.unlink()
+
+    # Act: detect.
+    detected = check_index_health(mock_memory.cfg, mock_memory)
+    assert detected["checks"]["missing_markdown"]["count"] >= 1
+    assert any(e["id"] == rec.id for e in detected["checks"]["missing_markdown"]["sample"])
+
+    # Act: repair must NOT delete a memory whose .md is (only) unreachable.
+    repaired = check_index_health(mock_memory.cfg, mock_memory, repair=True)
+    assert "missing_markdown" not in repaired["repaired"]
+    assert mock_memory.store.get(rec.id) is not None
+
+
+def test_md_divergence_detected_on_hand_edit(mock_memory):
+    # Arrange: a hand-edit to the canonical file, leaving the stale index.
+    rec = mock_memory.save(content="original body", title="Edited", type_="note")
+    md_path = mock_memory.cfg.memory_dir / rec.path
+    original = md_path.read_text(encoding="utf-8")
+    md_path.write_text(original + "\n\nAppended by hand in Obsidian.\n", encoding="utf-8")
+
+    # Act
+    result = check_index_health(mock_memory.cfg, mock_memory)
+
+    # Assert
+    check = result["checks"]["md_divergence"]
+    assert check["count"] >= 1
+    assert any(entry["id"] == rec.id for entry in check["sample"])
+
+
+def test_never_raises_on_empty_or_malformed_db(tmp_cfg):
+    # Arrange: a fake store over an empty in-memory DB (no memo tables).
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    class _FakeStore:
+        connection = conn
+        embedder_model = ""
+        dims = tmp_cfg.embedder_dims
+
+        def _vec_table_dims(self, table: str):
+            return None
+
+        @contextmanager
+        def _tx(self):
+            yield conn
+
+    class _FakeMem:
+        store = _FakeStore()
+
+    fake = _FakeMem()
+
+    # Act + Assert: must return a dict, never raise, even with repair=True.
+    for repair in (False, True):
+        result = check_index_health(tmp_cfg, fake, repair=repair)
+        assert isinstance(result, dict)
+        assert result["status"] in {"ok", "issues", "error"}
+        assert set(result) == {"status", "checks", "repaired", "errors"}
+
+    conn.close()


### PR DESCRIPTION
## Summary

Turns `memo dream run` into the **principal learning loop** of Memo. Every new behavior is **gated default-off**, records **structured evidence**, and is **reversible**. Implements all 8 phases of the plan.

> Stacked on the in-flight `release/v4.8.0` (5 prior commits); the dream learning-loop work is the single commit `feat(dream): learning-loop …`. Review that commit for this change set.

| Fase | What | Flag (default off) |
|---|---|---|
| 1 | Per-phase instrumentation + resumable checkpoints (`dream_phases.py`); `phases_summary` in receipt; `--resume` | — (always on, additive) |
| 2 | HyPE batch-embed (`embedder.embed_queries`), time budget, `missing_source` watermark (no false-empty) | `MEMO_DREAM_HYPE_BUDGET_S` |
| 3 | Auditable learning ledger (`dream_ledger.py`) source→action→evidence→outcome; `memo dream ledger` | `MEMO_DREAM_LEDGER_ENABLED` |
| 4 | 11-metric snapshot + six-condition `graduation_gate` (recorded always, enforced behind flag) | `MEMO_DREAM_TUNE_STRICT_GATE_ENABLED` |
| 5 | Per-pass incremental skip (`dream_incremental.py`) on dependency fingerprint; entities + synthesis | `MEMO_DREAM_INCREMENTAL_ENABLED` |
| 6 | Derived-index health check (`store/index_health.py`, 11 checks); repairs only derived orphans; `memo dream index-health` | `MEMO_DREAM_INDEX_REPAIR_ENABLED` |
| 7 | Conflict staging (`dream_staging.py`): a `WriteRefused` on a dream-minted synthesis is parked, not lost; `memo dream staging` | `MEMO_DREAM_STAGING_ENABLED` |
| 8 | Absolute latency-ceiling backstop in flag graduation + measure-only shadow (`dream_shadow.py`); `memo dream shadow` | `MEMO_DREAM_SHADOW_ENABLED` |

## Invariants preserved
- **Markdown is the source of truth** — no `memvec.db` rebuild; index_health repairs touch derived index only, never a `.md`.
- **MLX** — deferred imports, query-only asymmetric prefix (applied inside `embed_queries`), `embed()` takes `Sequence[str]`, empty→zero vector.
- Flags via the registry (`flag_bool/int/float`), never ad-hoc `os.environ`; `memo config validate` clean.
- Writes via `VecStore` / `_tx()`.
- All new dark flags carry a `dream_flags.GATES` entry (completeness CI-enforced).

## Test plan
- [x] `ruff check` clean on all changed/new files (src + tests)
- [x] `mypy src/memo` clean on all new/changed modules
- [x] Full `pytest -m "not slow" -n auto` — **6718 passed, 1 fixed** (architecture-boundary: index_health now uses the store-package relative deferred flags import)
- [x] New suites: ledger (29), metrics (32), staging (24), shadow (24), incremental (7), phases (21), index-health (6), strict-gate (3) + hype/flags additions — all green
- [x] `memo config validate` — all flags valid
- [x] Controlled `memo dream run --json --force` (isolated store, Fase 3–8 flags on): `errors: []`, every phase fires — ledger/index_health(ok)/staging_resume/shadow_review/learning_metrics/phases_summary all present
- [x] `memo eval recall` + pre-push recall gate: **PASS**, no regression (prec@k 0.697, noise 0.000)

## Notes
- Fixed a **pre-existing** test-isolation leak pattern (global `flag_float` monkeypatch) by giving the new strict-gate test module-attr stubs instead; `test_dream_tune.py` still carries the original leaky pattern (out of scope here).
- The live index shows ~6166 FTS rows with empty `body` (surfaced by the new `index-health` check) — a real pre-existing divergence worth a follow-up reindex; not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)