### PR TITLE
feat(context-pack): graph-aware entity-overlap compaction for memo_context_pack

### DIFF
--- a/docs/superpowers/plans/2026-08-04-context-graph-compact.md
+++ b/docs/superpowers/plans/2026-08-04-context-graph-compact.md
@@ -1,0 +1,434 @@
+# Graph-aware `memo_context_pack` source compaction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When `memo_context_pack` retrieves multiple distinct memories that share a rare entity, drop the redundant ones before they ever occupy a current/supporting/stale bucket slot — cutting pack size without changing which memories get retrieved or how `context_pack.py`'s bucketing/truncation works.
+
+**Architecture:** One new wrapper function, `compact_hits_by_entity_overlap` (`src/memo/context_compact.py`), adapts `memory.search()` hit *objects* to the minimal dict shape already consumed by the existing, already-tested `compact_by_entity_overlap` (`src/memo/chat/graph_compact.py`, shipped in PR #186), delegates the IDF/overlap/grouping math to it unchanged, then maps surviving rows back to the original hit objects by a synthetic index (order-preserving, not `id`-based). It's wired into `server_context_pack.py`'s `memo_context_pack` tool right before the `build_context_pack(...)` call, gated by a new default-off `MEMO_CONTEXT_GRAPH_COMPACT` flag registered the standard way in `src/memo/flags_search.py`.
+
+**Tech Stack:** Python 3.11+, pytest, existing `memo.*` package (no new dependencies; imports one function from `memo.chat.graph_compact`).
+
+## Global Constraints
+
+- Default OFF (`MEMO_CONTEXT_GRAPH_COMPACT` defaults to `False`) — ships inert.
+- Config is a normal registered `FlagSpec` pair in `src/memo/flags_search.py` (typed accessors `flag_bool`/`flag_float`) — NOT the chat env-only pattern (`context_pack` isn't part of the `MEMO_CHAT_*` family).
+- Fail-open: any exception during entity/IDF lookup or hit-to-dict adaptation returns the input `hits` list unchanged. Never raises, never blocks the tool response.
+- No change to retrieval, ranking, or `context_pack.py`'s bucketing/truncation logic — only pre-bucket compaction of an already-ranked hit list.
+- No new eval harness. Ships default-off with unit + integration test coverage; eval-gated graduation is an explicit follow-up (see spec's Out of scope).
+- Spec: `docs/superpowers/specs/2026-08-04-context-graph-compact-design.md`.
+
+---
+
+### Task 1: `compact_hits_by_entity_overlap` wrapper function
+
+**Files:**
+- Create: `src/memo/context_compact.py`
+- Test: `tests/test_context_compact.py`
+
+**Interfaces:**
+- Consumes: `memo.chat.graph_compact.compact_by_entity_overlap` (existing, shipped PR #186).
+- Produces: `compact_hits_by_entity_overlap(hits: list[Any], memory: Any, *, min_idf_overlap: float, min_group_size: int = 2) -> list[Any]`. Later tasks call this exact signature. Returns hit objects unchanged (no field mutation) — collapsed hits are simply absent from the returned list, in original relative order.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_context_compact.py`:
+
+```python
+from types import SimpleNamespace
+
+from memo.context_compact import compact_hits_by_entity_overlap
+
+
+class _FakeGraph:
+    def __init__(self, entities: dict[str, list[dict]], dfs: dict[str, float], total: int) -> None:
+        self._entities = entities
+        self._dfs = dfs
+        self._total = total
+
+    def memory_entities(self, memory_id: str) -> list[dict]:
+        return self._entities.get(memory_id, [])
+
+    def total_indexed_memories(self) -> int:
+        return self._total
+
+    def entity_doc_freqs(self, names) -> dict[str, float]:
+        return {n: self._dfs[n] for n in names if n in self._dfs}
+
+
+class _FakeMemory:
+    def __init__(self, graph) -> None:
+        self.graph = graph
+
+
+def _hit(hid: str, score: float, title: str = "") -> SimpleNamespace:
+    return SimpleNamespace(id=hid, title=title or f"T{hid}", score=score)
+
+
+def test_ubiquitous_entity_overlap_does_not_collapse() -> None:
+    entities = {
+        "a": [{"name": "memo"}, {"name": "topic-x"}],
+        "b": [{"name": "memo"}, {"name": "topic-y"}],
+    }
+    dfs = {"memo": 9.0, "topic-x": 1.0, "topic-y": 1.0}
+    mem = _FakeMemory(_FakeGraph(entities, dfs, total=10))
+    hits = [_hit("a", 1.0), _hit("b", 0.9)]
+
+    out = compact_hits_by_entity_overlap(hits, mem, min_idf_overlap=0.5)
+
+    assert [h.id for h in out] == ["a", "b"]
+
+
+def test_rare_shared_entity_collapses() -> None:
+    entities = {"c": [{"name": "topic-z"}], "d": [{"name": "topic-z"}]}
+    dfs = {"topic-z": 1.0}
+    mem = _FakeMemory(_FakeGraph(entities, dfs, total=10))
+    hits = [_hit("c", 1.0), _hit("d", 0.9)]
+
+    out = compact_hits_by_entity_overlap(hits, mem, min_idf_overlap=0.5)
+
+    assert [h.id for h in out] == ["c"]
+
+
+def test_no_entities_is_noop() -> None:
+    mem = _FakeMemory(_FakeGraph({}, {}, total=10))
+    hits = [_hit("e", 1.0), _hit("f", 0.9)]
+
+    out = compact_hits_by_entity_overlap(hits, mem, min_idf_overlap=0.5)
+
+    assert [h.id for h in out] == ["e", "f"]
+
+
+def test_group_below_min_group_size_stays_uncollapsed() -> None:
+    entities = {"c": [{"name": "topic-z"}], "d": [{"name": "topic-z"}], "g": []}
+    dfs = {"topic-z": 1.0}
+    mem = _FakeMemory(_FakeGraph(entities, dfs, total=10))
+    hits = [_hit("c", 1.0), _hit("d", 0.9), _hit("g", 0.5)]
+
+    out = compact_hits_by_entity_overlap(hits, mem, min_idf_overlap=0.5, min_group_size=3)
+
+    assert [h.id for h in out] == ["c", "d", "g"]
+
+
+def test_lookup_failure_returns_hits_unchanged() -> None:
+    class _BoomGraph:
+        def memory_entities(self, memory_id):
+            raise RuntimeError("graph db locked")
+
+    mem = _FakeMemory(_BoomGraph())
+    hits = [_hit("a", 1.0), _hit("b", 0.9)]
+
+    out = compact_hits_by_entity_overlap(hits, mem, min_idf_overlap=0.5)
+
+    assert out == hits
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run --no-sync pytest tests/test_context_compact.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'memo.context_compact'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/memo/context_compact.py`:
+
+```python
+"""Graph-aware compaction of memo_context_pack hits: drop hits that share a
+rare entity with a higher-ranked hit before they ever reach a pack bucket.
+Thin adapter over the chat pipeline's already-tested, IDF-weighted
+compact_by_entity_overlap — see
+docs/superpowers/specs/2026-08-04-context-graph-compact-design.md for why
+this wraps rather than duplicates that algorithm.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from memo.chat.graph_compact import compact_by_entity_overlap
+
+
+def compact_hits_by_entity_overlap(
+    hits: list[Any],
+    memory: Any,
+    *,
+    min_idf_overlap: float,
+    min_group_size: int = 2,
+) -> list[Any]:
+    """Drop `memory.search()` hit objects that are IDF-overlap duplicates of
+    a higher-ranked hit, before they occupy a context-pack bucket slot.
+
+    Adapts each hit to the dict shape `compact_by_entity_overlap` expects
+    (carrying a synthetic `_hit_index` so surviving rows map back to the
+    original hit objects without relying on `id` uniqueness), delegates the
+    overlap/IDF grouping to it unchanged, then filters the original `hits`
+    list — preserving its original rank order, not the delegate's internal
+    resort.
+
+    Fail-open: any exception (graph lookup, IDF lookup, or adaptation)
+    returns `hits` unchanged — this must never block a tool response.
+    """
+    if len(hits) < min_group_size:
+        return list(hits)
+    try:
+        dict_hits = []
+        for i, h in enumerate(hits):
+            score = getattr(h, "score", None)
+            dict_hits.append(
+                {
+                    "id": str(getattr(h, "id", "") or ""),
+                    "title": str(getattr(h, "title", "") or ""),
+                    "score": 0.0 if score is None else score,
+                    "_hit_index": i,
+                }
+            )
+        compacted = compact_by_entity_overlap(
+            dict_hits, memory, min_idf_overlap=min_idf_overlap, min_group_size=min_group_size
+        )
+        keep = {d["_hit_index"] for d in compacted}
+    except Exception:
+        return list(hits)
+    return [h for i, h in enumerate(hits) if i in keep]
+
+
+__all__ = ["compact_hits_by_entity_overlap"]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run --no-sync pytest tests/test_context_compact.py -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Lint and type-check**
+
+Run: `uv run --no-sync ruff check src/memo/context_compact.py tests/test_context_compact.py && uv run --no-sync mypy src/memo/context_compact.py`
+Expected: no errors (do NOT run `ruff format src/` — format only the touched files if needed, per the shared-worktree rule)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/memo/context_compact.py tests/test_context_compact.py
+git commit -m "feat(context-pack): add entity-overlap hit compaction wrapper"
+```
+
+---
+
+### Task 2: Wire `MEMO_CONTEXT_GRAPH_COMPACT` flags
+
+**Files:**
+- Modify: `src/memo/flags_search.py`
+- Test: `tests/test_flags.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `flag_bool("MEMO_CONTEXT_GRAPH_COMPACT")` and `flag_float("MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF")`, resolvable through the standard `flags.py` registry. Task 3 reads both.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_flags.py` (a new test function, near other `search` group flag tests):
+
+```python
+def test_context_graph_compact_flags_registered() -> None:
+    assert flags.flag_bool("MEMO_CONTEXT_GRAPH_COMPACT") is False
+    assert flags.flag_float("MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF") == 0.5
+    env = {"MEMO_CONTEXT_GRAPH_COMPACT": "1", "MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF": "0.7"}
+    assert flags.flag_bool("MEMO_CONTEXT_GRAPH_COMPACT", env=env) is True
+    assert flags.flag_float("MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF", env=env) == 0.7
+    assert flags.validate(env=env) == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-sync pytest tests/test_flags.py::test_context_graph_compact_flags_registered -v`
+Expected: FAIL — flag not registered, defaults return `None`/raise, or `validate` reports an unknown var.
+
+- [ ] **Step 3: Implement**
+
+In `src/memo/flags_search.py`, add two `_spec(...)` entries to `SPECS` immediately after the existing `MEMO_CONTEXT_PACK` entry:
+
+```python
+    _spec(
+        "MEMO_CONTEXT_GRAPH_COMPACT",
+        "bool",
+        False,
+        "search",
+        "Collapse memo_context_pack hits that share a rare (IDF-weighted) entity "
+        "with a higher-ranked hit before they occupy a bucket slot. Mirrors "
+        "MEMO_CHAT_GRAPH_COMPACT's algorithm via a thin adapter. Default off; "
+        "no dedicated eval harness exists yet for memo_context_pack.",
+    ),
+    _spec(
+        "MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF",
+        "float",
+        0.5,
+        "search",
+        "Minimum IDF-weighted entity overlap required to collapse two "
+        "memo_context_pack hits (matches MEMO_CHAT_GRAPH_COMPACT_MIN_IDF's "
+        "default). Conservative starting point.",
+        min_val=0.0,
+    ),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run --no-sync pytest tests/test_flags.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Lint and type-check**
+
+Run: `uv run --no-sync ruff check src/memo/flags_search.py tests/test_flags.py && uv run --no-sync mypy src/memo/flags_search.py`
+Expected: no errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/memo/flags_search.py tests/test_flags.py
+git commit -m "feat(context-pack): register MEMO_CONTEXT_GRAPH_COMPACT flags"
+```
+
+---
+
+### Task 3: Wire compaction into `memo_context_pack`
+
+**Files:**
+- Modify: `src/memo/server_context_pack.py`
+- Test: `tests/test_context_pack_surface.py`
+
+**Interfaces:**
+- Consumes: `compact_hits_by_entity_overlap` (Task 1), `MEMO_CONTEXT_GRAPH_COMPACT`/`MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF` flags (Task 2).
+- Produces: no new public interface — this is the integration point; `memo_context_pack`'s response reflects compacted hits when the flag is on.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_context_pack_surface.py`:
+
+```python
+class _CompactFakeGraph:
+    def memory_entities(self, memory_id):
+        if memory_id in ("m1", "m2"):
+            return [{"name": "proyecto-omega", "type": "topic", "mention_count": 1}]
+        return []
+
+    def total_indexed_memories(self):
+        return 10
+
+    def entity_doc_freqs(self, names):
+        return {"proyecto-omega": 1.0} if "proyecto-omega" in names else {}
+
+
+def _omega_hits():
+    return [
+        _hit(id="m1", title="Nota uno", score=0.9, body="cuerpo uno sobre proyecto omega"),
+        _hit(id="m2", title="Nota dos", score=0.85, body="cuerpo dos sobre proyecto omega"),
+    ]
+
+
+def test_context_pack_graph_compact_collapses_when_enabled(mem_with_stub, monkeypatch) -> None:
+    monkeypatch.setenv("MEMO_CONTEXT_PACK", "1")
+    monkeypatch.setenv("MEMO_CONTEXT_GRAPH_COMPACT", "1")
+    mem_with_stub.search = lambda *a, **kw: _omega_hits()  # type: ignore[method-assign]
+    monkeypatch.setattr(mem_with_stub, "graph", _CompactFakeGraph())
+    server = build_server(memory=mem_with_stub)
+    tool = asyncio.run(server.get_tool("memo_context_pack"))
+
+    payload = tool.fn(question="qué sabés del proyecto omega?")
+
+    rows = payload["current_facts"] + payload["supporting_context"] + payload["stale_or_conflicting"]
+    ids = {row["id"] for row in rows}
+    assert len(ids) == 1
+    assert ids <= {"m1", "m2"}
+
+
+def test_context_pack_graph_compact_noop_when_disabled(mem_with_stub, monkeypatch) -> None:
+    monkeypatch.setenv("MEMO_CONTEXT_PACK", "1")
+    monkeypatch.setenv("MEMO_CONTEXT_GRAPH_COMPACT", "0")
+    mem_with_stub.search = lambda *a, **kw: _omega_hits()  # type: ignore[method-assign]
+    monkeypatch.setattr(mem_with_stub, "graph", _CompactFakeGraph())
+    server = build_server(memory=mem_with_stub)
+    tool = asyncio.run(server.get_tool("memo_context_pack"))
+
+    payload = tool.fn(question="qué sabés del proyecto omega?")
+
+    rows = payload["current_facts"] + payload["supporting_context"] + payload["stale_or_conflicting"]
+    ids = {row["id"] for row in rows}
+    assert ids == {"m1", "m2"}
+```
+
+Note: `_hit(...)` is the existing helper at the top of this file (`SimpleNamespace` builder) — extend its call here with `body=` since the existing default already supports `**overrides`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run --no-sync pytest tests/test_context_pack_surface.py -v`
+Expected: FAIL — both `m1` and `m2` survive regardless of the flag (compaction not wired in yet).
+
+- [ ] **Step 3: Implement**
+
+In `src/memo/server_context_pack.py`, insert before the `pack = build_context_pack(...)` line:
+
+```python
+        from memo.flags import flag_bool, flag_float
+
+        if not flag_bool("MEMO_CONTEXT_PACK"):
+            return {
+                "status": "disabled",
+                "reason": "MEMO_CONTEXT_PACK=0 disables explicit context-pack tools.",
+                "question": question,
+            }
+        t0 = now_ms()
+        hits = memory.search(
+            question,
+            limit=k,
+            type_=type_,
+            mode="hybrid",
+            disable_reranker=True,
+            read_through=False,
+            quality_rerank=True,
+        )
+        if flag_bool("MEMO_CONTEXT_GRAPH_COMPACT"):
+            from memo.context_compact import compact_hits_by_entity_overlap
+
+            hits = compact_hits_by_entity_overlap(
+                hits, memory, min_idf_overlap=flag_float("MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF") or 0.5
+            )
+        pack = build_context_pack(question, hits, snippet_chars=snippet_chars)
+```
+
+(The existing `from memo.flags import flag_bool` import line gains `flag_float`; everything else in the function body is unchanged.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run --no-sync pytest tests/test_context_pack_surface.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full context-pack test surface + lint/type-check**
+
+Run: `uv run --no-sync pytest tests/test_context_pack.py tests/test_context_compact.py tests/test_context_pack_surface.py tests/test_context_pack_code.py tests/test_flags.py -v && uv run --no-sync ruff check src/memo/server_context_pack.py tests/test_context_pack_surface.py && uv run --no-sync mypy src/memo/server_context_pack.py`
+Expected: PASS, no lint/type errors — confirms this change didn't regress the rest of the context-pack surface.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/memo/server_context_pack.py tests/test_context_pack_surface.py
+git commit -m "feat(context-pack): wire graph-aware hit compaction into memo_context_pack"
+```
+
+---
+
+### Task 4: Full verification pass (no new code)
+
+This task is a verification checkpoint, not new code.
+
+**Files:** none.
+
+- [ ] **Step 1: Full relevant test surface**
+
+Run: `uv run --no-sync pytest tests/test_context_pack.py tests/test_context_compact.py tests/test_server_context_pack.py tests/test_context_pack_surface.py tests/test_flags.py -v` (drop any filename that doesn't exist — `test_server_context_pack.py` may not exist as a separate file; the actual `memo_context_pack` MCP-level tests live in `test_context_pack_surface.py`).
+Expected: all PASS.
+
+- [ ] **Step 2: `memo config validate` sanity**
+
+Run: `uv run --no-sync pytest tests/test_flags.py -v` (already covers `validate`/`unknown_memo_vars` for the new flags via Task 2's test).
+Expected: PASS — confirms the new flags don't trip typo detection.
+
+- [ ] **Step 3: Record the outcome**
+
+This flag ships default-off. No eval-harness gate exists to graduate it to default-on (see spec's Out of scope) — that is an explicit, separate follow-up requiring its own measurement story, not part of this plan.

--- a/docs/superpowers/specs/2026-08-04-context-graph-compact-design.md
+++ b/docs/superpowers/specs/2026-08-04-context-graph-compact-design.md
@@ -1,0 +1,106 @@
+# Design: graph-aware source compaction for `memo_context_pack`
+
+**Status:** proposed
+**Date:** 2026-08-04
+**Scope:** `memo_context_pack` (`src/memo/server_context_pack.py` / `src/memo/context_pack.py`) only. `memo_ask`/`memo_chat_ask`/chat UI synthesis already got this in PR #186 (`src/memo/chat/graph_compact.py`, v4.9.0) — this spec is the follow-up that design's "Out of scope" section flagged as a candidate: "The MCP tool's `budget_chars`/omissions packing is a natural second home for this, but has no dedicated eval harness today ... needs its own measurement story first." Recall-hook compaction remains out of scope here too, unchanged from the original design.
+
+## Problem
+
+`memo_context_pack` retrieves up to `k` (default 5) memories via `memory.search(...)` and composes them into a `ContextPack` (current/supporting/stale-or-conflicting buckets + a text summary), which callers render via `.to_prompt()`. When several retrieved hits are *different memories about the same underlying entity* — not chunks of the same document, and not literal near-duplicates — each occupies its own bucket slot and pays its full `snippet_chars` cost, exactly the redundancy problem `MEMO_CHAT_GRAPH_COMPACT` (PR #186) already solved for chat/ask synthesis. `memo_context_pack` has zero graph awareness today (verified: no hits for "graph" anywhere in `server_context_pack.py` or `context_pack.py`).
+
+Today the pack only shrinks by *truncating snippet text* (`_trim_to_budget` in `context_pack.py`) once the composed prompt exceeds `budget_chars` — it never drops a whole redundant hit before that point. A collapsed duplicate keeps its bucket slot (crowding out a would-be `k`-th distinct hit) and gets truncated character-by-character instead of removed whole.
+
+## Prior art — what NOT to repeat
+
+Same two closed graph experiments the chat design already ruled out, and for the same reason (this is post-rank compaction, not a ranking or retrieval-source change):
+
+- **Graph-as-ranking-signal** (`MEMO_RECALL_GRAPH_PROXIMITY`, memory `memo-graph-program-0-4`): measured, rejected — proximity re-rank doesn't improve precision on memo's corpus.
+- **Graph-as-retrieval-source** (`MEMO_GRAPH_RETRIEVAL_ENABLED`/`MEMO_GRAPH_EXPANSION_ENABLED`, memory `memo-graph-injection-negative`): measured, rejected — injecting graph-discovered candidates into the result set doesn't raise recovery.
+
+Same landmine carries over unchanged: **raw (unweighted) entity overlap is unsafe** — ubiquitous entities dominate and produce wrong groupings; the fix is IDF weighting, exactly as chat's design already established. This spec does not re-derive that mechanism; it reuses it (see Design below).
+
+**Verified before designing (per this spec's explicit instruction) that no existing mechanism already does this dedup for `memo_context_pack`:**
+
+- `build_context_row`/`_snippet` (`context_pack.py`) build one row per hit unconditionally — no grouping, no dedup key, no title/path collapsing (unlike chat's `dedup.collapse_near_duplicates`, which is chat-only and handles *same-document* `(§N/M)` chunk siblings, a different problem this spec also does not touch).
+- `_trim_to_budget` only removes/truncates rows to satisfy `budget_chars`, working strictly right-to-left through already-built buckets (supporting → stale → current), and never merges or groups by entity/content similarity.
+- `quality_rerank=True` (passed to `memory.search(...)` at the `memo_context_pack` call site, gated by `MEMO_QUALITY_RERANK`) demotes/boosts *individual* hits by verification/contradiction/supersession signals — it changes score ordering, not which distinct memories co-occur in the result set. It has no notion of "these N hits are about the same thing."
+
+Conclusion: the gap is real and clean. No existing redundant mechanism is being duplicated by this design.
+
+## Design
+
+### Module: thin wrapper, not a duplicated algorithm
+
+New module `src/memo/context_compact.py` with one function:
+
+```python
+def compact_hits_by_entity_overlap(
+    hits: list[Any],
+    memory: Any,
+    *,
+    min_idf_overlap: float,
+    min_group_size: int = 2,
+) -> list[Any]:
+    ...
+```
+
+**Adaptation decision:** `hits` here are `memory.search(...)` results — `MemoryRecord`-shaped *objects* with attributes (`.id`, `.title`, `.score`, ...), not the `dict` sources chat's pipeline already produces by the time `compact_by_entity_overlap` runs. Rather than duplicating chat's IDF/overlap/grouping algorithm for objects, this module adapts each hit to the minimal dict shape `compact_by_entity_overlap` (`src/memo/chat/graph_compact.py`) already expects — `{"id", "title", "score"}` — plus a synthetic `_hit_index` key, calls the existing (already-tested) function unchanged, then uses `_hit_index` to map surviving dict rows back to the original hit *objects*, filtering the original `hits` list in its original order (not the order the delegate returns, since order there is re-sorted by score and this module wants to preserve `memory.search`'s original rank order intact — hit 0 stays the pack's "current" candidate exactly as before, per `build_context_pack`'s `index == 0` rule).
+
+This was checked against the alternative (a parallel object-shaped reimplementation of the grouping/IDF logic) and rejected: the wrapper is ~20 lines, reuses the already-unit-tested overlap/IDF math verbatim (no algorithm drift between the chat and context_pack compaction paths), and the only real adaptation work — object-to-dict shape conversion and order-preserving id mapping — is exactly the "three similar lines" the task called out as preferable to a premature shared abstraction. `MemoryRecord` is also a dataclass with fields not safe to repurpose for scratch state (e.g. stuffing a citation pointer into `.extra` would leak into serialization paths `extra` is used for elsewhere), which further favors doing the bookkeeping in the adapter dict rather than mutating hit objects.
+
+**Why `_hit_index` instead of `id`-based reconciliation:** hit ids are assumed unique in practice, but nothing guarantees it structurally, and `_hit_index` sidesteps that assumption entirely — it's carried through both of `compact_by_entity_overlap`'s output paths (`dict(sources[group[0]])` copies it onto the survivor; `sources[i]` for below-`min_group_size` groups passes it through unchanged), so reconciliation never depends on `id` equality.
+
+**No `related_ids` citation surfaced in the pack.** Chat's design renders `related_ids` into the synthesis prompt (`(+2 related: ...)`) so a collapsed source's identity isn't fully lost to the LLM. `memo_context_pack` has no equivalent single downstream LLM-prompt-rendering step — its consumers read structured JSON (`current_facts`/`supporting_context`/`stale_or_conflicting`) built by `build_context_row`, which `context_pack.py` is deliberately left untouched by this change (see Data flow below). Surfacing which ids got absorbed would require either mutating hit objects (rejected above) or extending `build_context_pack`'s signature/row schema, both larger changes than this spec's stated goal ("a collapsed duplicate never occupies a bucket slot at all"). Listed under Out of scope as a candidate follow-up.
+
+### Data flow
+
+1. `server_context_pack.py`'s `memo_context_pack` tool calls `memory.search(...)` as it does today, producing `hits: list[Any]`.
+2. **New step**, gated by `MEMO_CONTEXT_GRAPH_COMPACT`: `hits = compact_hits_by_entity_overlap(hits, memory, min_idf_overlap=flag_float("MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF"))`, inserted immediately before the existing `pack = build_context_pack(question, hits, snippet_chars=snippet_chars)` call — i.e. before hits are bucketed, exactly mirroring where chat's compaction runs (right before `synth_head` slicing, before any downstream section-building/truncation).
+3. `build_context_pack`, `build_context_row`, `_trim_to_budget` — all of `context_pack.py` — are **unchanged**. A collapsed hit is simply absent from the `hits` list `build_context_pack` receives, so it never occupies a current/supporting/stale slot and is never a candidate for `_trim_to_budget`'s truncation pass. A non-redundant hit that would otherwise have been pushed out by `k`'s cap now has a better chance of a slot (same effect chat's design notes for `synth_head`).
+
+### Config
+
+Unlike chat's `MEMO_CHAT_*` family (env-only, deliberately outside `flags.py`'s markdown-config/tuned-overlay chain per existing precedent), `memo_context_pack`'s one existing flag (`MEMO_CONTEXT_PACK`) is a normal registered flag in `src/memo/flags_search.py`, read via `flag_bool`/`flag_float`. This feature follows that precedent — it is part of the `flags.py` registry, not the chat-config pattern, since `context_pack` is not part of the `MEMO_CHAT_*` family and there is no reason to special-case it.
+
+New `FlagSpec`s in `src/memo/flags_search.py`, alongside `MEMO_CONTEXT_PACK`:
+
+- `MEMO_CONTEXT_GRAPH_COMPACT` — bool, default `False`. Enables graph-aware entity-overlap compaction of `memo_context_pack` hits before bucketing.
+- `MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF` — float, default `0.5` (matches chat's `MEMO_CHAT_GRAPH_COMPACT_MIN_IDF` default; same conservative starting point — favors under-collapsing over merging unrelated hits), `min_val=0.0`.
+
+Both flow through `memo config validate`'s normal typo/unknown-var detection automatically (no exclusion-list entry needed, unlike the `MEMO_CHAT_*` vars — this is the benefit of using the standard registry instead of the chat env-only convention).
+
+### Error handling
+
+Fail-open, identical contract to chat's: any exception during entity lookup, IDF lookup, or hit-to-dict adaptation is caught inside `compact_hits_by_entity_overlap` and the function returns the input `hits` list unchanged. This can never raise into `memo_context_pack` and can never block the tool response — worst case, a silent no-op (the pack builds exactly as it does today). `compact_by_entity_overlap` (the delegate) already fail-opens internally for the graph/IDF lookup itself; the wrapper additionally guards its own adaptation step (dict construction, id remapping) with the same broad catch, since the fail-open contract in this spec covers the whole function, not just the delegated call.
+
+### Testing
+
+Unit tests for `compact_hits_by_entity_overlap` against a fake `memory.graph` stub (no DB, no MLX) — mirrors `tests/test_chat_graph_compact.py`'s five cases, adapted for hit *objects* instead of dicts:
+
+- Two hits sharing only a ubiquitous entity (high raw overlap, low IDF) → not collapsed.
+- Two hits sharing a rare entity (low raw overlap, high IDF) → collapsed (lower-scoring hit dropped, order preserved).
+- Empty graph / no entities on either hit → no-op passthrough.
+- A group below `min_group_size` → never collapses.
+- Exception from `memory.graph.*` → returns input unchanged (fail-open).
+
+Integration-level test at the `server_context_pack.py`/`context_pack.py` wiring point, mirroring `tests/test_chat_pipeline.py`'s `test_graph_compact_collapses_related_sources_when_enabled`/`test_graph_compact_noop_when_disabled`: using the existing `mem_with_stub` fixture (a real `Memory` with a real `GraphStore`, per `tests/test_context_pack_surface.py`'s established pattern), monkeypatch `.search()` to return two same-entity hits and `.graph.memory_entities`/`.entity_doc_freqs`/`.total_indexed_memories` to simulate a shared rare entity, then assert the resulting pack has one fewer distinct hit across its buckets with `MEMO_CONTEXT_GRAPH_COMPACT=1`, and both hits present with the flag off (default).
+
+No eval-harness-gated regression run is part of this spec — see Out of scope.
+
+## Success criteria
+
+- Zero behavior change when `MEMO_CONTEXT_GRAPH_COMPACT` is off (default) — ships inert, matching chat's precedent.
+- When on, `memo_context_pack` output for two-or-more hits sharing a rare (low document-frequency) entity collapses them into one bucket slot; hits sharing only a ubiquitous entity are left uncollapsed.
+- No change to `context_pack.py`'s bucketing/truncation behavior for hits that were never subject to compaction (i.e., the change is additive/subtractive on the `hits` list only, never a change to `build_context_pack`'s internal logic).
+- Zero new dependency on `flags.py`'s chat-config exclusion list — this stays a normal registered flag pair.
+
+## Out of scope (future follow-ups)
+
+- **Eval-harness-gated graduation to default-on.** Unlike chat (`memo eval chat`), there is no dedicated regression corpus for `memo_context_pack` today, and building one is explicit scope creep for this change (per the task's own "No existing eval harness" instruction). This ships default-off with unit + integration test coverage only. Flipping the default requires its own measurement story — a `memo_context_pack`-specific regression corpus (or a demonstrated proxy via the existing `eval/regression_labels.json` retrieval gate) plus a token-savings measurement, the same shape of gate chat's Task 4 defined — before any human graduates the flag. This spec deliberately does not build that gate.
+- **Surfacing `related_ids` in the pack's JSON or `.to_prompt()` output.** Chat cites collapsed sources by id in its synthesis prompt; `memo_context_pack` currently drops them silently. A follow-up could extend `build_context_pack`'s row schema (or the `omissions` free-text field, which already carries a similar "+N sensitive memories omitted" note) to record collapsed counts/ids. Deferred here to keep this change to the exact "don't occupy a bucket slot" scope the task asked for.
+- **Recall-hook compaction.** Unchanged from the original chat design's out-of-scope note — the 5s budget (CLAUDE.md) makes any addition there higher-risk for a much smaller per-turn ceiling. Still not this spec's problem.
+- **Preferring an existing `type=synthesis` memory over the mechanical representative.** Same YAGNI deferral as chat's design — not revisited here.
+
+## Dependencies
+
+Reads `memory.graph.memory_entities`/`entity_doc_freqs`/`total_indexed_memories` via the existing `compact_by_entity_overlap` delegate — same unconditional availability as chat's version (`GraphStore` is constructed unconditionally in `Memory.__init__`), so no hard dependency on the graph being populated; an empty graph just means the function never fires (fail-open, matches chat's dependency note verbatim). No new dependency on `src/memo/chat/*` beyond importing the one pure function `compact_by_entity_overlap` from `memo.chat.graph_compact` — that module has no chat-pipeline-specific state, so this is a plain function import, not a layering violation (context_pack does not depend on chat's `ChatConfig`, pipeline, or synthesis).

--- a/eval/quality_baseline.json
+++ b/eval/quality_baseline.json
@@ -47,6 +47,7 @@
     "src/memo/collaborative.py": 1,
     "src/memo/config.py": 2,
     "src/memo/consolidation.py": 3,
+    "src/memo/context_compact.py": 1,
     "src/memo/context_surface.py": 1,
     "src/memo/contextual.py": 4,
     "src/memo/contextual_retrieval.py": 1,

--- a/src/memo/context_compact.py
+++ b/src/memo/context_compact.py
@@ -1,0 +1,59 @@
+"""Graph-aware compaction of memo_context_pack hits: drop hits that share a
+rare entity with a higher-ranked hit before they ever reach a pack bucket.
+Thin adapter over the chat pipeline's already-tested, IDF-weighted
+compact_by_entity_overlap — see
+docs/superpowers/specs/2026-08-04-context-graph-compact-design.md for why
+this wraps rather than duplicates that algorithm.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from memo.chat.graph_compact import compact_by_entity_overlap
+
+
+def compact_hits_by_entity_overlap(
+    hits: list[Any],
+    memory: Any,
+    *,
+    min_idf_overlap: float,
+    min_group_size: int = 2,
+) -> list[Any]:
+    """Drop `memory.search()` hit objects that are IDF-overlap duplicates of
+    a higher-ranked hit, before they occupy a context-pack bucket slot.
+
+    Adapts each hit to the dict shape `compact_by_entity_overlap` expects
+    (carrying a synthetic `_hit_index` so surviving rows map back to the
+    original hit objects without relying on `id` uniqueness), delegates the
+    overlap/IDF grouping to it unchanged, then filters the original `hits`
+    list — preserving its original rank order, not the delegate's internal
+    resort.
+
+    Fail-open: any exception (graph lookup, IDF lookup, or adaptation)
+    returns `hits` unchanged — this must never block a tool response.
+    """
+    if len(hits) < min_group_size:
+        return list(hits)
+    try:
+        dict_hits = []
+        for i, h in enumerate(hits):
+            score = getattr(h, "score", None)
+            dict_hits.append(
+                {
+                    "id": str(getattr(h, "id", "") or ""),
+                    "title": str(getattr(h, "title", "") or ""),
+                    "score": 0.0 if score is None else score,
+                    "_hit_index": i,
+                }
+            )
+        compacted = compact_by_entity_overlap(
+            dict_hits, memory, min_idf_overlap=min_idf_overlap, min_group_size=min_group_size
+        )
+        keep = {d["_hit_index"] for d in compacted}
+    except Exception:
+        return list(hits)
+    return [h for i, h in enumerate(hits) if i in keep]
+
+
+__all__ = ["compact_hits_by_entity_overlap"]

--- a/src/memo/flags_search.py
+++ b/src/memo/flags_search.py
@@ -195,6 +195,26 @@ SPECS: tuple[FlagSpec, ...] = (
         "Default off; ambient recall does not use context packs.",
     ),
     _spec(
+        "MEMO_CONTEXT_GRAPH_COMPACT",
+        "bool",
+        False,
+        "search",
+        "Collapse memo_context_pack hits that share a rare (IDF-weighted) entity "
+        "with a higher-ranked hit before they occupy a bucket slot. Mirrors "
+        "MEMO_CHAT_GRAPH_COMPACT's algorithm via a thin adapter. Default off; "
+        "no dedicated eval harness exists yet for memo_context_pack.",
+    ),
+    _spec(
+        "MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF",
+        "float",
+        0.5,
+        "search",
+        "Minimum IDF-weighted entity overlap required to collapse two "
+        "memo_context_pack hits (matches MEMO_CHAT_GRAPH_COMPACT_MIN_IDF's "
+        "default). Conservative starting point.",
+        min_val=0.0,
+    ),
+    _spec(
         "MEMO_CONTEXT_SURFACE",
         "bool",
         True,

--- a/src/memo/server_context_pack.py
+++ b/src/memo/server_context_pack.py
@@ -67,7 +67,7 @@ def register(server: FastMCP, memory: Memory) -> None:
         a compact summary. Use this when search hits need interpretation before
         answering. `source` attributes consult logging.
         """
-        from memo.flags import flag_bool
+        from memo.flags import flag_bool, flag_float
 
         if not flag_bool("MEMO_CONTEXT_PACK"):
             return {
@@ -85,6 +85,14 @@ def register(server: FastMCP, memory: Memory) -> None:
             read_through=False,
             quality_rerank=True,
         )
+        if flag_bool("MEMO_CONTEXT_GRAPH_COMPACT"):
+            from memo.context_compact import compact_hits_by_entity_overlap
+
+            hits = compact_hits_by_entity_overlap(
+                hits,
+                memory,
+                min_idf_overlap=flag_float("MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF") or 0.5,
+            )
         pack = build_context_pack(question, hits, snippet_chars=snippet_chars)
         log_consult(
             memory,

--- a/tests/test_context_compact.py
+++ b/tests/test_context_compact.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+
+from memo.context_compact import compact_hits_by_entity_overlap
+
+
+class _FakeGraph:
+    def __init__(self, entities: dict[str, list[dict]], dfs: dict[str, float], total: int) -> None:
+        self._entities = entities
+        self._dfs = dfs
+        self._total = total
+
+    def memory_entities(self, memory_id: str) -> list[dict]:
+        return self._entities.get(memory_id, [])
+
+    def total_indexed_memories(self) -> int:
+        return self._total
+
+    def entity_doc_freqs(self, names) -> dict[str, float]:
+        return {n: self._dfs[n] for n in names if n in self._dfs}
+
+
+class _FakeMemory:
+    def __init__(self, graph) -> None:
+        self.graph = graph
+
+
+def _hit(hid: str, score: float, title: str = "") -> SimpleNamespace:
+    return SimpleNamespace(id=hid, title=title or f"T{hid}", score=score)
+
+
+def test_ubiquitous_entity_overlap_does_not_collapse() -> None:
+    entities = {
+        "a": [{"name": "memo"}, {"name": "topic-x"}],
+        "b": [{"name": "memo"}, {"name": "topic-y"}],
+    }
+    dfs = {"memo": 9.0, "topic-x": 1.0, "topic-y": 1.0}
+    mem = _FakeMemory(_FakeGraph(entities, dfs, total=10))
+    hits = [_hit("a", 1.0), _hit("b", 0.9)]
+
+    out = compact_hits_by_entity_overlap(hits, mem, min_idf_overlap=0.5)
+
+    assert [h.id for h in out] == ["a", "b"]
+
+
+def test_rare_shared_entity_collapses() -> None:
+    entities = {"c": [{"name": "topic-z"}], "d": [{"name": "topic-z"}]}
+    dfs = {"topic-z": 1.0}
+    mem = _FakeMemory(_FakeGraph(entities, dfs, total=10))
+    hits = [_hit("c", 1.0), _hit("d", 0.9)]
+
+    out = compact_hits_by_entity_overlap(hits, mem, min_idf_overlap=0.5)
+
+    assert [h.id for h in out] == ["c"]
+
+
+def test_no_entities_is_noop() -> None:
+    mem = _FakeMemory(_FakeGraph({}, {}, total=10))
+    hits = [_hit("e", 1.0), _hit("f", 0.9)]
+
+    out = compact_hits_by_entity_overlap(hits, mem, min_idf_overlap=0.5)
+
+    assert [h.id for h in out] == ["e", "f"]
+
+
+def test_group_below_min_group_size_stays_uncollapsed() -> None:
+    entities = {"c": [{"name": "topic-z"}], "d": [{"name": "topic-z"}], "g": []}
+    dfs = {"topic-z": 1.0}
+    mem = _FakeMemory(_FakeGraph(entities, dfs, total=10))
+    hits = [_hit("c", 1.0), _hit("d", 0.9), _hit("g", 0.5)]
+
+    out = compact_hits_by_entity_overlap(hits, mem, min_idf_overlap=0.5, min_group_size=3)
+
+    assert [h.id for h in out] == ["c", "d", "g"]
+
+
+def test_lookup_failure_returns_hits_unchanged() -> None:
+    class _BoomGraph:
+        def memory_entities(self, memory_id):
+            raise RuntimeError("graph db locked")
+
+    mem = _FakeMemory(_BoomGraph())
+    hits = [_hit("a", 1.0), _hit("b", 0.9)]
+
+    out = compact_hits_by_entity_overlap(hits, mem, min_idf_overlap=0.5)
+
+    assert out == hits

--- a/tests/test_context_pack_surface.py
+++ b/tests/test_context_pack_surface.py
@@ -148,3 +148,54 @@ def test_context_pack_mcp_logs_consult(mem_with_stub, monkeypatch) -> None:
         }
     ]
     assert captured["kwargs"]["read_through"] is False
+
+
+class _CompactFakeGraph:
+    def memory_entities(self, memory_id):
+        if memory_id in ("m1", "m2"):
+            return [{"name": "proyecto-omega", "type": "topic", "mention_count": 1}]
+        return []
+
+    def total_indexed_memories(self):
+        return 10
+
+    def entity_doc_freqs(self, names):
+        return {"proyecto-omega": 1.0} if "proyecto-omega" in names else {}
+
+
+def _omega_hits():
+    return [
+        _hit(id="m1", title="Nota uno", score=0.9, body="cuerpo uno sobre proyecto omega"),
+        _hit(id="m2", title="Nota dos", score=0.85, body="cuerpo dos sobre proyecto omega"),
+    ]
+
+
+def test_context_pack_graph_compact_collapses_when_enabled(mem_with_stub, monkeypatch) -> None:
+    monkeypatch.setenv("MEMO_CONTEXT_PACK", "1")
+    monkeypatch.setenv("MEMO_CONTEXT_GRAPH_COMPACT", "1")
+    mem_with_stub.search = lambda *a, **kw: _omega_hits()  # type: ignore[method-assign]
+    monkeypatch.setattr(mem_with_stub, "graph", _CompactFakeGraph())
+    server = build_server(memory=mem_with_stub)
+    tool = asyncio.run(server.get_tool("memo_context_pack"))
+
+    payload = tool.fn(question="qué sabés del proyecto omega?")
+
+    rows = payload["current_facts"] + payload["supporting_context"] + payload["stale_or_conflicting"]
+    ids = {row["id"] for row in rows}
+    assert len(ids) == 1
+    assert ids <= {"m1", "m2"}
+
+
+def test_context_pack_graph_compact_noop_when_disabled(mem_with_stub, monkeypatch) -> None:
+    monkeypatch.setenv("MEMO_CONTEXT_PACK", "1")
+    monkeypatch.setenv("MEMO_CONTEXT_GRAPH_COMPACT", "0")
+    mem_with_stub.search = lambda *a, **kw: _omega_hits()  # type: ignore[method-assign]
+    monkeypatch.setattr(mem_with_stub, "graph", _CompactFakeGraph())
+    server = build_server(memory=mem_with_stub)
+    tool = asyncio.run(server.get_tool("memo_context_pack"))
+
+    payload = tool.fn(question="qué sabés del proyecto omega?")
+
+    rows = payload["current_facts"] + payload["supporting_context"] + payload["stale_or_conflicting"]
+    ids = {row["id"] for row in rows}
+    assert ids == {"m1", "m2"}

--- a/tests/test_context_pack_surface.py
+++ b/tests/test_context_pack_surface.py
@@ -180,7 +180,9 @@ def test_context_pack_graph_compact_collapses_when_enabled(mem_with_stub, monkey
 
     payload = tool.fn(question="qué sabés del proyecto omega?")
 
-    rows = payload["current_facts"] + payload["supporting_context"] + payload["stale_or_conflicting"]
+    rows = (
+        payload["current_facts"] + payload["supporting_context"] + payload["stale_or_conflicting"]
+    )
     ids = {row["id"] for row in rows}
     assert len(ids) == 1
     assert ids <= {"m1", "m2"}
@@ -196,6 +198,8 @@ def test_context_pack_graph_compact_noop_when_disabled(mem_with_stub, monkeypatc
 
     payload = tool.fn(question="qué sabés del proyecto omega?")
 
-    rows = payload["current_facts"] + payload["supporting_context"] + payload["stale_or_conflicting"]
+    rows = (
+        payload["current_facts"] + payload["supporting_context"] + payload["stale_or_conflicting"]
+    )
     ids = {row["id"] for row in rows}
     assert ids == {"m1", "m2"}

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -62,6 +62,15 @@ def test_graph_integration_flags_have_safe_defaults(tmp_path: Path) -> None:
     assert flags.flag_float("MEMO_GRAPH_MIN_ENTITY_IDF", env=env) == 0.5
 
 
+def test_context_graph_compact_flags_registered() -> None:
+    assert flags.flag_bool("MEMO_CONTEXT_GRAPH_COMPACT") is False
+    assert flags.flag_float("MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF") == 0.5
+    env = {"MEMO_CONTEXT_GRAPH_COMPACT": "1", "MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF": "0.7"}
+    assert flags.flag_bool("MEMO_CONTEXT_GRAPH_COMPACT", env=env) is True
+    assert flags.flag_float("MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF", env=env) == 0.7
+    assert flags.validate(env=env) == []
+
+
 def test_typed_coercion() -> None:
     env = {
         "MEMO_RECALL_TOP_K": "7",


### PR DESCRIPTION
## Summary
- Follow-up to #186's chat/ask compaction: `memo_context_pack` retrieved hits that are different memories about the same underlying entity now get dropped (not just truncated) before they occupy a current/supporting/stale bucket slot — default-off (`MEMO_CONTEXT_GRAPH_COMPACT`, `MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF`), registered the standard way in `flags_search.py` (unlike chat's env-only `MEMO_CHAT_*` convention, since `memo_context_pack` isn't part of that family).
- Reuses `compact_by_entity_overlap` (`src/memo/chat/graph_compact.py`, PR #186) unchanged via a thin adapter (`src/memo/context_compact.py`) rather than duplicating the IDF/overlap algorithm — `memo_context_pack`'s `hits` are `MemoryRecord`-shaped objects, not the dicts chat already produces, so the wrapper converts each hit to a minimal dict (`id`/`title`/`score` + a synthetic `_hit_index`), delegates the grouping math, then filters the original hit list by surviving index — preserving `memory.search`'s original rank order (needed for `build_context_pack`'s `index == 0` "current" rule).
- Verified before designing that no existing mechanism already did this: `build_context_row`/`_trim_to_budget` only truncate text to fit `budget_chars`, never drop/merge whole hits; `quality_rerank=True` only reorders by individual verification/contradiction signals, no notion of "these hits are about the same thing." Documented in the design spec's "Prior art" section.
- Fail-open throughout: any exception during entity/IDF lookup or hit adaptation returns the input `hits` unchanged, never blocks the tool response.
- No `related_ids` citation surfaced in the pack (unlike chat's synthesis prompt) — `memo_context_pack` has no equivalent single downstream LLM-prompt render step; noted as a candidate follow-up in the spec's "Out of scope."
- No new eval harness (unlike `memo eval chat` for the chat precedent) — ships default-off with unit + integration test coverage; eval-gated graduation to default-on is an explicit, separate follow-up.
- Design spec: `docs/superpowers/specs/2026-08-04-context-graph-compact-design.md`
- Implementation plan: `docs/superpowers/plans/2026-08-04-context-graph-compact.md`

## Test plan
- [x] Unit tests for `compact_hits_by_entity_overlap` (ubiquitous-entity no-collapse, rare-entity collapse, no-entities no-op, below-min-group-size stays uncollapsed, fail-open on exception) — `tests/test_context_compact.py`
- [x] Flag registration/default/override + `memo config validate` typo-detection tests — `tests/test_flags.py`
- [x] MCP tool integration tests (`memo_context_pack` drops the redundant hit when enabled; both hits present when disabled) — `tests/test_context_pack_surface.py`
- [x] Relevant surface: `tests/test_context_pack.py tests/test_context_compact.py tests/test_context_pack_surface.py tests/test_context_pack_code.py tests/test_flags.py` — 67 passed
- [x] No regression in the chat precedent: `tests/test_chat_graph_compact.py tests/test_chat_pipeline.py` — 10 passed
- [x] Wider sanity sweep (`-k "context or flags or chat_graph or chat_pipeline"`) — 316 passed, 1 skipped (pre-existing, missing `[http]` extra, unrelated)
- [x] `ruff check` / `mypy` on every touched file — clean
- [x] Pre-push recall regression gate: PASS (prec@k 0.697, noise@k 0.000, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)