### PR TITLE
perf: stop materializing bodies in Memory.list sweeps that discard them

### DIFF
--- a/src/memo/analytics.py
+++ b/src/memo/analytics.py
@@ -66,7 +66,7 @@ class AnalyticsEngine:
         # The newest slice — big enough to characterise the corpus, bounded so
         # the command stays cheap. Distributions below describe this sample;
         # the total comes from the store so it never reports the page size.
-        memories = self.memory.list(limit=_SAMPLE_LIMIT)
+        memories = self.memory.list(limit=_SAMPLE_LIMIT, with_bodies=False)
 
         sample_size = len(memories)
         total_memories = self.memory.store.count()
@@ -128,7 +128,7 @@ class AnalyticsEngine:
         Returns:
             GrowthData with dates and counts.
         """
-        memories = self.memory.list(limit=_SAMPLE_LIMIT)
+        memories = self.memory.list(limit=_SAMPLE_LIMIT, with_bodies=False)
 
         # Group by date
         date_counts: Counter[str] = Counter()

--- a/src/memo/cli_code_facts.py
+++ b/src/memo/cli_code_facts.py
@@ -202,7 +202,7 @@ def mine_code_facts(conn: sqlite3.Connection, *, repo_id: str, top: int) -> list
 def _existing_hashes(mem: Any) -> set[str]:
     """Provenance hashes of codegraph-derived fact memories already saved."""
     hashes: set[str] = set()
-    for rec in mem.list(type_="fact", limit=_EXISTING_SCAN_LIMIT):
+    for rec in mem.list(type_="fact", limit=_EXISTING_SCAN_LIMIT, with_bodies=False):
         if "codegraph-derived" not in (rec.tags or []):
             continue
         value = (rec.extra or {}).get("provenance_hash")

--- a/src/memo/cli_ops.py
+++ b/src/memo/cli_ops.py
@@ -34,9 +34,12 @@ def ops_group() -> None:
     """Maintenance jobs (GC, vault re-ingest, ingest tombstones)."""
 
 
-def _all_records() -> tuple[Any, list[dict]]:
+def _all_records(*, with_bodies: bool = True) -> tuple[Any, list[dict]]:
+    """Whole-corpus sweep. Pass `with_bodies=False` when the GC rule keys off
+    `extra` only — reading every body off disk costs ~44s on a 10k-row corpus
+    and the duplicate rule is the only one that actually needs the text."""
     mem = _get_memory(Config.from_env())
-    return mem, [r.to_dict() for r in mem.list(limit=_LIST_ALL)]
+    return mem, [r.to_dict() for r in mem.list(limit=_LIST_ALL, with_bodies=with_bodies)]
 
 
 def _delete_records(mem: Any, records: list[dict]) -> int:
@@ -53,7 +56,7 @@ def _delete_records(mem: Any, records: list[dict]) -> int:
 @click.option("--json", "as_json", is_flag=True, help="Output raw JSON.")
 def gc_vault_orphans_cmd(dry_run: bool, as_json: bool) -> None:
     """Delete memo records whose vault source file no longer exists on disk."""
-    mem, records = _all_records()
+    mem, records = _all_records(with_bodies=False)
     orphans = find_vault_orphans(records)
     deleted = 0 if dry_run else _delete_records(mem, orphans)
     result = {

--- a/src/memo/federation.py
+++ b/src/memo/federation.py
@@ -188,9 +188,14 @@ class FederationManager:
     def __init__(self, memory: Any) -> None:
         self.memory = memory
 
-    def _records(self) -> list[Any]:
+    def _records(self, *, with_bodies: bool = True) -> list[Any]:
+        """Whole-corpus sweep. `with_bodies=False` for the metadata-only legs
+        (preview, the already-applied receipt set) — reading and YAML-parsing
+        every body just to drop it costs ~44s on a 10k-row corpus."""
         total = max(0, int(self.memory.store.count()))
-        return self.memory.list(limit=max(1, min(total + 1, _MAX_RECORDS + 1)))
+        return self.memory.list(
+            limit=max(1, min(total + 1, _MAX_RECORDS + 1)), with_bodies=with_bodies
+        )
 
     def preview(
         self,
@@ -209,7 +214,7 @@ class FederationManager:
                 "type": record.type,
                 "visibility": str((record.extra or {}).get("visibility") or Visibility.OWNER.value),
             }
-            for record in self._records()
+            for record in self._records(with_bodies=False)
             if record.type != "secret"
             and visible_to(record.extra, principal=target, owner_principal=owner)
         ]
@@ -385,7 +390,7 @@ class FederationManager:
                 str(federation.get("bundle_id") or ""),
                 str(federation.get("source_id") or ""),
             )
-            for record in self._records()
+            for record in self._records(with_bodies=False)
             if isinstance((record.extra or {}).get("federation"), dict)
             for federation in [(record.extra or {})["federation"]]
         }

--- a/src/memo/memory/outcome_feedback_ops.py
+++ b/src/memo/memory/outcome_feedback_ops.py
@@ -204,7 +204,9 @@ class _OutcomeFeedbackOpsMixin(_MemoryBase):
             raise ValueError("min_utility must be between 0 and 1")
         candidates: list[dict[str, Any]] = []
         total = max(0, int(self.store.count()))
-        for record in self.list(limit=max(1, total + 1)):
+        # Metadata-only sweep: the verdict comes from `extra.outcome_stats`,
+        # so materializing every body would be pure overhead.
+        for record in self.list(limit=max(1, total + 1), with_bodies=False):
             if record.type in _LEARNING_TYPES or record.type in {"secret", "reference"}:
                 continue
             stats = _stats(dict(record.extra or {}))

--- a/src/memo/memory/search_ops.py
+++ b/src/memo/memory/search_ops.py
@@ -1574,18 +1574,29 @@ class _SearchOpsMixin(_MemoryBase):
         type_: str | None = None,
         include_forgotten: bool = False,
         updated_since: str | None = None,
+        with_bodies: bool = True,
     ) -> list[MemoryRecord]:
-        """Recent entries by `updated` desc. Body included for each.
+        """Recent entries by `updated` desc. Body included unless opted out.
 
         Soft-forgotten memories (see `forget`) are excluded unless
         `include_forgotten=True`. `updated_since` (ISO-8601) filters at the
         DB level — incremental callers (e.g. contradiction scans) get the
         freshest anchors within `limit` instead of post-filtering a page of
         older rows.
+
+        `with_bodies=False` returns the same rows with `body=""` and skips
+        `_read_body` entirely. Every body costs a disk read plus a YAML
+        frontmatter parse (or an FTS lookup for vault-ingest rows), so a
+        full-corpus sweep of ~10k rows spends ~44s materializing text that
+        metadata-only callers (analytics, temporal, federation preview,
+        procedure candidates) immediately discard. Default stays True so
+        no existing caller changes semantics.
         """
         rows = self.store.list_recent(limit=limit, type_=type_, updated_since=updated_since)
         if not include_forgotten:
             rows = [r for r in rows if not (r.get("extra") or {}).get(IS_FORGOTTEN_KEY)]
+        if not with_bodies:
+            return [record_from_row(r) for r in rows]
         return [record_from_row(r, body=self._read_body(r["path"])) for r in rows]
 
     # -- get ----------------------------------------------------------------

--- a/src/memo/temporal.py
+++ b/src/memo/temporal.py
@@ -461,7 +461,7 @@ Body: {(r2.body or "")[:1000]}
         cutoff_dt = _parse_ts(cutoff)
 
         # Get all memories, filter by date
-        all_records = self.memory.list(limit=_ANALYSIS_ROW_CAP)
+        all_records = self.memory.list(limit=_ANALYSIS_ROW_CAP, with_bodies=False)
         if len(all_records) >= _ANALYSIS_ROW_CAP:
             _log.warning(
                 "detect_stale_memories: corpus hit the %d-row cap; older "
@@ -514,7 +514,7 @@ Body: {(r2.body or "")[:1000]}
             - type_distribution_over_time: how memory types change over time
             - most_active_entities: entities with most temporal churn
         """
-        all_records = self.memory.list(limit=_ANALYSIS_ROW_CAP)
+        all_records = self.memory.list(limit=_ANALYSIS_ROW_CAP, with_bodies=False)
         if len(all_records) >= _ANALYSIS_ROW_CAP:
             _log.warning(
                 "detect_temporal_patterns: corpus hit the %d-row cap; older "

--- a/tests/test_cli_ops.py
+++ b/tests/test_cli_ops.py
@@ -21,7 +21,7 @@ class _FakeMem:
         self.records = records
         self.deleted = []
 
-    def list(self, limit=20, type_=None):
+    def list(self, limit=20, type_=None, **_kw):
         return [_FakeRec(r) for r in self.records]
 
     def delete(self, id_, *, actor=None):

--- a/tests/test_lazy_bodies.py
+++ b/tests/test_lazy_bodies.py
@@ -1,0 +1,252 @@
+"""`Memory.list(with_bodies=False)` — corpus sweeps stop materializing bodies.
+
+`Memory.list` used to read every row's markdown off disk and YAML-parse it,
+even for callers that never touch `record.body`. On the live ~10k-row corpus
+that is ~44s per call, which blew the 120s MCP budget for the analytics,
+temporal, federation-preview and procedure-candidate sweeps.
+
+Each converted caller is pinned twice:
+
+1. it triggers ZERO `_read_body` reads (the work is provably gone), and
+2. its output is identical to the eager run (`with_bodies` forced True),
+   so the conversion is behaviour-preserving.
+
+Two anti-vacuity controls keep (2) honest:
+`test_force_with_bodies_harness_overrides_both_directions` proves the eager/lazy
+switch actually changes what `Memory.list` returns, and
+`test_body_blanking_is_detectable` proves a caller that DOES read bodies
+produces different output when they are suppressed. Without both, `lazy ==
+eager` could be green simply because nothing ever differed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from memo.memory import Memory
+
+_SEED_NOTES = 6
+_SEED_FACTS = 2
+_SEED_ROWS = _SEED_NOTES + _SEED_FACTS
+
+
+def _seed(mem: Memory) -> None:
+    """A corpus with real, distinct, non-empty bodies on disk.
+
+    The `fact` rows exist so `cli_code_facts._existing_hashes` (which filters
+    `type_="fact"`) sweeps a non-empty result set — otherwise its "no body
+    reads" assertion would be trivially green.
+    """
+    for i in range(_SEED_NOTES):
+        mem.save(
+            content=f"body number {i}\n\n" + f"distinctive detail {i} " * 20,
+            title=f"note {i}",
+            type_="note",
+            tags=["alpha", "beta", f"idx-{i}"],
+            auto_project=False,
+            extra={"outcome_stats": {"successes": 3, "total": 4, "utility": 0.9}},
+        )
+    for i in range(_SEED_FACTS):
+        mem.save(
+            content=f"fact body {i}\n\n" + f"mined detail {i} " * 20,
+            title=f"fact {i}",
+            type_="fact",
+            tags=["codegraph-derived", "alpha", f"fact-{i}"],
+            auto_project=False,
+            extra={"provenance_hash": f"hash-{i}"},
+        )
+
+
+@pytest.fixture
+def body_reads(mock_memory: Memory, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Records every `_read_body` call made on the fixture's Memory."""
+    seen: list[str] = []
+    original = mock_memory._read_body
+
+    def spy(rel_path: str) -> str:
+        seen.append(rel_path)
+        return original(rel_path)
+
+    monkeypatch.setattr(mock_memory, "_read_body", spy)
+    return seen
+
+
+# --- Memory.list itself ---------------------------------------------------
+
+
+def test_list_default_still_materializes_bodies(mock_memory: Memory, body_reads: list[str]) -> None:
+    _seed(mock_memory)
+    body_reads.clear()
+
+    records = mock_memory.list(limit=50)
+
+    assert len(records) == _SEED_ROWS
+    assert len(body_reads) == _SEED_ROWS, "default must read one body per row"
+    assert sorted(r.body.splitlines()[0] for r in records) == sorted(
+        [f"body number {i}" for i in range(_SEED_NOTES)]
+        + [f"fact body {i}" for i in range(_SEED_FACTS)]
+    )
+
+
+def test_list_with_bodies_false_skips_read_body(mock_memory: Memory, body_reads: list[str]) -> None:
+    _seed(mock_memory)
+    body_reads.clear()
+
+    records = mock_memory.list(limit=50, with_bodies=False)
+
+    assert body_reads == [], "with_bodies=False must not touch _read_body at all"
+    assert [r.id for r in records] == [r.id for r in mock_memory.list(limit=50)]
+    assert all(r.body == "" for r in records)
+    assert all(r.title and r.tags and r.updated for r in records), "metadata still populated"
+
+
+# --- converted callers ----------------------------------------------------
+
+
+def _analytics_summary(mem: Memory) -> Any:
+    from memo.analytics import AnalyticsEngine
+
+    return AnalyticsEngine(mem).compute_corpus_metrics().__dict__
+
+
+def _analytics_growth(mem: Memory) -> Any:
+    from memo.analytics import AnalyticsEngine
+
+    return AnalyticsEngine(mem).compute_growth_data().__dict__
+
+
+def _temporal_stale(mem: Memory) -> Any:
+    from memo.temporal import TemporalAnalyzer
+
+    return TemporalAnalyzer(mem).detect_stale_memories(days_threshold=0)
+
+
+def _temporal_patterns(mem: Memory) -> Any:
+    from memo.temporal import TemporalAnalyzer
+
+    return TemporalAnalyzer(mem).detect_temporal_patterns()
+
+
+def _federation_preview(mem: Memory) -> Any:
+    from memo.federation import FederationManager
+
+    return FederationManager(mem).preview(principal="owner-a", owner_principal="owner-a")
+
+
+def _procedure_candidates(mem: Memory) -> Any:
+    return mem.procedure_candidates(min_successes=2, min_utility=0.5)
+
+
+def _code_facts_existing_hashes(mem: Memory) -> Any:
+    from memo.cli_code_facts import _existing_hashes
+
+    return sorted(_existing_hashes(mem))
+
+
+def _gc_vault_orphans(mem: Memory) -> Any:
+    import memo.cli_ops as cli_ops
+    from memo.cli_ops import ops_group
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(cli_ops, "_get_memory", lambda cfg: mem)
+        result = CliRunner().invoke(ops_group, ["gc-vault-orphans", "--dry-run", "--json"])
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)
+
+
+_CONVERTED = [
+    pytest.param(_analytics_summary, id="analytics.compute_corpus_metrics"),
+    pytest.param(_analytics_growth, id="analytics.compute_growth_data"),
+    pytest.param(_temporal_stale, id="temporal.detect_stale_memories"),
+    pytest.param(_temporal_patterns, id="temporal.detect_temporal_patterns"),
+    pytest.param(_federation_preview, id="federation.preview"),
+    pytest.param(_procedure_candidates, id="memory.procedure_candidates"),
+    pytest.param(_code_facts_existing_hashes, id="cli_code_facts._existing_hashes"),
+    pytest.param(_gc_vault_orphans, id="cli_ops.gc-vault-orphans"),
+]
+
+
+def _force_with_bodies(mp: pytest.MonkeyPatch, value: bool) -> None:
+    """Override every `Memory.list` call's `with_bodies` decision."""
+    original = Memory.list
+
+    def patched(self: Memory, **kwargs: Any) -> Any:
+        kwargs["with_bodies"] = value
+        return original(self, **kwargs)
+
+    mp.setattr(Memory, "list", patched)
+
+
+def test_force_with_bodies_harness_overrides_both_directions(mock_memory: Memory) -> None:
+    """The eager-vs-lazy comparison below is only meaningful if this switch works.
+
+    A `_force_with_bodies` that silently did nothing would make every
+    `lazy == eager` assertion compare two identical lazy runs.
+    """
+    _seed(mock_memory)
+
+    with pytest.MonkeyPatch.context() as mp:
+        _force_with_bodies(mp, True)
+        forced_on = mock_memory.list(limit=50, with_bodies=False)
+    with pytest.MonkeyPatch.context() as mp:
+        _force_with_bodies(mp, False)
+        forced_off = mock_memory.list(limit=50, with_bodies=True)
+
+    assert forced_on and forced_off
+    assert all(r.body for r in forced_on), "forced True must beat a caller's with_bodies=False"
+    assert all(r.body == "" for r in forced_off), "forced False must beat a caller's True"
+
+
+@pytest.mark.parametrize("caller", _CONVERTED)
+def test_converted_caller_reads_no_bodies(
+    mock_memory: Memory, body_reads: list[str], caller: Any
+) -> None:
+    _seed(mock_memory)
+    body_reads.clear()
+
+    caller(mock_memory)
+
+    assert body_reads == [], f"{caller.__name__} still materializes bodies"
+
+
+@pytest.mark.parametrize("caller", _CONVERTED)
+def test_converted_caller_output_matches_eager_run(mock_memory: Memory, caller: Any) -> None:
+    _seed(mock_memory)
+
+    lazy = caller(mock_memory)
+    with pytest.MonkeyPatch.context() as mp:
+        _force_with_bodies(mp, True)
+        eager = caller(mock_memory)
+
+    assert lazy == eager
+
+
+# --- anti-vacuity control -------------------------------------------------
+
+
+def test_body_blanking_is_detectable(mock_memory: Memory) -> None:
+    """A caller that DOES read bodies must notice when they are blanked.
+
+    Without this, every equality assertion above could be green simply because
+    the fixture corpus has empty bodies, or because the harness never actually
+    changes what `Memory.list` returns.
+    """
+    from memo.memory_profile import build_memory_profile
+
+    _seed(mock_memory)
+
+    with_bodies = build_memory_profile(mock_memory)
+    with pytest.MonkeyPatch.context() as mp:
+        _force_with_bodies(mp, False)
+        without_bodies = build_memory_profile(mock_memory)
+
+    assert with_bodies != without_bodies
+    assert [row["text"] for row in with_bodies["active"]] != [
+        row["text"] for row in without_bodies["active"]
+    ]
+    assert all(row["text"] for row in with_bodies["active"])
+    assert all(row["text"] == "" for row in without_bodies["active"])


### PR DESCRIPTION
## What

`Memory.list` (`search_ops.py:1589`) materializes the body of every row it returns. Nine full-corpus sweep callers read only metadata and throw the bodies away, which is why the MCP tools built on them all take ~44s against the live store while `memo_list(limit=20)` takes 0.02s.

Adds `with_bodies: bool = True` to `Memory.list` — default unchanged, so no existing caller shifts semantics — and passes `with_bodies=False` from the nine callers verified to discard the body.

## Why it's ~44s and not the query

The FTS fallback (`get_fts_body_by_path`) measures 0.87 ms/row, ~9.3s across 10.7k rows. The remaining ~35s is per-row disk read plus YAML frontmatter parsing in `_read_body`. So the fix is to not call it, not to tune the query.

## Verification

- Every converted caller has a test asserting its output is byte-identical to the eager run — that regression guard matters more than the perf one.
- Every new test was shown failing first (18 failed / 1 passed pre-fix; 20 passed after). The one intentional pre-fix pass is the behaviour-preservation baseline.
- One draft test was vacuously green — `_existing_hashes` filters `type="fact"` and the fixture had zero fact rows, so it swept an empty set. Fixture corrected, test then failed red as intended.
- Reviewer independently reconstructed pre-fix source and re-ran: 19 failed / 1 passed, failing on real assertions rather than TypeError.

## Not covered

Changed-line coverage rests on CI: local `--cov` crashes in the `mem.save` seed path (pre-existing, unrelated to this diff).