### PR TITLE
fix: darwin process-birth-identity test used its own long-lived pid

### DIFF
--- a/tests/test_terminal_live.py
+++ b/tests/test_terminal_live.py
@@ -1110,9 +1110,14 @@ def test_native_process_birth_identity_has_subsecond_or_tick_precision() -> None
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="Darwin libproc layout only")
 def test_darwin_process_birth_identity_matches_live_libproc_layout() -> None:
-    identity = _darwin_process_birth_identity(os.getpid())
-    prefix, seconds, microseconds = identity.split(":")
+    process = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        identity = _darwin_process_birth_identity(process.pid)
+        prefix, seconds, microseconds = identity.split(":")
 
-    assert prefix == "darwin-start"
-    assert abs(time.time() - int(seconds)) < 60
-    assert 0 <= int(microseconds) < 1_000_000
+        assert prefix == "darwin-start"
+        assert 0 <= time.time() - int(seconds) < 60
+        assert 0 <= int(microseconds) < 1_000_000
+    finally:
+        process.terminate()
+        process.wait(timeout=5)


### PR DESCRIPTION
## Summary
- The test read its own process's start time via `_darwin_process_birth_identity`, but the test-runner process can predate "now" by more than the 60s window on a long-lived session, and a negative delta from clock skew slipped past an `abs()` check.
- Spawns a short-lived child process instead and asserts the delta is non-negative.

Found while doing a production-readiness pass on `release/v4.8.0` (already merged to master via #180) — this was an uncommitted local fix left over from a prior session, unrelated to that PR's content.

## Test plan
- [x] `pytest tests/test_terminal_live.py -k darwin_process_birth_identity_matches_live_libproc_layout`
- [x] Full suite green (6816 passed, 1 skipped) before this change