### PR TITLE
fix(release): operate on the checkout you are standing in

### DIFF
--- a/src/memo/cli_release.py
+++ b/src/memo/cli_release.py
@@ -137,10 +137,41 @@ _VERSION_TARGETS = (
 )
 
 
+def _is_memo_checkout(candidate: Path) -> bool:
+    """Whether ``candidate`` is a memo source checkout, not just any project."""
+    pyproject = candidate / "pyproject.toml"
+    if not pyproject.is_file() or not (candidate / "src" / "memo").is_dir():
+        return False
+    try:
+        return 'name = "mlx-memo"' in pyproject.read_text(encoding="utf-8")
+    except OSError:
+        return False
+
+
+def _checkout_containing_cwd() -> Path | None:
+    """The memo checkout the caller is standing in, if any."""
+    try:
+        start = Path.cwd().resolve()
+    except OSError:
+        return None
+    for candidate in (start, *start.parents):
+        if _is_memo_checkout(candidate):
+            return candidate
+    return None
+
+
 def _resolve_repo() -> Path:
-    """Dev repo to operate on: MEMO_DEV_REPO if set, else the running checkout."""
+    """Dev repo to operate on: MEMO_DEV_REPO, else the checkout holding the cwd,
+    else the one this module was imported from.
+
+    The cwd step is what keeps a release cut from an isolated worktree — the
+    procedure CLAUDE.md prescribes — from rewriting the shared working tree the
+    module happens to be imported from.
+    """
     dev = flag_str("MEMO_DEV_REPO")
-    return Path(dev).expanduser() if dev else _REPO_ROOT
+    if dev:
+        return Path(dev).expanduser()
+    return _checkout_containing_cwd() or _REPO_ROOT
 
 
 def bump_version(current: str, level: str) -> str:

--- a/tests/test_cli_release_repo_resolution.py
+++ b/tests/test_cli_release_repo_resolution.py
@@ -1,0 +1,90 @@
+"""Regression: release helpers must operate on the checkout you are standing
+in, not on the one the module happened to be imported from.
+
+Found cutting v4.9.2: `memo release bump` was run from an isolated release
+worktree, but `_resolve_repo` fell back to `Path(__file__).parents[2]` — the
+*shared* working tree — so the bump landed there instead. CLAUDE.md's release
+procedure exists precisely to keep releases out of the shared tree, and this
+silently defeated it.
+
+Resolution order is now: MEMO_DEV_REPO (explicit) > the memo checkout
+containing the cwd > the module's own checkout.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memo.cli_release import _REPO_ROOT, _resolve_repo
+
+PYPROJECT = """\
+[project]
+name = "mlx-memo"
+version = "9.9.9"
+"""
+
+
+def _make_checkout(root, *, name: str = "mlx-memo"):
+    (root / "src" / "memo").mkdir(parents=True)
+    (root / "pyproject.toml").write_text(PYPROJECT.replace("mlx-memo", name), encoding="utf-8")
+    return root
+
+
+def test_cwd_checkout_wins_over_the_module_checkout(tmp_path, monkeypatch) -> None:
+    worktree = _make_checkout(tmp_path / "release-worktree")
+    monkeypatch.delenv("MEMO_DEV_REPO", raising=False)
+    monkeypatch.chdir(worktree)
+
+    assert _resolve_repo() == worktree
+
+
+def test_a_subdirectory_of_the_checkout_resolves_to_its_root(tmp_path, monkeypatch) -> None:
+    worktree = _make_checkout(tmp_path / "release-worktree")
+    nested = worktree / "docs" / "homebrew"
+    nested.mkdir(parents=True)
+    monkeypatch.delenv("MEMO_DEV_REPO", raising=False)
+    monkeypatch.chdir(nested)
+
+    assert _resolve_repo() == worktree
+
+
+def test_explicit_dev_repo_still_wins(tmp_path, monkeypatch) -> None:
+    worktree = _make_checkout(tmp_path / "release-worktree")
+    explicit = _make_checkout(tmp_path / "explicit")
+    monkeypatch.chdir(worktree)
+    monkeypatch.setenv("MEMO_DEV_REPO", str(explicit))
+
+    assert _resolve_repo() == explicit
+
+
+def test_an_unrelated_project_never_hijacks_the_release(tmp_path, monkeypatch) -> None:
+    """A pyproject.toml alone is not a memo checkout — cutting a memo release
+    from some other repo's directory must not rewrite that repo."""
+    other = _make_checkout(tmp_path / "other-project", name="some-other-package")
+    monkeypatch.delenv("MEMO_DEV_REPO", raising=False)
+    monkeypatch.chdir(other)
+
+    assert _resolve_repo() == _REPO_ROOT
+
+
+def test_falls_back_to_the_module_checkout_outside_any_repo(tmp_path, monkeypatch) -> None:
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.delenv("MEMO_DEV_REPO", raising=False)
+    monkeypatch.chdir(elsewhere)
+
+    assert _resolve_repo() == _REPO_ROOT
+
+
+@pytest.mark.parametrize("missing", ["pyproject.toml", "src/memo"])
+def test_a_partial_checkout_is_not_accepted(tmp_path, monkeypatch, missing) -> None:
+    partial = _make_checkout(tmp_path / "partial")
+    target = partial / missing
+    if target.is_dir():
+        target.rmdir()
+    else:
+        target.unlink()
+    monkeypatch.delenv("MEMO_DEV_REPO", raising=False)
+    monkeypatch.chdir(partial)
+
+    assert _resolve_repo() == _REPO_ROOT


### PR DESCRIPTION
Cutting v4.9.2 from an isolated worktree — the procedure CLAUDE.md prescribes precisely to keep releases out of the shared working tree — bumped the **shared** tree instead. `_resolve_repo` fell back to `Path(__file__).parents[2]`, so it followed the module the interpreter imported, not the checkout the caller was standing in. I caught it and reverted, but the next release cut that way would hit it again.

Resolution order is now `MEMO_DEV_REPO` > the memo checkout containing the cwd > the module's own checkout.

"memo checkout" means a `pyproject.toml` naming `mlx-memo` **and** a `src/memo/` directory, so standing in some unrelated project cannot redirect a memo release into it — a test covers that case, along with a partial checkout, a nested subdirectory, and a cwd outside any repo.