### PR TITLE
fix(graph): close two small graph-usage gaps (flag graduation + agent guidance)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,6 +456,10 @@ Before deciding or answering anything that prior work might already cover,
 consult memo FIRST:
 - Start with `memo_unified_briefing` (or `memo_search` / `memo_ask`) to
   pull durable facts, decisions, and preferences.
+- Already hold a memory id or a named entity and want what's connected to
+  it? Reach for `memo_graph` / `memo_related` (cheap graph traversal —
+  id/title only) before firing a fresh `memo_search`/`memo_ask` (full
+  retrieval) for the same thing.
 - Pass `source="<this-client>"` on the read tools so usage is attributed
   (e.g. `source="codex"`). A client that never appears in memo's consult log is
   flagged as a silent gap by `memo usefulness`.

--- a/src/memo/cli_mandate.py
+++ b/src/memo/cli_mandate.py
@@ -30,6 +30,10 @@ Before deciding or answering anything that prior work might already cover,
 consult memo FIRST:
 - Start with `memo_unified_briefing` (or `memo_search` / `memo_ask`) to
   pull durable facts, decisions, and preferences.
+- Already hold a memory id or a named entity and want what's connected to
+  it? Reach for `memo_graph` / `memo_related` (cheap graph traversal —
+  id/title only) before firing a fresh `memo_search`/`memo_ask` (full
+  retrieval) for the same thing.
 - Pass `source="<this-client>"` on the read tools so usage is attributed
   (e.g. `source="codex"`). A client that never appears in memo's consult log is
   flagged as a silent gap by `memo usefulness`.

--- a/src/memo/dream_flags.py
+++ b/src/memo/dream_flags.py
@@ -57,11 +57,12 @@ CODE_DRIFT_FLAG = "MEMO_DREAM_CODE_DRIFT_ENABLED"
 # Gates auto-repair inside the code-drift pass; canonical FlagSpec in
 # flags_misc.py next to MEMO_DREAM_CODE_DRIFT_ENABLED.
 CODE_REPAIR_FLAG = "MEMO_DREAM_CODE_REPAIR_ENABLED"
-# Dark scalar flags (default 0.0 = OFF) that owe a graduation gate like any
-# bool dark flag: the A/B seam pins them "0"/"1" (0.0 = off, 1.0 = full
-# boost), so the recall gate measures them unchanged. Explicit allowlist —
-# most float knobs are tuner territory, not graduation candidates.
-_DARK_SCALAR_FLAGS = ("MEMO_RECALL_CODE_PROXIMITY_BOOST",)
+# Dark flags that owe a graduation gate like any bool `*_ENABLED` flag but
+# escape the automatic `dark_flags()` bool filter — either a scalar (the A/B
+# seam pins "0"/"1", e.g. 0.0 = off, 1.0 = full boost) or a bool whose name
+# doesn't end in `_ENABLED`. Explicit allowlist — most float knobs are tuner
+# territory, not graduation candidates.
+_DARK_SCALAR_FLAGS = ("MEMO_RECALL_CODE_PROXIMITY_BOOST", "MEMO_GRAPH_SEMANTIC_RELATIONS")
 
 
 @dataclass(frozen=True)
@@ -178,6 +179,12 @@ GATES: dict[str, GateSpec] = dict(
             "context-risk trigger; measurable via avoid@k on release/delete prompts, human flips",
         ),
         _g("MEMO_GRAPH_REASON_ENABLED", "manual", "attribution metadata only, no ranking effect"),
+        _g(
+            "MEMO_GRAPH_SEMANTIC_RELATIONS",
+            "manual",
+            "extra relation rows on the graph_reason dict; only has effect "
+            "when MEMO_GRAPH_REASON_ENABLED is also on, no ranking effect",
+        ),
         _g("MEMO_VERDICT_ENABLED", "manual", "next-turn reaction telemetry; no retrieval effect"),
         _g("MEMO_MAINT_SLEEP_CYCLE_ENABLED", "manual", "background maintenance; op cost decision"),
         _g(


### PR DESCRIPTION
## Summary

Two small, independent gaps found while auditing how much of memo's graph
subsystem is actually exercised (dev-side codegraph + the product's own
knowledge graph), for both memo's own development and end users of memo:

- `MEMO_GRAPH_SEMANTIC_RELATIONS` is a genuine dark bool flag (default
  `False`) but its name doesn't end in `_ENABLED`, so
  `dream_flags.dark_flags()`'s automatic bool filter never saw it — it could
  never be tracked by the flag-graduation completeness contract
  (`test_every_dark_flag_has_a_gate`). Added it to the existing
  `_DARK_SCALAR_FLAGS` allowlist (same mechanism already used for
  `MEMO_RECALL_CODE_PROXIMITY_BOOST`, a non-bool escapee of the same filter)
  and declared its `GateSpec` (`manual`, same rationale as its sibling
  `MEMO_GRAPH_REASON_ENABLED`).
- `MANDATE_TEXT` (`src/memo/cli_mandate.py`) is memo's cross-client "consult
  memo first" block, written verbatim into every consuming client's
  project-local instruction file (`AGENTS.md`, `CLAUDE.md`,
  `.cursor/rules/memo.md`, etc.). It told agents to reach for
  `memo_search`/`memo_ask`/`memo_unified_briefing`, but never mentioned
  `memo_graph`/`memo_related` as the cheaper alternative when an agent
  already holds a memory id or entity and wants its neighbors — so agents
  defaulted to a full semantic search even when a free graph hop would do,
  mirroring the `CLAUDE.md` "codegraph-first" guidance already written for
  the dev-side code graph. Also hand-synced memo's own `CLAUDE.md` copy of
  the block, since `--write` is idempotent (skips existing markers) and
  won't rewrite it.

## Test plan

- [x] `uv run --no-sync pytest tests/test_dream_flags.py -v` — 22 passed
- [x] `uv run --no-sync pytest tests/test_mandate.py -v` — 10 passed
- [x] `uv run --no-sync ruff check` + `ruff format --check` + `mypy` on both touched `src/` files — clean