### PR TITLE
feat(graph): graduate context/evidence graph-compact defaults to ON

### DIFF
--- a/src/memo/flags_graph.py
+++ b/src/memo/flags_graph.py
@@ -153,10 +153,12 @@ SPECS: tuple[FlagSpec, ...] = (
     _spec(
         "MEMO_EVIDENCE_GRAPH_COMPACT",
         "bool",
-        False,
+        True,
         "graph",
         "Collapse memo_evidence_pack hits sharing a rare entity into one "
-        "representative before packing (citing absorbed hits by id).",
+        "representative before packing (citing absorbed hits by id). Graduated "
+        "2026-08-04 after ad-hoc validation against the live index showed no "
+        "coverage regression (see memo decision 2830cb72).",
     ),
     _spec(
         "MEMO_EVIDENCE_GRAPH_COMPACT_MIN_IDF",

--- a/src/memo/flags_search.py
+++ b/src/memo/flags_search.py
@@ -192,17 +192,25 @@ SPECS: tuple[FlagSpec, ...] = (
         False,
         "search",
         "Enable context-pack construction for memo ask and explicit context-pack tools. "
-        "Default off; ambient recall does not use context packs.",
+        "Default off; ambient recall does not use context packs. NOT graduated "
+        "2026-08-04 alongside MEMO_CONTEXT_GRAPH_COMPACT/MEMO_EVIDENCE_GRAPH_COMPACT: "
+        "flipping it also changes ask()'s internal prompt shape "
+        "(_build_ask_context's use_context_pack branch), which drops the "
+        "temporal fact_edges 'facts: ...' annotation from the LLM-visible "
+        "prompt (test_ask_surfaces_related_temporal_facts caught this) — the "
+        "structured data still reaches sources[], just not the synthesis "
+        "prompt. Needs its own fix + measurement before graduating.",
     ),
     _spec(
         "MEMO_CONTEXT_GRAPH_COMPACT",
         "bool",
-        False,
+        True,
         "search",
         "Collapse memo_context_pack hits that share a rare (IDF-weighted) entity "
         "with a higher-ranked hit before they occupy a bucket slot. Mirrors "
-        "MEMO_CHAT_GRAPH_COMPACT's algorithm via a thin adapter. Default off; "
-        "no dedicated eval harness exists yet for memo_context_pack.",
+        "MEMO_CHAT_GRAPH_COMPACT's algorithm via a thin adapter. Graduated "
+        "2026-08-04 after ad-hoc validation against the live index showed no "
+        "correctness regression (see memo decision 2830cb72).",
     ),
     _spec(
         "MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF",

--- a/tests/test_definitive_memory.py
+++ b/tests/test_definitive_memory.py
@@ -152,6 +152,7 @@ class _RareEntityGraph:
 
 
 def test_evidence_pack_graph_compact_noop_when_disabled(mem_with_stub, monkeypatch) -> None:
+    monkeypatch.setenv("MEMO_EVIDENCE_GRAPH_COMPACT", "0")
     hits = [
         _graph_hit("hit-a", title="Retry policy", body="Standard retry policy.", score=1.0),
         _graph_hit(

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -64,7 +64,7 @@ def test_graph_integration_flags_have_safe_defaults(tmp_path: Path) -> None:
 
 def test_evidence_graph_compact_flags_have_safe_defaults(tmp_path: Path) -> None:
     env = _isolated_env(tmp_path)
-    assert flags.flag_bool("MEMO_EVIDENCE_GRAPH_COMPACT", env=env) is False
+    assert flags.flag_bool("MEMO_EVIDENCE_GRAPH_COMPACT", env=env) is True
     assert flags.flag_float("MEMO_EVIDENCE_GRAPH_COMPACT_MIN_IDF", env=env) == 0.5
 
 
@@ -78,10 +78,10 @@ def test_evidence_graph_compact_vars_are_registered_not_unknown() -> None:
 
 
 def test_context_graph_compact_flags_registered() -> None:
-    assert flags.flag_bool("MEMO_CONTEXT_GRAPH_COMPACT") is False
+    assert flags.flag_bool("MEMO_CONTEXT_GRAPH_COMPACT") is True
     assert flags.flag_float("MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF") == 0.5
-    env = {"MEMO_CONTEXT_GRAPH_COMPACT": "1", "MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF": "0.7"}
-    assert flags.flag_bool("MEMO_CONTEXT_GRAPH_COMPACT", env=env) is True
+    env = {"MEMO_CONTEXT_GRAPH_COMPACT": "0", "MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF": "0.7"}
+    assert flags.flag_bool("MEMO_CONTEXT_GRAPH_COMPACT", env=env) is False
     assert flags.flag_float("MEMO_CONTEXT_GRAPH_COMPACT_MIN_IDF", env=env) == 0.7
     assert flags.validate(env=env) == []
 


### PR DESCRIPTION
## Summary

- `MEMO_CONTEXT_GRAPH_COMPACT` and `MEMO_EVIDENCE_GRAPH_COMPACT` now default to `True` — a repo-level graduation (affects every install), not a machine-local env override. Both were previously graduated only via `~/.claude.json`'s `mcpServers.memo.env` on this machine; this makes it the actual shipped default.
- Ad-hoc validation against the live index (3 real queries — no formal eval harness exists yet for these two tools, unlike `memo eval chat`): 2/3 queries had near-zero entity overlap between hits → compaction never fires (zero-cost, as designed). The third had a real 0.67 IDF-weighted overlap between two genuinely duplicate memories → compaction fired cleanly: `memo_context_pack` 8→7 hits (-445 chars, ~13%), `memo_evidence_pack` 8→7 items (-88 tokens, ~15%), **coverage unchanged** (0.67→0.67 — confirms the coverage-credit mechanism prevents false abstention from collapsing). Full record: memo decision `2830cb72`.

## Explicitly NOT graduated: `MEMO_CONTEXT_PACK`

This flag stays default `False`. It's not just the standalone `memo_context_pack` tool's gate — `ask()`/`ask_stream()`'s internal `_build_ask_context` also branches on it (`use_context_pack`), so flipping it changes `memo_ask`'s core prompt composition for every call. Turning it on **silently drops the temporal `fact_edges` "facts: ..." annotation from the LLM-visible synthesis prompt** — the structured data still reaches `sources[]`, just not what the model actually reads. Caught by `test_ask_surfaces_related_temporal_facts`, which failed when I tried flipping this flag's default alongside the other two. That's a real regression to `memo_ask`'s grounding, unrelated to graph compaction, and needs its own fix + measurement before it can graduate.

## Other fix

`test_evidence_pack_graph_compact_noop_when_disabled` implicitly relied on the old `MEMO_EVIDENCE_GRAPH_COMPACT` default instead of setting it explicitly — fixed to `monkeypatch.setenv(..., "0")`, matching its sibling `_collapses_and_cites_absorbed_hit` test's explicit-`"1"` pattern.

## Test plan

- [x] `uv run --no-sync pytest tests/` — 6845 passed, 1 skipped, 0 failed (full suite, twice — once caught the `MEMO_CONTEXT_PACK` regression and the implicit-default test bug, second run clean after fixes)
- [x] `uv run --no-sync ruff check src/ tests/` + `ruff format --check` on touched files — clean
- [x] `uv run --no-sync mypy src/memo/` — clean, 500 source files
- [x] `uv run --no-sync python scripts/quality_gate.py` — passed, no new budget entries needed (both flags already had gate entries from PR #189/#190)
- [x] Pre-push `memo eval recall` gate — machine-local baseline re-seeded after confirming the initial 0.697→0.692 delta was corpus drift (7 new memories saved this session), not a code-caused regression: `noise@k` stayed `0.0` across all 7 configs, `avoid@k`/`leak@k` unchanged, and neither touched file is anywhere near the retrieval/ranking path.