### PR TITLE
fix: collapse parent_path chunk floods, not just parent_id ones

### DIFF
--- a/src/memo/flags_search.py
+++ b/src/memo/flags_search.py
@@ -383,12 +383,18 @@ SPECS: tuple[FlagSpec, ...] = (
         "bool",
         False,
         "search",
-        "Map winning reference-tier CHUNK hits (extra.parent_id from "
-        "MEMO_CHUNK_INGEST) back to their parent memory in explicit search: "
-        "the parent surfaces once at the best chunk's rank/score, deduped "
-        "against parents already in the result list. Skipped when the caller "
+        "Collapse winning reference-tier CHUNK hits in explicit search so one "
+        "source document cannot flood the result. Two ingest schemas, both "
+        "handled: extra.parent_id (MEMO_CHUNK_INGEST) resolves to the parent "
+        "memory, which surfaces once at the best chunk's rank/score; "
+        "extra.parent_path (`memo ingest --chunk`, which materializes no "
+        "parent record) keeps the best-ranked chunk of each source document — "
+        "a real, citable row — and drops its siblings. Collapsing runs on a "
+        "widened candidate pool, so freed slots refill with the next distinct "
+        "documents instead of shrinking the result. Skipped when the caller "
         "filters type='reference'. Recall hook unaffected (reference tier is "
-        "SQL-excluded there). Off by default — eval-gated before any flip.",
+        "SQL-excluded there, and the pool is not widened when it is). Off by "
+        "default — eval-gated before any flip.",
     ),
     _spec(
         "MEMO_ASK_MULTI_ROUND",

--- a/src/memo/memory/search_ops.py
+++ b/src/memo/memory/search_ops.py
@@ -601,6 +601,28 @@ class _SearchOpsMixin(_MemoryBase):
             )
             return [], None
 
+    def _chunk_parent_pool_limit(
+        self, limit: int, type_: str | None, exclude_types: set[str] | None
+    ) -> int:
+        """Candidate-pool size that leaves room for chunk→parent collapsing.
+
+        Collapsing removes hits by design (every chunk of one source document
+        becomes one), so without slack the caller silently gets fewer results
+        than it asked for. Widen the pool enough that the collapse refills
+        from the next distinct documents.
+
+        Widen only when a chunk can actually reach the pool: with the flag off
+        (the default) this is the identity, and it stays the identity when the
+        caller asked for the reference tier explicitly (`_stage_chunk_parent`
+        skips those) or excluded it entirely — the recall hook's case, where a
+        4x pool would spend the 5s budget fetching rows that cannot collapse.
+        """
+        if not flag_bool("MEMO_SEARCH_CHUNK_PARENT"):
+            return limit
+        if type_ in REFERENCE_TYPES or (exclude_types and exclude_types >= REFERENCE_TYPES):
+            return limit
+        return limit * _CHUNK_PARENT_POOL_FACTOR
+
     def _build_candidate_pool(
         self,
         query: str,
@@ -630,11 +652,11 @@ class _SearchOpsMixin(_MemoryBase):
         """
         emb = None  # set in vec/hybrid branches; consumed by feedback boost below
 
-        emb = None  # set in vec/hybrid branches; consumed by feedback boost below
+        pool_limit = self._chunk_parent_pool_limit(limit, type_, exclude_types)
 
         if mode == "bm25":
             rows = self.store.search_bm25(
-                query, limit=limit, type_=type_, exclude_types=exclude_types, as_of=as_of
+                query, limit=pool_limit, type_=type_, exclude_types=exclude_types, as_of=as_of
             )
             emit(
                 trace,
@@ -649,7 +671,7 @@ class _SearchOpsMixin(_MemoryBase):
             # outranks the same term buried in a body. See search_bm25.
             rows = self.store.search_bm25(
                 query,
-                limit=limit,
+                limit=pool_limit,
                 type_=type_,
                 exclude_types=exclude_types,
                 field_boost="exact",
@@ -664,7 +686,7 @@ class _SearchOpsMixin(_MemoryBase):
             )
         elif mode == "fuzzy":
             rows = self.store.search_fuzzy(
-                query, limit=limit, type_=type_, exclude_types=exclude_types, as_of=as_of
+                query, limit=pool_limit, type_=type_, exclude_types=exclude_types, as_of=as_of
             )
             emit(
                 trace,
@@ -681,7 +703,7 @@ class _SearchOpsMixin(_MemoryBase):
             emb = self.embedder.embed_query(query)
             rows = self.store.search(
                 emb,
-                limit=limit,
+                limit=pool_limit,
                 type_=type_,
                 exclude_types=exclude_types,
                 date_from=date_from,
@@ -722,12 +744,7 @@ class _SearchOpsMixin(_MemoryBase):
             # the cross-encoder has more candidates to discriminate
             # between; the final `limit` is applied AFTER rerank.
             input_k = max(self.cfg.rerank_input_k, limit) if self.cfg.reranker_enabled else limit
-            # Chunk→parent collapsing removes hits by design (eight chunks of
-            # one note become one). Without slack in the pool the caller gets
-            # fewer results than it asked for, so widen it enough that the
-            # collapse can refill from the next distinct documents.
-            if flag_bool("MEMO_SEARCH_CHUNK_PARENT") and type_ not in REFERENCE_TYPES:
-                input_k = max(input_k, limit * _CHUNK_PARENT_POOL_FACTOR)
+            input_k = max(input_k, pool_limit)
             (
                 vec_hits,
                 bm_hits,
@@ -1513,17 +1530,47 @@ class _SearchOpsMixin(_MemoryBase):
         list dedup by id; a chunk whose parent was deleted stays as-is.
         Zero hook cost: the recall hook SQL-excludes the reference tier, so
         this loop never sees a chunk row on that path.
+
+        Two chunk→parent schemas coexist and both must collapse:
+
+        - `extra.parent_id` (MEMO_CHUNK_INGEST) materializes a parent record,
+          so the chunk resolves to that whole note — the behaviour above.
+        - `extra.parent_path` + `chunk_seq` (`memo ingest --chunk`) is the
+          bulk of the chunked corpus and materializes NO parent record, so
+          there is nothing for `self.get()` to resolve and every sibling used
+          to survive — ten chunks of one file taking all ten slots. Since no
+          parent exists, none is fabricated: keep the best-ranked chunk of
+          each source document (a real row, with its own id, citable and
+          fetchable) and drop its siblings. `parent_path` is an established
+          store key — `around()` already resolves siblings by it through
+          `store.chunks_adjacent`, over the `idx_meta_extra_parent_path` index.
+
+        `parent_id` wins when both are present, so the record-resolving path
+        keeps its exact behaviour; the fallback applies only when a chunk has
+        no `parent_id`. Freed slots are not lost: this runs on the wide pool
+        before the trim to `limit`, and `_CHUNK_PARENT_POOL_FACTOR` (already
+        applied whenever the flag is on, for either schema) leaves the slack
+        to refill from the next distinct documents.
         """
         import dataclasses
 
         mapped: list[MemoryRecord] = []
         seen_ids: set[str] = set()
+        seen_parent_paths: set[str] = set()
         for r in out:
-            parent_id = (r.extra or {}).get("parent_id")
-            if r.type in REFERENCE_TYPES and isinstance(parent_id, str) and parent_id:
+            extra = r.extra or {}
+            parent_id = extra.get("parent_id")
+            is_chunk = r.type in REFERENCE_TYPES
+            if is_chunk and isinstance(parent_id, str) and parent_id:
                 parent = self.get(parent_id)
                 if parent is not None:
                     r = dataclasses.replace(parent, score=r.score)
+            elif is_chunk:
+                parent_path = extra.get("parent_path")
+                if isinstance(parent_path, str) and parent_path:
+                    if parent_path in seen_parent_paths:
+                        continue  # a better-ranked chunk already stands for this doc
+                    seen_parent_paths.add(parent_path)
             if r.id in seen_ids:
                 continue  # a better-ranked chunk/parent already covers it
             seen_ids.add(r.id)

--- a/tests/test_search_chunk_parent_path.py
+++ b/tests/test_search_chunk_parent_path.py
@@ -1,0 +1,214 @@
+"""Chunk flood from the `parent_path` schema (MEMO_SEARCH_CHUNK_PARENT).
+
+Found running memo as an end user: `memo search "Comandos disponibles CLI por
+función"` returned 10/10 hits that were ten chunks of the *same* source file.
+MEMO_SEARCH_CHUNK_PARENT did not help, because two chunk->parent schemas
+coexist and only one was handled:
+
+- `MEMO_CHUNK_INGEST` writes `extra.parent_id` AND materializes a parent
+  record. `_map_chunks_to_parents` resolves it — that path works.
+- `memo ingest --chunk` writes `extra.parent_path` + `chunk_seq` and never
+  materializes a parent record. `self.get(parent_id)` had nothing to resolve,
+  so every chunk survived and flooded the window. That is 92% of the chunked
+  corpus, including the repro above.
+
+There is no parent record to resolve to and none is fabricated: the collapse
+keeps the best-ranked chunk of each source document — a real, citable row with
+its own id — and drops its siblings. Freed slots refill from the wide
+candidate pool (`_CHUNK_PARENT_POOL_FACTOR`), which the flag already widens.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+QUERY = "comandos disponibles CLI por funcion"
+SOURCE_DOC = "Vault/Referencia/Comandos.md"
+
+
+def _ingest_chunk(mem, seq: int, *, parent_path: str = SOURCE_DOC):
+    """A chunk exactly as `memo ingest --chunk` writes it: parent_path +
+    chunk_seq in `extra`, type=reference, and NO parent_id."""
+    return mem.save(
+        # The body carries `parent_path` so two source documents never collide
+        # on memo's content dedup — each chunk stays its own stored record.
+        content=(
+            f"## Comandos disponibles CLI por funcion — seccion {seq}\n\n"
+            "Listado de comandos disponibles del CLI agrupados por funcion, "
+            f"fragmento {seq} del documento de referencia {parent_path}."
+        ),
+        title=f"Comandos (§{seq}) — {parent_path}",
+        type_="reference",
+        tags=["chunk"],
+        extra={
+            "parent_path": parent_path,
+            "chunk_seq": seq,
+            "chunk_count": 6,
+            "chunk_heading": f"seccion {seq}",
+        },
+    )
+
+
+@pytest.fixture
+def flooded_corpus(mock_memory, monkeypatch):
+    """Six chunks of ONE source doc (parent_path only) plus unrelated
+    documents that match the query at least as well."""
+    monkeypatch.setenv("MEMO_SEARCH_CHUNK_PARENT", "1")
+    chunk_ids = [_ingest_chunk(mock_memory, seq).id for seq in range(6)]
+    others = [
+        mock_memory.save(
+            content=(
+                "Comandos disponibles CLI por funcion: referencia independiente "
+                f"numero {index} con el listado completo de comandos por funcion."
+            ),
+            title=f"Otra referencia de comandos {index}",
+            type_="reference",
+        ).id
+        for index in range(4)
+    ]
+    return mock_memory, chunk_ids, others
+
+
+def _parent_paths(hits) -> list[str]:
+    return [(hit.extra or {}).get("parent_path") for hit in hits]
+
+
+def test_one_source_document_no_longer_dominates_the_window(flooded_corpus) -> None:
+    """The bug itself: pre-fix every slot was a chunk of SOURCE_DOC."""
+    memory, _chunk_ids, _others = flooded_corpus
+
+    hits = memory.search(QUERY, limit=5, mode="bm25", type_=None)
+
+    from_source_doc = [path for path in _parent_paths(hits) if path == SOURCE_DOC]
+    assert len(from_source_doc) <= 1, (
+        f"{len(from_source_doc)}/{len(hits)} hits are chunks of the same source "
+        f"document — the flood is still crowding out every other answer"
+    )
+
+
+def test_collapse_keeps_exactly_one_chunk_per_source_document(flooded_corpus) -> None:
+    memory, _chunk_ids, _others = flooded_corpus
+
+    hits = memory.search(QUERY, limit=10, mode="bm25", type_=None)
+
+    seen = [path for path in _parent_paths(hits) if path]
+    assert len(seen) == len(set(seen)), f"sibling chunks survived the collapse: {seen}"
+
+
+def test_survivor_is_a_real_citable_record_not_a_synthesized_one(flooded_corpus) -> None:
+    """No parent record exists for parent_path; the survivor must still be a
+    row that actually exists and can be fetched back by its own id."""
+    memory, chunk_ids, _others = flooded_corpus
+
+    hits = memory.search(QUERY, limit=10, mode="bm25", type_=None)
+
+    survivors = [hit for hit in hits if (hit.extra or {}).get("parent_path") == SOURCE_DOC]
+    assert survivors, "the source document vanished entirely from the results"
+    for hit in survivors:
+        assert hit.id in chunk_ids, f"{hit.id} is not one of the ingested chunks"
+        assert memory.get(hit.id) is not None, f"{hit.id} does not resolve to a stored record"
+
+
+def test_freed_slots_refill_with_other_documents(flooded_corpus) -> None:
+    """Collapsing must not silently shrink the result: the slots the dropped
+    siblings occupied go to the next distinct documents."""
+    memory, _chunk_ids, others = flooded_corpus
+
+    hits = memory.search(QUERY, limit=5, mode="bm25", type_=None)
+
+    ids = [hit.id for hit in hits]
+    assert len(hits) > 1, "collapsing shrank the result instead of refilling it"
+    assert any(other in ids for other in others), (
+        "no independent document made it into the window after the collapse"
+    )
+
+
+def test_flag_off_leaves_the_parent_path_chunks_alone(mock_memory, monkeypatch) -> None:
+    """The fallback stays behind MEMO_SEARCH_CHUNK_PARENT — no second flag."""
+    monkeypatch.delenv("MEMO_SEARCH_CHUNK_PARENT", raising=False)
+    for seq in range(6):
+        _ingest_chunk(mock_memory, seq)
+
+    hits = mock_memory.search(QUERY, limit=10, mode="bm25", type_=None)
+
+    from_source_doc = [path for path in _parent_paths(hits) if path == SOURCE_DOC]
+    assert len(from_source_doc) > 1, "collapsed with the flag off"
+
+
+def test_explicit_reference_ask_keeps_every_chunk(flooded_corpus) -> None:
+    """An explicit `type_="reference"` ask wants the fragments themselves."""
+    memory, _chunk_ids, _others = flooded_corpus
+
+    hits = memory.search(QUERY, limit=10, mode="bm25", type_="reference")
+
+    from_source_doc = [path for path in _parent_paths(hits) if path == SOURCE_DOC]
+    assert len(from_source_doc) > 1, "explicit tier ask lost its chunks"
+
+
+def test_distinct_source_documents_are_not_collapsed_together(mock_memory, monkeypatch) -> None:
+    """Collapsing is per source document, not a blanket chunk filter."""
+    monkeypatch.setenv("MEMO_SEARCH_CHUNK_PARENT", "1")
+    for seq in range(3):
+        _ingest_chunk(mock_memory, seq, parent_path="Vault/A.md")
+    for seq in range(3):
+        _ingest_chunk(mock_memory, seq, parent_path="Vault/B.md")
+
+    hits = mock_memory.search(QUERY, limit=10, mode="bm25", type_=None)
+
+    assert {"Vault/A.md", "Vault/B.md"} <= set(_parent_paths(hits)), (
+        "one of the two source documents was collapsed away entirely"
+    )
+
+
+def test_pool_widens_only_when_a_chunk_can_reach_it(mock_memory, monkeypatch) -> None:
+    """Recall-hook budget (5s): the hook SQL-excludes the reference tier, so
+    no chunk can reach its pool and a 4x fetch would be pure waste."""
+    monkeypatch.setenv("MEMO_SEARCH_CHUNK_PARENT", "1")
+
+    assert mock_memory._chunk_parent_pool_limit(10, None, None) > 10, (
+        "the pool must widen when chunks can reach it, or the collapse shrinks the result"
+    )
+    assert mock_memory._chunk_parent_pool_limit(10, None, {"reference"}) == 10, (
+        "widened a pool that excludes the reference tier — wasted hook budget"
+    )
+    assert mock_memory._chunk_parent_pool_limit(10, "reference", None) == 10, (
+        "widened for an explicit reference ask, which never collapses"
+    )
+
+
+def test_pool_is_untouched_with_the_flag_off(mock_memory, monkeypatch) -> None:
+    """Flag off (the default) must be a byte-for-byte no-op on retrieval."""
+    monkeypatch.delenv("MEMO_SEARCH_CHUNK_PARENT", raising=False)
+
+    assert mock_memory._chunk_parent_pool_limit(10, None, None) == 10
+
+
+def test_parent_id_chunks_still_resolve_to_the_parent_record(mock_memory, monkeypatch) -> None:
+    """Regression: the MEMO_CHUNK_INGEST schema keeps resolving to the real
+    parent RECORD, unchanged — the parent_path fallback must not shadow it."""
+    monkeypatch.setenv("MEMO_SEARCH_CHUNK_PARENT", "1")
+    parent = mock_memory.save(
+        content="Comandos disponibles CLI por funcion: documento padre completo.",
+        title="Comandos padre",
+        type_="reference",
+    )
+    for seq in range(5):
+        mock_memory.save(
+            content=(
+                f"## Comandos disponibles CLI por funcion — parte {seq}\n\n"
+                "Fragmento con parent_id que debe colapsar al registro padre."
+            ),
+            title=f"Comandos padre (§{seq})",
+            type_="reference",
+            # The MEMO_CHUNK_INGEST shape: both keys, parent_id authoritative.
+            extra={"parent_id": parent.id, "parent_path": "Vault/Padre.md", "chunk_seq": seq},
+        )
+
+    hits = mock_memory.search(QUERY, limit=10, mode="bm25", type_=None)
+
+    ids = [hit.id for hit in hits]
+    assert parent.id in ids, "the parent record no longer stands in for its chunks"
+    assert ids.count(parent.id) == 1, "the parent surfaced more than once"
+    assert not [hit for hit in hits if (hit.extra or {}).get("parent_id")], (
+        "a raw parent_id chunk survived the collapse"
+    )


### PR DESCRIPTION
## The bug

`memo search "Comandos disponibles CLI por función"` returned 10/10 hits that were all chunks of the same source file. `MEMO_SEARCH_CHUNK_PARENT` was supposed to prevent exactly this and did not, because two chunk→parent schemas never interoperated:

- `_map_chunks_to_parents` collapsed only on `extra.parent_id`, resolving it via `self.get()` to a materialized parent record.
- **418** records carry `parent_id`. **3,924** carry `parent_path` and no `parent_id` — written by `memo ingest --chunk`, which never materializes a parent. `self.get()` had nothing to resolve.

Worst offender in the live corpus: one source document with **1,767 chunks** — enough to fill any result window by itself.

A prior spec concluded no cheap fallback existed. That was wrong: `around()` already resolves siblings by `parent_path` through `store.chunks_adjacent`, backed by `idx_meta_extra_parent_path`. `parent_path` is an established queryable key.

## The fix

When `parent_id` is absent but `parent_path` is present, collapse to the highest-scoring chunk of each source document. No parent record is fabricated — the survivor is always a real, citable chunk with its own id. The `parent_id` path is unchanged.

Freed slots are **backfilled**, not reported: the collapse already ran on a widened pool before the trim to `limit`, so the caller gets `limit` distinct documents instead of a short list plus an explanation.

## A pre-existing silent truncation, fixed on the way

The pool widening was hybrid-leg only. On bm25 the collapse **shrank** results instead of refilling them — 5 hits became 1, with no signal. The refill test caught it. Widening is now hoisted into `_chunk_parent_pool_limit()` and covers bm25/exact/fuzzy/vec.

## Behaviour change worth reviewing

The helper widens only when a chunk can actually reach the pool. The recall hook uses bm25/vec and SQL-excludes the reference tier, so without that guard this would 4x the hook's fetch against its 5s budget for rows that can never collapse. Consequence: hybrid no longer widens when reference is excluded. Provably useless work, but it is a behaviour change in the flag-on case, not an invisible optimisation.

**Flag off (the default) is an exact no-op** — `pool_limit == limit` on every leg and `_stage_chunk_parent` never runs. Verified across the matrix: off→10, on→40, on+exclude-reference→10, on+`type_="reference"`→10.

## Verification

Ten mutation/test pairs, each shown red before the fix — removing the `parent_path` fallback, removing pool widening, bypassing `parent_id` resolution, a blanket chunk filter, removing the flag gate, removing the tier guard, fabricating a synthetic parent, removing the `exclude_types` guard, and widening regardless of the flag. The repro fixture carries `parent_path` + `chunk_seq` and no `parent_id`, and returns 5/5 hits from one document pre-fix.

Two honest notes: the first mutation attempted against the `parent_id` regression test did **not** kill it (the parent still resolved), so it was replaced with one that does. And one fixture initially failed for the wrong reason — identical bodies across two files hit memo's content dedup.

Recall gate: **PASS** — prec@k 0.697 >= 0.697, noise@k 0.000 <= 0.000. Run with the flag at its default, so it confirms the no-op rather than measuring the improvement.

Quality gate initially failed on `_build_candidate_pool` complexity 13→14. Refactored rather than raising the budget; extracting the helper and dropping the duplicated hybrid branch put it below the original.

## Unrelated, found while testing

`tests/conformance` hangs in `tantivy.commit()` inside the `big_corpus` fixture. Verified pre-existing by reproducing it with these changes stashed. It blocks anyone running the full suite.