### PR TITLE
chore(launchd): activate HyDE-tune + graph-hygiene dream passes

### DIFF
--- a/docs/superpowers/plans/2026-08-03-dream-hyde-graph-hygiene-activation.md
+++ b/docs/superpowers/plans/2026-08-03-dream-hyde-graph-hygiene-activation.md
@@ -114,8 +114,10 @@ Expected: three lines, each `1`.
 - [ ] **Step 4: Verify the placeholders are untouched**
 
 Run: `grep -c '__HOME__\|__MEMO_BIN__' launchd/com.memo.dream.plist`
-Expected: `3` (one `__MEMO_BIN__` in `ProgramArguments`, two `__HOME__` in
-the log paths — unchanged from before this edit).
+Expected: `5` (the header comment's prose mentions both placeholders on one
+line, plus `__MEMO_BIN__` in `ProgramArguments` and `__HOME__` in the two
+log paths and the `PATH` entry — unchanged from before this edit; the exact
+number matters less than that it's identical before and after).
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-08-03-dream-hyde-graph-hygiene-activation.md
+++ b/docs/superpowers/plans/2026-08-03-dream-hyde-graph-hygiene-activation.md
@@ -1,0 +1,314 @@
+# Dream HyDE-Tune + Graph-Hygiene Activation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn on three dormant, manual-kind memo dream self-improvement
+passes (`MEMO_DREAM_HYDE_TUNE_ENABLED`, `MEMO_DREAM_ENTITY_CANON_ENABLED`,
+`MEMO_DREAM_EDGE_VERIFY_ENABLED`) for the nightly `com.memo.dream`
+LaunchAgent, verified both in isolation and end-to-end.
+
+**Architecture:** Config-only change. Add the three flags to the repo's
+committed LaunchAgent plist *template* (which still carries
+`__HOME__`/`__MEMO_BIN__` placeholders, same as every other agent in the
+fleet), re-render the deployed copy under `~/Library/LaunchAgents/`, and
+reload the agent. No memo source code changes — the passes and their flag
+gates already exist and ship in the installed `mlx-memo` build.
+
+**Tech Stack:** macOS `launchd` (plist XML, `launchctl`, `plutil`,
+`PlistBuddy`), the installed `memo` CLI (`~/.local/bin/memo`, uv-tool
+isolated runtime — never the repo's `.venv`).
+
+## Global Constraints
+
+- Config/plist only — no edits under `src/memo/`. The three flags and their
+  passes already exist and are already gated in `cli_dream.py`.
+- Do not add a markdown-config dotted key for these flags (spec explicitly
+  scoped this out as a follow-up) — the LaunchAgent's own
+  `EnvironmentVariables` is the mechanism.
+- Do not touch any other `EnvironmentVariables` entry already in the plist
+  (`MEMO_DREAM_TUNE_ENABLED`, `MEMO_BELIEF_NWAY`, etc.) — additive only.
+- Preserve the `__HOME__` / `__MEMO_BIN__` placeholders in the **repo**
+  template file — only the rendered copy under `~/Library/LaunchAgents/`
+  gets real paths substituted in.
+- The repo working tree is shared across concurrent agent sessions
+  (`~/repos/memo/CLAUDE.md`) — stage only `launchd/com.memo.dream.plist` by
+  exact path when committing, never `git add -A`.
+- `memo` must resolve from the isolated uv-tool runtime
+  (`~/.local/bin/memo`), never a repo `.venv` — every verification command
+  below assumes plain `memo ...`, not `uv run memo ...`.
+- Before running any verification command in this plan, run
+  `memo doctor 2>&1 | grep -i "outside the isolated runtime"`. If it warns,
+  `unset PYTHONPATH` in that shell first — a `PYTHONPATH=src` (relative to
+  a `~/repos/memo` cwd) silently shadows the isolated install with the
+  working-tree source, so `memo --version` looks right while the code that
+  actually runs is stale/local (documented gotcha, not specific to this
+  change, but every command below depends on running the real installed
+  build).
+
+---
+
+## File Structure
+
+- **Modify (repo, tracked):** `launchd/com.memo.dream.plist` — add three
+  `<key>`/`<string>` pairs to the existing `EnvironmentVariables` dict.
+- **Modify (machine-local, untracked):**
+  `~/Library/LaunchAgents/com.memo.dream.plist` — re-rendered from the
+  template above; this is the file `launchd` actually loads.
+- **No new files.**
+
+---
+
+### Task 1: Add the three flags to the plist template
+
+**Files:**
+- Modify: `launchd/com.memo.dream.plist:59-62`
+
+**Interfaces:**
+- Produces: an updated template, still containing the literal placeholder
+  strings `__HOME__` and `__MEMO_BIN__`, with three new
+  `EnvironmentVariables` entries (`MEMO_DREAM_HYDE_TUNE_ENABLED`,
+  `MEMO_DREAM_ENTITY_CANON_ENABLED`, `MEMO_DREAM_EDGE_VERIFY_ENABLED`, all
+  `"1"`). Task 3 renders this file into the deployed copy.
+
+- [ ] **Step 1: Edit the template**
+
+Insert the three new entries right after the existing
+`MEMO_DREAM_CONSOLIDATE_EPISODES_ENABLED` pair, matching the file's existing
+comment style:
+
+```xml
+    <key>MEMO_DREAM_ANTICIPATE_ENABLED</key>
+    <string>1</string>
+    <key>MEMO_DREAM_COMMUNITIES_ENABLED</key>
+    <string>1</string>
+    <key>MEMO_DREAM_CONSOLIDATE_EPISODES_ENABLED</key>
+    <string>1</string>
+    <!-- Dream v2 self-improvement passes (batch 2026-08-03): nightly HyDE A/B
+         (self-applying/self-reverting via the tuned overlay, gated on the
+         curated eval set), MinHash-blocked LLM entity-dedup (bounded 30
+         pairs/night), and grounded co-use edge-confidence curation
+         (never touches recall ranking, never deletes). -->
+    <key>MEMO_DREAM_HYDE_TUNE_ENABLED</key>
+    <string>1</string>
+    <key>MEMO_DREAM_ENTITY_CANON_ENABLED</key>
+    <string>1</string>
+    <key>MEMO_DREAM_EDGE_VERIFY_ENABLED</key>
+    <string>1</string>
+```
+
+- [ ] **Step 2: Verify the XML is well-formed**
+
+Run: `plutil -lint launchd/com.memo.dream.plist`
+Expected: `launchd/com.memo.dream.plist: OK`
+
+- [ ] **Step 3: Verify the three keys read back correctly**
+
+Run:
+```bash
+for k in MEMO_DREAM_HYDE_TUNE_ENABLED MEMO_DREAM_ENTITY_CANON_ENABLED MEMO_DREAM_EDGE_VERIFY_ENABLED; do
+  /usr/libexec/PlistBuddy -c "Print :EnvironmentVariables:$k" launchd/com.memo.dream.plist
+done
+```
+Expected: three lines, each `1`.
+
+- [ ] **Step 4: Verify the placeholders are untouched**
+
+Run: `grep -c '__HOME__\|__MEMO_BIN__' launchd/com.memo.dream.plist`
+Expected: `3` (one `__MEMO_BIN__` in `ProgramArguments`, two `__HOME__` in
+the log paths — unchanged from before this edit).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add launchd/com.memo.dream.plist
+git commit -m "$(cat <<'EOF'
+chore(launchd): activate HyDE-tune + graph-hygiene dream passes
+
+Add MEMO_DREAM_HYDE_TUNE_ENABLED, MEMO_DREAM_ENTITY_CANON_ENABLED, and
+MEMO_DREAM_EDGE_VERIFY_ENABLED to the nightly dream LaunchAgent's
+EnvironmentVariables. All three are manual-kind gates in
+dream_flags.GATES that the graduation pipeline never flips on its own.
+See docs/superpowers/specs/2026-08-03-dream-hyde-graph-hygiene-design.md.
+EOF
+)"
+```
+
+---
+
+### Task 2: Isolated functional smoke test (dry-run, before touching the live agent)
+
+Proves the three passes actually run and produce the expected receipt shape
+— cheap, no mutation, no LaunchAgent involvement yet. Runs against the real
+installed `memo` and the real local corpus, in dry-run mode.
+
+**Files:** none (verification only).
+
+**Interfaces:**
+- Consumes: nothing from Task 1's file changes directly (the flags are
+  exported in-shell here, not yet read from the deployed plist — that
+  wiring is proven in Task 4).
+- Produces: confirmation that `entity_canon`, `edge_verify`, and
+  `hyde_tuner` all appear in the pipeline receipt with `status` other than
+  `"disabled"`/`"skipped"`/`"error"`, before spending effort deploying.
+
+- [ ] **Step 1: Run the full pipeline in dry-run with only the three new flags set**
+
+```bash
+MEMO_DREAM_HYDE_TUNE_ENABLED=1 \
+MEMO_DREAM_ENTITY_CANON_ENABLED=1 \
+MEMO_DREAM_EDGE_VERIFY_ENABLED=1 \
+memo dream run --dry-run --json > /tmp/dream-smoke.json
+```
+
+- [ ] **Step 2: Verify entity-canon ran**
+
+Run: `python3 -c "import json; d=json.load(open('/tmp/dream-smoke.json')); print(d.get('entity_canon'))"`
+Expected: a dict with `status` equal to `"done"` or `"skipped"` (skipped
+only if the graph currently has zero entities — not expected here, the last
+receipt showed 245) — must NOT be `"disabled"` (that would mean the flag
+wasn't read) or `"error"`.
+
+- [ ] **Step 3: Verify edge-verify ran**
+
+Run: `python3 -c "import json; d=json.load(open('/tmp/dream-smoke.json')); print(d.get('edge_verify'))"`
+Expected: a dict with `status` in `{"done", "noop", "skipped"}` — must NOT
+be `"error"`.
+
+- [ ] **Step 4: Verify hyde-tuner ran**
+
+Run: `python3 -c "import json; d=json.load(open('/tmp/dream-smoke.json')); print(d.get('hyde_tuner'))"`
+Expected: a dict with a `status` key present — must not be absent (absence
+would mean `MEMO_DREAM_HYDE_TUNE_ENABLED` wasn't read as true).
+
+- [ ] **Step 5: Confirm no NEW errors from these three passes**
+
+Run: `python3 -c "import json; d=json.load(open('/tmp/dream-smoke.json')); print([e for e in d.get('errors', []) if any(p in e for p in ('entity_canon', 'edge_verify', 'hyde_tuner'))])"`
+Expected: `[]` (empty list). The pre-existing unrelated
+`contradict: FileNotFoundError` warning (missing WhatsApp vault chunk,
+tracked separately, out of scope for this plan) may still appear in
+`errors` for a different key — that is expected and not a regression.
+
+If any of Steps 2-5 fail, stop and fix the plist/flag before proceeding to
+Task 3 — do not deploy an unverified configuration.
+
+---
+
+### Task 3: Render and deploy the LaunchAgent, reload
+
+**Files:**
+- Modify (machine-local, untracked): `~/Library/LaunchAgents/com.memo.dream.plist`
+
+**Interfaces:**
+- Consumes: `launchd/com.memo.dream.plist` from Task 1 (the template with
+  placeholders + the three new flags).
+- Produces: a loaded `com.memo.dream` LaunchAgent whose live
+  `EnvironmentVariables` include the three new flags with real paths
+  substituted for `__HOME__`/`__MEMO_BIN__`. Task 4 exercises this loaded
+  agent.
+
+- [ ] **Step 1: Render the template into the deployed path**
+
+```bash
+MEMO_BIN="$(command -v memo)"
+sed -e "s#__HOME__#${HOME}#g" -e "s#__MEMO_BIN__#${MEMO_BIN}#g" \
+  launchd/com.memo.dream.plist > ~/Library/LaunchAgents/com.memo.dream.plist
+```
+
+- [ ] **Step 2: Verify the rendered plist is well-formed**
+
+Run: `plutil -lint ~/Library/LaunchAgents/com.memo.dream.plist`
+Expected: `~/Library/LaunchAgents/com.memo.dream.plist: OK`
+
+- [ ] **Step 3: Verify no placeholders leaked through**
+
+Run: `grep -c '__HOME__\|__MEMO_BIN__' ~/Library/LaunchAgents/com.memo.dream.plist`
+Expected: `0`
+
+- [ ] **Step 4: Verify the three flags are present with real substitution intact**
+
+```bash
+for k in MEMO_DREAM_HYDE_TUNE_ENABLED MEMO_DREAM_ENTITY_CANON_ENABLED MEMO_DREAM_EDGE_VERIFY_ENABLED; do
+  /usr/libexec/PlistBuddy -c "Print :EnvironmentVariables:$k" ~/Library/LaunchAgents/com.memo.dream.plist
+done
+/usr/libexec/PlistBuddy -c "Print :ProgramArguments:0" ~/Library/LaunchAgents/com.memo.dream.plist
+```
+Expected: three lines of `1`, then the last line prints the absolute path
+to the installed `memo` binary (matching `command -v memo`), not the
+literal string `__MEMO_BIN__`.
+
+- [ ] **Step 5: Reload the agent**
+
+```bash
+launchctl bootout gui/$(id -u)/com.memo.dream 2>/dev/null
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.memo.dream.plist
+```
+(A non-zero exit / "No such process" from `bootout` is expected and
+harmless if the agent wasn't currently loaded — the goal is that
+`bootstrap` succeeds.)
+
+- [ ] **Step 6: Verify the agent is loaded**
+
+Run: `launchctl list | grep com.memo.dream`
+Expected: one line starting with a PID-or-`-` column, an exit-status
+column, then `com.memo.dream` — presence of the line proves it loaded; a
+`-` PID just means it isn't running at this instant (expected, it's a
+`StartCalendarInterval` job, not `KeepAlive`).
+
+---
+
+### Task 4: End-to-end live verification
+
+Proves the deployed LaunchAgent's environment actually reaches the three
+passes when `launchd` itself invokes `memo dream run` — the thing Task 2
+could not prove (Task 2 exported the flags in an interactive shell, not via
+`launchd`).
+
+**Files:** none (verification only).
+
+**Interfaces:**
+- Consumes: the loaded agent from Task 3.
+- Produces: a real (non-dry-run) dream receipt confirming the three passes
+  ran under `launchd`'s own environment.
+
+- [ ] **Step 1: Trigger an immediate run instead of waiting for 03:00**
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.memo.dream
+```
+
+- [ ] **Step 2: Wait for completion**
+
+Run: `tail -f ~/Library/Logs/memo/dream.log`
+Wait until the log stops updating for at least 30 seconds (the pipeline
+includes real MLX chat calls for entity-canon and HyDE — this can take
+several minutes on a first run). Press Ctrl-C once it looks idle.
+
+- [ ] **Step 3: Check the receipt via the CLI**
+
+Run: `memo dream status`
+Expected: a `last dream run:` timestamp matching the time you just
+triggered (not the prior `2026-08-02 21:55` run), and no new `warn:` lines
+mentioning `entity_canon`, `edge_verify`, or `hyde_tuner`. The pre-existing
+`contradict: FileNotFoundError` warning may still be present — expected,
+out of scope.
+
+- [ ] **Step 4: Confirm all three passes reported success in the run log**
+
+Run: `grep -E '\[entity-canon\]|\[edge-verify\]|\[tune\] hyde A/B' ~/Library/Logs/memo/dream.log | tail -3`
+Expected: three lines (one per pass), each containing a checkmark
+(`✓`), matching the progress text emitted by `cli_dream.py`'s `run`
+command (`"[entity-canon] ✓  N LLM calls vs M naive"`,
+`"[edge-verify] ✓  N promoted, M decayed"`,
+`"[tune] hyde A/B ✓  <status>"`). A line ending in `warn` instead of `✓`
+means that pass raised an exception — check `memo dream status` for the
+matching `errors` entry and stop.
+
+If Step 3 or 4 shows a new error tied to one of the three passes: revert by
+removing the three lines from `launchd/com.memo.dream.plist`, re-run Task 3
+Steps 1, 2, 5, 6 to redeploy the reverted template, and stop — do not
+proceed further until the failure is understood.
+
+- [ ] **Step 5: No commit needed**
+
+This task only exercises the already-committed Task 1 change and the
+machine-local deployment from Task 3 — nothing new to commit.

--- a/docs/superpowers/specs/2026-08-03-dream-hyde-graph-hygiene-design.md
+++ b/docs/superpowers/specs/2026-08-03-dream-hyde-graph-hygiene-design.md
@@ -37,6 +37,14 @@ The last dream receipt showed 245 entities with 13 duplicate merges found
 by the (currently manual, ad hoc) dedup path — signal that entity-canon and
 edge-verify have real noise to work on.
 
+**Update (post-activation, 2026-08-03):** the real corpus turned out to be
+far larger than that receipt suggested — the live end-to-end run (see
+Execution notes below) saw 8619 entities and 37.1M naive pairs, MinHash/LSH
+blocking cut that to 2789 candidates, and the 30-pair/night LLM-confirmation
+cap produced 12 real merges on the first run. The activation decision still
+holds (MinHash/LSH blocking is built for exactly this scale), but "245
+entities" undersold the actual backlog by ~35x.
+
 None of the three flags have a dotted markdown-config key registered in
 `src/memo/tui/config/catalog.py` (`path_to_env()` doesn't list them), so
 `memo config set <key> <value>` cannot reach them today. The mechanism
@@ -101,12 +109,44 @@ Rejected alternatives:
 | `HYDE_TUNE` | Low | Self-measuring, self-applying, self-reverting; gated by the curated eval set; refuses to activate under live hybrid mode (hook-budget guard) | `memo dream tune --rollback`, or remove the plist line |
 | `ENTITY_CANON` | Low-medium | Bounded to 30 LLM-confirmed pairs/night; merge is a real mutation (`entity_aliases`) with no automated undo | Manually reverse specific `entity_aliases` rows if a bad merge surfaces; remove the plist line to stop new merges |
 | `EDGE_VERIFY` | Low | Confidence-only curation, floored, never deletes, never touches recall ranking | Remove the plist line; no state mutation to undo beyond confidence scores, which re-earn from evidence |
+| Nightly MLX/GPU contention (discovered during activation, not in the original design) | Medium — operational, not correctness | The three passes add real MLX/LLM load to the 03:00 window; the always-on `com.memo.watch` LaunchAgent (`KeepAlive`, holds a 30B model in continuous GPU residency) can lock-contend with `memo dream run`'s in-process embedder fallback badly enough to hang the whole pipeline (observed: ~35 minutes, no completion, during end-to-end verification — see Execution notes) | Kill the stuck `memo dream run` process (safe — checkpointed, `--resume`-capable) and retry; root fix (dream/watch MLX coordination) is a separate follow-up, not part of this activation |
 
 Monitoring: `memo dream status` after each of the next 2-3 nightly runs —
 check `receipt["errors"]` is clean and inspect the entity-canon /
-edge-verify pass results (pairs proposed/confirmed, edges adjusted).
+edge-verify pass results (pairs proposed/confirmed, edges adjusted). Given
+the contention risk above, also check that the run *completed* at all (a
+receipt timestamp that hasn't advanced past the previous day is the signal
+to look for).
 `memo dream graduate-flags --status` does not track manual-kind flags'
 outcomes automatically; the receipt is the source of truth for these three.
+
+## Execution notes (post-activation, 2026-08-03)
+
+Live end-to-end verification hit and resolved a real production incident,
+unrelated to this design's correctness: the first real (non-dry-run)
+`launchctl kickstart` of `com.memo.dream` hung for ~35 minutes in a
+pre-existing, unrelated pipeline phase (per-memory entity extraction during
+signal-gather), never reaching any of the three new passes. Root cause:
+`com.memo.watch` (a separate `KeepAlive` LaunchAgent holding a 30B
+generation model + 4B reranker in continuous MLX/GPU residency) contended
+with `memo dream run`'s in-process embedder fallback for the same shared
+MLX advisory lock. Stopping `memo watch`, retrying, and restoring it
+afterward confirmed the diagnosis: the retry completed in ~22 minutes with
+all three passes reporting `status: "done"` (`entity_canon`, `edge_verify`)
+and `"hyde_loses"` (`hyde_tuner`, a real completed A/B, not an error), zero
+entries in `receipt["errors"]`.
+
+Also discovered as a side effect, out of scope for this plan to fix
+(requires a `src/memo/` edit): `dream_tune.py`'s `_curated_raw()` resolves
+its curated-labels fallback path relative to `__file__`, which only lands on
+`eval/regression_labels.json` in a dev/editable checkout — under the real
+installed `uv tool` runtime this activation targets, that path is
+unreachable, so `tuner`/`graph_tuner`/`hyde_tuner` all silently ran on
+mined-only labels (`curated_used: false`) instead of the curated regression
+set. This makes the `hyde_loses` verdict from the first real run
+untrustworthy pending that fix, and likely affects the safety story for the
+already-graduated `tune`/`tune-boost` passes too. Tracked as a follow-up
+bug, not fixed here.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-08-03-dream-hyde-graph-hygiene-design.md
+++ b/docs/superpowers/specs/2026-08-03-dream-hyde-graph-hygiene-design.md
@@ -54,17 +54,19 @@ Add the three flags to the dream LaunchAgent's `EnvironmentVariables`,
 scoped to the nightly job only — no source-code change, no new
 markdown-config key, no change to any already-graduated flag.
 
-1. Edit `~/repos/memo/launchd/com.memo.dream.plist` — this file is the
-   committed template *and* the deployed form (no `__HOME__`-style
-   placeholder substitution for this agent, unlike `recall-daemon`). Add
-   three `<key>`/`<string>` entries to the existing `EnvironmentVariables`
-   dict, alongside `MEMO_DREAM_COMMUNITIES_ENABLED` etc.:
+1. Edit the committed template `~/repos/memo/launchd/com.memo.dream.plist`
+   (it still carries `__HOME__`/`__MEMO_BIN__` placeholders — same pattern
+   as every other agent in the fleet). Add three `<key>`/`<string>` entries
+   to the existing `EnvironmentVariables` dict, alongside
+   `MEMO_DREAM_COMMUNITIES_ENABLED` etc.:
    ```
    MEMO_DREAM_HYDE_TUNE_ENABLED = 1
    MEMO_DREAM_ENTITY_CANON_ENABLED = 1
    MEMO_DREAM_EDGE_VERIFY_ENABLED = 1
    ```
-   Then copy the edited template to `~/Library/LaunchAgents/com.memo.dream.plist`.
+   Then re-render (substitute `__HOME__` → `$HOME`, `__MEMO_BIN__` →
+   `command -v memo`) into `~/Library/LaunchAgents/com.memo.dream.plist`,
+   matching the deployed copy's existing already-substituted values.
 2. Reload the agent:
    ```bash
    launchctl bootout gui/$(id -u)/com.memo.dream

--- a/docs/superpowers/specs/2026-08-03-dream-hyde-graph-hygiene-design.md
+++ b/docs/superpowers/specs/2026-08-03-dream-hyde-graph-hygiene-design.md
@@ -1,0 +1,121 @@
+# Activate HyDE-Tune + Graph-Hygiene Dream Passes
+
+## Context
+
+Prompted by "how much is memo actually using the LLM/MLX, and are there
+improvement opportunities we're not taking advantage of?" An audit of
+`src/memo/dream_flags.py`'s `GATES` registry (~55 entries) via
+`memo dream graduate-flags --status` showed most dream self-improvement
+passes are already `human_graduated` (ON): anticipate, bridges, chronicle,
+code-drift, code-repair, communities, consolidate-episodes, distill,
+hype-generator, tune, tune-boost, dynamic-mandate-sync, graph-code-trace,
+graph-discovery, graph-projection, graph-reason, graph-signal,
+negative-recall (×4), proactive, recall-code-refs, sampling-synth.
+
+Three substantive, non-deprecated passes remain OFF. All three are
+`kind="manual"` in `GATES` — the nightly flag-graduation pipeline
+(`run_flag_graduation_pass`) never auto-flips a manual-kind flag; a human
+must enable it explicitly:
+
+- `MEMO_DREAM_HYDE_TUNE_ENABLED` (`flags_misc.py`) — meta-gate for a nightly
+  A/B of the never-measured `MEMO_HYDE_ENABLED` against mined+curated recall
+  labels. Applies `MEMO_HYDE_ENABLED=1` via the tuned overlay only when it
+  wins precision without raising noise, passes the curated gate, stays
+  within latency headroom, and the live recall mode is not hybrid.
+  Reversible via `memo dream tune --rollback`. Never run once — always OFF.
+- `MEMO_DREAM_ENTITY_CANON_ENABLED` (`flags_misc.py`) — MinHash+LSH blocking
+  proposes near-duplicate entity-name pairs; the helper LLM confirms each
+  candidate; confirmed pairs merge via `entity_aliases`. Capped at 30
+  LLM-confirmed pairs/night (`MEMO_DREAM_ENTITY_CANON_MAX_PAIRS`).
+- `MEMO_DREAM_EDGE_VERIFY_ENABLED` (`flags_behavior.py`) — memory↔memory
+  graph edges earn confidence from grounded co-use evidence
+  (`grounding.log`); edges that never accumulate evidence decay gently.
+  Curation of edge confidence only — never touches recall ranking, never
+  deletes.
+
+The last dream receipt showed 245 entities with 13 duplicate merges found
+by the (currently manual, ad hoc) dedup path — signal that entity-canon and
+edge-verify have real noise to work on.
+
+None of the three flags have a dotted markdown-config key registered in
+`src/memo/tui/config/catalog.py` (`path_to_env()` doesn't list them), so
+`memo config set <key> <value>` cannot reach them today. The mechanism
+already used for every other human-graduated dream flag (anticipate,
+communities, tune, tune-boost, consolidate-episodes — confirmed by
+inspecting `~/Library/LaunchAgents/com.memo.dream.plist`'s
+`EnvironmentVariables`) is the LaunchAgent's own env block, sourced from the
+template at `~/repos/memo/launchd/com.memo.dream.plist` per the machine-level
+convention in `~/CLAUDE.md` ("editá el template y re-renderizá, no el plist
+a mano").
+
+## Chosen approach
+
+Add the three flags to the dream LaunchAgent's `EnvironmentVariables`,
+scoped to the nightly job only — no source-code change, no new
+markdown-config key, no change to any already-graduated flag.
+
+1. Edit `~/repos/memo/launchd/com.memo.dream.plist` — this file is the
+   committed template *and* the deployed form (no `__HOME__`-style
+   placeholder substitution for this agent, unlike `recall-daemon`). Add
+   three `<key>`/`<string>` entries to the existing `EnvironmentVariables`
+   dict, alongside `MEMO_DREAM_COMMUNITIES_ENABLED` etc.:
+   ```
+   MEMO_DREAM_HYDE_TUNE_ENABLED = 1
+   MEMO_DREAM_ENTITY_CANON_ENABLED = 1
+   MEMO_DREAM_EDGE_VERIFY_ENABLED = 1
+   ```
+   Then copy the edited template to `~/Library/LaunchAgents/com.memo.dream.plist`.
+2. Reload the agent:
+   ```bash
+   launchctl bootout gui/$(id -u)/com.memo.dream
+   launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.memo.dream.plist
+   ```
+3. No `memo config set` call — no dotted key exists for these flags.
+
+Rejected alternatives:
+
+- **Add markdown-config dotted keys first, then `memo config set`.** More
+  correct long-term (keeps all dream-flag control in one place instead of
+  split between plist and markdown), but it's a source change to
+  `tui/config/catalog.py` — out of scope for a same-day activation of an
+  already-built, already-gated feature. Tracked as a follow-up, not blocking.
+- **Flip all ten remaining OFF-but-viable candidates at once**
+  (`INDEX_REPAIR`, `VECTOR_HYGIENE`/`VECTOR_VIEWS`, `RETAG_GLOBAL`,
+  `PROFILE`, `INCREMENTAL`, `STAGING`, `TUNE_STRICT_GATE`, `SHADOW`,
+  `LEDGER`). Rejected: conflates unrelated risk profiles and makes a bad
+  night's receipt hard to attribute to one cause. This design scopes to the
+  three flags with the clearest LLM-quality payoff and the best-understood
+  blast radius; the rest is a separate future batch.
+- **Prewarm/backfill entity-canon and edge-verify against the existing
+  245-entity graph in one manual run before enabling nightly.** Rejected as
+  unnecessary ceremony — both passes are designed to run incrementally and
+  bounded (30 pairs/night cap on entity-canon); the first few nightly runs
+  already function as the backfill.
+
+## Risk and monitoring
+
+| Flag | Risk | Why | Rollback |
+|---|---|---|---|
+| `HYDE_TUNE` | Low | Self-measuring, self-applying, self-reverting; gated by the curated eval set; refuses to activate under live hybrid mode (hook-budget guard) | `memo dream tune --rollback`, or remove the plist line |
+| `ENTITY_CANON` | Low-medium | Bounded to 30 LLM-confirmed pairs/night; merge is a real mutation (`entity_aliases`) with no automated undo | Manually reverse specific `entity_aliases` rows if a bad merge surfaces; remove the plist line to stop new merges |
+| `EDGE_VERIFY` | Low | Confidence-only curation, floored, never deletes, never touches recall ranking | Remove the plist line; no state mutation to undo beyond confidence scores, which re-earn from evidence |
+
+Monitoring: `memo dream status` after each of the next 2-3 nightly runs —
+check `receipt["errors"]` is clean and inspect the entity-canon /
+edge-verify pass results (pairs proposed/confirmed, edges adjusted).
+`memo dream graduate-flags --status` does not track manual-kind flags'
+outcomes automatically; the receipt is the source of truth for these three.
+
+## Out of scope
+
+- Every already-`human_graduated` flag — untouched.
+- The seven secondary candidates listed above.
+- Adding a markdown-config dotted key for these three flags (noted as a
+  nice-to-have follow-up).
+- The unrelated `contradict: FileNotFoundError` WARN seen in the last dream
+  receipt (missing WhatsApp vault chunk) — pre-existing bug, separate fix.
+- MCP-sampling-based LLM routing — investigated and discarded earlier in
+  this brainstorm: Claude Code doesn't implement the MCP `sampling`
+  capability (anthropics/claude-code#1785) and the MCP spec itself
+  deprecated sampling as of SEP-2577 (spec version 2026-07-28) in favor of
+  MRTR. Not worth building against.

--- a/launchd/com.memo.dream.plist
+++ b/launchd/com.memo.dream.plist
@@ -60,6 +60,17 @@
     <string>1</string>
     <key>MEMO_DREAM_CONSOLIDATE_EPISODES_ENABLED</key>
     <string>1</string>
+    <!-- Dream v2 self-improvement passes (batch 2026-08-03): nightly HyDE A/B
+         (self-applying/self-reverting via the tuned overlay, gated on the
+         curated eval set), MinHash-blocked LLM entity-dedup (bounded 30
+         pairs/night), and grounded co-use edge-confidence curation
+         (never touches recall ranking, never deletes). -->
+    <key>MEMO_DREAM_HYDE_TUNE_ENABLED</key>
+    <string>1</string>
+    <key>MEMO_DREAM_ENTITY_CANON_ENABLED</key>
+    <string>1</string>
+    <key>MEMO_DREAM_EDGE_VERIFY_ENABLED</key>
+    <string>1</string>
     <!-- Contradiction/support signals: capture tool evidence, weigh mutability in
          contradiction scans, require N supporting memories before supersede, and
          lift confidence per corroborating source. -->


### PR DESCRIPTION
## Summary

- Adds `MEMO_DREAM_HYDE_TUNE_ENABLED`, `MEMO_DREAM_ENTITY_CANON_ENABLED`, `MEMO_DREAM_EDGE_VERIFY_ENABLED` to the `com.memo.dream` LaunchAgent template (`launchd/com.memo.dream.plist`) — config-only, no `src/memo/` changes.
- Design spec + implementation plan included (`docs/superpowers/specs/2026-08-03-dream-hyde-graph-hygiene-design.md`, `docs/superpowers/plans/2026-08-03-dream-hyde-graph-hygiene-activation.md`), executed via subagent-driven-development with a full SDD ledger.
- Deployed and verified end-to-end on this machine: dry-run smoke test, live LaunchAgent reload, and a real (non-dry-run) `launchctl kickstart` run — all three passes completed with `errors: []`.

## Live-verification incident (documented in the spec's "Execution notes")

The first real end-to-end trigger hung for ~35 minutes due to a pre-existing, unrelated MLX/GPU model-residency lock contention between `com.memo.watch` (a `KeepAlive` daemon holding a 30B model in continuous GPU residency) and `memo dream run`'s in-process embedder fallback. Root-caused, safely killed (checkpointed/`--resume`-capable pipeline), and confirmed by a successful retry after stopping `memo watch` (restored afterward). Not caused by this change, but the risk is real for the next 03:00 run — flagged as a follow-up (dream/watch MLX coordination), not fixed here.

Also surfaced as a side effect: a pre-existing `dream_tune.py` bug where curated eval labels are unreachable under the installed runtime (`_curated_raw()`'s repo-relative fallback path), affecting the already-graduated `tune`/`tune-boost` passes too. Documented in the spec, tracked as a separate follow-up (requires a `src/memo/` edit, out of this plan's scope).

## Test plan

- [x] `uv run --no-sync pytest tests/` — 6817 passed, 1 skipped, 0 failed (this worktree, `--all-extras` synced)
- [x] `plutil -lint` on both the template and rendered deployed plist — OK
- [x] Dry-run smoke test (`memo dream run --dry-run --json` with the 3 flags exported) — all 3 passes ran clean
- [x] Live deploy + `launchctl bootstrap` — verified byte-identical against a fresh render of the template
- [x] Real `launchctl kickstart` end-to-end — all 3 passes `status: done`/`hyde_loses` (a real completed A/B, not an error), `errors: []`
- [x] Daemon fleet (`memo watch`) restored and verified running after the verification retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)