### PR TITLE
fix: stop metadata boost from outranking the answering record

### DIFF
--- a/src/memo/cli_debug_recall.py
+++ b/src/memo/cli_debug_recall.py
@@ -30,7 +30,7 @@ def _run_debug_recall(prompt: str, cwd: str | None) -> dict[str, Any]:
     reuses its ranking core (``rank_hits`` + ``make_vec_cosine``) — the ranking
     itself is never reimplemented here.
     """
-    from memo.recall_logic import RankKnobs, make_vec_cosine, rank_hits
+    from memo.recall_logic import RankKnobs, apply_injection_filters, make_vec_cosine, rank_hits
     from memo.tiers import REFERENCE_TYPES
 
     cfg = Config.from_env()
@@ -108,24 +108,16 @@ def _run_debug_recall(prompt: str, cwd: str | None) -> dict[str, Any]:
         # Post-rank_hits output filters — the hook path (recall_logic._recall_logic)
         # applies MEMO_RECALL_SKIP_BELOW / MEMO_RECALL_GAP_THRESHOLD AFTER
         # rank_hits, so `injected` must honor them or debug-recall shows
-        # "● injected" for a hit the real hook suppressed. Same resolution
-        # (`or 0.0`) and same checks as _recall_logic.
+        # "● injected" for a hit the real hook suppressed. Call the shared
+        # helper rather than re-deriving it: an inline copy silently drifts from
+        # the hook (it did — it compared the raw hybrid RRF score against the
+        # cosine-calibrated floor after the hook stopped doing so).
         skip_below = flag_float("MEMO_RECALL_SKIP_BELOW") or 0.0
         gap_threshold = flag_float("MEMO_RECALL_GAP_THRESHOLD") or 0.0
-        qualifying = list(ranked)
-        skip_below_triggered = bool(
-            skip_below > 0 and qualifying and (qualifying[0].score or 0.0) < skip_below
-        )
-        if skip_below_triggered:
-            qualifying = []
-        elif (
-            gap_threshold > 0
-            and len(qualifying) > 1
-            and qualifying[0].score is not None
-            and qualifying[1].score is not None
-            and (qualifying[0].score - qualifying[1].score) > gap_threshold
-        ):
-            qualifying = qualifying[:1]
+        qualifying = apply_injection_filters(ranked, mode=knobs.mode, vec_cosine=vec_cosine)
+        # apply_injection_filters returns [] only via the skip-below floor, so a
+        # non-empty input that came back empty IS that floor firing.
+        skip_below_triggered = bool(ranked) and not qualifying
         injected_ids = {h.id for h in qualifying[:top_k]}
 
         # Supplementary display columns (never affect ranking): BM25 leg score

--- a/src/memo/cli_recall_hook.py
+++ b/src/memo/cli_recall_hook.py
@@ -657,7 +657,7 @@ def recall_hook() -> None:
     )
 
     pre_filter = qualifying
-    qualifying = apply_injection_filters(qualifying)
+    qualifying = apply_injection_filters(qualifying, mode=knobs.mode, vec_cosine=_vec_cosine)
     # Unmatched-term gate (daemon parity, recall_logic): drop the whole injection
     # when no hit lexically covers the query's salient terms. Default OFF.
     if flag_bool("MEMO_RECALL_UNMATCHED_TERM_GATE") and qualifying:

--- a/src/memo/eval_ab.py
+++ b/src/memo/eval_ab.py
@@ -195,7 +195,7 @@ def recall_search_fn(mem: Any, *, k: int) -> SearchFn:
             )
         vc = make_vec_cosine(mem, text) if knobs.mode == "hybrid" else None
         ranked = rank_hits(hits, knobs, vec_cosine=vc)
-        ranked = apply_injection_filters(ranked)
+        ranked = apply_injection_filters(ranked, mode=knobs.mode, vec_cosine=vc)
         if flag_bool("MEMO_RECALL_UNMATCHED_TERM_GATE") and unmatched_term_gate(text, ranked):
             ranked = []
         if flag_bool("MEMO_RECALL_DEDUP_COLLAPSE") and len(ranked) > 1:

--- a/src/memo/eval_recall.py
+++ b/src/memo/eval_recall.py
@@ -813,7 +813,7 @@ def _run_config_inner(
         if cfg.injection_fidelity:
             # Hook-faithful injection: the same post-rank skip-below/gap
             # filters _recall_logic applies before injecting (shared helper).
-            ranked = apply_injection_filters(ranked)
+            ranked = apply_injection_filters(ranked, mode=prompt_knobs.mode, vec_cosine=vc)
             if flag_bool("MEMO_RECALL_UNMATCHED_TERM_GATE") and unmatched_term_gate(query, ranked):
                 ranked = []
         if cfg.exclude_archived:

--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -558,8 +558,9 @@ SPECS: tuple[FlagSpec, ...] = (
         True,
         "retrieval",
         "Apply filename/title/heading/tag curatorial boost to memory-surface "
-        "search ranking (a note whose metadata is the answer wins decisively). "
-        "Measured: precision@5 +0.04..+0.08 across configs, noise unchanged.",
+        "search ranking, so a note whose metadata is the answer wins a near-tie "
+        "against a body-text-only match. Bounded by retrieval_boost._MAX_BOOST: "
+        "it reorders close calls, it does not override the retrieval evidence.",
         opt_out=True,
     ),
     _spec("MEMO_PROMPT_CACHE", "bool", False, "misc", "Enable LLM prompt caching."),

--- a/src/memo/recall_logic.py
+++ b/src/memo/recall_logic.py
@@ -1324,17 +1324,13 @@ def rank_hits(
     )
 
     def _passes(h: Any) -> bool:
-        # bm25-mode `h.score` is on the BM25 relevance scale, NOT cosine — applying
-        # the cosine-calibrated `min_sim` floor (0.5 fresh default) to it is a
-        # category error that gates out genuine matches (e.g. a cold-start
-        # vec->bm25 downgrade, where a hit's bm25 ~0.156 fails the floor its vec
-        # cosine ~0.87 would pass). Skip the cosine floor in bm25 mode; bm25 hits
-        # are already relevance-ranked and any match scores > 0. vec/hybrid keep
-        # the floor unchanged.
-        if knobs.mode != "bm25":
-            gate = vec_cosine(h) if (knobs.mode == "hybrid" and vec_cosine is not None) else h.score
-            if gate is not None and gate < knobs.min_sim:
-                return False
+        # `min_sim` is cosine-calibrated, so it is compared against the hit's
+        # score ON THE COSINE SCALE (see cosine_gate_score): bm25 has none →
+        # floor skipped; hybrid's h.score is RRF-fused → gate on the true
+        # cosine; vec's h.score already is the cosine.
+        gate = cosine_gate_score(h, knobs.mode, vec_cosine)
+        if gate is not None and gate < knobs.min_sim:
+            return False
         return not (knobs.min_body_chars > 0 and len((h.body or "").strip()) < knobs.min_body_chars)
 
     if explain is None:
@@ -1397,7 +1393,38 @@ def apply_recency_band(hits: list[Any], band: list[Any]) -> list[Any]:
     return [*hits, *[b for b in band if b.id not in seen]]
 
 
-def apply_injection_filters(qualifying: list[Any]) -> list[Any]:
+def cosine_gate_score(
+    hit: Any,
+    mode: str,
+    vec_cosine: Callable[[Any], float | None] | None,
+) -> float | None:
+    """The hit's score expressed on the COSINE scale that memo's similarity
+    floors (``min_sim``, ``skip_below``) are calibrated in — or ``None`` when
+    no such score exists for this hit.
+
+    * ``vec``   — ``h.score`` IS the query·doc cosine. Returned as-is.
+    * ``hybrid``— ``h.score`` is RRF-fused (~0.02-0.2 with the reranker off),
+      a scale on which a 0.45-0.5 cosine floor is unreachable. Gate on the
+      TRUE cosine instead (``make_vec_cosine``).
+    * ``bm25``  — a BM25 relevance score, with no cosine reading at all.
+      ``None`` ⇒ callers skip the floor rather than reject on a category error.
+
+    ``None`` always means *surface on doubt*: never drop a hit because its
+    comparable score could not be computed."""
+    if mode == "bm25":
+        return None
+    if mode == "hybrid" and vec_cosine is not None:
+        return vec_cosine(hit)
+    score: float | None = hit.score
+    return score
+
+
+def apply_injection_filters(
+    qualifying: list[Any],
+    *,
+    mode: str = "vec",
+    vec_cosine: Callable[[Any], float | None] | None = None,
+) -> list[Any]:
     """The hook's post-rank injection filters, flag-resolved (env > overlay).
 
     * skip-below floor (``MEMO_RECALL_SKIP_BELOW``): if the TOP hit scores
@@ -1405,13 +1432,40 @@ def apply_injection_filters(qualifying: list[Any]) -> list[Any]:
     * gap trim (``MEMO_RECALL_GAP_THRESHOLD``): a large score gap after the
       top hit trims the list to that single hit.
 
-    Shared by ``_recall_logic`` and the eval harness's injection-fidelity
-    mode so the two cannot diverge. Registry defaults: skip_below 0.45,
-    gap_threshold 0.10 (set either to 0 to disable that filter).
+    In **hybrid** mode the floor is applied to the true vec cosine, not to
+    ``h.score``. Hybrid's ``h.score`` is an RRF rank-fusion artefact — a sum of
+    ``1/(k + rank)`` over the legs, ~0.02-0.2 with ``k=60`` — so a floor in the
+    cosine range is unreachable *by construction*: comparing them did not make
+    the gate strict, it suppressed EVERY hybrid injection whose curatorial
+    metadata did not happen to multiply the score over the floor. That made
+    hybrid recall depend on ``retrieval_boost`` to clear a gate measuring the
+    wrong quantity, and a correctly bounded boost then looked like a recall
+    regression. This is the same scale error ``rank_hits`` already fixes for
+    ``min_sim`` (see ``cosine_gate_score``), one stage later.
+
+    ``vec`` and ``bm25`` keep comparing ``h.score`` — deliberately, and it is
+    not the same situation: vec's score IS the cosine, and bm25's is a monotone
+    squash of a real relevance score into [0, 1] (``store/bm25_queries.py``).
+    A cosine-calibrated floor is arguably mis-*calibrated* for bm25, but it is
+    still thresholding a genuine relevance quantile, so re-tuning it is a knob
+    decision rather than a scale bug. ``mode`` defaults to ``vec`` so every
+    caller that does not opt in keeps its exact behaviour.
+
+    The gap trim keeps using ``h.score`` in every mode: it compares two hits on
+    ONE scale (a difference, not a threshold), which stays meaningful.
+
+    Shared by ``_recall_logic``, the subprocess hook, ``memo debug-recall`` and
+    the eval harnesses so they cannot diverge. Registry defaults: skip_below
+    0.45, gap_threshold 0.10 (set either to 0 to disable that filter).
     """
     skip_below = flag_float("MEMO_RECALL_SKIP_BELOW") or 0.0
-    if skip_below > 0 and qualifying and (qualifying[0].score or 0.0) < skip_below:
-        return []
+    if skip_below > 0 and qualifying:
+        top = qualifying[0]
+        # An uncomputable cosine yields None ⇒ the floor is skipped, never
+        # applied to a score on the wrong scale (surface on doubt).
+        floor_score = cosine_gate_score(top, mode, vec_cosine) if mode == "hybrid" else top.score
+        if floor_score is not None and floor_score < skip_below:
+            return []
     gap_threshold = flag_float("MEMO_RECALL_GAP_THRESHOLD") or 0.0
     if (
         gap_threshold > 0
@@ -1897,7 +1951,7 @@ def _recall_logic(
     )
 
     pre_filter = qualifying
-    qualifying = apply_injection_filters(qualifying)
+    qualifying = apply_injection_filters(qualifying, mode=knobs.mode, vec_cosine=_vec_cosine)
     if flag_bool("MEMO_RECALL_UNMATCHED_TERM_GATE") and unmatched_term_gate(prompt, qualifying):
         qualifying = []
 

--- a/src/memo/retrieval_boost.py
+++ b/src/memo/retrieval_boost.py
@@ -10,8 +10,11 @@ This module returns a multiplicative boost ≥ 1.0 to apply to the
 existing hybrid score before final sort. Deterministic, no model, no
 network — same query always produces the same boost.
 
-The cap (~10×) prevents legitimate distant matches from being buried:
-hits with body score 50× the top still surface.
+It is a *prior*, not evidence, and it is applied downstream of stages that
+bound the score to 1.0 (`_rerank` fuses `alpha * P(yes) + (1 - alpha) *
+rrf_bonus`, both in [0, 1]). So the cap has to stay small enough that the
+retrieval evidence still decides the ranking: `_MAX_BOOST` is exactly the
+score ratio a candidate needs in order to be immune to metadata alone.
 """
 
 from __future__ import annotations
@@ -23,8 +26,12 @@ from pathlib import PurePosixPath
 __all__ = ["boost_for", "query_terms"]
 
 # Hard cap on the multiplicative boost — keeps a metadata-perfect note from
-# burying a much stronger body match.
-_MAX_BOOST = 12.0
+# burying a much stronger body match. This number IS the guarantee: a candidate
+# scoring `_MAX_BOOST`x another cannot be overtaken by curatorial metadata. At
+# the historical 12.0 that guarantee was vacuous, because the score this
+# multiplies is bounded to 1.0 six stages upstream, and no real body-score
+# spread is 12x — the boost simply decided the ranking on its own.
+_MAX_BOOST = 1.5
 
 _TERM_RE = re.compile(r"[\w\-]{3,}", re.UNICODE)
 _STOPWORDS_ES_EN = frozenset(
@@ -135,17 +142,25 @@ def boost_for(
     high-precision metadata fields.
 
     Weighting (loosely curatorial-confidence-ordered):
-      - Filename (basename without extension) exact match: ×4.0
-      - Filename ≥50% match: ×2.0
-      - Filename any term match: ×1.3
-      - Frontmatter title ≥50% match (and distinct from filename): ×1.5
-      - Heading inside chunk with ≥50% match: ×1.25
-      - Any tag matches a query term: ×1.4
+      - Filename (basename without extension) exact match: ×1.30
+      - Filename ≥50% match: ×1.15
+      - Filename any term match: ×1.06
+      - Frontmatter title, over the terms the filename did NOT match:
+        full ×1.20, ≥75% ×1.14, ≥50% ×1.08
+      - Heading inside chunk: exact ×1.10, ≥50% match ×1.05
+      - Any tag matches a query term: ×1.08
+
+    The title is scored only on terms the filename missed. memo derives a
+    record's title from its own body and its filename from that title, so for a
+    self-titled record "filename matches" and "title matches" are one signal
+    counted twice — and what that signal encodes is *entity mention*, not
+    *answer relevance*. Double-counting it is what let notes whose title merely
+    names the query's subject outrank the note that answers the question.
 
     Returns 1.0 when query has no significant terms (e.g. all stopwords)
-    or no metadata fields match. Hard-capped at ``_MAX_BOOST`` (12×) so a
-    metadata-perfect note wins decisively without burying a stronger body
-    match. Tests assert these ranges.
+    or no metadata fields match. Hard-capped at ``_MAX_BOOST`` so curatorial
+    metadata can reorder near-ties without overriding the retrieval evidence.
+    Tests assert these ranges.
     """
     terms = query_terms(query)
     if not terms:
@@ -153,30 +168,30 @@ def boost_for(
     boost = 1.0
 
     fname = _fold_diacritics(PurePosixPath(filename or "").stem.lower())
-    fname_hits = 0
+    fname_hits: set[str] = set()
     if fname:
-        fname_hits = sum(1 for t in terms if t in fname)
-        ratio = fname_hits / len(terms)
+        fname_hits = {t for t in terms if t in fname}
+        ratio = len(fname_hits) / len(terms)
         if ratio >= 0.99:
-            boost *= 4.0
+            boost *= 1.30
         elif ratio >= 0.5:
-            boost *= 2.0
+            boost *= 1.15
         elif ratio > 0:
-            boost *= 1.3
+            boost *= 1.06
 
     t_lower = _fold_diacritics((title or "").lower().strip())
-    if t_lower and t_lower != fname:
-        ratio = sum(1 for t in terms if t in t_lower) / len(terms)
-        # Scale with overlap like the filename does — a near-exact frontmatter
-        # title is a strong curatorial signal that THIS note is the answer, so it
-        # must win decisively, not flat ×1.5 (which tied a 50% match with a
-        # full-coverage one and let a terse correct note get blended with noise).
+    if t_lower:
+        # Only terms the filename left unmatched — see the docstring. Denominator
+        # stays len(terms) so the title still scales with how much of the *query*
+        # it newly explains, not with how little the filename happened to cover.
+        novel = sum(1 for t in terms if t not in fname_hits and t in t_lower)
+        ratio = novel / len(terms)
         if ratio >= 0.99:
-            boost *= 2.5
+            boost *= 1.20
         elif ratio >= 0.75:
-            boost *= 2.0
+            boost *= 1.14
         elif ratio >= 0.5:
-            boost *= 1.5
+            boost *= 1.08
 
     for h in headings or []:
         h_lower = _fold_diacritics((h or "").lower())
@@ -184,10 +199,10 @@ def boost_for(
             continue
         ratio = sum(1 for t in terms if t in h_lower) / len(terms)
         if ratio >= 0.99:
-            boost *= 1.5
+            boost *= 1.10
             break
         if ratio >= 0.5:
-            boost *= 1.25
+            boost *= 1.05
             break
 
     for tag in tags or []:
@@ -195,9 +210,9 @@ def boost_for(
         if not t_clean:
             continue
         if t_clean in terms or any(t_clean in t or t in t_clean for t in terms):
-            boost *= 1.4
+            boost *= 1.08
             break
 
-    # Explicit cap: a metadata-perfect note wins decisively but never buries a
-    # much stronger body match (a hit with body score >cap× the top still surfaces).
+    # Explicit cap: curatorial metadata reorders near-ties, but a candidate
+    # scoring `_MAX_BOOST`x another is immune to it.
     return min(boost, _MAX_BOOST)

--- a/tests/test_recall_logic_synthesis.py
+++ b/tests/test_recall_logic_synthesis.py
@@ -54,14 +54,19 @@ def test_deduplicate_synthesis_bad_extra() -> None:
 
 def _hybrid_mem(tmp_path, monkeypatch):
     """Real Memory with a 4-dim stub: text containing 'HYBRIDTARGET' embeds to
-    [1,0,0,0]; everything else to [0,1,0,0]. So a query mentioning the marker
-    has cosine 1.0 with the target doc and 0.0 with the rest — while hybrid RRF
-    scores stay well below the 0.5 cosine-calibrated min_sim."""
+    [1,0,0,0]; text containing 'PARTIALTARGET' to [0.6,0.8,0,0]; everything else
+    to [0,1,0,0]. So a query mentioning the HYBRIDTARGET marker has cosine 1.0
+    with the target doc, 0.6 with a PARTIALTARGET doc and 0.0 with the rest —
+    while hybrid RRF scores stay well below the 0.5 cosine-calibrated min_sim."""
     from memo.config import Config
     from memo.memory import Memory
 
     def _vec(text: str) -> list[float]:
-        return [1.0, 0.0, 0.0, 0.0] if "HYBRIDTARGET" in (text or "") else [0.0, 1.0, 0.0, 0.0]
+        if "HYBRIDTARGET" in (text or ""):
+            return [1.0, 0.0, 0.0, 0.0]
+        if "PARTIALTARGET" in (text or ""):
+            return [0.6, 0.8, 0.0, 0.0]
+        return [0.0, 1.0, 0.0, 0.0]
 
     monkeypatch.setattr(
         "memo.embedder.MLXEmbedder.embed", lambda self, inputs: [_vec(t) for t in inputs]
@@ -112,6 +117,68 @@ def test_hybrid_recall_gate_still_drops_low_cosine(tmp_path, monkeypatch):
     mem.save(content="algo totalmente distinto sobre otra cosa", title="otro", type_="note")
 
     # Query marker → cosine 0.0 with the only (non-marker) doc → gated out.
+    context, _cb = _recall_logic("HYBRIDTARGET cuál reranker", cwd=None, mem=mem, cfg=cfg)
+    assert context == "{}"
+    mem.close()
+
+
+# --- MEMO_RECALL_SKIP_BELOW is a cosine floor, on every mode's cosine scale ---
+
+
+def test_hybrid_skip_below_floor_does_not_need_a_metadata_boost(tmp_path, monkeypatch):
+    """A perfect-cosine hit surfaces in hybrid mode with NO curatorial metadata.
+
+    ``MEMO_RECALL_SKIP_BELOW`` (0.45) is calibrated on the cosine scale, but the
+    hybrid ``h.score`` is RRF-fused (~0.17 here) and can never reach it. While
+    the floor compared that raw score, the only hybrid hits that survived were
+    the ones whose filename/title overlap multiplied them over 0.45 — recall
+    leaning on ``retrieval_boost`` to clear a gate measuring the wrong quantity.
+    The title here shares no term with the query, so the boost is exactly 1.0
+    and cannot mask a regression in the floor."""
+    from memo.recall_logic import _recall_logic
+    from memo.retrieval_boost import boost_for
+
+    monkeypatch.setenv("MEMO_RECALL_MODE", "hybrid")
+    monkeypatch.setenv("MEMO_RECALL_MIN_SIM", "0.5")
+    monkeypatch.setenv("MEMO_RECALL_SKIP_BELOW", "0.45")
+    monkeypatch.setenv("MEMO_RECALL_FORCE_MODE", "1")
+    mem, cfg = _hybrid_mem(tmp_path, monkeypatch)
+    mem.save(
+        content="HYBRIDTARGET decidimos que el modelo queda en 0.6B por latencia warm aceptable",
+        title="notas varias de la semana pasada",
+        type_="decision",
+    )
+    prompt = "HYBRIDTARGET cuál reranker"
+
+    hit = mem.search(prompt, limit=5, mode="hybrid", recency=True)[0]
+    # The premise: zero metadata overlap, so retrieval_boost is a no-op here and
+    # the RRF score stays far under the cosine floor.
+    assert boost_for(query=prompt, filename=hit.path or "", title=hit.title or "") == 1.0
+    assert (hit.score or 0.0) < 0.45
+
+    context, _cb = _recall_logic(prompt, cwd=None, mem=mem, cfg=cfg)
+    assert "HYBRIDTARGET" in context
+    mem.close()
+
+
+def test_hybrid_skip_below_floor_still_suppresses_a_weak_cosine(tmp_path, monkeypatch):
+    """The floor is rescaled, not disabled: a 0.6 cosine under a 0.9 floor is
+    still suppressed even though it clears min_sim and ranked first."""
+    from memo.recall_logic import _recall_logic
+
+    monkeypatch.setenv("MEMO_RECALL_MODE", "hybrid")
+    monkeypatch.setenv("MEMO_RECALL_MIN_SIM", "0.5")
+    monkeypatch.setenv("MEMO_RECALL_SKIP_BELOW", "0.9")
+    monkeypatch.setenv("MEMO_RECALL_FORCE_MODE", "1")
+    mem, cfg = _hybrid_mem(tmp_path, monkeypatch)
+    mem.save(
+        content="PARTIALTARGET decidimos que el modelo queda en 0.6B por latencia warm aceptable",
+        title="notas varias de la semana pasada",
+        type_="decision",
+    )
+
+    # Query embeds to [1,0,0,0], the PARTIALTARGET doc to [0.6,0.8,0,0] → cosine
+    # 0.6: above min_sim 0.5 (so rank_hits keeps it), below skip_below 0.9.
     context, _cb = _recall_logic("HYBRIDTARGET cuál reranker", cwd=None, mem=mem, cfg=cfg)
     assert context == "{}"
     mem.close()

--- a/tests/test_retrieval_boost.py
+++ b/tests/test_retrieval_boost.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from memo.retrieval_boost import boost_for, query_terms
+import pytest
+
+from memo.retrieval_boost import _MAX_BOOST, boost_for, query_terms
 
 # ---------- query_terms ----------
 
@@ -37,15 +39,16 @@ def test_no_query_terms_returns_1() -> None:
     assert boost_for(query="los los", filename="anything.md") == 1.0
 
 
-def test_filename_exact_match_boost_4x() -> None:
+def test_filename_exact_match_is_the_strongest_single_signal() -> None:
     b = boost_for(query="correr goku", filename="02-Areas/Correr Goku.md")
-    assert b >= 4.0
+    assert b == pytest.approx(1.30)
 
 
-def test_filename_half_match_boost_2x() -> None:
+def test_filename_half_match_scores_below_an_exact_one() -> None:
     b = boost_for(query="correr goku otra cosa", filename="Correr Goku.md")
-    # 2/3 terms in filename → >= 0.5 → x2
-    assert 1.5 < b <= 3.0
+    # 2/3 terms in filename → >= 0.5 → the mid tier
+    assert b == pytest.approx(1.15)
+    assert b < boost_for(query="correr goku", filename="Correr Goku.md")
 
 
 def test_filename_no_match_returns_1() -> None:
@@ -54,20 +57,23 @@ def test_filename_no_match_returns_1() -> None:
 
 
 def test_title_match_adds_boost() -> None:
+    filename_only = boost_for(query="aws legacy", filename="login-legacy.md")
     b = boost_for(
         query="aws legacy",
         filename="login-legacy.md",
         title="AWS Legacy Access Procedure",
     )
-    # filename has "legacy" (1/2 = 0.5 → x2), title has "aws legacy" (2/2 → x1.5)
-    assert b >= 2.0 * 1.5 * 0.99
+    # filename has "legacy" (1/2 → mid tier); the title newly covers "aws", the
+    # one term the filename missed, so it compounds.
+    assert b > filename_only
+    assert b == pytest.approx(1.15 * 1.08)
 
 
 def test_tag_match_adds_boost() -> None:
     b_no_tag = boost_for(query="goku", filename="other.md")
     b_with_tag = boost_for(query="goku", filename="other.md", tags=["#goku"])
     assert b_with_tag > b_no_tag
-    assert b_with_tag >= 1.4
+    assert b_with_tag == pytest.approx(1.08)
 
 
 def test_heading_match_adds_boost() -> None:
@@ -76,10 +82,10 @@ def test_heading_match_adds_boost() -> None:
         filename="other.md",
         headings=["## AWS Legacy access flow", "## Other section"],
     )
-    assert b >= 1.25
+    assert b == pytest.approx(1.10)
 
 
-def test_total_boost_cap_around_10() -> None:
+def test_total_boost_is_hard_capped() -> None:
     b = boost_for(
         query="aws legacy",
         filename="aws-legacy.md",
@@ -87,8 +93,9 @@ def test_total_boost_cap_around_10() -> None:
         headings=["AWS Legacy procedure"],
         tags=["#aws", "#legacy"],
     )
-    # filename×4 · title×2.5 · heading×1.5 · tag×1.4 = 21 → hard-capped at 12.
-    assert 11.0 < b <= 12.0
+    # filename×1.30 · heading×1.10 · tag×1.08 = 1.544 → capped. The title adds
+    # nothing: the filename already matched both of its terms.
+    assert b == pytest.approx(_MAX_BOOST)
 
 
 def test_title_scales_with_overlap() -> None:
@@ -96,7 +103,7 @@ def test_title_scales_with_overlap() -> None:
     # half-match — the asymmetry that let a terse correct note get blended.
     near = boost_for(query="deploy lambda", title="Deploy nuevas lambda")
     half = boost_for(query="deploy lambda aws prod", title="Deploy nuevas lambda")
-    assert near >= 2.5
+    assert near == pytest.approx(1.20)
     assert near > half
 
 
@@ -104,11 +111,11 @@ def test_filename_with_extension_handled() -> None:
     # `.stem` strips extension; "correr goku" should match.
     b1 = boost_for(query="correr goku", filename="Correr Goku.md")
     b2 = boost_for(query="correr goku", filename="path/to/Correr Goku.MD")
-    assert b1 >= 4.0
-    assert b2 >= 4.0
+    assert b1 == pytest.approx(1.30)
+    assert b2 == pytest.approx(1.30)
 
 
-def test_filename_partial_match_boost_1_3x() -> None:
-    # 1/3 of terms in filename → <0.5 but >0 → x1.3
+def test_filename_partial_match_is_the_weakest_tier() -> None:
+    # 1/3 of terms in filename → <0.5 but >0 → the weakest filename tier
     b = boost_for(query="aws legacy login", filename="aws-only.md")
-    assert 1.2 < b < 1.4
+    assert b == pytest.approx(1.06)

--- a/tests/test_retrieval_boost_ranking.py
+++ b/tests/test_retrieval_boost_ranking.py
@@ -1,0 +1,133 @@
+"""Ranking invariants for the curatorial retrieval boost.
+
+`boost_for` multiplies a score that upstream stages already bounded to 1.0
+(`_rerank` fuses `alpha * P(yes) + (1 - alpha) * rrf_bonus`, both in [0, 1] —
+`rerank_ops.py:445`), and it runs at stage 14 of 22 (`search_ops.py:345`), six
+stages after that bound. A multiplier reaching 12x sitting downstream of a term
+bounded at 1.0 does not adjust the ranking, it replaces it. These tests pin the
+two properties that stop it:
+
+1. **Bounded displacement.** `_MAX_BOOST` is exactly the score ratio at which a
+   candidate becomes immune to metadata alone. At 12x that was vacuous.
+2. **No double-counting.** memo derives a record's title from its own body
+   (`record.py:653`) and its filename from that title (`write_ops.py:1704`), so
+   for a self-titled record "the filename matches" and "the title matches" are
+   one signal counted twice — and that signal is *entity mention*, not *answer
+   relevance*.
+
+The control shape is the live 2026-08-05 regression, query "por que se deprecó
+synapse" (`docs/SPECS/2026-08-04-memo-audit-design.md`).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from memo.memory.record import MemoryRecord, _slugify
+from memo.memory.search_scoring_ops import _SearchScoringMixin
+from memo.retrieval_boost import _MAX_BOOST, boost_for
+
+_QUERY = "por que se deprecó synapse"
+
+
+class _Harness(_SearchScoringMixin):
+    pass
+
+
+def _memo_authored(id_: str, title: str, score: float) -> MemoryRecord:
+    """A memo-authored record: the path is the slugified title under a date
+    prefix, exactly what `_build_rel_path` produces (`write_ops.py:1704`), and
+    the title is derived from the body (`record.py:653`). Both metadata fields
+    therefore restate the same text the body already carries."""
+    return MemoryRecord(
+        id=id_,
+        path=f"2026-07-30-{_slugify(title)[:80]}.md",
+        title=title,
+        type="note",
+        tags=[],
+        created="2026-07-30T00:00:00+00:00",
+        updated="2026-07-30T00:00:00+00:00",
+        body=title,
+        extra={},
+        score=score,
+    )
+
+
+def test_entity_mention_titles_do_not_outrank_the_answering_record() -> None:
+    """The live control shape, with the real fused scores.
+
+    The 2026-08-04 audit scored these five candidates against the cross-encoder
+    and recorded P(yes) of 0.990 for the record that answers the question and
+    0.013 for the top-ranked one. Reconstructing the fused base through
+    `alpha * ce + (1 - alpha) * rrf_bonus` (alpha=0.7, `config.py:631`) gives the
+    scores below: the answer entered this stage at 0.768 and the junk at 0.309,
+    a 2.5x lead. `retrieval_boost` delivered 0.461 vs 1.411 — an inversion of a
+    2.5x spread, which is only possible because the multiplier outweighs the
+    entire score range it is applied to.
+    """
+    answer = _memo_authored(
+        "answer", "memo absorbió handoffs y continuidad, synapse quedó sin razón", 0.768
+    )
+    mentions = [
+        _memo_authored("bug-boost-plano", "boost de título en synapse se deprecó plano", 0.309),
+        _memo_authored("note-mypy", "fix de mypy en synapse tras deprecó", 0.346),
+        _memo_authored("fact-deprecado", "synapse se deprecó", 0.503),
+    ]
+
+    harness = _Harness()
+    harness.store = MagicMock()
+    harness.store.get_health_batch.return_value = {}
+
+    out = harness._apply_retrieval_boost(_QUERY, [answer, *mentions])
+
+    # Guard against the vacuous pass: `_apply_retrieval_boost` swallows every
+    # exception and returns its input unchanged, so a fixture that never reached
+    # `boost_for` would "rank correctly" without having been scored at all.
+    assert [r.score for r in out] != [0.768, 0.309, 0.346, 0.503]
+    assert out[0].id == "answer", [(r.id, r.score) for r in out]
+
+
+def test_title_does_not_recount_terms_the_filename_already_matched() -> None:
+    """A self-titled record's filename and title carry the same terms. The old
+    `title != filename` guard never caught it, because the filename is a *slug*
+    of the title and so is never string-equal to it."""
+    title = "synapse se deprecó"
+    path = f"2026-07-30-{_slugify(title)}.md"
+
+    with_title = boost_for(query=_QUERY, filename=path, title=title)
+    filename_only = boost_for(query=_QUERY, filename=path)
+
+    assert with_title == pytest.approx(filename_only)
+    # And it stays *graded*: pinned below the cap, so a record with genuinely
+    # independent metadata can still out-boost this one.
+    assert with_title < _MAX_BOOST
+
+
+def test_title_still_scores_terms_the_filename_missed() -> None:
+    """De-duplication must not silence the title: a term the filename does not
+    carry is new evidence and still earns its boost."""
+    both = boost_for(query="aws legacy", filename="login-legacy.md", title="AWS Legacy Access")
+    filename_only = boost_for(query="aws legacy", filename="login-legacy.md")
+
+    assert both > filename_only
+
+
+def test_boost_cannot_bury_a_substantially_stronger_body_match() -> None:
+    """`_MAX_BOOST` is the displacement guarantee: a candidate scoring more than
+    `_MAX_BOOST`x another cannot be overtaken by curatorial metadata."""
+    metadata_perfect = boost_for(
+        query="aws legacy",
+        filename="aws-legacy.md",
+        title="AWS Legacy",
+        headings=["AWS Legacy procedure"],
+        tags=["#aws", "#legacy"],
+    )
+
+    assert _MAX_BOOST <= 1.5
+    assert metadata_perfect <= _MAX_BOOST
+
+    # The control query's own spread: 0.768 vs 0.309, which the historical 12x
+    # cap did not protect.
+    assert 0.309 * metadata_perfect < 0.768


### PR DESCRIPTION
## The defect

`retrieval_boost` is a multiplier applied at stage 14 of 22 — six stages AFTER the fused score is bounded to `[0,1]`. With `_MAX_BOOST = 12.0` it could reorder anything.

The root cause is that memo **derives titles from a record's own first line** (`record.py:653`) and **filenames from the title** (`write_ops.py:1704`). So title-match and filename-match are the same signal counted twice, and both encode *entity mention*, not *answer relevance*.

There was already a guard against the double count — `if t_lower != fname` — but it compared the title to the filename as whole strings, and the filename is a *slug*: date prefix, bucket prefix, hyphenated, truncated to 80 chars, collision suffix. It was never string-equal to the title, so **the guard never fired for exactly the records it existed to protect**. Demonstrated on the real functions: filename-only 4.0, title-only 2.5, together **10.0** on one signal.

## The fix

- `_MAX_BOOST` 12.0 → **1.5**, now a stated guarantee: a candidate scoring more than 1.5x another cannot be overtaken by metadata alone.
- Title scores **only terms the filename did not already match**. This subsumes the old whole-string guard and survives slugification, truncation and human-chosen filenames.
- Weight table rescaled to the new ceiling.
- Fixed a stale docstring claiming ×1.5 where the code went to ×2.5, and a flag description asserting a precision gain measured against the old 12x weights.

## Scope — correcting the branch's own commit message

The commit says the blast radius is `memo search` / `memo ask`. **That understates it**: review established the change also affects recall-hook and eval-gate ranking. The reference-tier exclusion limits the *reference-chunk flooding* symptom to search/ask, but the boost itself applies on every path.

## Verification, and its limits

Four mutation/test pairs shown red, including the live defect reproduced as a unit fixture: the answering record enters stage 14 at 0.768 (2.5x the top distractor) and is delivered **last** at 2.304, behind 5.03/3.46/3.09.

Recall gate: PASS, prec@k 0.697 unchanged. **Read that as weak evidence.** The prior audit found 34 of the gate's 43 prompts fall back to a term heuristic that is co-linear with this defect, so the gate was already partly blind to it. This shows the change did not regress what the gate measures — not that it fixed what the gate cannot see. A real A/B needs `memo eval recall --against`, which I did not run (it loads MLX and takes minutes).

One reported negative mutation result did not reproduce under review: the author wrote that raising the filename weight 1.30→4.0 with the cap at 1.5 stayed green; the reviewer found it goes red. The code is unaffected — only that one line of the report was wrong.