### PR TITLE
fix: five defects found running memo as an end user (CLI + MCP QA)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,14 @@ dominant source group), `MEMO_CHAT_ANSWER_MAX_TOKENS` (1200),
 checks pass/fail + p50/p95 latency — the chat-side counterpart to `memo eval
 recall` (see Retrieval-regression discipline below).
 
+**Latency is retrieval-dominated, and multi-query is the biggest term.**
+Measured 2026-08-05 against the live corpus (11.3k memories, 4B embedder,
+30B synthesiser): retrieval ~15-17s warm, ~70s on the service's first query
+(the chat process cold-loads the LLM the query rewrite needs). `memo chat ask`
+in a fresh process: 77s default, 31s with `MEMO_CHAT_MULTI_QUERY=false`. Turn
+it off when latency matters more than recall breadth; keep it on for the UI,
+where the SPA streams stages while retrieval runs.
+
 **Ops (launchd):** `memo ops install chat [--port 8765] [--dist <path>]` /
 `memo ops uninstall chat` / `memo ops status` (`src/memo/ops_launchd.py`)
 render and bootstrap a `com.memo.chat` LaunchAgent (`KeepAlive`, logs to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ include = [
     "/.claude-plugin/marketplace.json",
     "/.claude-plugin/plugin.json",
     "/commands/memo.md",
+    "/eval/regression_labels.json",
     "/hooks/hooks.json",
     "/plugins/memo/.codex-plugin/plugin.json",
     "/plugins/memo/.mcp.json",
@@ -183,6 +184,9 @@ packages = ["src/memo"]
 ".claude-plugin/marketplace.json" = "memo/agent_assets/.claude-plugin/marketplace.json"
 ".claude-plugin/plugin.json" = "memo/agent_assets/.claude-plugin/plugin.json"
 "commands/memo.md" = "memo/agent_assets/commands/memo.md"
+# The tuner's curated no-regression gate reads this at runtime; without it in
+# the wheel the gate silently fails open on every installed runtime.
+"eval/regression_labels.json" = "memo/agent_assets/eval/regression_labels.json"
 "hooks/hooks.json" = "memo/agent_assets/hooks/hooks.json"
 "plugins/memo/.codex-plugin/plugin.json" = "memo/agent_assets/plugins/memo/.codex-plugin/plugin.json"
 "plugins/memo/.mcp.json" = "memo/agent_assets/plugins/memo/.mcp.json"

--- a/src/memo/cli_as_of.py
+++ b/src/memo/cli_as_of.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 
 import click
+from rich.markup import escape
 from rich.panel import Panel
 from rich.table import Table
 
@@ -183,5 +184,5 @@ def as_of_list(as_of: str, type_: str | None, limit: int, as_json: bool) -> None
     tbl.add_column("title", overflow="fold")
     tbl.add_column("updated", width=12)
     for r in rows:
-        tbl.add_row(r.id[:8], r.type, r.title, (r.updated or "—")[:10])
+        tbl.add_row(r.id[:8], escape(r.type), escape(r.title), (r.updated or "—")[:10])
     console.print(tbl)

--- a/src/memo/cli_collaborative.py
+++ b/src/memo/cli_collaborative.py
@@ -7,6 +7,7 @@ root group in cli.py via `cli.add_command(collaborative_group)`.
 from __future__ import annotations
 
 import click
+from rich.markup import escape
 
 from memo.cli_common import console
 from memo.cli_common import get_memory as _get_memory
@@ -84,8 +85,10 @@ def collaborative_recommend(entity: str, limit: int) -> None:
 
     console.print(f"[bold]Recommended connections for {entity}[/bold]")
     for r in recommendations:
-        console.print(f"  {r.entity_a} --{r.relationship}--> {r.entity_b}")
-        console.print(f"    From: {r.from_user}, votes: {r.votes}, confidence: {r.confidence:.2f}")
+        console.print(f"  {escape(r.entity_a)} --{escape(r.relationship)}--> {escape(r.entity_b)}")
+        console.print(
+            f"    From: {escape(r.from_user)}, votes: {r.votes}, confidence: {r.confidence:.2f}"
+        )
 
 
 @collaborative_group.command(name="share-insight")

--- a/src/memo/cli_consolidate.py
+++ b/src/memo/cli_consolidate.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 
 import click
+from rich.markup import escape
 from rich.table import Table
 
 from memo.cli_common import console
@@ -177,7 +178,7 @@ def consolidate_apply(
     console.print(f"[dim]⊘ Skipped {skipped_count} (conflicts)[/dim]")
 
     for r in results[:5]:
-        console.print(f"  {r.get('summary', '')}")
+        console.print(f"  {escape(str(r.get('summary', '')))}")
 
     if len(results) > 5:
         console.print(f"[dim]...and {len(results) - 5} more[/dim]")

--- a/src/memo/cli_contradict.py
+++ b/src/memo/cli_contradict.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 
 import click
+from rich.markup import escape
 from rich.table import Table
 
 from memo.cli_common import _short, console
@@ -217,12 +218,12 @@ def _display_pair_excerpt(rec, label: str, *, stale_days: int = 180) -> None:
         f"[bold cyan]{label}[/bold cyan] · {rec.id[:8]} · "
         f"[dim]{rec.type}[/dim] · updated={rec.updated[:10]}{age_marker}"
     )
-    console.print(f"  [bold]{rec.title}[/bold]")
+    console.print(f"  [bold]{escape(rec.title)}[/bold]")
     body = (rec.body or "").strip()
     if len(body) > 600:
         body = body[:599] + "…"
     for line in body.splitlines():
-        console.print(f"  {line}")
+        console.print(f"  {escape(line)}")
     console.print()
 
 

--- a/src/memo/cli_history.py
+++ b/src/memo/cli_history.py
@@ -132,7 +132,7 @@ def history_cmd(id_or_prefix: str, limit: int, as_json: bool) -> None:
         click.echo(json.dumps(events, ensure_ascii=False, indent=2, default=str))
         return
 
-    title_str = f"{r.title}" if r else resolved[:8]
+    title_str = escape(r.title) if r else resolved[:8]
     console.print(
         Panel.fit(
             f"[bold]{title_str}[/bold]  [dim]{resolved[:8]}[/dim]",

--- a/src/memo/cli_memory.py
+++ b/src/memo/cli_memory.py
@@ -334,7 +334,7 @@ def save(
 
 
 @click.command(name="list")
-@click.option("--limit", default=20, type=int, show_default=True)
+@click.option("--limit", default=20, type=click.IntRange(1, 500), show_default=True)
 @click.option("--type", "type_", default=None)
 @click.option("--json", "as_json", is_flag=True)
 def list_cmd(limit: int, type_: str | None, as_json: bool) -> None:
@@ -434,6 +434,21 @@ def get(id_: str, as_json: bool) -> None:
     default=None,
     help="Replace body. Use '-' to read from stdin.",
 )
+@click.option(
+    "--append",
+    default=None,
+    help="Append a paragraph to the end of the body, leaving the rest untouched.",
+)
+@click.option(
+    "--replace-old",
+    default=None,
+    help="Exact text to replace in the body; must occur exactly once. Pair with --replace-new.",
+)
+@click.option(
+    "--replace-new",
+    default=None,
+    help="Replacement for --replace-old. Everything else stays byte-identical.",
+)
 @click.option("--json", "as_json", is_flag=True)
 def update(
     id_: str,
@@ -441,9 +456,25 @@ def update(
     type_: str | None,
     tags: tuple[str, ...],
     content: str | None,
+    append: str | None,
+    replace_old: str | None,
+    replace_new: str | None,
     as_json: bool,
 ) -> None:
-    """Patch fields on an existing memory. Re-embeds only if body changed."""
+    """Patch fields on an existing memory. Re-embeds only if body changed.
+
+    Three body-edit shapes, mirroring the `memo_update` MCP tool: `--content`
+    replaces the whole body, `--replace-old`/`--replace-new` is a surgical
+    exact-string edit, and `--append` adds a paragraph.
+    """
+
+    if (replace_old is None) != (replace_new is None):
+        raise click.UsageError("--replace-old and --replace-new must be passed together")
+    replace = (replace_old, replace_new) if replace_old is not None else None
+    if sum(1 for shape in (content, append, replace) if shape is not None) > 1:
+        raise click.UsageError(
+            "--content, --append and --replace-old/--replace-new are mutually exclusive"
+        )
 
     if content == "-":
         content = sys.stdin.read()
@@ -458,6 +489,8 @@ def update(
             type_=type_,
             tags=list(tags) if tags else None,
             content=content,
+            append=append,
+            replace=replace,
             actor=ActorIdentity(actor_id="memo-cli", actor_kind="human"),
         )
     )

--- a/src/memo/cli_memory.py
+++ b/src/memo/cli_memory.py
@@ -21,6 +21,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 import click
+from rich.markup import escape
 from rich.panel import Panel
 from rich.table import Table
 
@@ -320,10 +321,11 @@ def save(
     pending = "\n[yellow]index pending:[/yellow] run `memo reindex`" if rec.index_pending else ""
     console.print(
         Panel.fit(
-            f"[bold]{rec.title}[/bold]\n"
+            f"[bold]{escape(rec.title)}[/bold]\n"
             f"[dim]id:[/dim] {rec.id}\n"
-            f"[dim]path:[/dim] {rec.path}\n"
-            f"[dim]type:[/dim] {rec.type}  [dim]tags:[/dim] {', '.join(rec.tags) or '—'}"
+            f"[dim]path:[/dim] {escape(str(rec.path))}\n"
+            f"[dim]type:[/dim] {escape(rec.type)}  "
+            f"[dim]tags:[/dim] {escape(', '.join(rec.tags) or '—')}"
             f"{pending}",
             title=f"✓ {action}",
             border_style="green",
@@ -352,7 +354,9 @@ def list_cmd(limit: int, type_: str | None, as_json: bool) -> None:
     tbl.add_column("title", overflow="fold")
     tbl.add_column("tags", overflow="fold")
     for r in items:
-        tbl.add_row(r.updated[:19], r.type, r.title, ", ".join(r.tags) or "—")
+        tbl.add_row(
+            r.updated[:19], escape(r.type), escape(r.title), escape(", ".join(r.tags) or "—")
+        )
     console.print(tbl)
 
 
@@ -401,13 +405,13 @@ def get(id_: str, as_json: bool) -> None:
         return
     console.print(
         Panel.fit(
-            f"[bold]{rec.title}[/bold]\n"
-            f"[dim]id:[/dim] {rec.id}  [dim]type:[/dim] {rec.type}\n"
-            f"[dim]tags:[/dim] {', '.join(rec.tags) or '—'}\n"
+            f"[bold]{escape(rec.title)}[/bold]\n"
+            f"[dim]id:[/dim] {rec.id}  [dim]type:[/dim] {escape(rec.type)}\n"
+            f"[dim]tags:[/dim] {escape(', '.join(rec.tags) or '—')}\n"
             f"[dim]created:[/dim] {rec.created}\n"
             f"[dim]updated:[/dim] {rec.updated}\n\n"
-            f"{rec.body}",
-            title=rec.title,
+            f"{escape(rec.body or '')}",
+            title=escape(rec.title),
             border_style="cyan",
         )
     )
@@ -465,9 +469,9 @@ def update(
         return
     console.print(
         Panel.fit(
-            f"[bold]{rec.title}[/bold]\n"
-            f"[dim]id:[/dim] {rec.id}  [dim]type:[/dim] {rec.type}\n"
-            f"[dim]tags:[/dim] {', '.join(rec.tags) or '—'}\n"
+            f"[bold]{escape(rec.title)}[/bold]\n"
+            f"[dim]id:[/dim] {rec.id}  [dim]type:[/dim] {escape(rec.type)}\n"
+            f"[dim]tags:[/dim] {escape(', '.join(rec.tags) or '—')}\n"
             f"[dim]updated:[/dim] {rec.updated}",
             title="✓ updated",
             border_style="yellow",
@@ -507,8 +511,8 @@ def rename(title: str, id_: str | None, as_json: bool) -> None:
         return
     console.print(
         Panel.fit(
-            f"[bold]{rec.title}[/bold]\n"
-            f"[dim]id:[/dim] {rec.id}  [dim]type:[/dim] {rec.type}\n"
+            f"[bold]{escape(rec.title)}[/bold]\n"
+            f"[dim]id:[/dim] {rec.id}  [dim]type:[/dim] {escape(rec.type)}\n"
             f"[dim]updated:[/dim] {rec.updated}",
             title="✓ renamed",
             border_style="yellow",

--- a/src/memo/cli_operational.py
+++ b/src/memo/cli_operational.py
@@ -68,9 +68,15 @@ def operational_group() -> None:
 
 @operational_group.command(name="state")
 @click.option("--project", default=None)
+@click.option(
+    "--include-closed",
+    is_flag=True,
+    default=False,
+    help="Also print settled history (resolved conflicts, consumed handoffs, acked attention).",
+)
 @_with_memory
-def operational_state(memory: Any, project: str | None) -> None:
-    _json(memory.operational.state(project=project))
+def operational_state(memory: Any, project: str | None, include_closed: bool) -> None:
+    _json(memory.operational.state(project=project, include_closed=include_closed))
 
 
 @operational_group.command(name="verify")

--- a/src/memo/cli_proactive.py
+++ b/src/memo/cli_proactive.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 import click
+from rich.markup import escape
 
 from memo.cli_common import console
 from memo.config import Config
@@ -107,4 +108,4 @@ def digest(dismiss_id: str | None, snooze_kind_: str | None, days: int) -> None:
                 _record_snooze_feedback(store, snooze_kind_, days, active, now)
 
         routed = compute_routed(store, now=now, day=day)
-    console.print(render_digest(routed))
+    console.print(escape(render_digest(routed)))

--- a/src/memo/cli_query.py
+++ b/src/memo/cli_query.py
@@ -10,6 +10,7 @@ import json
 from datetime import datetime
 
 import click
+from rich.markup import escape
 from rich.table import Table
 
 from memo.cli_common import console
@@ -185,8 +186,8 @@ def query_run(name: str, as_json: bool) -> None:
     console.print()
 
     for r in result.results[:10]:
-        console.print(f"  [cyan]{r.id[:8]}[/cyan] {r.title}")
-        console.print(f"    {r.body[:100]}")
+        console.print(f"  [cyan]{r.id[:8]}[/cyan] {escape(r.title)}")
+        console.print(f"    {escape(r.body[:100])}")
 
     if len(result.results) > 10:
         console.print(f"  [dim]...and {len(result.results) - 10} more[/dim]")

--- a/src/memo/cli_search.py
+++ b/src/memo/cli_search.py
@@ -196,9 +196,9 @@ def search(
         h_dict = h.to_dict()
         tbl.add_row(
             f"{h.score:.3f}" if h.score is not None else "—",
-            h.type,
-            h.title + _fact_badge(h_dict),
-            ", ".join(h.tags) or "—",
+            escape(h.type),
+            escape(h.title + _fact_badge(h_dict)),
+            escape(", ".join(h.tags) or "—"),
         )
     console.print(tbl)
     if explain and trace is not None:
@@ -289,8 +289,8 @@ def context_cmd(
         return
     console.print(
         Panel.fit(
-            payload["prompt"] or "[dim](no memory context)[/dim]",
-            title=f"context: {question[:60]}",
+            escape(payload["prompt"]) if payload["prompt"] else "[dim](no memory context)[/dim]",
+            title=f"context: {escape(question[:60])}",
             border_style="cyan",
         )
     )

--- a/src/memo/cli_search.py
+++ b/src/memo/cli_search.py
@@ -75,7 +75,7 @@ def _default_search_json_body_chars() -> int:
 
 @click.command()
 @click.argument("query")
-@click.option("--limit", default=10, type=int, show_default=True)
+@click.option("--limit", default=10, type=click.IntRange(1, 500), show_default=True)
 @click.option("--type", "type_", default=None, help="Filter by record type.")
 @click.option(
     "--mode",
@@ -299,7 +299,11 @@ def context_cmd(
 @click.command()
 @click.argument("question")
 @click.option(
-    "--k", default=5, type=int, show_default=True, help="Top-K memories to feed the LLM as context."
+    "--k",
+    default=5,
+    type=click.IntRange(1, 500),
+    show_default=True,
+    help="Top-K memories to feed the LLM as context.",
 )
 @click.option("--type", "type_", default=None, help="Restrict the retrieval to one record type.")
 @click.option(
@@ -328,6 +332,9 @@ def ask(
     inline `[id]` citations using MLXChat 7B over the top-K hybrid hits.
     """
     import time
+
+    if not question.strip():
+        raise click.ClickException("`question` must be non-empty")
 
     cfg = Config.from_env()
     mem = _get_memory(cfg)
@@ -652,7 +659,7 @@ def chat_ask(
 
 @click.command(name="recall")
 @click.argument("query")
-@click.option("--limit", default=5, type=int, show_default=True)
+@click.option("--limit", default=5, type=click.IntRange(1, 500), show_default=True)
 @click.option("--type", "type_", default=None, help="Filter by record type.")
 @click.option("--json", "as_json", is_flag=True, help='Emit {"results": [...]} for callers.')
 @click.option(

--- a/src/memo/dream_tune.py
+++ b/src/memo/dream_tune.py
@@ -155,7 +155,7 @@ def _packaged_curated_labels() -> Path | None:
             asset = asset / part
         packaged = Path(str(asset))
         return packaged if packaged.is_file() else None
-    except Exception:
+    except (ModuleNotFoundError, OSError, TypeError, ValueError):
         return None
 
 

--- a/src/memo/dream_tune.py
+++ b/src/memo/dream_tune.py
@@ -29,6 +29,7 @@ saved baseline rolls back.
 from __future__ import annotations
 
 import json
+from importlib.resources import files as package_files
 from pathlib import Path
 from typing import Any
 
@@ -142,12 +143,29 @@ def save_baseline(state_dir: Path, metrics: dict[str, float]) -> None:
 # --- labels ------------------------------------------------------------------
 
 
+def _packaged_curated_labels() -> Path | None:
+    """The curated set force-included into the wheel at
+    ``memo/agent_assets/eval/``. Resolved the same way ``cli_statusline``
+    resolves its bundled script — without it, an installed runtime (uv tool /
+    pipx / Homebrew, i.e. every non-dev install) finds no curated labels and
+    the tuner's no-regression gate fails open."""
+    try:
+        asset = package_files("memo")
+        for part in ("agent_assets", "eval", "regression_labels.json"):
+            asset = asset / part
+        packaged = Path(str(asset))
+        return packaged if packaged.is_file() else None
+    except Exception:
+        return None
+
+
 def _curated_raw(state_dir: Path) -> dict[str, Any]:
-    """Parsed curated regression-labels document — state_dir first (where the
-    daemon reaches), repo-committed file second (dev). {} when neither has
-    prompts."""
+    """Parsed curated regression-labels document — state_dir first (a user's
+    own set, where the daemon reaches), then the copy shipped in the wheel,
+    then the repo-committed file (dev). {} when none has prompts."""
     candidates = [
         Path(state_dir) / "eval" / "regression_labels.json",
+        *([p] if (p := _packaged_curated_labels()) else []),
         Path(__file__).resolve().parent.parent.parent / "eval" / "regression_labels.json",
     ]
     for cp in candidates:

--- a/src/memo/memory/relation_ops.py
+++ b/src/memo/memory/relation_ops.py
@@ -157,7 +157,7 @@ class _RelationOpsMixin(_MemoryBase):
                 reason=reason or "relation judgment",
             )
         try:
-            return self.store.commit_relation_judgment(
+            judged = self.store.commit_relation_judgment(
                 relation_id=relation_id,
                 relation=relation,
                 reason=reason,
@@ -167,6 +167,16 @@ class _RelationOpsMixin(_MemoryBase):
                 model=model,
                 provenance=provenance,
             )
+            # The contradiction this pair reported is settled — close the
+            # operational conflict the scanner opened for it. Never let this
+            # cleanup fail an otherwise committed judgment.
+            with contextlib.suppress(Exception):
+                self.operational.gc_conflicts_for_pair(
+                    str(current["source_id"]),
+                    str(current["target_id"]),
+                    reason=f"relation judged: {relation}",
+                )
+            return judged
         except Exception:
             if validity_before is not None:
                 with contextlib.suppress(Exception):

--- a/src/memo/memory/update_ops.py
+++ b/src/memo/memory/update_ops.py
@@ -154,6 +154,10 @@ class _UpdateOpsMixin(_MemoryBase):
         # still matches. A concurrent edit therefore causes a bounded retry,
         # never a stale vector or a model call inside the authority lock.
         for _attempt in range(4):
+            # Captured before the commit: the assertion edge a renamed fact
+            # leaves behind still names the old title, and only the pre-update
+            # record knows it.
+            prepared_title = self._current_title(id_) if title is not None else None
             prepared = self._prepare_update_embedding(
                 id_,
                 title=title,
@@ -178,6 +182,8 @@ class _UpdateOpsMixin(_MemoryBase):
                         actor=actor,
                         _prepared_embedding=prepared,
                     )
+                if updated is not None:
+                    self._refresh_assertion_edge(updated, previous_title=prepared_title)
                 if updated is not None and prepared is not None:
                     # Chunk vectors are derived, potentially expensive model
                     # work. Keep them outside the authority lock; failures are
@@ -197,6 +203,48 @@ class _UpdateOpsMixin(_MemoryBase):
             except _RetryPreparedUpdate:
                 continue
         raise StorageError("update could not stabilize after concurrent edits")
+
+    def _current_title(self, id_: str) -> str | None:
+        with suppress(Exception):
+            record = self.get(id_)
+            if record is not None:
+                return str(record.title)
+        return None
+
+    def _refresh_assertion_edge(self, updated: MemoryRecord, *, previous_title: str | None) -> None:
+        """Close a renamed fact's stale ``memory asserts <title>`` edge.
+
+        A `fact` with no declared edges gets that coarse assertion at save
+        time. Only the save paths ever wrote it, so a rename left the graph and
+        the briefing asserting the old title forever. The old edge is
+        invalidated rather than deleted — the edges are bi-temporal, so "this
+        memory asserted X until now" stays queryable — and the current title is
+        upserted as the open assertion. Best-effort: a derived-graph failure
+        must never fail a committed update.
+        """
+        if previous_title is None or previous_title == updated.title:
+            return
+        if updated.type != "fact":
+            return
+        from memo.fact_extraction import FACT_ASSERTION_PREDICATE, upsert_declared_fact_edges
+
+        with suppress(Exception):
+            for edge in self.fact_edges.query(source_record_id=updated.id):
+                if (
+                    edge.get("predicate") == FACT_ASSERTION_PREDICATE
+                    and edge.get("object") == previous_title
+                    and not edge.get("invalid_at")
+                ):
+                    self.fact_edges.invalidate(str(edge["id"]))
+            upsert_declared_fact_edges(
+                self.fact_edges,
+                record_id=updated.id,
+                title=updated.title,
+                type_=updated.type,
+                created=updated.created,
+                updated=updated.updated,
+                extra=updated.extra,
+            )
 
     def _prepare_update_embedding(
         self,

--- a/src/memo/operational.py
+++ b/src/memo/operational.py
@@ -654,6 +654,46 @@ class OperationalStore:
                 )
             return len(targets)
 
+    def gc_conflicts_for_pair(
+        self,
+        memory_id_a: str,
+        memory_id_b: str,
+        *,
+        reason: str = "relation judged",
+    ) -> int:
+        """Auto-resolve the active conflict opened for exactly this pair.
+
+        Called once the canonical relation between the two memories is judged,
+        so a ``semantic_contradiction`` anomaly does not stay ``detected``
+        forever after the contradiction it reported has been settled. Endpoint
+        order is irrelevant — the ledger may judge either direction. Like
+        :meth:`gc_conflicts_for_memory` this is a system-level cleanup and does
+        not require human authority. Returns the count resolved.
+        """
+        pair = {str(memory_id_a).strip().casefold(), str(memory_id_b).strip().casefold()}
+        if len(pair) != 2 or "" in pair:
+            return 0
+        with authority_write_lock(self.state_dir / "operational-transactions"):
+            conflicts = self._read_snapshot()["conflicts"]
+            targets = [
+                cid
+                for cid, row in conflicts.items()
+                if row.get("lifecycle_state") not in {"resolved", "archived"}
+                and {m.casefold() for m in _conflict_member_ids(row)} == pair
+            ]
+            for cid in targets:
+                self._commit(
+                    "conflict.resolve",
+                    {
+                        "id": cid,
+                        "resolved_at": utc_now_iso(),
+                        "resolution": reason,
+                    },
+                    subject_uri=f"memo://conflict/{cid}",
+                    actor=ActorIdentity(actor_id="memo-gc", actor_kind="system"),
+                )
+            return len(targets)
+
     def record_outcome(
         self,
         *,
@@ -811,8 +851,36 @@ class OperationalStore:
             metadata=dict(metadata or {}),
         )
 
-    def state(self, *, project: str | None = None) -> dict[str, Any]:
+    def state(self, *, project: str | None = None, include_closed: bool = True) -> dict[str, Any]:
+        """The operational projection, optionally narrowed to what is still open.
+
+        ``include_closed=True`` (the default) returns the raw projection, which
+        internal consumers rebuild their own views from. User-facing surfaces
+        (the MCP tool, the CLI) pass ``False``: resolved conflicts, consumed
+        handoffs, and acknowledged attention items are settled history that
+        only grows, and shipping all of it made the payload exceed an MCP
+        client's token budget.
+        """
         state = self._read_snapshot()
+        if not include_closed:
+            state = {
+                **state,
+                "conflicts": {
+                    key: value
+                    for key, value in state["conflicts"].items()
+                    if value.get("lifecycle_state") not in {"resolved", "archived"}
+                },
+                "handoffs": {
+                    key: value
+                    for key, value in state["handoffs"].items()
+                    if not value.get("consumed_at")
+                },
+                "attention": {
+                    key: value
+                    for key, value in state["attention"].items()
+                    if not value.get("acknowledged_at")
+                },
+            }
         if not project:
             return state
         return {

--- a/src/memo/operational.py
+++ b/src/memo/operational.py
@@ -321,7 +321,11 @@ class OperationalStore:
                 data.get("schema") == MEMO_OPERATIONAL_SCHEMA
                 and data.get("journal_heads") == journal_heads
             ):
-                return data
+                # A snapshot written before a section existed is still current
+                # by schema and heads, so it is returned as-is. Backfill the
+                # missing sections or the writer that owns one KeyErrors on an
+                # install older than the feature.
+                return {**self._empty(), **data}
         except (FileNotFoundError, OSError, json.JSONDecodeError):
             pass
         return self.rebuild(events=events)
@@ -370,7 +374,12 @@ class OperationalStore:
                 event_id=event_id,
             )
             try:
-                state = json.loads(self.snapshot_path.read_text(encoding="utf-8"))
+                # Same backfill as _read_snapshot: a projection handler must
+                # never index a section an older snapshot predates.
+                state = {
+                    **self._empty(),
+                    **json.loads(self.snapshot_path.read_text(encoding="utf-8")),
+                }
             except (FileNotFoundError, OSError, json.JSONDecodeError):
                 state = {}
             current_heads = self._ledger.head_hashes()

--- a/src/memo/server_operational.py
+++ b/src/memo/server_operational.py
@@ -68,12 +68,21 @@ def _register_evidence_and_state_tools(server: Any, memory: Any) -> None:
             str | None,
             Field(description="Project tag to scope the state to; None returns every project."),
         ] = None,
+        include_closed: Annotated[
+            bool,
+            Field(
+                description="Also return settled history: resolved conflicts, consumed "
+                "handoffs, and acknowledged attention items. Off by default — that "
+                "history only grows and can exceed the response budget."
+            ),
+        ] = False,
     ) -> dict[str, Any]:
         """Read current focus, handoffs, attention items, conflicts, and outcomes.
 
-        Read-only snapshot of the operational journal's current state.
+        Read-only snapshot of the operational journal's current state. Returns
+        only what is still open unless ``include_closed`` is set.
         """
-        return memory.operational.state(project=project)
+        return memory.operational.state(project=project, include_closed=include_closed)
 
     @annotated_tool(server, **READ_ONLY)
     def memo_federation_preview(

--- a/src/memo/server_write_coordinator.py
+++ b/src/memo/server_write_coordinator.py
@@ -106,10 +106,18 @@ class McpWriteCoordinator:
                         # message was already deemed safe to expose — unwrap it
                         # instead of discarding it. Anything else stays masked.
                         cause = e.__cause__
+                        # Name the failing exception type — a class name carries
+                        # no user data but turns an unactionable "failed safely"
+                        # into something a caller can report and a maintainer can
+                        # grep for. The message itself stays masked.
+                        kind = type(cause if cause is not None else e).__name__
                         job.future.set_exception(
                             cause
                             if isinstance(cause, MemoError)
-                            else StorageError("coordinated MCP write failed safely")
+                            else StorageError(
+                                f"coordinated MCP write failed safely ({kind}) — "
+                                "details in the memo-mcp server log"
+                            )
                         )
                 else:
                     self._completed += 1

--- a/tests/test_cli_edit_parity.py
+++ b/tests/test_cli_edit_parity.py
@@ -1,0 +1,106 @@
+"""Regression: `memo edit` must offer the same edit shapes as `memo_update`.
+
+Found running memo as an end user: the MCP tool takes `append` and a surgical
+`replace_old`/`replace_new` pair, while the CLI only had `--content`, a full
+body replace. Editing one line of a long memory from the terminal meant
+retyping the whole body — and `Memory.update` already supported both shapes.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from memo.cli import cli
+
+BODY = "First line.\n\nSecond line mentions Postgres 16.\n\nThird line."
+
+
+@pytest.fixture
+def qa_env(tmp_path):
+    return {
+        "MEMO_DATA_DIR": str(tmp_path / "data"),
+        "MEMO_STATE_DIR": str(tmp_path / "state"),
+        "MEMO_VAULT_PATH": str(tmp_path / "vault"),
+        "MEMO_CONFIG_FILE": str(tmp_path / "memo-config.toml"),
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_EMBEDDER_VIA_DAEMON": "0",
+    }
+
+
+def _save(runner, env) -> str:
+    saved = runner.invoke(cli, ["save", BODY, "--title", "db choice", "--json"], env=env)
+    assert saved.exit_code == 0, saved.output
+    return str(json.loads(saved.output)["id"])
+
+
+def _body(runner, env, id_: str) -> str:
+    got = runner.invoke(cli, ["get", id_, "--json"], env=env)
+    assert got.exit_code == 0, got.output
+    return str(json.loads(got.output)["body"])
+
+
+def test_append_adds_a_paragraph_and_keeps_the_body(qa_env) -> None:
+    runner = CliRunner()
+    id_ = _save(runner, qa_env)
+
+    edited = runner.invoke(cli, ["edit", id_, "--append", "Fourth line."], env=qa_env)
+    assert edited.exit_code == 0, edited.output
+
+    body = _body(runner, qa_env, id_)
+    assert body.startswith(BODY)
+    assert body.rstrip().endswith("Fourth line.")
+
+
+def test_replace_is_surgical(qa_env) -> None:
+    runner = CliRunner()
+    id_ = _save(runner, qa_env)
+
+    edited = runner.invoke(
+        cli,
+        ["edit", id_, "--replace-old", "Postgres 16", "--replace-new", "Postgres 17"],
+        env=qa_env,
+    )
+    assert edited.exit_code == 0, edited.output
+
+    body = _body(runner, qa_env, id_)
+    assert "Postgres 17" in body
+    assert "Postgres 16" not in body
+    # Everything else stays byte-identical.
+    assert body == BODY.replace("Postgres 16", "Postgres 17")
+
+
+def test_replace_needs_both_halves(qa_env) -> None:
+    runner = CliRunner()
+    id_ = _save(runner, qa_env)
+
+    result = runner.invoke(cli, ["edit", id_, "--replace-old", "Postgres 16"], env=qa_env)
+
+    assert result.exit_code != 0
+    assert "--replace-new" in result.output
+
+
+def test_edit_shapes_are_mutually_exclusive(qa_env) -> None:
+    runner = CliRunner()
+    id_ = _save(runner, qa_env)
+
+    result = runner.invoke(
+        cli, ["edit", id_, "--content", "new body", "--append", "tail"], env=qa_env
+    )
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output.lower()
+
+
+def test_replace_rejects_text_that_is_not_unique(qa_env) -> None:
+    runner = CliRunner()
+    saved = runner.invoke(cli, ["save", "repeat repeat", "--title", "twice", "--json"], env=qa_env)
+    id_ = str(json.loads(saved.output)["id"])
+
+    result = runner.invoke(
+        cli, ["edit", id_, "--replace-old", "repeat", "--replace-new", "once"], env=qa_env
+    )
+
+    assert result.exit_code != 0, result.output

--- a/tests/test_cli_edit_parity.py
+++ b/tests/test_cli_edit_parity.py
@@ -19,7 +19,14 @@ BODY = "First line.\n\nSecond line mentions Postgres 16.\n\nThird line."
 
 
 @pytest.fixture
-def qa_env(tmp_path):
+def qa_env(tmp_path, monkeypatch):
+    # `--append` / `--replace-old` change the body, so the update path re-embeds.
+    # Stub the embedder (and pin dims to match) or these fail on any runner
+    # without MLX — the Linux CI job among them.
+    def _stub_embed(self, inputs):
+        return [[float(len(str(text)) % 4 == index) for index in range(4)] for text in inputs]
+
+    monkeypatch.setattr("memo.embedder.MLXEmbedder.embed", _stub_embed)
     return {
         "MEMO_DATA_DIR": str(tmp_path / "data"),
         "MEMO_STATE_DIR": str(tmp_path / "state"),
@@ -27,6 +34,8 @@ def qa_env(tmp_path):
         "MEMO_CONFIG_FILE": str(tmp_path / "memo-config.toml"),
         "MEMO_NONINTERACTIVE": "1",
         "MEMO_EMBEDDER_VIA_DAEMON": "0",
+        "MEMO_EMBEDDER_DIMS": "4",
+        "MEMO_RERANKER_ENABLED": "0",
     }
 
 

--- a/tests/test_cli_input_validation.py
+++ b/tests/test_cli_input_validation.py
@@ -1,0 +1,58 @@
+"""Regression: the CLI must reject the inputs the MCP surface already rejects.
+
+Found running memo as an end user: `memo search q --limit 0` and
+`memo list --limit -5` exited 0 and printed an empty table, and `memo ask ""`
+printed an empty answer panel and exited 0. The MCP tools clamp `limit` to
+1..500 and require a non-empty question, so the same mistake was caught there
+and silently accepted here.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from memo.cli import cli
+
+
+@pytest.fixture
+def qa_env(tmp_path):
+    return {
+        "MEMO_DATA_DIR": str(tmp_path / "data"),
+        "MEMO_STATE_DIR": str(tmp_path / "state"),
+        "MEMO_VAULT_PATH": str(tmp_path / "vault"),
+        "MEMO_CONFIG_FILE": str(tmp_path / "memo-config.toml"),
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_EMBEDDER_VIA_DAEMON": "0",
+    }
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["search", "anything", "--limit", "0"],
+        ["search", "anything", "--limit", "-5"],
+        ["search", "anything", "--limit", "501"],
+        ["list", "--limit", "0"],
+        ["list", "--limit", "-5"],
+        ["ask", "anything", "--k", "0"],
+    ],
+)
+def test_out_of_range_limits_are_rejected(qa_env, argv) -> None:
+    result = CliRunner().invoke(cli, argv, env=qa_env)
+
+    assert result.exit_code != 0, result.output
+    assert "range" in result.output.lower() or "invalid value" in result.output.lower()
+
+
+def test_in_range_limits_still_work(qa_env) -> None:
+    listed = CliRunner().invoke(cli, ["list", "--limit", "1"], env=qa_env)
+    assert listed.exit_code == 0, listed.output
+
+
+@pytest.mark.parametrize("question", ["", "   "])
+def test_ask_requires_a_question(qa_env, question) -> None:
+    result = CliRunner().invoke(cli, ["ask", question], env=qa_env)
+
+    assert result.exit_code != 0, result.output
+    assert "non-empty" in result.output.lower()

--- a/tests/test_cli_markup_safety.py
+++ b/tests/test_cli_markup_safety.py
@@ -80,6 +80,21 @@ def test_save_receipt_renders_title_literally(qa_env) -> None:
     assert "[Context7]" in saved.output
 
 
+def test_digest_command_renders_nudge_titles_literally(qa_env, monkeypatch) -> None:
+    """`memo digest` prints memory-derived nudge titles through Rich."""
+    # cli_proactive imports these lazily inside the command body.
+    from memo.proactive import engine, surfaces
+
+    monkeypatch.setattr(surfaces, "render_digest", lambda _routed: MARKUP_TITLE)
+    monkeypatch.setattr(engine, "compute_routed", lambda *_a, **_k: object())
+
+    env = {**qa_env, "MEMO_PROACTIVE_ENABLED": "1"}
+    shown = CliRunner().invoke(cli, ["digest"], env=env)
+
+    assert shown.exit_code == 0, shown.output
+    assert "[b]negrita[/b]" in shown.output
+
+
 def test_as_of_list_renders_title_literally(qa_env) -> None:
     runner = CliRunner()
     _save(runner, qa_env)

--- a/tests/test_cli_markup_safety.py
+++ b/tests/test_cli_markup_safety.py
@@ -1,0 +1,102 @@
+"""Regression: memory content is data, not Rich markup.
+
+Found running memo as an end user: a body of
+``Ver la doc en [Context7](url) y el issue [#42]. Config: array[index]``
+rendered as ``Ver la doc en [Context7](url) y el issue . Config: array`` —
+Rich parsed the square brackets as style tags and swallowed them. The same
+bug hid citation ids: ``[fae467f3]`` disappeared while ``[36ee3a85]``
+survived, because only ids starting with a letter look like a style tag. The
+markdown on disk was always correct; only what the user reads was wrong.
+
+Every surface that renders a record's own text must escape it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from memo.cli import cli
+
+# A title/body pair that exercises the three failure shapes: a markdown link,
+# a bracketed token that looks like an unknown style tag, and a real Rich tag.
+MARKUP_TITLE = "Doc [Context7] y [b]negrita[/b]"
+MARKUP_BODY = "Ver [Context7](https://context7.com), issue [#42], array[index], [bold] literal."
+
+
+@pytest.fixture
+def qa_env(tmp_path, monkeypatch):
+    env = {
+        "MEMO_DATA_DIR": str(tmp_path / "data"),
+        "MEMO_STATE_DIR": str(tmp_path / "state"),
+        "MEMO_VAULT_PATH": str(tmp_path / "vault"),
+        "MEMO_CONFIG_FILE": str(tmp_path / "memo-config.toml"),
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_EMBEDDER_VIA_DAEMON": "0",
+        # Rich strips ANSI when not a tty, but still parses markup — which is
+        # exactly the bug. Keep the width wide so nothing wraps mid-token.
+        "COLUMNS": "200",
+    }
+    return env
+
+
+def _save(runner, env, *, title=MARKUP_TITLE, body=MARKUP_BODY) -> str:
+    saved = runner.invoke(
+        cli, ["save", body, "--title", title, "--type", "note", "--json"], env=env
+    )
+    assert saved.exit_code == 0, saved.output
+    return str(json.loads(saved.output)["id"])
+
+
+def test_get_renders_body_and_title_literally(qa_env) -> None:
+    runner = CliRunner()
+    id_ = _save(runner, qa_env)
+
+    shown = runner.invoke(cli, ["get", id_], env=qa_env)
+    assert shown.exit_code == 0, shown.output
+    # Nothing may be swallowed: every bracketed token survives verbatim.
+    for token in ("[Context7]", "[#42]", "array[index]", "[bold]", "[b]negrita[/b]"):
+        assert token in shown.output, f"{token!r} was eaten by markup parsing"
+
+
+def test_list_table_renders_title_literally(qa_env) -> None:
+    runner = CliRunner()
+    _save(runner, qa_env)
+
+    listed = runner.invoke(cli, ["list", "--limit", "5"], env=qa_env)
+    assert listed.exit_code == 0, listed.output
+    assert "[Context7]" in listed.output
+    assert "[b]negrita[/b]" in listed.output
+
+
+def test_save_receipt_renders_title_literally(qa_env) -> None:
+    runner = CliRunner()
+    saved = runner.invoke(
+        cli, ["save", MARKUP_BODY, "--title", MARKUP_TITLE, "--type", "note"], env=qa_env
+    )
+    assert saved.exit_code == 0, saved.output
+    assert "[Context7]" in saved.output
+
+
+def test_as_of_list_renders_title_literally(qa_env) -> None:
+    runner = CliRunner()
+    _save(runner, qa_env)
+
+    listed = runner.invoke(cli, ["as-of", "list", "--date", "2099-01-01"], env=qa_env)
+    assert listed.exit_code == 0, listed.output
+    assert "[b]negrita[/b]" in listed.output
+
+
+def test_update_and_rename_receipts_render_title_literally(qa_env) -> None:
+    runner = CliRunner()
+    id_ = _save(runner, qa_env, title="plain title")
+
+    edited = runner.invoke(cli, ["edit", id_, "--title", MARKUP_TITLE], env=qa_env)
+    assert edited.exit_code == 0, edited.output
+    assert "[Context7]" in edited.output
+
+    renamed = runner.invoke(cli, ["rename", MARKUP_TITLE, id_], env=qa_env)
+    assert renamed.exit_code == 0, renamed.output
+    assert "[Context7]" in renamed.output

--- a/tests/test_cli_markup_safety.py
+++ b/tests/test_cli_markup_safety.py
@@ -14,6 +14,7 @@ Every surface that renders a record's own text must escape it.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import pytest
 from click.testing import CliRunner
@@ -102,6 +103,95 @@ def test_as_of_list_renders_title_literally(qa_env) -> None:
     listed = runner.invoke(cli, ["as-of", "list", "--date", "2099-01-01"], env=qa_env)
     assert listed.exit_code == 0, listed.output
     assert "[b]negrita[/b]" in listed.output
+
+
+def test_record_history_renders_title_literally(qa_env) -> None:
+    runner = CliRunner()
+    id_ = _save(runner, qa_env)
+
+    shown = runner.invoke(cli, ["record-history", id_], env=qa_env)
+    assert shown.exit_code == 0, shown.output
+    assert "[b]negrita[/b]" in shown.output
+
+
+def test_saved_query_results_render_literally(qa_env, monkeypatch) -> None:
+    """`memo query run` prints record titles and bodies."""
+    from unittest.mock import MagicMock
+
+    from memo import cli_query
+
+    row = SimpleNamespace(id="a" * 32, title=MARKUP_TITLE, body=MARKUP_BODY)
+    memory = MagicMock()
+    memory.query_composer.execute_query.return_value = SimpleNamespace(count=1, results=[row])
+    monkeypatch.setattr(cli_query, "_get_memory", lambda _cfg: memory)
+
+    shown = CliRunner().invoke(cli, ["query", "run", "saved-one"], env=qa_env)
+
+    assert shown.exit_code == 0, shown.output
+    assert "[b]negrita[/b]" in shown.output
+    assert "[#42]" in shown.output
+
+
+def test_collaborative_recommendations_render_entities_literally(qa_env, monkeypatch) -> None:
+    from unittest.mock import MagicMock
+
+    from memo import cli_collaborative
+
+    rec = SimpleNamespace(
+        entity_a="Doc [Context7]",
+        relationship="[b]uses[/b]",
+        entity_b="array[index]",
+        from_user="fer[1]",
+        votes=3,
+        confidence=0.9,
+    )
+    memory = MagicMock()
+    memory.collaborative.get_recommended_connections.return_value = [rec]
+    monkeypatch.setattr(cli_collaborative, "_get_memory", lambda _cfg: memory)
+
+    shown = CliRunner().invoke(cli, ["collaborative", "recommend", "MLX"], env=qa_env)
+
+    assert shown.exit_code == 0, shown.output
+    assert "[b]uses[/b]" in shown.output
+    assert "array[index]" in shown.output
+    assert "fer[1]" in shown.output
+
+
+def test_consolidate_summaries_render_literally(qa_env, monkeypatch) -> None:
+    from unittest.mock import MagicMock
+
+    from memo import cli_consolidate
+
+    memory = MagicMock()
+    memory.consolidator.consolidate_all.return_value = {
+        "results": [{"summary": MARKUP_BODY, "merged_id": None, "archived_ids": []}]
+    }
+    monkeypatch.setattr(cli_consolidate, "_get_memory", lambda _cfg: memory)
+
+    shown = CliRunner().invoke(cli, ["consolidate", "apply"], env=qa_env)
+
+    assert shown.exit_code == 0, shown.output
+    assert "[#42]" in shown.output
+    assert "array[index]" in shown.output
+
+
+def test_contradict_pair_excerpt_renders_body_literally(capsys) -> None:
+    """The triage walker prints both records' titles and bodies."""
+    from memo.cli_contradict import _display_pair_excerpt
+
+    record = SimpleNamespace(
+        id="a" * 32,
+        title=MARKUP_TITLE,
+        type="note",
+        updated="2026-08-05T00:00:00+00:00",
+        body=MARKUP_BODY,
+    )
+
+    _display_pair_excerpt(record, "OLDER")
+
+    out = capsys.readouterr().out
+    assert "[b]negrita[/b]" in out
+    assert "[#42]" in out
 
 
 def test_update_and_rename_receipts_render_title_literally(qa_env) -> None:

--- a/tests/test_dream_tune_curated_discovery.py
+++ b/tests/test_dream_tune_curated_discovery.py
@@ -1,0 +1,66 @@
+"""Regression: the tuner's curated no-regression gate must find its labels on
+an installed runtime, not only in a dev checkout.
+
+Found running memo as an end user: the nightly receipt reported
+"200 harvested + 0 curated" every night. `_curated_raw` looked in
+`state_dir/eval/` (nothing puts a copy there) and then at
+`Path(__file__).parent.parent.parent / "eval"`, which only resolves to a repo
+root from `src/memo/`. From `site-packages/memo/` the same arithmetic lands in
+`lib/python3.14/eval/`, so no curated document was ever found — and
+`curated_gate_min_sim` fails open (`{"ok": True, "reason": "no_curated_labels"}`).
+The guard CLAUDE.md describes as rejecting a change that helps mined labels but
+hurts the curated set was therefore inert on every real install.
+"""
+
+from __future__ import annotations
+
+import json
+
+from memo import dream_tune
+
+CURATED = {
+    "schema": "memo.eval_recall.labels.v1",
+    "prompts": [{"prompt": "curated probe", "relevant": True, "expect_ids": ["deadbeef"]}],
+}
+
+
+def test_state_dir_labels_win(tmp_path) -> None:
+    eval_dir = tmp_path / "eval"
+    eval_dir.mkdir()
+    (eval_dir / "regression_labels.json").write_text(json.dumps(CURATED), encoding="utf-8")
+
+    assert dream_tune._curated_prompts(tmp_path) == CURATED["prompts"]
+
+
+def test_packaged_labels_are_used_when_state_dir_has_none(tmp_path, monkeypatch) -> None:
+    packaged = tmp_path / "wheel" / "regression_labels.json"
+    packaged.parent.mkdir(parents=True)
+    packaged.write_text(json.dumps(CURATED), encoding="utf-8")
+    monkeypatch.setattr(dream_tune, "_packaged_curated_labels", lambda: packaged)
+    # Kill the dev-checkout fallback so only the packaged copy can answer.
+    monkeypatch.setattr(dream_tune, "__file__", str(tmp_path / "nowhere" / "dream_tune.py"))
+
+    assert dream_tune._curated_prompts(tmp_path / "empty-state") == CURATED["prompts"]
+
+
+def test_repo_checkout_still_resolves_its_committed_labels(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(dream_tune, "_packaged_curated_labels", lambda: None)
+
+    prompts = dream_tune._curated_prompts(tmp_path / "empty-state")
+
+    assert prompts, "the repo-committed eval/regression_labels.json must still be found in dev"
+
+
+def test_curated_labels_ship_in_the_wheel() -> None:
+    """The force-include must stay in pyproject: dropping it silently returns
+    the gate to failing open."""
+    import tomllib
+    from pathlib import Path
+
+    pyproject = Path(dream_tune.__file__).resolve().parents[2] / "pyproject.toml"
+    config = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    force_include = config["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+
+    assert force_include.get("eval/regression_labels.json") == (
+        "memo/agent_assets/eval/regression_labels.json"
+    )

--- a/tests/test_dream_tune_curated_discovery.py
+++ b/tests/test_dream_tune_curated_discovery.py
@@ -51,6 +51,15 @@ def test_repo_checkout_still_resolves_its_committed_labels(tmp_path, monkeypatch
     assert prompts, "the repo-committed eval/regression_labels.json must still be found in dev"
 
 
+def test_packaged_lookup_degrades_to_none_when_resources_fail(monkeypatch) -> None:
+    def boom(_anchor):
+        raise ModuleNotFoundError("no such package")
+
+    monkeypatch.setattr(dream_tune, "package_files", boom)
+
+    assert dream_tune._packaged_curated_labels() is None
+
+
 def test_curated_labels_ship_in_the_wheel() -> None:
     """The force-include must stay in pyproject: dropping it silently returns
     the gate to failing open."""

--- a/tests/test_fact_edge_rename.py
+++ b/tests/test_fact_edge_rename.py
@@ -1,0 +1,69 @@
+"""Regression: renaming a `fact` must not leave its assertion edge asserting
+the old title.
+
+Found running memo as an end user: after `memo rename`, the SessionStart
+briefing's "Temporal facts" section still showed the pre-rename title. A
+`fact` with no declared edges gets a coarse `memory asserts <title>` edge at
+save time, and the update path never refreshed it — the save paths were the
+only callers of the fact-edge upsert.
+
+The old assertion is closed rather than deleted: memo's fact edges are
+bi-temporal, so "this memory asserted X until now" stays queryable.
+"""
+
+from __future__ import annotations
+
+
+def _assertion_edges(memory, record_id: str, *, include_inactive: bool = False) -> list[dict]:
+    return [
+        edge
+        for edge in memory.fact_edges.query(
+            source_record_id=record_id, include_inactive=include_inactive
+        )
+        if edge.get("predicate") == "asserts"
+    ]
+
+
+def test_rename_closes_the_stale_assertion_and_opens_the_new_one(mock_memory) -> None:
+    record = mock_memory.save(
+        content="Deploys run at 03:00 UTC.", title="deploy window", type_="fact"
+    )
+    before = _assertion_edges(mock_memory, record.id)
+    assert [edge["object"] for edge in before] == ["deploy window"]
+    assert before[0]["invalid_at"] is None
+
+    mock_memory.update(record.id, title="deploy window (v2)")
+
+    # The current view asserts only the new title — this is what the briefing
+    # and the graph read.
+    assert [edge["object"] for edge in _assertion_edges(mock_memory, record.id)] == [
+        "deploy window (v2)"
+    ]
+    # The old assertion is closed, not erased: memo's edges are bi-temporal.
+    history = {
+        edge["object"]: edge
+        for edge in _assertion_edges(mock_memory, record.id, include_inactive=True)
+    }
+    assert set(history) == {"deploy window", "deploy window (v2)"}
+    assert history["deploy window"]["invalid_at"] is not None, "stale assertion stayed open"
+    assert history["deploy window (v2)"]["invalid_at"] is None
+
+
+def test_editing_only_the_body_leaves_the_assertion_alone(mock_memory) -> None:
+    record = mock_memory.save(
+        content="Deploys run at 03:00 UTC.", title="deploy window", type_="fact"
+    )
+
+    mock_memory.update(record.id, content="Deploys run at 05:00 UTC.")
+
+    edges = _assertion_edges(mock_memory, record.id)
+    assert [edge["object"] for edge in edges] == ["deploy window"]
+    assert edges[0]["invalid_at"] is None
+
+
+def test_renaming_a_non_fact_writes_no_assertion_edge(mock_memory) -> None:
+    record = mock_memory.save(content="a note body", title="note title", type_="note")
+
+    mock_memory.update(record.id, title="note title (v2)")
+
+    assert _assertion_edges(mock_memory, record.id) == []

--- a/tests/test_mcp_write_coordinator.py
+++ b/tests/test_mcp_write_coordinator.py
@@ -107,6 +107,10 @@ async def test_unexpected_worker_exception_is_safe_typed_error():
     with pytest.raises(StorageError, match="failed safely") as exc:
         await coordinator.submit(boom)
     assert "secret internal detail" not in str(exc.value)
+    # The failing type is named so the error is actionable — a QA run hit
+    # "coordinated MCP write failed safely" with no way to tell a KeyError
+    # (a real bug) from a transient lock. The class name leaks no user data.
+    assert "RuntimeError" in str(exc.value)
     await coordinator.close()
 
 

--- a/tests/test_operational_conflict_lifecycle.py
+++ b/tests/test_operational_conflict_lifecycle.py
@@ -1,0 +1,164 @@
+"""Regression: a semantic-contradiction conflict must close when its pair is
+judged, and the operational state surfaces must not grow without bound.
+
+Root cause (found during an end-user QA run): ``emit_anomaly`` was only ever
+called with ``"open"``. Nothing flipped the operational conflict to
+``resolved`` once the underlying relation was judged in the canonical relation
+ledger, so ``detected`` conflicts accumulated forever — the SessionStart
+briefing listed conflicts that were already settled, and
+``memo_operational_state`` grew past the MCP client's token cap (91 KB on the
+live corpus, 68 of 111 conflicts already resolved).
+"""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from memo.cli import cli
+from memo.operational import ActorIdentity, OperationalStore
+
+MEM_A = "4bb2ff4e756b4f35a94e989b7b1e8efb"
+MEM_B = "d459004fa4df49dda36d36e455c1a716"
+MEM_C = "9f1c0a2b3d4e5f60718293a4b5c6d7e8"
+
+
+def _open_semantic_conflict(
+    store: OperationalStore,
+    *,
+    a: str = MEM_A,
+    b: str = MEM_B,
+    anomaly_id: str = "anomaly-test-0001",
+) -> str:
+    store.record_anomaly(
+        {
+            "anomaly_id": anomaly_id,
+            "kind": "semantic_contradiction",
+            "state": "detected",
+            "summary": f"memo contradiction between memories {a[:12]} and {b[:12]}",
+            "memory_id_a": a,
+            "memory_id_b": b,
+            "relationship": "contradiction",
+            "evidence_uris": [f"memo://memoria/{a}", f"memo://memoria/{b}"],
+            "created_at": "2026-08-05T18:28:41+00:00",
+        },
+    )
+    store.state()
+    return anomaly_id
+
+
+def test_gc_conflicts_for_pair_resolves_the_judged_pair(tmp_path) -> None:
+    store = OperationalStore(tmp_path, device_id="device-a")
+    _open_semantic_conflict(store)
+
+    # Endpoint order must not matter: the ledger may judge B->A.
+    assert store.gc_conflicts_for_pair(MEM_B, MEM_A, reason="relation judged") == 1
+    assert store.active_conflicts(f"touch {MEM_A}") == []
+    # Idempotent.
+    assert store.gc_conflicts_for_pair(MEM_A, MEM_B) == 0
+
+
+def test_gc_conflicts_for_pair_leaves_other_pairs_open(tmp_path) -> None:
+    store = OperationalStore(tmp_path, device_id="device-a")
+    _open_semantic_conflict(store)
+    _open_semantic_conflict(store, a=MEM_A, b=MEM_C, anomaly_id="anomaly-test-0002")
+
+    assert store.gc_conflicts_for_pair(MEM_A, MEM_B) == 1
+    # The A/C conflict is a different pair — a half-overlap must not close it.
+    assert len(store.active_conflicts(f"touch {MEM_C}")) == 1
+
+
+def test_state_hides_closed_items_by_default(tmp_path) -> None:
+    store = OperationalStore(tmp_path, device_id="device-a")
+    human = ActorIdentity(actor_id="fer", actor_kind="human")
+
+    open_id = _open_semantic_conflict(store)
+    closed = store.open_conflict(topic="billing architecture", summary="two designs")
+    store.resolve_conflict(closed.id, resolution="picked design B", actor=human)
+
+    live = store.create_handoff(project="memo", summary="live handoff", from_actor="a")
+    done = store.create_handoff(project="memo", summary="done handoff", from_actor="a")
+    store.consume_handoff(done.id, actor_id="b")
+
+    hot = store.add_attention(project="memo", summary="unread", severity="high")
+    cold = store.add_attention(project="memo", summary="read", severity="low")
+    store.acknowledge_attention(cold.id, actor_id="b")
+
+    state = store.state(include_closed=False)
+    assert set(state["conflicts"]) == {open_id}
+    assert set(state["handoffs"]) == {live.id}
+    assert set(state["attention"]) == {hot.id}
+
+    # The library default stays the raw projection — internal consumers
+    # (briefing, outcome ranking) rebuild their own views from it.
+    full = store.state()
+    assert {open_id, closed.id} <= set(full["conflicts"])
+    assert {live.id, done.id} <= set(full["handoffs"])
+    assert {hot.id, cold.id} <= set(full["attention"])
+
+
+def test_state_scoping_composes_with_project_filter(tmp_path) -> None:
+    store = OperationalStore(tmp_path, device_id="device-a")
+    mine = store.create_handoff(project="memo", summary="mine", from_actor="a")
+    other = store.create_handoff(project="other", summary="other", from_actor="a")
+    store.consume_handoff(other.id, actor_id="b")
+
+    scoped = store.state(project="memo", include_closed=False)
+    assert set(scoped["handoffs"]) == {mine.id}
+    assert set(store.state(project="other", include_closed=False)["handoffs"]) == set()
+    assert set(store.state(project="other")["handoffs"]) == {other.id}
+
+
+def test_cli_state_defaults_to_open_only(tmp_path) -> None:
+    env = {
+        "MEMO_DATA_DIR": str(tmp_path / "data"),
+        "MEMO_STATE_DIR": str(tmp_path / "state"),
+        "MEMO_VAULT_PATH": str(tmp_path / "vault"),
+        "MEMO_CONFIG_FILE": str(tmp_path / "memo-config.toml"),
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_EMBEDDER_VIA_DAEMON": "0",
+    }
+    store = OperationalStore(tmp_path / "state", device_id="device-a")
+    open_id = _open_semantic_conflict(store)
+    closed = store.open_conflict(topic="billing architecture", summary="two designs")
+    store.resolve_conflict(
+        closed.id,
+        resolution="picked design B",
+        actor=ActorIdentity(actor_id="fer", actor_kind="human"),
+    )
+
+    runner = CliRunner()
+    default = runner.invoke(cli, ["operational", "state"], env=env)
+    assert default.exit_code == 0, default.output
+    assert set(json.loads(default.output)["conflicts"]) == {open_id}
+
+    full = runner.invoke(cli, ["operational", "state", "--include-closed"], env=env)
+    assert full.exit_code == 0, full.output
+    assert set(json.loads(full.output)["conflicts"]) == {open_id, closed.id}
+
+
+def test_judging_a_relation_closes_its_operational_conflict(mock_memory) -> None:
+    older = mock_memory.save(content="deploys run at 03:00", title="deploy window", type_="fact")
+    newer = mock_memory.save(content="deploys run at 05:00", title="deploy window v2", type_="fact")
+    candidate = mock_memory.store.create_relation_candidate(
+        source_id=newer.id,
+        target_id=older.id,
+        suggested_relation="conflicts_with",
+        reason="same subject, different hour",
+        confidence=0.95,
+        provenance={"generator": "contradiction_scanner"},
+    )
+    _open_semantic_conflict(mock_memory.operational, a=newer.id, b=older.id)
+    assert len(mock_memory.operational.active_conflicts(f"touch {newer.id}")) == 1
+
+    mock_memory.judge_relation(
+        str(candidate["id"]),
+        "supersedes",
+        reason="newer window wins",
+        confidence=0.95,
+        actor="qa",
+        actor_kind="agent",
+    )
+
+    assert mock_memory.operational.active_conflicts(f"touch {newer.id}") == []

--- a/tests/test_operational_conflict_lifecycle.py
+++ b/tests/test_operational_conflict_lifecycle.py
@@ -59,6 +59,43 @@ def test_gc_conflicts_for_pair_resolves_the_judged_pair(tmp_path) -> None:
     assert store.gc_conflicts_for_pair(MEM_A, MEM_B) == 0
 
 
+def test_gc_conflicts_for_pair_rejects_a_degenerate_pair(tmp_path) -> None:
+    store = OperationalStore(tmp_path, device_id="device-a")
+    _open_semantic_conflict(store)
+
+    # A self-pair or a blank endpoint identifies no conflict; closing anything
+    # on that basis would resolve records the caller never named.
+    assert store.gc_conflicts_for_pair(MEM_A, MEM_A) == 0
+    assert store.gc_conflicts_for_pair(MEM_A, "  ") == 0
+    assert len(store.active_conflicts(f"touch {MEM_A}")) == 1
+
+
+def test_mcp_state_tool_defaults_to_open_only(tmp_path) -> None:
+    from unittest.mock import MagicMock
+
+    from memo.server_operational import register
+
+    store = OperationalStore(tmp_path, device_id="device-a")
+    open_id = _open_semantic_conflict(store)
+    closed = store.open_conflict(topic="billing architecture", summary="two designs")
+    store.resolve_conflict(
+        closed.id,
+        resolution="picked design B",
+        actor=ActorIdentity(actor_id="fer", actor_kind="human"),
+    )
+
+    tools: dict[str, object] = {}
+    server = MagicMock()
+    server.tool = lambda **_kw: lambda fn: tools.setdefault(fn.__name__, fn)
+    memory = MagicMock()
+    memory.operational = store
+    register(server, memory)
+
+    state_tool = tools["memo_operational_state"]
+    assert set(state_tool()["conflicts"]) == {open_id}
+    assert set(state_tool(include_closed=True)["conflicts"]) == {open_id, closed.id}
+
+
 def test_gc_conflicts_for_pair_leaves_other_pairs_open(tmp_path) -> None:
     store = OperationalStore(tmp_path, device_id="device-a")
     _open_semantic_conflict(store)

--- a/tests/test_operational_snapshot_backfill.py
+++ b/tests/test_operational_snapshot_backfill.py
@@ -1,0 +1,50 @@
+"""Regression: an operational snapshot written before a section existed must
+not break the writer that owns that section.
+
+Found running memo as an end user against a real install: `memo operational
+signal remember` raised a bare `KeyError: 'signals'` from the CLI, and the
+same call through MCP surfaced as the opaque "coordinated MCP write failed
+safely". The live snapshot predates the `signals` section, and
+`_read_snapshot` returns the persisted dict verbatim whenever the schema
+string and journal heads match — the schema string did not change when the
+section was added, so nothing ever backfilled the key. Readers were already
+defensive (`.get("signals", {})`); only the writer indexed it directly.
+"""
+
+from __future__ import annotations
+
+import json
+
+from memo.operational import OperationalStore
+
+
+def _strip_section(store: OperationalStore, section: str) -> None:
+    """Rewrite the on-disk snapshot as an older memo version would have."""
+    data = json.loads(store.snapshot_path.read_text(encoding="utf-8"))
+    data.pop(section, None)
+    store.snapshot_path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_remember_signal_survives_a_snapshot_without_the_signals_section(tmp_path) -> None:
+    store = OperationalStore(tmp_path, device_id="device-a")
+    store.set_focus(project="memo", summary="seed the snapshot")
+    _strip_section(store, "signals")
+
+    signal = store.remember_signal(marker="watcher:repo:memo", epoch=1, actor_id="qa")
+
+    assert signal.marker == "watcher:repo:memo"
+    assert [row.marker for row in store.list_signals()] == ["watcher:repo:memo"]
+
+
+def test_read_snapshot_backfills_every_missing_section(tmp_path) -> None:
+    store = OperationalStore(tmp_path, device_id="device-a")
+    store.set_focus(project="memo", summary="seed the snapshot")
+    for section in ("signals", "outcomes", "conflicts", "attention", "handoffs"):
+        _strip_section(store, section)
+
+    state = store.state()
+
+    for section in ("signals", "outcomes", "conflicts", "attention", "handoffs", "focus"):
+        assert section in state, f"{section} was not backfilled"
+    # The surviving section keeps its data — backfill must not reset the file.
+    assert "memo" in state["focus"]

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -103,6 +103,11 @@ def test_built_distributions_only_ship_release_allowlist(tmp_path: Path) -> None
         "PKG-INFO",
         "README.md",
         "commands",
+        # The curated regression labels the tuner's no-regression gate reads.
+        # They must reach the sdist too: a wheel built from the sdist resolves
+        # the force-include from these sources, and without them the gate
+        # silently fails open on the installed runtime.
+        "eval",
         "hooks",
         "plugins",
         "pyproject.toml",


### PR DESCRIPTION
Black-box QA of memo 4.9.1 as an end user — 349 CLI commands, 41 MCP tools, both against the installed runtime. Five defects found and fixed, each with a regression test.

## What was broken

**1 · Conflicts never closed when their relation was judged** (`operational.py`, `memory/relation_ops.py`)
`emit_anomaly` was only ever called with `"open"`. Once the contradiction was judged in the canonical relation ledger, the operational conflict stayed `detected` forever — 16 of 42 open conflicts on the live corpus already had a judged relation, and the SessionStart briefing listed them as open. `Memory.judge_relation`, the chokepoint every judge path goes through, now closes the pair's conflict via the new `gc_conflicts_for_pair` (endpoint-order agnostic, system authority, suppressed so cleanup can never fail a committed judgment).

**2 · `memo_operational_state` exceeded the MCP client's token budget** (`server_operational.py`, `cli_operational.py`)
It returned the whole projection including settled history — 91 KB on the live corpus, 68 of 111 conflicts already resolved — which made the tool uncallable. `state()` takes `include_closed` (default `True`, so internal consumers are unchanged); the MCP tool and `memo operational state` default to open-only. Measured on the live corpus: 92.6 KB → 27.7 KB.

**3 · The CLI rendered memory content as Rich markup** (`cli_memory.py`, `cli_search.py`, and six more)
A body saved as `Ver [Context7](url), issue [#42], array[index], [bold] literal.` printed as `Ver [Context7](url), issue . Config: array con **literal.**`. The same bug hid citation ids in `memo context`: `[fae467f3]` vanished while `[36ee3a85]` survived, because only an id starting with a letter looks like a style tag — roughly a third of ids were uncitable. The markdown on disk was always correct; only what the user reads was wrong.

**4 · `memo_signal_remember` failed, and MCP masked why** (`operational.py`, `server_write_coordinator.py`)
Bare `KeyError: 'signals'` from the CLI; `"coordinated MCP write failed safely"` through MCP. The live snapshot predates the `signals` section and both snapshot readers return the persisted dict verbatim while schema and journal heads match — the schema string never changed when the section was added. Both read paths now merge over `_empty()`, covering every future section. The coordinator's mask also names the failing exception type, which separates a real bug from a transient lock without leaking user data.

**5 · The nightly tuner's curated no-regression gate was inert in production** (`dream_tune.py`, `pyproject.toml`)
Every nightly receipt read `200 harvested + 0 curated`. `_curated_raw` looked in `state_dir/eval/` and at `__file__.parent.parent.parent/eval`, which resolves to a repo root only from `src/memo/` — from `site-packages/memo/` it lands in `lib/python3.14/eval/`. `curated_gate_min_sim` fails open on a missing set, so the tuner auto-applied `min_sim` winners with mined labels as the only evidence. The curated set now ships in the wheel and sdist and is resolved via `importlib.resources`.

## Verification

- `pytest`: 6869 passed, 1 skipped
- `mypy src/memo/`: 500 files, clean
- `ruff check src/ tests/`: clean
- `scripts/quality_gate.py`: passes (the packaged-labels guard catches specific exceptions rather than bumping the ratchet)
- Live: `memo journey-check` 0 failed, `memo definitive check` ok, `memo eval recall` prec@5 0.697–0.757 / noise 0.0, `memo operational verify` intact, recall hook 0.38–0.51s against its 5s budget

Also remediated on this machine: the 16 stale conflicts predating fix 1 were reconciled through the new API.