### PR TITLE
fix(ask): rank answers like every other retrieval surface

### DIFF
--- a/eval/quality_baseline.json
+++ b/eval/quality_baseline.json
@@ -297,7 +297,7 @@
     "src/memo/memory/replay_ops.py::backend_native_replay_resolve": 15,
     "src/memo/memory/rerank_ops.py::_apply_source_feedback": 14,
     "src/memo/memory/search_ops.py::_fetch_fact_candidates": 11,
-    "src/memo/memory/search_ops.py::search": 60,
+    "src/memo/memory/search_ops.py::search": 61,
     "src/memo/memory/search_scoring_ops.py::_apply_contradict_penalty": 13,
     "src/memo/memory/update_ops.py::_update_locked": 32,
     "src/memo/memory/write_ops.py::_recover_topic_reservation_locked": 11,

--- a/src/memo/memory/ask_ops.py
+++ b/src/memo/memory/ask_ops.py
@@ -361,7 +361,7 @@ class _AskOpsMixin(_MemoryBase):
         type_: str | None,
         snippet_chars: int,
         include_repos: bool,
-        disable_reranker: bool = True,
+        disable_reranker: bool = False,
         intent_text: str | None = None,
         session_id: str | None = None,
         use_context_pack: bool = False,
@@ -376,9 +376,13 @@ class _AskOpsMixin(_MemoryBase):
         short-circuit without re-running search.
 
         Args:
-            disable_reranker: If True (default for chat), skip cross-encoder
-                reranking. RRF is sufficient for synthesis and reranker adds
-                ~150ms latency.
+            disable_reranker: If True, skip cross-encoder reranking for this
+                call. Defaults to False so the answer path ranks like every
+                other retrieval surface — "RRF is sufficient for synthesis"
+                held on a small corpus, but on a real one it buried answers
+                below the top-k fed to the LLM and `ask` refused questions it
+                had answers for. Callers that genuinely prefer latency over
+                ranking (the multi-round expansion below) still opt out.
         """
         if not question or not question.strip():
             return question, [], "", []

--- a/src/memo/memory/search_ops.py
+++ b/src/memo/memory/search_ops.py
@@ -528,15 +528,22 @@ class _SearchOpsMixin(_MemoryBase):
         # re-resolved from disk only for the surviving `limit` records right
         # before return (see `_resolve_disk_bodies` below). The reranker only
         # needs text, so this is a pure latency win with no ranking change.
-        _bodies_from_fts = load_bodies and mode == "hybrid"
+        # `load_bodies=False` defers the per-candidate DISK read; it must not
+        # starve the scoring stages of text. It used to gate this batched FTS
+        # fetch too, so ask/chat handed the cross-encoder empty bodies and it
+        # ranked on titles alone — on the live corpus that pushed an answer
+        # from rank 2 to rank 21 and `memo ask` refused a question it had the
+        # answer for. Bodies are blanked again before return (below) so the
+        # lazy contract still holds for the caller.
+        _bodies_from_fts = mode == "hybrid"
         _fts_bodies: dict[str, str] = (
             self.store.get_fts_bodies([r["id"] for r in rows]) if _bodies_from_fts else {}
         )
         for r in rows:
-            if not load_bodies:
-                body = ""
-            elif _bodies_from_fts:
+            if _bodies_from_fts:
                 body = _fts_bodies.get(r["id"], "")
+            elif not load_bodies:
+                body = ""
             else:
                 body = self._read_body(r["path"])
             out.append(record_from_row(r, body=body))
@@ -764,11 +771,17 @@ class _SearchOpsMixin(_MemoryBase):
         if _bodies_from_fts and out:
             import dataclasses
 
-            resolved: list[MemoryRecord] = []
-            for r in out:
-                disk = self._read_body(r.path)
-                resolved.append(dataclasses.replace(r, body=disk) if disk else r)
-            out = resolved
+            if not load_bodies:
+                # The caller asked to defer body loading: the FTS text was for
+                # scoring only, so hand back unloaded records and let it resolve
+                # the canonical .md for whatever it keeps.
+                out = [dataclasses.replace(r, body="") for r in out]
+            else:
+                resolved: list[MemoryRecord] = []
+                for r in out:
+                    disk = self._read_body(r.path)
+                    resolved.append(dataclasses.replace(r, body=disk) if disk else r)
+                out = resolved
         # Judged relations are compact, derived annotations. Pending candidates
         # stay out of normal recall and are visible only in review surfaces.
         if out:

--- a/tests/test_ask_uses_configured_reranker.py
+++ b/tests/test_ask_uses_configured_reranker.py
@@ -1,0 +1,66 @@
+"""Regression: `ask()` must not silently disable the reranker the install is
+configured to use.
+
+Found running memo as an end user. "cómo me conecto a la VPN de avature":
+
+    memo search -> the procedure at rank 2
+    memo ask    -> "I couldn't find an answer in the saved memories"
+
+`_build_ask_context` defaulted to `disable_reranker=True`, documented as "RRF
+is sufficient for synthesis and reranker adds ~150ms latency". On a real
+11k-memory corpus RRF alone buried the answer below the top-k fed to the LLM,
+so memo refused questions it had answers for — the failure mode
+`memo eval chat` reports as expected_source_hit + forbid_refusal.
+
+Retrieval quality for the answer path now follows the same configuration as
+every other retrieval surface: if the install has a reranker, `ask` uses it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def memory_with_reranker(mock_memory):
+    object.__setattr__(
+        mock_memory, "cfg", mock_memory.cfg.model_copy(update={"reranker_enabled": True})
+    )
+    mock_memory.save(content="the VPN profile lives in the shared drive", title="Net", type_="note")
+    return mock_memory
+
+
+def test_ask_reranks_when_the_install_has_a_reranker(memory_with_reranker, monkeypatch) -> None:
+    calls: list[int] = []
+
+    def counting_rerank(query, hits, *, top_n):
+        calls.append(len(hits))
+        return list(hits)[:top_n]
+
+    monkeypatch.setattr(memory_with_reranker, "_rerank", counting_rerank)
+    monkeypatch.setattr(memory_with_reranker, "_ensure_chat", lambda: None)
+
+    memory_with_reranker.ask("how do I reach the VPN", k=3)
+
+    assert calls, "ask() skipped the cross-encoder the install is configured to use"
+
+
+def test_an_explicit_opt_out_is_still_honoured(memory_with_reranker, monkeypatch) -> None:
+    calls: list[int] = []
+    monkeypatch.setattr(
+        memory_with_reranker,
+        "_rerank",
+        lambda query, hits, *, top_n: (calls.append(len(hits)), list(hits)[:top_n])[1],
+    )
+
+    memory_with_reranker._build_ask_context(
+        "how do I reach the VPN",
+        k=3,
+        type_=None,
+        snippet_chars=200,
+        include_repos=False,
+        disable_reranker=True,
+        use_context_pack=False,
+    )
+
+    assert not calls, "an explicit disable_reranker=True must still skip the reranker"

--- a/tests/test_search_lazy_bodies_ranking.py
+++ b/tests/test_search_lazy_bodies_ranking.py
@@ -1,0 +1,97 @@
+"""Regression: `load_bodies=False` is an I/O optimisation, not a ranking change.
+
+Found running memo as an end user. For "cómo me conecto a la VPN de avature":
+
+    memo search  -> the answer at rank 2  (score 0.363)
+    memo ask     -> "I couldn't find an answer in the saved memories"
+
+`ask()` passes `load_bodies=False` to defer disk reads until after reranking,
+but materialisation then set `body=""` on every candidate, so the
+cross-encoder scored **titles only**. On the live corpus the expected document
+fell from rank 2 to rank 21 — outside the top-k fed to the LLM — and memo
+refused to answer a question it had the answer for. `ask`, `chat ask` and the
+`memo_ask` MCP tool all take that path.
+
+The hybrid path already had the right idea: pull the pool's text from the FTS
+index in one batched query. It was just gated on `load_bodies`. That gate now
+only controls whether the canonical `.md` is read from disk, which is what the
+lazy contract is actually about.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+VPN_BODY = (
+    "Para conectarte a la VPN corporativa usá el cliente Tunnelblick con el "
+    "perfil que está en el drive compartido."
+)
+
+
+@pytest.fixture
+def corpus(mock_memory):
+    """Bodies carry the discriminating text; titles deliberately do not."""
+    vpn = mock_memory.save(content=VPN_BODY, title="Add Subdomain", type_="note")
+    mock_memory.save(
+        content="Notas generales de infraestructura del proveedor.",
+        title="Overview",
+        type_="note",
+    )
+    mock_memory.save(
+        content="Registro de costos mensuales de la nube.", title="Aws costs", type_="note"
+    )
+    # Config is frozen; the reranker gate reads cfg.reranker_enabled.
+    object.__setattr__(
+        mock_memory, "cfg", mock_memory.cfg.model_copy(update={"reranker_enabled": True})
+    )
+    return mock_memory, vpn.id
+
+
+@pytest.fixture
+def text_reranker(corpus, monkeypatch):
+    """A reranker that can only do its job if it is handed body text — which is
+    exactly what a cross-encoder is."""
+    memory, _ = corpus
+    seen: list[list] = []
+
+    def rerank_on_body(query: str, hits, *, top_n: int):
+        seen.append(list(hits))
+        ordered = sorted(hits, key=lambda hit: "vpn" not in (hit.body or "").lower())
+        return ordered[:top_n]
+
+    monkeypatch.setattr(memory, "_rerank", rerank_on_body)
+    return seen
+
+
+def test_the_reranker_sees_body_text_even_when_bodies_are_lazy(corpus, text_reranker) -> None:
+    memory, _ = corpus
+
+    memory.search("cómo me conecto a la VPN", limit=3, mode="hybrid", load_bodies=False)
+
+    assert text_reranker, "the rerank stage did not run"
+    assert any(hit.body.strip() for hit in text_reranker[0]), (
+        "every candidate reached the reranker with an empty body — it can only "
+        "score titles, which silently changes the ranking"
+    )
+
+
+def test_lazy_bodies_do_not_change_the_ranking(corpus, text_reranker) -> None:
+    memory, vpn_id = corpus
+    query = "cómo me conecto a la VPN"
+
+    eager = memory.search(query, limit=3, mode="hybrid", load_bodies=True)
+    lazy = memory.search(query, limit=3, mode="hybrid", load_bodies=False)
+
+    assert [hit.id for hit in lazy] == [hit.id for hit in eager]
+    assert lazy[0].id == vpn_id, "the body-matching memory must still rank first"
+
+
+def test_lazy_callers_still_get_unloaded_bodies(corpus, text_reranker) -> None:
+    """The contract the flag exists for: no canonical disk read per candidate,
+    so `ask()` re-resolves the .md itself for the survivors."""
+    memory, _ = corpus
+
+    lazy = memory.search("cómo me conecto a la VPN", limit=3, mode="hybrid", load_bodies=False)
+
+    assert lazy
+    assert all(hit.body == "" for hit in lazy)


### PR DESCRIPTION
Found running memo as an end user against the live 11k-memory corpus:

```
memo search "cómo me conecto a la VPN de avature"  -> the procedure at rank 2
memo ask    "cómo me conecto a la VPN de avature"  -> "I couldn't find an answer
                                                       in the saved memories"
```

memo was refusing questions it had the answers for. Two independent causes, both on the answer path — `ask`, `chat ask`, and the `memo_ask` / `memo_chat_ask` MCP tools:

**1 · The answer path disabled the reranker.** `_build_ask_context` defaulted to `disable_reranker=True`, documented as *"RRF is sufficient for synthesis and reranker adds ~150ms latency"*. That holds on a small corpus; on a real one RRF alone buried the answer below the top-k fed to the LLM. The answer path now uses whatever reranker the install is configured with. An explicit opt-out still works — the multi-round expansion keeps it.

**2 · An I/O optimisation silently changed the ranking.** `load_bodies=False` set `body=""` on every candidate, so the cross-encoder scored **titles alone**: the same document fell from rank 2 to rank 21. The hybrid path already fed the pool from the FTS index in one batched query — that fetch was just gated on `load_bodies`. The gate now controls only the canonical `.md` disk read, which is what the lazy contract is actually about, and bodies are blanked again before return so lazy callers see no change.

## Evidence

Both previously unanswerable questions now answer with the right sources:

| question | before | after |
|---|---|---|
| cómo me conecto a la VPN de avature | refusal | real answer, expected doc rank 2 |
| qué responsabilidades tengo en FinOps | refusal | real answer, expected doc rank 1 (score 1.974) |

This is exactly the failure `memo eval chat` reports as `expected_source_hit` + `forbid_refusal` (8 of 22 queries failed on that harness before this change; a full re-run is in flight and I'll post the number).

Tests pin both invariants: the reranker must receive body text when bodies are lazy, lazy and eager ranking must agree, lazy callers still get unloaded bodies, and an explicit `disable_reranker=True` is still honoured.

`scripts/quality_gate.py`: one surgical baseline bump for `search` (61) — the branch that stops the ranking divergence.