### PR TITLE
fix(deps): bump nanoid to 3.3.18 for GHSA-2v37-7h3g-55p8

### DIFF
--- a/web-chat/package-lock.json
+++ b/web-chat/package-lock.json
@@ -2209,9 +2209,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
`npm audit` consults the live advisory database, so an unchanged lockfile flips from green to red the moment an advisory is published. GHSA-2v37-7h3g-55p8 landed against `nanoid <3.3.17` and now fails **Audit web chat dependencies** on every open PR — it passed on #211 earlier today and fails on #212 now, with neither PR touching JavaScript.

`nanoid` is transitive through `postcss`, whose declared range `^3.3.16` already admits 3.3.18, so only the lockfile entry moves. `package.json` is untouched and `nanoid` does not become a direct dependency.

## Why this was patched by hand

`npm audit fix` produces the right nanoid bump but also strips the `libc` field from 11 optional platform packages, because the local npm is a different version from the one that generated the lockfile. Those fields are how npm selects the correct prebuilt binary on musl versus glibc, and this repo builds on Linux in CI, so that collateral churn is excluded. The diff is 3 lines.

The npm-version drift is worth a separate look: anyone running `npm install` in `web-chat/` with a current npm will churn those same 11 entries.

## Test plan

- [x] `npm ci` succeeds (lockfile and package.json agree)
- [x] `npm audit --audit-level=low` → found 0 vulnerabilities
- [x] `npm run build` → vite build ok, 278 modules

Unblocks #211 and #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)