### PR TITLE
fix(search): chunk→parent collapsing refills instead of shrinking

### DIFF
--- a/eval/quality_baseline.json
+++ b/eval/quality_baseline.json
@@ -297,7 +297,7 @@
     "src/memo/memory/replay_ops.py::backend_native_replay_resolve": 15,
     "src/memo/memory/rerank_ops.py::_apply_source_feedback": 14,
     "src/memo/memory/search_ops.py::_fetch_fact_candidates": 11,
-    "src/memo/memory/search_ops.py::search": 61,
+    "src/memo/memory/search_ops.py::search": 62,
     "src/memo/memory/search_scoring_ops.py::_apply_contradict_penalty": 13,
     "src/memo/memory/update_ops.py::_update_locked": 32,
     "src/memo/memory/write_ops.py::_recover_topic_reservation_locked": 11,

--- a/src/memo/memory/search_ops.py
+++ b/src/memo/memory/search_ops.py
@@ -39,6 +39,11 @@ from memo.tiers import REFERENCE_TYPES, SENSITIVE_TYPES
 # unbounded caller value cannot exhaust the shared DB or blow the latency budget.
 _MAX_SEARCH_LIMIT = 500
 
+# Pool slack for chunk→parent collapsing: a note's chunks can dominate the
+# window, so retrieve this many times `limit` and let the collapse refill the
+# result with the next distinct documents.
+_CHUNK_PARENT_POOL_FACTOR = 4
+
 if TYPE_CHECKING:
     from memo.store.hype_store import HypeStore
 
@@ -301,6 +306,12 @@ class _SearchOpsMixin(_MemoryBase):
             # the cross-encoder has more candidates to discriminate
             # between; the final `limit` is applied AFTER rerank.
             input_k = max(self.cfg.rerank_input_k, limit) if self.cfg.reranker_enabled else limit
+            # Chunk→parent collapsing removes hits by design (eight chunks of
+            # one note become one). Without slack in the pool the caller gets
+            # fewer results than it asked for, so widen it enough that the
+            # collapse can refill from the next distinct documents.
+            if flag_bool("MEMO_SEARCH_CHUNK_PARENT") and type_ not in REFERENCE_TYPES:
+                input_k = max(input_k, limit * _CHUNK_PARENT_POOL_FACTOR)
             k_each = max(input_k * 2, 20)
             try:
                 _query_for_embed = query
@@ -562,6 +573,17 @@ class _SearchOpsMixin(_MemoryBase):
             before = len(out)
             out = [r for r in out if not (r.extra or {}).get(IS_FORGOTTEN_KEY)]
             _add_trace("forget_filter", input_count=before, output_count=len(out))
+        # Chunk→parent mapping (MEMO_SEARCH_CHUNK_PARENT, default off) runs on
+        # the WIDE pool, before rerank and the trim to `limit`. Collapsing after
+        # the trim could only shrink the result: a long note whose eight chunks
+        # all rank well returned eight near-identical hits, and enabling the
+        # flag turned those eight into one instead of one plus the next seven
+        # distinct documents. Collapsing first also stops the reranker from
+        # spending its window on fragments of a single note.
+        if out and flag_bool("MEMO_SEARCH_CHUNK_PARENT") and type_ not in REFERENCE_TYPES:
+            before = len(out)
+            out = self._map_chunks_to_parents(out)
+            _add_trace("chunk_parent", input_count=before, output_count=len(out))
         # Source-level feedback (👍 / 👎) — applied AFTER RRF/vec retrieval
         # but BEFORE cross-encoder rerank so the reranker doesn't waste
         # cycles on hits the user already vetoed. Embeds the query once
@@ -745,14 +767,6 @@ class _SearchOpsMixin(_MemoryBase):
                 output_count=len(out),
                 floor=_ref_floor,
             )
-        # Chunk→parent mapping (K3): a winning reference CHUNK stands in for
-        # its parent note. Flag-gated default off; skipped when the caller
-        # explicitly asked for the reference tier (same rule as the floor
-        # above). See _map_chunks_to_parents.
-        if out and flag_bool("MEMO_SEARCH_CHUNK_PARENT") and type_ not in REFERENCE_TYPES:
-            before = len(out)
-            out = self._map_chunks_to_parents(out)
-            _add_trace("chunk_parent", input_count=before, output_count=len(out))
         out = self._apply_curated_graph_order(query, out, _add_trace)
         if _track_usage:
             self._record_access([r.id for r in out])

--- a/tests/test_search_chunk_parent_refill.py
+++ b/tests/test_search_chunk_parent_refill.py
@@ -1,0 +1,75 @@
+"""Regression: collapsing chunks to their parent must not shrink the result.
+
+Found running memo as an end user. "qué dominios cubre synapse como cerebro
+neutral" returned eight hits that were eight chunks of the *same* note —
+everything else was crowded out. Turning on MEMO_SEARCH_CHUNK_PARENT made it
+worse in a different way: the collapse ran after the trim to `limit`, so the
+eight chunks became **one** result instead of one plus the next seven distinct
+documents.
+
+Collapsing now runs on the wide pool, before rerank and before the trim, so
+the caller gets `limit` distinct documents — and the reranker stops spending
+its window on fragments of a single note.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def chunked_corpus(mock_memory, monkeypatch):
+    monkeypatch.setenv("MEMO_SEARCH_CHUNK_PARENT", "1")
+    parent = mock_memory.save(
+        content="Synapse cubre dominios de orquestación, memoria y federación.",
+        title="Synapse dominios",
+        type_="reference",
+    )
+    for index in range(6):
+        mock_memory.save(
+            content=(
+                f"## Synapse dominios — fragmento {index}\n\n"
+                "Cubre orquestación, memoria federada y ruteo entre agentes locales."
+            ),
+            title=f"Synapse dominios (§{index})",
+            type_="reference",
+            extra={"parent_id": parent.id},
+        )
+    others = [
+        mock_memory.save(
+            content=(
+                f"## Synapse nota independiente {index}\n\n"
+                "Documento separado que también describe dominios de Synapse."
+            ),
+            title=f"Synapse otra {index}",
+            type_="reference",
+        ).id
+        for index in range(4)
+    ]
+    return mock_memory, parent.id, others
+
+
+def test_collapsed_chunks_leave_room_for_other_documents(chunked_corpus) -> None:
+    memory, parent_id, others = chunked_corpus
+
+    hits = memory.search("Synapse dominios", limit=5, mode="hybrid", type_=None)
+
+    ids = [hit.id for hit in hits]
+    assert ids.count(parent_id) <= 1, "the parent was returned more than once"
+    assert len(set(ids)) == len(ids), "duplicate documents in the result"
+    assert len(hits) > 1, (
+        "collapsing shrank the result instead of refilling it with the next distinct documents"
+    )
+    assert any(other in ids for other in others), "no other document made it into the window"
+
+
+def test_the_parent_stands_in_for_its_chunks(chunked_corpus) -> None:
+    memory, parent_id, _ = chunked_corpus
+
+    hits = memory.search("Synapse dominios", limit=5, mode="hybrid", type_=None)
+
+    returned = {hit.id for hit in hits}
+    assert parent_id in returned, "the parent note did not stand in for its chunks"
+    assert not [hit for hit in hits if (hit.extra or {}).get("parent_id")], (
+        "a raw chunk survived the collapse"
+    )


### PR DESCRIPTION
Found running memo as an end user. `memo search "qué dominios cubre synapse como cerebro neutral"` returned **eight hits that were eight chunks of the same note** — every other document was crowded out of the window.

memo already models this with `MEMO_SEARCH_CHUNK_PARENT`, but turning it on made things worse in a different way: the collapse ran *after* the trim to `limit`, so those eight chunks became **one** result instead of one plus the next seven distinct documents. That is why the flag was effectively unusable.

Collapsing now runs on the wide pool — before rerank and before the trim — and the pool is widened while the flag is on so the collapse has slack to refill from.

## Measured on the live corpus

| | hits | distinct documents |
|---|---|---|
| flag off | 8 | 1 |
| flag on, before | 1 | 1 |
| flag on, after | 8 | 8 |

…and the window is now led by the note that actually answers the question ("Synapse: Arquitectura técnica y dominios de …").

Collapsing first also stops the cross-encoder from spending its window on fragments of a single note.

Still default-off, so nothing changes for installs that have not opted in. The curated recall gate is unchanged: prec@5 0.697, noise@5 0.0.