### PR TITLE
ci: calibrate the journal throughput floor to catch regressions, not runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,5 +139,12 @@ jobs:
           tests/test_operational_memory.py
           tests/test_definitive_memory.py
           tests/test_definitive_gate.py
+      # The floor catches a REGRESSION in journal append cost (an fsync per
+      # event, an O(n) re-verify), not the speed of the runner we happened to
+      # get. At 250 it measured the latter: two unrelated PRs failed here in
+      # one evening at 93.6 and 108 eps on contended shared runners, and both
+      # passed on re-run with no code change. A healthy runner clears 250+;
+      # the regressions worth catching are order-of-magnitude, so 60 keeps the
+      # signal (2.4x the library's own 25 eps default) without the false reds.
       - name: Gate causal-journal throughput
-        run: .venv/bin/memo definitive benchmark --events 1000 --minimum-eps 250
+        run: .venv/bin/memo definitive benchmark --events 1000 --minimum-eps 60


### PR DESCRIPTION
The `runtime-independence` job demanded **250 events/s** from GitHub's shared runners — ten times the library's own 25 eps default.

Two unrelated PRs failed it in one evening:

| PR | measured | required | after re-run, no code change |
|---|---|---|---|
| #203 (ask ranking) | 108.07 eps | 250 | pass |
| #207 (embedder notice) | 93.60 eps | 250 | pass |

Neither diff touches the journal. The gate was measuring which runner we drew, not journal append cost.

A healthy machine is nowhere near the floor — **1720 eps** locally, and CI clears 250 whenever it is not contended. The regressions this gate exists to catch (an fsync per event, an O(n) re-verify) are order-of-magnitude, so **60** keeps the signal at 2.4× the library default while dropping false reds.

That matters beyond convenience: a gate that goes red for reasons unrelated to the diff trains everyone to re-run without reading it, which is how a real regression slips through.