### PR TITLE
fix(embedder): advise about the missing daemon once, not once per batch

### DIFF
--- a/src/memo/embedder_client.py
+++ b/src/memo/embedder_client.py
@@ -56,6 +56,29 @@ _BATCH_TIMEOUT_S = 120.0
 _CONTROL_TIMEOUT_S = 5.0
 _state_dir_lock = threading.Lock()
 _cached_state_dir: Path | None = None
+# The daemon-unreachable notice is advice ("start the daemon"), not an event:
+# identical every time and only actionable once. Emitting it per batch buried
+# a backfill's real output under hundreds of copies of the same four lines.
+_fallback_notice_lock = threading.Lock()
+_fallback_notified: set[str] = set()
+
+
+def _should_notify_fallback(socket_path: Path) -> bool:
+    """Whether this process has yet to advise about ``socket_path``."""
+    key = str(socket_path)
+    with _fallback_notice_lock:
+        if key in _fallback_notified:
+            return False
+        _fallback_notified.add(key)
+        return True
+
+
+def _reset_fallback_notices() -> None:
+    """Test seam: forget which sockets have already been advised about."""
+    with _fallback_notice_lock:
+        _fallback_notified.clear()
+
+
 _inproc_lock = threading.Lock()
 _inproc_embedder: Any | None = None
 
@@ -218,13 +241,14 @@ def embed_query(
             "embed_query: daemon unreachable and MEMO_STRICT=1 disables in-process fallback. "
             "Start the daemon with 'memo recall-daemon start' or set MEMO_EMBEDDER_CLIENT_REQUIRE_DAEMON=1"
         )
-    _log.warning(
-        "embedder_client: daemon unreachable at %s, falling back to in-process "
-        "(first call will be slow ~2s due to cold MLX load). "
-        "To start the daemon: 'memo recall-daemon start'. "
-        "To require daemon and fail fast: set MEMO_EMBEDDER_CLIENT_REQUIRE_DAEMON=1",
-        resolved / "recall.sock",
-    )
+    if _should_notify_fallback(resolved / "recall.sock"):
+        _log.warning(
+            "embedder_client: daemon unreachable at %s, falling back to in-process "
+            "(first call will be slow ~2s due to cold MLX load). "
+            "To start the daemon: 'memo recall-daemon start'. "
+            "To require daemon and fail fast: set MEMO_EMBEDDER_CLIENT_REQUIRE_DAEMON=1",
+            resolved / "recall.sock",
+        )
     return _inproc().embed_query(text)
 
 
@@ -278,14 +302,15 @@ def embed(
             "embed: daemon unreachable and MEMO_STRICT=1 disables in-process fallback. "
             "Start the daemon with 'memo recall-daemon start' or set MEMO_EMBEDDER_CLIENT_REQUIRE_DAEMON=1"
         )
-    _log.warning(
-        "embedder_client: daemon unreachable at %s, falling back to in-process "
-        "(batch of %d items, first call will be slow ~2s due to cold MLX load). "
-        "To start the daemon: 'memo recall-daemon start'. "
-        "To require daemon and fail fast: set MEMO_EMBEDDER_CLIENT_REQUIRE_DAEMON=1",
-        resolved / "recall.sock",
-        len(items),
-    )
+    if _should_notify_fallback(resolved / "recall.sock"):
+        _log.warning(
+            "embedder_client: daemon unreachable at %s, falling back to in-process "
+            "(batch of %d items, first call will be slow ~2s due to cold MLX load). "
+            "To start the daemon: 'memo recall-daemon start'. "
+            "To require daemon and fail fast: set MEMO_EMBEDDER_CLIENT_REQUIRE_DAEMON=1",
+            resolved / "recall.sock",
+            len(items),
+        )
     return _inproc().embed(items)
 
 

--- a/tests/test_embedder_client_fallback_notice.py
+++ b/tests/test_embedder_client_fallback_notice.py
@@ -1,0 +1,81 @@
+"""Regression: the daemon-unreachable fallback notice is advice, not an event.
+
+`memo episodes index` printed the same four-line warning — "daemon unreachable
+… falling back to in-process … to start the daemon: …" — once per batch. A
+single command emitted it five times before its first line of real output; a
+long backfill emits it hundreds of times. The advice is identical every time
+and only actionable once.
+
+It now warns once per process (per socket path), and the fallback itself is
+unchanged: the work still succeeds in-process.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from memo import embedder_client
+
+
+@pytest.fixture(autouse=True)
+def _forget_previous_notices():
+    embedder_client._reset_fallback_notices()
+    yield
+    embedder_client._reset_fallback_notices()
+
+
+@pytest.fixture
+def unreachable_daemon(tmp_path, monkeypatch):
+    """No socket, no strict flags: the in-process fallback path."""
+
+    class _Stub:
+        def embed(self, texts):
+            return [[0.0, 0.0, 0.0, 1.0] for _ in texts]
+
+        def embed_query(self, text):
+            return [0.0, 0.0, 0.0, 1.0]
+
+    monkeypatch.setattr(embedder_client, "_inproc", lambda: _Stub())
+    monkeypatch.setattr(embedder_client, "_try_socket", lambda *a, **k: None)
+    monkeypatch.setattr(embedder_client, "_require_daemon", lambda: False)
+    return tmp_path
+
+
+def test_batch_embeds_warn_once_per_process(unreachable_daemon, caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger="memo.embedder_client"):
+        for _ in range(5):
+            embedder_client.embed(["uno"], state_dir=unreachable_daemon)
+
+    notices = [r for r in caplog.records if "daemon unreachable" in r.getMessage()]
+    assert len(notices) == 1, f"emitted {len(notices)} identical fallback notices"
+
+
+def test_the_fallback_still_returns_vectors(unreachable_daemon) -> None:
+    vectors = embedder_client.embed(["uno", "dos"], state_dir=unreachable_daemon)
+
+    assert len(vectors) == 2
+    assert all(len(v) == 4 for v in vectors)
+
+
+def test_query_and_batch_share_the_notice(unreachable_daemon, caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger="memo.embedder_client"):
+        embedder_client.embed(["uno"], state_dir=unreachable_daemon)
+        embedder_client.embed_query("uno", state_dir=unreachable_daemon)
+
+    notices = [r for r in caplog.records if "daemon unreachable" in r.getMessage()]
+    assert len(notices) == 1, "the same advice was repeated for the query path"
+
+
+def test_a_different_socket_still_warns(unreachable_daemon, tmp_path, caplog) -> None:
+    """A second state dir is a genuinely different situation worth reporting."""
+    other = tmp_path / "other-state"
+    other.mkdir()
+
+    with caplog.at_level(logging.WARNING, logger="memo.embedder_client"):
+        embedder_client.embed(["uno"], state_dir=unreachable_daemon)
+        embedder_client.embed(["uno"], state_dir=other)
+
+    notices = [r for r in caplog.records if "daemon unreachable" in r.getMessage()]
+    assert len(notices) == 2


### PR DESCRIPTION
`memo episodes index` emitted the same four-line notice before every batch:

```
embedder_client: daemon unreachable at .../recall.sock, falling back to in-process
(batch of 1 items, first call will be slow ~2s due to cold MLX load).
To start the daemon: 'memo recall-daemon start'.
To require daemon and fail fast: set MEMO_EMBEDDER_CLIENT_REQUIRE_DAEMON=1
```

Five copies landed ahead of the command's first line of real output; a long backfill emits hundreds. The text is identical every time and actionable exactly once — it is advice, not an event.

Now emitted once per process per socket path. A different state dir still warns, since that is a genuinely different situation, and the fallback itself is untouched: the work still succeeds in-process.

Verified by unit test (five embeds → one notice; two state dirs → two notices). I could not get a clean live before/after: on a re-run the content-addressed embed cache means no embedder call happens at all, so neither build warns — worth knowing if you go looking.