### PR TITLE
fix: single-source memo's version and correct the tool-count/token labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Most memory servers *add* context. memo is built to remove it.
 | `core` / `slim` | 58 | ~12.9k |
 | `full` / `default` | 164 | ~30.4k |
 
-The default MCP surface is 41 tools, not 164: about 75% fewer tool schemas. It exposes **41 tools / ~9.4k schema tokens** versus **164 tools / ~30.4k tokens** on the full surface — overhead paid every session, in every client.
+The default MCP surface is 41 tools, not 164 — 75% fewer tools, and about 69% less schema context: **41 tools / ~9.4k schema tokens** versus **164 tools / ~30.4k tokens** on the full surface — overhead paid every session, in every client.
 
 Ambient recall injects one relevant memory before the model answers. The bundled Claude Code hook caps that injection at ~160 tokens. `memo roi` reads the real grounding and re-ask ledgers, then estimates accumulated savings with disclosed defaults (350 tokens per grounded recall and 900 per avoided re-ask).
 

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ Most memory servers *add* context. memo is built to remove it.
 
 | Profile | Tools | Schema tokens |
 |---|---:|---:|
-| `agent` (default) | 41 | ~4.1k |
-| `core` / `slim` | 58 | ~5.3k |
-| `full` / `default` | 164 | ~18.1k |
+| `agent` (default) | 41 | ~9.4k |
+| `core` / `slim` | 58 | ~12.9k |
+| `full` / `default` | 164 | ~30.4k |
 
-The default MCP surface is 41 tools, not 164: about 75% fewer tool schemas. It exposes **41 tools / ~4.1k schema tokens** versus **164 tools / ~18.1k tokens** on the full surface — overhead paid every session, in every client.
+The default MCP surface is 41 tools, not 164: about 75% fewer tool schemas. It exposes **41 tools / ~9.4k schema tokens** versus **164 tools / ~30.4k tokens** on the full surface — overhead paid every session, in every client.
 
 Ambient recall injects one relevant memory before the model answers. The bundled Claude Code hook caps that injection at ~160 tokens. `memo roi` reads the real grounding and re-ask ledgers, then estimates accumulated savings with disclosed defaults (350 tokens per grounded recall and 900 per avoided re-ask).
 

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -38,7 +38,7 @@
 
   <!-- Title -->
   <text x="40" y="40" class="title">memo — how it fits in your stack</text>
-  <text x="40" y="60" class="sub">Local MCP memory · MLX on Apple Silicon or CPU on Linux · 142 CLI commands · 162 MCP tools (full)</text>
+  <text x="40" y="60" class="sub">Local MCP memory · MLX on Apple Silicon or CPU on Linux · 142 CLI commands · 164 MCP tools (full)</text>
 
   <!-- ============== CLIENTS ROW ============== -->
   <text x="40" y="96" class="section">clients</text>
@@ -81,8 +81,8 @@
   <rect x="40" y="199" width="880" height="58" class="group-rect" rx="10"/>
 
   <rect x="55" y="207" width="650" height="42" class="box box-blue" rx="8" filter="url(#shadow)"/>
-  <text x="380" y="227" class="label">memo-mcp (FastMCP stdio) — 162 tools in the full profile</text>
-  <text x="380" y="243" class="meta">MEMO_MCP_PROFILE:  agent (41 tools ~4.1k tokens)  ·  core/slim (58 tools ~5.3k)  ·  full/default (162 tools ~18.1k)</text>
+  <text x="380" y="227" class="label">memo-mcp (FastMCP stdio) — 164 tools in the full profile</text>
+  <text x="380" y="243" class="meta">MEMO_MCP_PROFILE:  agent (41 tools ~9.4k tokens)  ·  core/slim (58 tools ~12.9k)  ·  full/default (164 tools ~30.4k)</text>
 
   <rect x="720" y="207" width="190" height="42" class="box" rx="8" filter="url(#shadow)"/>
   <text x="815" y="227" class="label">memo CLI</text>

--- a/docs/how-memo-works.svg
+++ b/docs/how-memo-works.svg
@@ -113,8 +113,8 @@
   <!-- ====================== TOKEN ECONOMY BANNER ====================== -->
   <rect x="40" y="572" width="848" height="104" rx="12" fill="#0f172a"/>
   <text x="64" y="606" font-size="13" font-weight="700" fill="#e2e8f0" letter-spacing="0.06em" style="text-transform:uppercase">Token economy</text>
-  <text x="64" y="636" font-size="15" font-weight="600" fill="#ffffff">Default MCP surface: 41 tools · ~4.1k tokens   vs   full 162 tools · ~18.1k tokens</text>
-  <text x="64" y="660" font-size="13" fill="#94a3b8">≈ 77% less schema context per session · recall injects the answer the agent would otherwise re-derive (~160-token budget).</text>
-  <text x="788" y="636" font-size="34" font-weight="800" fill="#38bdf8" text-anchor="middle">77%</text>
+  <text x="64" y="636" font-size="15" font-weight="600" fill="#ffffff">Default MCP surface: 41 tools · ~9.4k tokens   vs   full 164 tools · ~30.4k tokens</text>
+  <text x="64" y="660" font-size="13" fill="#94a3b8">≈ 69% less schema context per session · recall injects the answer the agent would otherwise re-derive (~160-token budget).</text>
+  <text x="788" y="636" font-size="34" font-weight="800" fill="#38bdf8" text-anchor="middle">69%</text>
   <text x="788" y="658" font-size="11" fill="#94a3b8" text-anchor="middle">less context overhead</text>
 </svg>

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -433,9 +433,9 @@ The live MCP server is profile-gated by `MEMO_MCP_PROFILE`:
 
 | Profile | Tool count | Schema tokens | Use |
 |---|---:|---:|---|
-| `agent` (default) | 41 | ~4.1k | Essential memory, evidence, continuity, lifecycle, terminal status, and outcome-learning surface. |
-| `core` / `slim` | 58 | ~5.3k | Agent tools plus CRUD, embeddings, history, sessions, and lint. |
-| `full` / `default` | 164 | ~18.1k | Every advanced domain module and diagnostic tool. |
+| `agent` (default) | 41 | ~9.4k | Essential memory, evidence, continuity, lifecycle, terminal status, and outcome-learning surface. |
+| `core` / `slim` | 58 | ~12.9k | Agent tools plus CRUD, embeddings, history, sessions, and lint. |
+| `full` / `default` | 164 | ~30.4k | Every advanced domain module and diagnostic tool. |
 
 Mutating MCP calls pass through a bounded process-local FIFO by default
 (`MEMO_MCP_WRITE_QUEUE_SIZE=32`); read-only calls bypass it. The
@@ -1375,8 +1375,8 @@ read-only, `$EDITOR`, and backup restore paths.
 
 ### Token economy
 
-The default MCP profile exposes 41 tools (~4.1k schema tokens), compared with
-164 tools (~18.1k) on the full profile. The bundled Claude Code recall hook also
+The default MCP profile exposes 41 tools (~9.4k schema tokens), compared with
+164 tools (~30.4k) on the full profile. The bundled Claude Code recall hook also
 pins `MEMO_RECALL_TOP_K=1` and `MEMO_RECALL_TOKEN_BUDGET=160`; the general
 runtime default remains 600 tokens for clients that do not use that hook.
 

--- a/src/memo/__init__.py
+++ b/src/memo/__init__.py
@@ -55,6 +55,11 @@ def _checkout_version(pkg_init: Path) -> str | None:
     ``None`` whenever ``pkg_init`` is not the ``<repo>/src/memo/__init__.py`` of
     an mlx-memo checkout — which is every installed distribution, and also any
     unrelated project that happens to vendor a ``src/memo/``.
+
+    Identity is decided on the *parsed* ``[project] name``: the literal string
+    ``name = "mlx-memo"`` can appear anywhere in a foreign pyproject (a vendoring
+    manifest, a ``[tool.uv.sources]`` pin, a comment) without that file declaring
+    this distribution.
     """
     if pkg_init.parent.parent.name != "src":
         return None
@@ -62,15 +67,16 @@ def _checkout_version(pkg_init: Path) -> str | None:
         text = (pkg_init.parents[2] / "pyproject.toml").read_text(encoding="utf-8")
     except OSError:
         return None
-    if 'name = "mlx-memo"' not in text:
-        return None
     import tomllib
 
     try:
         data = tomllib.loads(text)
     except tomllib.TOMLDecodeError:
         return None
-    declared = data.get("project", {}).get("version")
+    project = data.get("project")
+    if not isinstance(project, dict) or project.get("name") != "mlx-memo":
+        return None
+    declared = project.get("version")
     return declared if isinstance(declared, str) else None
 
 

--- a/src/memo/__init__.py
+++ b/src/memo/__init__.py
@@ -9,8 +9,8 @@
 - Vector store: `sqlite-vec` (single file, no daemon, no Qdrant).
 - Storage of record: markdown files under `MEMO_DATA_DIR`, or under
   `<vault>/<SYSTEM_DIR>/AI/memory/` when `MEMO_MEMORIES_IN_VAULT=1`.
-- MCP server: `fastmcp`, profile-gated from the 30-tool `agent`
-  surface through the 158-tool `full` surface.
+- MCP server: `fastmcp`, profile-gated from the 41-tool `agent`
+  surface through the 164-tool `full` surface.
 
 Public API:
 
@@ -23,6 +23,7 @@ Public API:
 """
 
 import os
+from pathlib import Path
 
 # Silence HuggingFace hub progress/download bars globally, before any model
 # load. Otherwise embedder/llm/reranker loads, prewarm, and daemon startups
@@ -39,17 +40,55 @@ from memo.config import Config  # noqa: E402
 from memo.memory import Memory, MemoryRecord  # noqa: E402
 
 # Single source of truth lives in pyproject.toml `[project] version`.
-# Resolve at import time from the installed distribution metadata so
-# `memo.__version__` always matches `pip show mlx-memo`. Falls back to
-# a sentinel when running from an uninstalled checkout.
-try:
-    from importlib.metadata import PackageNotFoundError
-    from importlib.metadata import version as _version
+#
+# Distribution metadata is only a *snapshot* of that. For an editable install
+# the snapshot goes stale the instant the version is bumped — nothing rewrites
+# `.dist-info` until someone reinstalls — so trusting it makes freshly bumped
+# source report the previous release (this is how 4.9.3's code reported 4.9.2).
+# A source checkout is therefore authoritative for its own version; an
+# installed wheel has no pyproject above it and falls through to the metadata.
 
-    __version__ = _version("mlx-memo")
-except PackageNotFoundError:  # pragma: no cover — editable install w/o metadata
-    __version__ = "0.0.0+unknown"
-except Exception:  # pragma: no cover — defensive
-    __version__ = "0.0.0+unknown"
+
+def _checkout_version(pkg_init: Path) -> str | None:
+    """Version declared by the mlx-memo checkout that owns ``pkg_init``.
+
+    ``None`` whenever ``pkg_init`` is not the ``<repo>/src/memo/__init__.py`` of
+    an mlx-memo checkout — which is every installed distribution, and also any
+    unrelated project that happens to vendor a ``src/memo/``.
+    """
+    if pkg_init.parent.parent.name != "src":
+        return None
+    try:
+        text = (pkg_init.parents[2] / "pyproject.toml").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if 'name = "mlx-memo"' not in text:
+        return None
+    import tomllib
+
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError:
+        return None
+    declared = data.get("project", {}).get("version")
+    return declared if isinstance(declared, str) else None
+
+
+def _resolve_version() -> str:
+    checkout = _checkout_version(Path(__file__).resolve())
+    if checkout is not None:
+        return checkout
+    try:
+        from importlib.metadata import PackageNotFoundError
+        from importlib.metadata import version as _version
+
+        return _version("mlx-memo")
+    except PackageNotFoundError:  # pragma: no cover — checkout w/o metadata
+        return "0.0.0+unknown"
+    except Exception:  # pragma: no cover — defensive
+        return "0.0.0+unknown"
+
+
+__version__ = _resolve_version()
 
 __all__ = ["Config", "Memory", "MemoryRecord", "__version__"]

--- a/src/memo/cli_banner.py
+++ b/src/memo/cli_banner.py
@@ -1,7 +1,7 @@
 """`memo startup-banner` — prints [Memo ver] status at agent launch.
 
 Called by agent shims (installed via `memo install-shims`). Must stay
-fast and MLX-free: only git + importlib.metadata, no embedding.
+fast and MLX-free: only git + `memo.__version__`, no embedding.
 
 For opencode the printed banner is wiped by its TUI, so we also stamp the
 live memo version into opencode's `username` — the only config-controlled
@@ -23,12 +23,7 @@ import click
 @click.option("--agent", default="", help="Agent name shown in header (e.g. codex).")
 def startup_banner_cmd(agent: str) -> None:
     """Print memo status banner to stderr. Called by agent shims on startup."""
-    import importlib.metadata
-
-    try:
-        version = importlib.metadata.version("mlx-memo")
-    except Exception:
-        version = "?"
+    from memo import __version__ as version
 
     sync_str = _fast_sync_state()
     update_tag = _pending_update_tag()

--- a/src/memo/cli_doctor.py
+++ b/src/memo/cli_doctor.py
@@ -531,8 +531,8 @@ def doctor(
             console.print(
                 f"[yellow]![/yellow] token cost: {_profile_label}  {_tool_count} tools "
                 f"({_tok_cost} tokens/connection)  "
-                "[dim](set MEMO_MCP_PROFILE=agent for 41 tools / ~4.1k tokens, or "
-                "`memo install-mcp --profile core` for 58 tools / ~5.3k tokens — "
+                "[dim](set MEMO_MCP_PROFILE=agent for 41 tools / ~9.4k tokens, or "
+                "`memo install-mcp --profile core` for 58 tools / ~12.9k tokens — "
                 "for constrained clients)[/dim]"
             )
         try:

--- a/src/memo/cli_install_mcp.py
+++ b/src/memo/cli_install_mcp.py
@@ -366,12 +366,7 @@ def _seed_install_memory() -> None:
         stamp = cfg.state_dir / ".install_seed.json"
         if stamp.exists():
             return
-        try:
-            from importlib.metadata import version as _pkg_version
-
-            ver = _pkg_version("mlx-memo")
-        except Exception:
-            ver = "unknown"
+        from memo import __version__ as ver
         from memo.memory import Memory
 
         cfg.state_dir.mkdir(parents=True, exist_ok=True)

--- a/src/memo/cli_install_mcp.py
+++ b/src/memo/cli_install_mcp.py
@@ -276,8 +276,8 @@ def _report(result: dict[str, Any]) -> None:
     "--profile",
     default="",
     type=click.Choice(["", "core", "slim", "default"], case_sensitive=False),
-    help="MCP surface profile. 'core'/'slim' expose 58 tools (~5.3k tokens); "
-    "'default' exposes all 164 tools (~18.1k tokens). "
+    help="MCP surface profile. 'core'/'slim' expose 58 tools (~12.9k tokens); "
+    "'default' exposes all 164 tools (~30.4k tokens). "
     "Constrained clients (codex, opencode) default to 'core' automatically.",
 )
 def install_mcp(

--- a/src/memo/import_export.py
+++ b/src/memo/import_export.py
@@ -26,13 +26,14 @@ _EXPORT_PAGE_SIZE = 10_000
 
 
 def _generator_string() -> str:
-    """``memo/<version>`` for the passport header, or ``memo`` if unknown."""
-    from importlib.metadata import PackageNotFoundError, version
+    """``memo/<version>`` for the passport header.
 
-    try:
-        return f"memo/{version('mlx-memo')}"
-    except PackageNotFoundError:
-        return "memo"
+    Provenance of the code that wrote the file, so it reads the same single
+    source as ``memo --version``.
+    """
+    from memo import __version__
+
+    return f"memo/{__version__}"
 
 
 @contextmanager

--- a/src/memo/runtime/agent_registry.py
+++ b/src/memo/runtime/agent_registry.py
@@ -593,12 +593,11 @@ def verify_agent(
         and memo_cli.parent == runtime.parent
     )
 
-    try:
-        from importlib.metadata import version
-
-        runtime_version = version("mlx-memo")
-    except Exception:  # pragma: no cover - editable/uninstalled source tree
-        runtime_version = "unknown"
+    # The version this process *is* — `memo doctor` prints it, and the smoke
+    # probe asserts the isolated `memo` binary reports the same one. Reading
+    # distribution metadata here would make `memo doctor` disagree with
+    # `memo --version` in the very checkout being verified.
+    from memo import __version__ as runtime_version
 
     config_ok, config_runtime, profile_current, config_detail = _probe_agent_configuration(
         adapter=adapter,

--- a/src/memo/runtime/codex_notify.py
+++ b/src/memo/runtime/codex_notify.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import importlib.metadata
 import os
 from pathlib import Path
 
@@ -39,11 +38,9 @@ def emit_codex_notify(title: str, body: str = "") -> bool:
 
 
 def memo_version_badge() -> str:
-    try:
-        version = importlib.metadata.version("mlx-memo")
-    except Exception:
-        version = "?"
-    return f"[Memo {version}]"
+    from memo import __version__
+
+    return f"[Memo {__version__}]"
 
 
 def emit_memo_badge() -> bool:

--- a/src/memo/runtime/update.py
+++ b/src/memo/runtime/update.py
@@ -344,7 +344,12 @@ def self_update(stray: str | None, check: bool, to_tag: str | None) -> None:
     # renamed memory-edit command instead of silently self-updating.
     if stray is not None:
         raise click.ClickException(f"did you mean `memo edit {stray}`?")
-    current_version = importlib.metadata.version("mlx-memo")
+    # Same source the background auto-updater compares against
+    # (`runtime/autoupdate.py` uses `memo.__version__`); reading distribution
+    # metadata here instead would let the two paths disagree about what
+    # "current" is.
+    from memo import __version__ as current_version
+
     console.print(f"[dim]current version:[/dim] {current_version}")
 
     # An editable/dev install (project .venv) can't be updated by this command —

--- a/src/memo/server.py
+++ b/src/memo/server.py
@@ -128,15 +128,11 @@ _SERVER_INSTRUCTIONS = (
 async def _health_route_handler(request):  # type: ignore[no-untyped-def]
     """Lightweight HTTP liveness probe without touching Memory."""
 
-    import importlib.metadata
-
     from starlette.responses import JSONResponse
 
-    try:
-        version = importlib.metadata.version("mlx-memo")
-    except Exception:
-        version = "unknown"
-    return JSONResponse({"ok": True, "version": version})
+    from memo import __version__
+
+    return JSONResponse({"ok": True, "version": __version__})
 
 
 def _chat_event_stream(

--- a/src/memo/surface.py
+++ b/src/memo/surface.py
@@ -186,9 +186,9 @@ def mcp_tools_to_remove() -> frozenset[str]:
 # Per-profile token-cost estimates for the `memo doctor` advisory. Reduced
 # profiles (agent/core/slim) are cheap; only the full/default surface warns.
 _PROFILE_TOKEN_COST: dict[str, tuple[str, str]] = {
-    "agent": ("41", "~4.1k"),
-    "core": ("58", "~5.3k"),
-    "slim": ("58", "~5.3k"),
+    "agent": ("41", "~9.4k"),
+    "core": ("58", "~12.9k"),
+    "slim": ("58", "~12.9k"),
 }
 
 
@@ -197,5 +197,5 @@ def mcp_profile_token_cost(profile: str | None = None) -> tuple[str, str, bool]:
     (or the active profile when ``None``). ``is_reduced`` is False only for the
     full/default surface — the costly one doctor warns about."""
     resolved = profile if profile is not None else mcp_profile()
-    count, cost = _PROFILE_TOKEN_COST.get(resolved, ("164", "~18.1k"))
+    count, cost = _PROFILE_TOKEN_COST.get(resolved, ("164", "~30.4k"))
     return count, cost, resolved in _PROFILE_TOKEN_COST

--- a/tests/conformance/test_mcp_response_budget.py
+++ b/tests/conformance/test_mcp_response_budget.py
@@ -430,7 +430,7 @@ async def test_every_tool_result_fits_its_cap(
     monkeypatch.setattr(STEmbedder, "_ensure_loaded", _no_live_model)
     monkeypatch.setattr(MLXChat, "chat", _stub_chat)
 
-    # -- Full MCP surface (162 tools), not the 41-tool "agent" default profile
+    # -- Full MCP surface (164 tools), not the 41-tool "agent" default profile
     # mcp_profile() falls back to -- the two originally-measured defects
     # (memo_graph_export, memo_lint's advanced siblings) live in the
     # advanced-only tool set gated behind "full"/"default".

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import subprocess
-from importlib.metadata import version
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
 
+from memo import __version__
 from memo import cli_setup as cli_setup_module
 from memo.cli_setup import setup_cmd
 from memo.config import Config
@@ -234,7 +234,7 @@ def test_agent_doctor_verifies_runtime_profile_protocol_and_isolated_smoke(
         if args[:4] == ["codex", "mcp", "get", "memo"]:
             stdout = f"command: {runtime}\nenv: MEMO_MCP_PROFILE=core\n"
         elif "--version" in args:
-            stdout = f"memo, version {version('mlx-memo')}\n"
+            stdout = f"memo, version {__version__}\n"
         elif "save" in args:
             stdout = '{"id":"smoke-id"}'
         elif "search" in args:
@@ -455,7 +455,7 @@ def test_isolated_runtime_smoke_reports_command_failure(monkeypatch, tmp_path: P
     )
 
     smoke_ok, version_ok, detail = registry._isolated_runtime_smoke(
-        runtime, expected_version=version("mlx-memo")
+        runtime, expected_version=__version__
     )
 
     assert smoke_ok is False

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import base64
-import importlib.metadata
 import json
 import os
 import pty
@@ -12,6 +11,7 @@ import subprocess
 
 from click.testing import CliRunner
 
+import memo
 from memo.cli import cli
 from memo.runtime.shims import install_path_snippet, install_shims
 
@@ -267,11 +267,7 @@ def test_codex_badge_uses_memo_notify_protocol(tmp_cfg, tmp_path, monkeypatch) -
     tty = tmp_path / "tty"
     tty.touch()
     monkeypatch.setenv("MEMO_AGENT_TTY", str(tty))
-    monkeypatch.setattr(
-        importlib.metadata,
-        "version",
-        lambda name: "9.8.7" if name == "mlx-memo" else "0",
-    )
+    monkeypatch.setattr(memo, "__version__", "9.8.7")
 
     result = CliRunner().invoke(
         cli,

--- a/tests/test_surface_profiles.py
+++ b/tests/test_surface_profiles.py
@@ -175,7 +175,7 @@ def test_token_cost_recognizes_agent() -> None:
 
     count, cost, reduced = mcp_profile_token_cost("agent")
     assert count == "41"
-    assert cost == "~4.1k"
+    assert cost == "~9.4k"
     assert reduced is True
 
 
@@ -185,7 +185,7 @@ def test_token_cost_core_and_slim_are_reduced() -> None:
     for profile in ("core", "slim"):
         count, cost, reduced = mcp_profile_token_cost(profile)
         assert count == "58"
-        assert cost == "~5.3k"
+        assert cost == "~12.9k"
         assert reduced is True
 
 
@@ -195,7 +195,7 @@ def test_token_cost_full_is_not_reduced() -> None:
     for profile in ("full", "default"):
         count, cost, reduced = mcp_profile_token_cost(profile)
         assert count == "164"
-        assert cost == "~18.1k"
+        assert cost == "~30.4k"
         assert reduced is False
 
 
@@ -206,7 +206,7 @@ def test_token_cost_active_default_resolves_to_agent(monkeypatch) -> None:
 
     count, cost, reduced = mcp_profile_token_cost()
     assert count == "41"
-    assert cost == "~4.1k"
+    assert cost == "~9.4k"
     assert reduced is True
 
 
@@ -235,3 +235,73 @@ def test_token_cost_count_matches_real_server(tmp_path, monkeypatch, profile) ->
 
     count_label, _cost, _reduced = mcp_profile_token_cost(profile)
     assert len(tools) == int(count_label)
+
+
+def _measure_wire_tokens(tmp_path, monkeypatch, profile: str) -> tuple[int, int]:
+    """Measure the real `tools/list` payload for `profile`.
+
+    Returns ``(tool_count, estimated_tokens)``. The payload is what a client
+    actually pays for on every connection — ``name`` + ``description`` +
+    ``inputSchema`` per tool, serialized as compact JSON — sized with memo's
+    own chars/4 estimator so the advisory label speaks the same units as the
+    rest of memo's token accounting.
+    """
+    import json
+
+    from memo.eval_tokens import count_tokens
+
+    cfg = Config(
+        data_dir=tmp_path / "data",
+        state_dir=tmp_path / "state",
+        vault_path=tmp_path / "vault",
+        embedder_dims=4,
+    )
+    monkeypatch.setenv("MEMO_MCP_PROFILE", profile)
+    monkeypatch.delenv("MEMO_MCP_SLIM", raising=False)
+    mem = Memory(cfg)
+    try:
+        tools = asyncio.run(build_server(memory=mem).list_tools())
+    finally:
+        mem.close()
+
+    payload = []
+    for tool in tools:
+        mcp_tool = tool.to_mcp_tool()
+        payload.append(
+            {
+                "name": mcp_tool.name,
+                "description": mcp_tool.description or "",
+                "inputSchema": mcp_tool.inputSchema,
+            }
+        )
+    wire = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+    return len(tools), count_tokens(wire)
+
+
+# The label is an advisory rounded to 0.1k, so it must not red on byte-level
+# churn in one tool description — but it must red on the ~2x understatement
+# that let "~18.1k" survive against a 30k surface.
+_LABEL_TOLERANCE = 0.05
+
+
+@pytest.mark.parametrize("profile", ["agent", "core", "full"])
+def test_token_cost_label_matches_measured_wire_payload(tmp_path, monkeypatch, profile) -> None:
+    """`_PROFILE_TOKEN_COST` is hand-maintained; this is what re-derives it.
+
+    Run this test to get the current number: on a mismatch the failure message
+    carries the exact label to paste in. Keep `docs/`, `README.md`, and the
+    `install-mcp`/`doctor` advisories in step with it — they quote the same
+    figures.
+    """
+    from memo.surface import mcp_profile_token_cost
+
+    count, measured = _measure_wire_tokens(tmp_path, monkeypatch, profile)
+    count_label, cost_label, _reduced = mcp_profile_token_cost(profile)
+
+    assert count == int(count_label)
+
+    claimed = float(cost_label.removeprefix("~").removesuffix("k")) * 1000
+    assert abs(claimed - measured) <= _LABEL_TOLERANCE * measured, (
+        f"{profile} profile advertises {cost_label} but its {count} tool schemas "
+        f"measure {measured} tokens — update the label to ~{measured / 1000:.1f}k"
+    )

--- a/tests/test_version_single_source.py
+++ b/tests/test_version_single_source.py
@@ -1,0 +1,129 @@
+"""`memo.__version__` must describe the code that is actually running.
+
+`pyproject.toml` `[project].version` is the single source of truth. An
+installed distribution carries a *snapshot* of it in its `.dist-info`
+metadata, and for an **editable** install that snapshot goes stale the moment
+the version is bumped — nothing rewrites it until someone reinstalls. That is
+how the running 4.9.3 source came to report `memo.__version__ == "4.9.2"`.
+
+So the resolution order is: a source checkout is authoritative for its own
+version; everywhere else (a real wheel in site-packages, where no pyproject
+exists) the distribution metadata is.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+
+def _checkout_root(pkg_init: Path) -> Path | None:
+    """Repo root for a `<repo>/src/memo/__init__.py` layout, else None."""
+    if pkg_init.parent.parent.name != "src":
+        return None
+    return pkg_init.parents[2]
+
+
+def test_version_matches_the_checkout_it_is_imported_from() -> None:
+    """The end-to-end invariant: when `memo` is imported from a source
+    checkout, `memo.__version__` equals that checkout's declared version.
+
+    This is the drift itself — a stale editable `.dist-info` reporting the
+    previous release while the source on disk is the next one.
+    """
+    import memo
+
+    pkg_init = Path(memo.__file__).resolve()
+    repo = _checkout_root(pkg_init)
+    if repo is None:
+        pytest.skip(f"memo imported from an installed distribution, not a checkout: {pkg_init}")
+
+    declared = tomllib.loads((repo / "pyproject.toml").read_text(encoding="utf-8"))["project"][
+        "version"
+    ]
+
+    assert memo.__version__ == declared, (
+        f"memo.__version__ is {memo.__version__!r} but {repo}/pyproject.toml "
+        f"declares {declared!r} — the running code reports a different release "
+        f"than the one it is"
+    )
+
+
+def _make_checkout(root: Path, *, version: str, name: str = "mlx-memo") -> Path:
+    """Build `<root>/{pyproject.toml,src/memo/__init__.py}`; return the __init__."""
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "{name}"\nversion = "{version}"\n', encoding="utf-8"
+    )
+    pkg = root / "src" / "memo"
+    pkg.mkdir(parents=True)
+    init = pkg / "__init__.py"
+    init.write_text("# memo\n", encoding="utf-8")
+    return init
+
+
+def test_checkout_version_wins_over_installed_metadata(tmp_path: Path) -> None:
+    """A checkout's pyproject version is returned verbatim — not the version of
+    whatever `mlx-memo` distribution happens to be installed in this venv."""
+    from importlib.metadata import version as installed_version
+
+    from memo import _checkout_version
+
+    init = _make_checkout(tmp_path, version="99.98.97")
+
+    resolved = _checkout_version(init)
+
+    assert resolved == "99.98.97"
+    assert resolved != installed_version("mlx-memo")
+
+
+def test_site_packages_layout_defers_to_metadata(tmp_path: Path) -> None:
+    """An installed wheel lives at `<site-packages>/memo/__init__.py` — no `src`
+    parent, no pyproject — so the resolver must decline and let the
+    distribution metadata answer."""
+    from memo import _checkout_version
+
+    pkg = tmp_path / "site-packages" / "memo"
+    pkg.mkdir(parents=True)
+    init = pkg / "__init__.py"
+    init.write_text("# memo\n", encoding="utf-8")
+
+    assert _checkout_version(init) is None
+
+
+def test_foreign_project_with_a_src_memo_is_ignored(tmp_path: Path) -> None:
+    """Some other project vendoring a `src/memo/` must not donate its version."""
+    from memo import _checkout_version
+
+    init = _make_checkout(tmp_path, version="1.0.0", name="not-mlx-memo")
+
+    assert _checkout_version(init) is None
+
+
+def test_missing_pyproject_defers_to_metadata(tmp_path: Path) -> None:
+    """A `src/memo/` with no pyproject above it (e.g. a partial copy) resolves
+    to None rather than raising at import time."""
+    from memo import _checkout_version
+
+    pkg = tmp_path / "src" / "memo"
+    pkg.mkdir(parents=True)
+    init = pkg / "__init__.py"
+    init.write_text("# memo\n", encoding="utf-8")
+
+    assert _checkout_version(init) is None
+
+
+def test_malformed_pyproject_defers_to_metadata(tmp_path: Path) -> None:
+    """Invalid TOML must not break `import memo`."""
+    from memo import _checkout_version
+
+    (tmp_path / "pyproject.toml").write_text(
+        'name = "mlx-memo" this is not [ valid toml !!!\n', encoding="utf-8"
+    )
+    pkg = tmp_path / "src" / "memo"
+    pkg.mkdir(parents=True)
+    init = pkg / "__init__.py"
+    init.write_text("# memo\n", encoding="utf-8")
+
+    assert _checkout_version(init) is None

--- a/tests/test_version_single_source.py
+++ b/tests/test_version_single_source.py
@@ -13,10 +13,20 @@ exists) the distribution metadata is.
 
 from __future__ import annotations
 
+import re
 import tomllib
 from pathlib import Path
 
 import pytest
+
+SRC = Path(__file__).resolve().parents[1] / "src" / "memo"
+
+# `version("mlx-memo")` in any spelling — `importlib.metadata.version(...)`,
+# a `from importlib.metadata import version` call, or an aliased
+# `_version` / `_pkg_version`. `distribution("mlx-memo")` is deliberately not
+# matched: `runtime/update.py` reads `direct_url.json` off it for install
+# provenance, which is metadata's job and has nothing to do with the version.
+_METADATA_VERSION_CALL = re.compile(r'version\s*\(\s*["\']mlx-memo["\']\s*\)')
 
 
 def _checkout_root(pkg_init: Path) -> Path | None:
@@ -79,15 +89,25 @@ def test_checkout_version_wins_over_installed_metadata(tmp_path: Path) -> None:
 
 
 def test_site_packages_layout_defers_to_metadata(tmp_path: Path) -> None:
-    """An installed wheel lives at `<site-packages>/memo/__init__.py` — no `src`
-    parent, no pyproject — so the resolver must decline and let the
-    distribution metadata answer."""
+    """An installed wheel lives at `<site-packages>/memo/__init__.py`. The
+    directory two levels up is *not* the wheel's own project, so its pyproject
+    must never be read — only a `src` parent marks a checkout.
+
+    A real mlx-memo pyproject is planted exactly where a missing `src` check
+    would look (`pkg.parents[2]`, the layout `pip install --target
+    site-packages` produces inside a checkout), so this fails if that guard is
+    dropped instead of passing through the no-pyproject path.
+    """
     from memo import _checkout_version
 
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "mlx-memo"\nversion = "99.98.97"\n', encoding="utf-8"
+    )
     pkg = tmp_path / "site-packages" / "memo"
     pkg.mkdir(parents=True)
     init = pkg / "__init__.py"
     init.write_text("# memo\n", encoding="utf-8")
+    assert (init.parents[2] / "pyproject.toml").is_file(), "fixture must bait the missing guard"
 
     assert _checkout_version(init) is None
 
@@ -99,6 +119,50 @@ def test_foreign_project_with_a_src_memo_is_ignored(tmp_path: Path) -> None:
     init = _make_checkout(tmp_path, version="1.0.0", name="not-mlx-memo")
 
     assert _checkout_version(init) is None
+
+
+def test_foreign_project_merely_mentioning_mlx_memo_is_ignored(tmp_path: Path) -> None:
+    """Identity comes from the parsed `[project] name`, not from the bytes.
+
+    A vendoring manifest / dependency pin / comment can carry the literal
+    `name = "mlx-memo"` while `[project] name` is someone else — a raw
+    substring test hands that project's version to `memo.__version__`.
+    """
+    from memo import _checkout_version
+
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "acme-agents"\n'
+        'version = "9.9.9"\n'
+        "\n"
+        "[[tool.acme.vendored]]\n"
+        'name = "mlx-memo"\n'
+        'revision = "v4.9.3"\n',
+        encoding="utf-8",
+    )
+    pkg = tmp_path / "src" / "memo"
+    pkg.mkdir(parents=True)
+    init = pkg / "__init__.py"
+    init.write_text("# memo\n", encoding="utf-8")
+
+    assert _checkout_version(init) is None
+
+
+def test_resolve_falls_back_to_installed_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The branch every *installed* user takes.
+
+    `_checkout_version` returns None off a checkout (wheel in site-packages),
+    and `_resolve_version` must then answer with the distribution metadata
+    rather than a placeholder. Unreachable in a source checkout otherwise, so
+    the checkout probe is stubbed to the None it returns when installed.
+    """
+    from importlib.metadata import version as installed_version
+
+    import memo
+
+    monkeypatch.setattr(memo, "_checkout_version", lambda _pkg_init: None)
+
+    assert memo._resolve_version() == installed_version("mlx-memo")
 
 
 def test_missing_pyproject_defers_to_metadata(tmp_path: Path) -> None:
@@ -127,3 +191,79 @@ def test_malformed_pyproject_defers_to_metadata(tmp_path: Path) -> None:
     init.write_text("# memo\n", encoding="utf-8")
 
     assert _checkout_version(init) is None
+
+
+def test_only_the_resolver_reads_installed_metadata_for_the_version() -> None:
+    """One reader of distribution metadata, and it is the fallback in
+    `_resolve_version`.
+
+    Fixing `memo.__version__` alone is not enough: every surface that answers
+    "what version is this?" has to route through it, or a dev checkout reports
+    4.9.3 from `memo --version` and 4.9.2 from the passport header / `/health`
+    / the doctor probe standing right next to it.
+    """
+    offenders = [
+        f"{path.relative_to(SRC.parent.parent)}:{lineno}: {line.strip()}"
+        for path in sorted(SRC.rglob("*.py"))
+        if path.name != "__init__.py"
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
+        if _METADATA_VERSION_CALL.search(line)
+    ]
+
+    assert offenders == [], (
+        "these read the installed distribution's version snapshot instead of "
+        "`memo.__version__`, so they go stale on an editable install the moment "
+        "the version is bumped:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_every_version_surface_reports_the_single_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Behavioural half of the guard above: pin `memo.__version__` to a
+    sentinel and every surface must echo it.
+
+    Only works because each call site imports the attribute at call time; a
+    site reading `importlib.metadata` reports the real installed version and
+    fails here.
+    """
+    import memo
+    from memo.import_export import _generator_string
+    from memo.runtime.codex_notify import memo_version_badge
+
+    monkeypatch.setattr(memo, "__version__", "77.66.55")
+
+    assert _generator_string() == "memo/77.66.55"
+    assert memo_version_badge() == "[Memo 77.66.55]"
+
+
+def test_mcp_health_route_reports_the_single_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The FastMCP server's `/health` liveness payload — a separate route from
+    `server_http.py`'s `/health`, and the one the version fix originally
+    claimed but missed."""
+    import asyncio
+    import json
+
+    pytest.importorskip("starlette")
+
+    import memo
+    from memo.server import _health_route_handler
+
+    monkeypatch.setattr(memo, "__version__", "77.66.55")
+
+    response = asyncio.run(_health_route_handler(None))
+
+    assert json.loads(bytes(response.body)) == {"ok": True, "version": "77.66.55"}
+
+
+def test_startup_banner_reports_the_single_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`memo startup-banner` stamps `[Memo <ver>]` into every agent launch."""
+    from click.testing import CliRunner
+
+    import memo
+    from memo.cli_banner import startup_banner_cmd
+
+    monkeypatch.setattr(memo, "__version__", "77.66.55")
+
+    result = CliRunner().invoke(startup_banner_cmd, [])
+
+    assert result.exit_code == 0, result.output
+    assert "[Memo 77.66.55]" in result.output


### PR DESCRIPTION
## What

Three drifts, all found by measuring rather than reading docs:

1. **`memo.__version__` said 4.9.2 while `pyproject.toml` said 4.9.3** — a hardcoded duplicate that was not bumped with the release. Now derived from the checkout's `pyproject.toml`, falling back to installed distribution metadata.
2. **Seven call sites read `importlib.metadata` directly**, so in a dev checkout adjacent code paths reported *different* versions (`memo.__version__` 4.9.3 vs `_generator_string()` `memo/4.9.2`). All seven now route through the single source: FastMCP `/health`, the passport `generator` header, the launch banner, the install seed memory, `memo update`, the codex badge, and `memo doctor`'s `runtime_version`.
3. **Two SVGs still claimed 162 tools** and the token labels understated the real wire payload. Re-measured off an actual `tools/list`: agent 41 tools / 9,373 tokens, full 164 / 30,429.

Deliberately left alone: `runtime/update.py:88` reads `direct_url.json` for install *provenance* (editable vs isolated), which is not a version.

## Behavior change worth reviewing

`memo doctor`'s `runtime_version_match` now compares the isolated binary against the checkout version rather than the editable `.dist-info` snapshot. Installed runtimes are unaffected. A dev checkout whose isolated tool is a release behind now **reports** that mismatch instead of hiding it behind two equally stale numbers — which is exactly the drift that motivated this branch.

## Verification

Every test was proven against the mutation it claims to catch, with the red output captured:

- Removing the src-layout guard → `AssertionError: assert '99.98.97' is None`. The first draft of this test was **vacuous** — it passed with the guard removed, because its fixture had no `pyproject.toml` anywhere above it and returned `None` via the `OSError` path regardless. Fixture rebuilt so it discriminates.
- Reverting the parsed-`project.name` identity check to the old raw substring test → a foreign project merely mentioning `mlx-memo` is picked up.
- Stubbing the installed-metadata fallback (dead in CI coverage before this branch, since every CI run takes the checkout path) → caught.
- Reverting all seven call sites → 6 failures, with a structural scanner naming each file:line.

## Also

README stated "about 75% fewer tool schemas" next to figures yielding 69%. Both ratios are real and different — 75.0% fewer *tools*, 69.2% fewer *schema tokens* — so the sentence now names both instead of labelling one with the other's number.