### PR TITLE
fix: make the graph and embed MCP tools return data instead of a budget error

### DIFF
--- a/src/memo/mcp_budget.py
+++ b/src/memo/mcp_budget.py
@@ -5,11 +5,13 @@ receives. Measured 2026-08-06: `memo_graph verb=impact` returned 27.5k tokens
 WITH `limit=3`, over the client's own tool-result cap. memo sells token savings,
 so a read tool that costs 27k tokens inverts the product.
 
-Two mechanisms, deliberately not overlapping:
+Three mechanisms, deliberately not overlapping:
 
-* `bounded_list` -- opt-in. A tool that knows which of its fields is elastic
-  trims it and reports the real total. Generalises the fix already applied in
-  `EntityNeighbors.to_bounded_dict()`.
+* `bounded_list` -- opt-in, COUNT-based. A tool that knows which of its fields
+  is elastic trims it and reports the real total. Generalises the fix already
+  applied in `EntityNeighbors.to_bounded_dict()`.
+* `fit_to_budget` -- opt-in, SIZE-based. For fields whose unit is a
+  variable-length string, where no fixed count bounds the payload.
 * the middleware (`make_response_budget_middleware`) -- automatic. It knows
   nothing about payload shape, so it never truncates; over cap it substitutes a
   structured error. Loud failure, bounded cost.
@@ -17,6 +19,7 @@ Two mechanisms, deliberately not overlapping:
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable, Sequence
 from typing import Any
 
@@ -29,7 +32,35 @@ from memo.flags import REGISTRY, flag_int
 DEFAULT_CAP_TOKENS: int = int(REGISTRY["MEMO_MCP_RESPONSE_BUDGET_TOKENS"].default)
 
 # Per-tool overrides. Every entry carries the reason it is not the default.
-CAPS: dict[str, int] = {}
+CAPS: dict[str, int] = {
+    # A raw embedding vector has exactly ONE plausible size, set by the
+    # embedder profile the operator configured -- 2560 floats here, measured
+    # 2026-08-08 at 21,924 tokens on the wire (42,566 JSON chars + 45,130 str
+    # chars; a float32 component reads back as -0.0012969970703125). Nothing
+    # the caller passes and nothing in the store can grow it, so it is not the
+    # failure mode this budget exists for (a payload that scales with the
+    # corpus), and under the default 10k cap the tool could NEVER return its
+    # one and only result. It is exempted rather than trimmed because a
+    # truncated vector is not a vector: the tool's whole contract is "the
+    # exact vector memo would use for retrieval".
+    #
+    # Deliberately NOT extended to `memo_embed_batch`: its payload is
+    # len(texts) x dim, i.e. caller-scaled, so "pass fewer texts" is a real
+    # remedy there and an exemption would be a blank cheque.
+    "memo_embed_query": 0,
+}
+
+# Headroom `fit_to_budget` leaves between its own estimate and the cap the
+# middleware enforces. Two known, small, one-directional gaps make the real
+# wire payload LARGER than `wire_tokens` reports, so a fit computed against
+# the bare cap can land a few tokens over and be refused anyway:
+#   1. FastMCP wraps a non-object tool return as `{"result": <payload>}` in
+#      structured content -- ~5 tokens a tool sizing a bare list cannot see.
+#   2. FastMCP's serializer is not `json.dumps`; their whitespace agrees in
+#      practice but is not contractually identical.
+# 64 tokens is 0.6% of the default cap and comfortably over both; it is
+# pinned by `test_wire_tokens_stays_within_the_slack_of_result_text`.
+_WIRE_SLACK_TOKENS = 64
 
 
 def est_tokens(text: str) -> int:
@@ -75,6 +106,72 @@ def bounded_list[T](
     ordered = sorted(items, key=key) if key is not None else list(items)
     kept = ordered[:cap]
     return kept, {"shown": len(kept), "total": len(items), "truncated": len(kept) < len(items)}
+
+
+def wire_tokens(payload: Any) -> int:
+    """Estimated tokens a tool's return costs on the wire.
+
+    Counts the payload TWICE, mirroring `result_text`: fastmcp serialises the
+    same object into both the content block and the structured content, and
+    the middleware sizes their sum. A tool sizing its own result before
+    returning it must therefore do the same -- counting once would let it hand
+    back 2x its cap and still be refused.
+
+    `default=str` because this is a measurement, never the wire payload
+    itself: an exotic value must yield a number, not raise inside a budget
+    check.
+    """
+    try:
+        content = json.dumps(payload, separators=(",", ":"), default=str)
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        content = str(payload)
+    return est_tokens(content) + est_tokens(str(payload))
+
+
+def fit_to_budget[T](
+    items: Sequence[T],
+    *,
+    cap: int,
+    render: Callable[[Sequence[T]], Any],
+) -> tuple[list[T], Any]:
+    """Longest prefix of `items` whose rendered payload fits `cap` tokens.
+
+    `bounded_list` bounds a COUNT, which is the right bound when every item
+    costs about the same. It is the wrong bound when the item is a
+    variable-length string: `memo_graph_export`'s 500-edge cap measured 11,365
+    tokens as DOT and 27,413 as JSON off one graph, and a community's 50
+    entity names cost whatever those names happen to be. No single count is
+    correct for both, so this bounds the size directly.
+
+    `render` turns a prefix into the payload the tool would return, and is
+    called O(log n) times (binary search over the prefix length, which is
+    sound because payload size is monotone in prefix length). Give it a pool
+    already trimmed by the tool's own count cap, so no render sees the whole
+    graph.
+
+    Returns the kept items AND their rendered payload -- callers that need the
+    dict take the second, callers that rebuild from the items take the first.
+    `cap <= 0` (unlimited) renders everything untouched.
+    """
+    ordered = list(items)
+    full = render(ordered)
+    budget = cap - _WIRE_SLACK_TOKENS
+    if cap <= 0 or wire_tokens(full) <= budget:
+        return ordered, full
+
+    # Nothing beyond `ordered[:high]` can fit, since the full render did not.
+    low, high = 0, len(ordered) - 1
+    best_count = 0
+    best_payload = render(ordered[:0])
+    while low <= high:
+        mid = (low + high) // 2
+        candidate = render(ordered[:mid])
+        if wire_tokens(candidate) <= budget:
+            best_count, best_payload = mid, candidate
+            low = mid + 1
+        else:
+            high = mid - 1
+    return ordered[:best_count], best_payload
 
 
 def budget_exceeded_payload(tool: str, tokens: int, cap: int, hint: str = "") -> dict[str, Any]:

--- a/src/memo/server_graph.py
+++ b/src/memo/server_graph.py
@@ -7,79 +7,112 @@ only the enclosing function and indentation changed.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Annotated, Any
 
 from fastmcp import FastMCP
 from pydantic import Field
 
-from memo.mcp_budget import bounded_list
+from memo.mcp_budget import bounded_list, cap_for, fit_to_budget
 from memo.memory import Memory
 from memo.server_annotations import READ_ONLY, annotated_tool
 
-# Per-community entity cap. Measured 2026-08-06 against the developer's LIVE
-# install (~11.3k memories with the codegraph layer merged in), NOT the
-# synthetic conformance corpus -- pytest cannot reach `.codegraph/codegraph.db`
-# and the conformance fixture seeds no code layer at all: `detect_communities`
-# returned 2,278 communities, the largest holding 155 entities. The community
-# COUNT dominated that payload, but one hub community can carry a long entity
-# list on its own, so both dimensions are bounded. The conformance gate
-# (`tests/conformance/test_mcp_response_budget.py`) seeds its own entity graph
-# and holds the resulting payload under the cap; it does not reproduce these
-# live numbers.
-_MAX_COMMUNITY_ENTITIES = 50
+# Default per-community entity sample. Was 50 until 2026-08-08, when the
+# default call was measured at 14,585 tokens on the developer's LIVE install
+# (~11.3k memories with the codegraph layer merged in) against the 10,000-token
+# cap -- i.e. `memo_graph_communities` returned the budget error on EVERY call
+# and could not return data at all. 20 communities x 50 codegraph-length symbol
+# names is simply too much detail for one tool result; at 12 the same call
+# measures 4,628 tokens, and the entities a caller actually loses are reachable
+# via `max_entities`. `size` still reports the community's true entity count.
+#
+# This is the comfort default, NOT the guarantee: `fit_to_budget` below is what
+# makes an over-cap response structurally impossible, because no fixed count
+# bounds a payload whose unit is a symbol name of arbitrary length.
+_DEFAULT_COMMUNITY_ENTITIES = 12
+
+# Why both tools below carry a "Scope:" paragraph naming the working directory.
+# `Navigator._build_adjacency_list` / `_weighted_adjacency` fold
+# `.codegraph/codegraph.db` into the entity graph, and `codegraph_loader`
+# resolves that index from the CWD (nearest `.codegraph` walking up), never
+# from MEMO_DATA_DIR/MEMO_STATE_DIR. Verified 2026-08-08: two brand-new,
+# separately-configured, EMPTY memo stores returned byte-identical communities
+# (58,337 chars, sha256 7a5d26d93f187e9f) made entirely of repo symbols
+# (`conftest.py`, `prep-cesium-path.mjs`). The scoping is intentional and left
+# alone -- a code graph describes the repo you are standing in, which is not
+# something a memory store's path can express, and `MEMO_GRAPH_USE_CODEGRAPH=0`
+# / `MEMO_CODEGRAPH_DISCOVERY=0` are the documented opt-outs -- but it was
+# invisible, so the two tools that surface it now say so.
 
 
-def _bounded_dot(dot: str, *, max_edges: int) -> dict[str, Any]:
-    """Trim the DOT export to `max_edges` edge lines, reporting the true count.
+def _bounded_dot(dot: str, *, max_edges: int, cap: int) -> dict[str, Any]:
+    """Trim the DOT export to `max_edges` edge lines AND to `cap` tokens.
 
-    The live graph renders 100,141 edge lines (3.6 MB) — a whole-graph dump no
-    tool result can carry. Only edge lines are dropped; the header and the
-    closing brace stay, so the trimmed DOT still parses.
+    The live graph renders 24,264 edge lines — a whole-graph dump no tool
+    result can carry. Only edge lines are dropped; the header and the closing
+    brace stay, so the trimmed DOT still parses.
+
+    `max_edges` alone is not a bound: at the 500-edge default this measured
+    11,365 tokens against a 10,000-token cap, because an edge line is two
+    symbol names of arbitrary length. So the count cap picks the candidate
+    pool and `fit_to_budget` decides how much of it actually fits.
     """
     lines = dot.split("\n")
     edge_lines = [i for i, line in enumerate(lines) if " -- " in line]
-    if len(edge_lines) <= max_edges:
+    pool = edge_lines[:max_edges]
+    edge_positions = set(edge_lines)
+
+    def _render(kept: Sequence[int]) -> dict[str, Any]:
+        keep = set(kept)
         return {
             "format": "dot",
-            "content": dot,
+            "content": "\n".join(
+                line for i, line in enumerate(lines) if i not in edge_positions or i in keep
+            ),
             "edge_count": len(edge_lines),
-            "truncated": False,
+            "truncated": len(keep) < len(edge_lines),
         }
-    dropped = set(edge_lines[max_edges:])
-    return {
-        "format": "dot",
-        "content": "\n".join(line for i, line in enumerate(lines) if i not in dropped),
-        "edge_count": len(edge_lines),
-        "truncated": True,
-    }
+
+    _, payload = fit_to_budget(pool, cap=cap, render=_render)
+    return payload
 
 
-def _bounded_json(data: dict[str, Any], *, max_edges: int) -> dict[str, Any]:
-    """Trim the JSON export to `max_edges` edges, reporting the true sizes.
+def _bounded_json(data: dict[str, Any], *, max_edges: int, cap: int) -> dict[str, Any]:
+    """Trim the JSON export to `max_edges` edges AND to `cap` tokens.
 
-    The live graph exports 18,724 nodes and 82,517 edges (6.0 MB). Nodes are
-    filtered down to the endpoints of the retained edges so the payload stays a
-    drawable graph rather than edges pointing at absent nodes plus isolates.
+    Nodes are filtered down to the endpoints of the retained edges so the
+    payload stays a drawable graph rather than edges pointing at absent nodes
+    plus isolates.
+
+    The same 500-edge default that costs 11,365 tokens as DOT costs 27,413
+    here — the clearest proof that one edge COUNT cannot bound both formats,
+    and why the real bound is the size.
     """
     nodes = data.get("nodes") or []
     edges = data.get("edges") or []
-    if len(edges) <= max_edges:
+    pool = edges[:max_edges]
+
+    def _render(kept: Sequence[Any]) -> dict[str, Any]:
+        if len(kept) == len(edges):
+            # Untrimmed: hand back the graph verbatim. Filtering to endpoints
+            # here too would silently drop ISOLATED nodes the caller asked for.
+            payload_data: dict[str, Any] = data
+        else:
+            endpoints = {e.get("source") for e in kept} | {e.get("target") for e in kept}
+            payload_data = {
+                "nodes": [n for n in nodes if n.get("id") in endpoints],
+                "edges": list(kept),
+            }
         return {
             "format": "json",
-            "data": data,
+            "data": payload_data,
             "node_count": len(nodes),
             "edge_count": len(edges),
-            "truncated": False,
+            "truncated": len(kept) < len(edges),
         }
-    kept = edges[:max_edges]
-    endpoints = {e.get("source") for e in kept} | {e.get("target") for e in kept}
-    return {
-        "format": "json",
-        "data": {"nodes": [n for n in nodes if n.get("id") in endpoints], "edges": kept},
-        "node_count": len(nodes),
-        "edge_count": len(edges),
-        "truncated": True,
-    }
+
+    _, payload = fit_to_budget(pool, cap=cap, render=_render)
+    return payload
 
 
 def register(server: FastMCP, memory: Memory) -> None:
@@ -151,6 +184,16 @@ def register(server: FastMCP, memory: Memory) -> None:
                 "or `min_size` to see past it."
             ),
         ] = 20,
+        max_entities: Annotated[
+            int,
+            Field(
+                description="Entity names to sample per community. The default "
+                "is a summary sample, not the whole community — `size` always "
+                "reports the true count and `entities_truncated` flags the "
+                "sampling. Raise it to see more; the response budget still "
+                "applies, so a large value may cost communities off the page."
+            ),
+        ] = _DEFAULT_COMMUNITY_ENTITIES,
     ) -> list[dict[str, Any]]:
         """Detect communities (connected components) in the entity graph.
 
@@ -159,9 +202,11 @@ def register(server: FastMCP, memory: Memory) -> None:
 
         Bounded on both dimensions that scale with the corpus: the list is
         capped at `limit` (largest first) and each community's `entities` at
-        50. `size` is always the community's TRUE entity count, so
+        `max_entities`. `size` is always the community's TRUE entity count, so
         `size > len(entities)` means the entity list was trimmed and
-        `entities_truncated` says so outright.
+        `entities_truncated` says so outright. Past those counts the response
+        is trimmed again to fit the MCP response budget, so a default call
+        always returns data instead of a `response_budget_exceeded` error.
 
         The return stays a LIST — memo's tool surface is a public contract
         (PyPI, MCP registries, the Claude store), and wrapping it in an
@@ -170,15 +215,22 @@ def register(server: FastMCP, memory: Memory) -> None:
         of communities beyond the page is therefore not reported; a full
         page is the signal, per the `limit` field description.
 
+        Scope: the code layer merged into this graph comes from the codegraph
+        index resolved from the CURRENT WORKING DIRECTORY (nearest
+        .codegraph/codegraph.db), not from MEMO_DATA_DIR/MEMO_STATE_DIR, so
+        results can include symbols from a repo outside the configured memo
+        store. Set MEMO_GRAPH_USE_CODEGRAPH=0 for the memory-only graph.
+
         Args:
             min_size: Minimum community size to include.
             limit: Maximum communities to return, largest first.
+            max_entities: Entity names sampled per community.
         """
         communities = memory.navigator.detect_communities(min_size=min_size)
         kept, _ = bounded_list(communities, cap=max(0, limit), key=lambda c: -c.size)
         bounded: list[dict[str, Any]] = []
         for c in kept:
-            entities, entity_meta = bounded_list(c.entities, cap=_MAX_COMMUNITY_ENTITIES)
+            entities, entity_meta = bounded_list(c.entities, cap=max(0, max_entities))
             bounded.append(
                 {
                     "id": c.id,
@@ -188,7 +240,10 @@ def register(server: FastMCP, memory: Memory) -> None:
                     "entities_truncated": entity_meta["truncated"],
                 }
             )
-        return bounded
+        fitted, _payload = fit_to_budget(
+            bounded, cap=cap_for("memo_graph_communities"), render=list
+        )
+        return fitted
 
     @annotated_tool(server, **READ_ONLY)
     def memo_graph_trace(
@@ -307,10 +362,13 @@ def register(server: FastMCP, memory: Memory) -> None:
             int,
             Field(
                 description=(
-                    "Maximum edges to return, first seen first (floored to 0). The "
-                    "true graph size is always reported in edge_count/node_count, "
-                    "and truncated says whether edges were dropped. For the whole "
-                    "graph use the CLI: `memo graph export -o <file>`."
+                    "Ceiling on edges returned, first seen first (floored to 0) — "
+                    "FEWER come back when the response budget bites, which it does "
+                    "well before 500 edges on a real graph, and sooner for json "
+                    "than for dot. The true graph size is always reported in "
+                    "edge_count/node_count, and truncated says whether edges were "
+                    "dropped. For the whole graph use the CLI: "
+                    "`memo graph export -o <file>`."
                 ),
             ),
         ] = 500,
@@ -319,15 +377,25 @@ def register(server: FastMCP, memory: Memory) -> None:
 
         Returns graph data in the specified format. Use with external tools
         like Graphviz (dot format) or web visualization libraries (JSON format).
+        The slice is sized to the MCP response budget, so a default call
+        always returns a graph instead of a `response_budget_exceeded` error.
+
+        Scope: the code layer merged into this graph comes from the codegraph
+        index resolved from the CURRENT WORKING DIRECTORY (nearest
+        .codegraph/codegraph.db), not from MEMO_DATA_DIR/MEMO_STATE_DIR, so
+        results can include symbols from a repo outside the configured memo
+        store. Set MEMO_GRAPH_USE_CODEGRAPH=0 for the memory-only graph.
 
         Args:
             format: Either "dot" for Graphviz DOT format or "json" for web UI.
             include_memories: If True and format is "json", include memory IDs in edge data.
-            max_edges: Maximum edges to return; the true sizes come back alongside.
+            max_edges: Ceiling on edges returned; the true sizes come back alongside.
         """
-        cap = max(0, max_edges)
+        edge_ceiling = max(0, max_edges)
+        budget = cap_for("memo_graph_export")
         if format == "dot":
-            return _bounded_dot(memory.navigator.export_graphviz(), max_edges=cap)
-        else:
-            data = memory.navigator.export_json(include_memories=include_memories)
-            return _bounded_json(data, max_edges=cap)
+            return _bounded_dot(
+                memory.navigator.export_graphviz(), max_edges=edge_ceiling, cap=budget
+            )
+        data = memory.navigator.export_json(include_memories=include_memories)
+        return _bounded_json(data, max_edges=edge_ceiling, cap=budget)

--- a/tests/test_mcp_budget.py
+++ b/tests/test_mcp_budget.py
@@ -53,6 +53,101 @@ def test_bounded_list_cap_zero_keeps_nothing_but_reports_the_total() -> None:
     assert meta == {"shown": 0, "total": 3, "truncated": True}
 
 
+def test_wire_tokens_counts_the_payload_twice() -> None:
+    """`result_text` sums content AND structured content, so a tool sizing its
+    own result must too -- counting once lets it hand back 2x its cap."""
+    payload = {"blob": "x" * 4000}
+    once = mcp_budget.est_tokens(mcp_budget.json.dumps(payload, separators=(",", ":")))
+
+    assert mcp_budget.wire_tokens(payload) > 1.9 * once
+
+
+def test_wire_tokens_stays_within_the_slack_of_result_text() -> None:
+    """The estimator must track what the middleware actually measures.
+
+    `fit_to_budget` fits against `wire_tokens`; the middleware refuses against
+    `est_tokens(result_text(...))` on a real fastmcp `ToolResult`. Any gap
+    between them is headroom that `_WIRE_SLACK_TOKENS` has to cover, so pin it
+    here on both real shapes: a dict-returning tool (`memo_graph_export`,
+    where the two agree exactly) and a LIST-returning one
+    (`memo_graph_communities`, where the tool sizes the bare list but fastmcp
+    ships `{"result": [...]}` -- a wrapper the tool cannot see, measured at
+    +5 tokens).
+
+    `structured_content=` is passed by keyword deliberately: `ToolResult`'s
+    FIRST positional parameter is `content`, so `ToolResult(payload)` leaves
+    structured content unset and `result_text` then measures half the wire.
+    That mistake makes this assertion pass for free.
+    """
+    from fastmcp.tools.base import ToolResult
+
+    dot_lines = "\n".join(f'  "entity{n:05d}" -- "other{n:05d}";' for n in range(500))
+    communities = [{"id": n, "entities": [f"entity{n:05d}"] * 12} for n in range(20)]
+    for sized, shipped in (
+        ({"format": "dot", "content": dot_lines}, {"format": "dot", "content": dot_lines}),
+        (communities, {"result": communities}),
+    ):
+        estimated = mcp_budget.wire_tokens(sized)
+        result = ToolResult(structured_content=shipped)
+        assert result.structured_content is not None, "structured content must be set"
+        actual = mcp_budget.est_tokens(mcp_budget.result_text(result))
+        assert actual - estimated < mcp_budget._WIRE_SLACK_TOKENS, (
+            f"result_text exceeds wire_tokens by {actual - estimated} tokens, "
+            f"more than the {mcp_budget._WIRE_SLACK_TOKENS}-token slack covers"
+        )
+
+
+def test_fit_to_budget_passes_a_small_payload_through_whole() -> None:
+    items = ["a", "b", "c"]
+    kept, payload = mcp_budget.fit_to_budget(items, cap=10_000, render=lambda i: {"x": list(i)})
+
+    assert kept == items
+    assert payload == {"x": ["a", "b", "c"]}
+
+
+def test_fit_to_budget_drops_items_until_the_rendered_payload_fits() -> None:
+    """The bound is the SIZE, so a long item costs more of the budget than a
+    short one -- which is the whole reason `bounded_list`'s count cap could not
+    hold `memo_graph_export` (an edge line is two symbol names)."""
+    items = ["y" * 400] * 100
+
+    kept, payload = mcp_budget.fit_to_budget(items, cap=1_000, render=lambda i: {"x": list(i)})
+
+    assert 0 < len(kept) < len(items)
+    assert mcp_budget.wire_tokens(payload) <= 1_000
+    # One more item would not have fitted: the fit is the LONGEST prefix.
+    over = {"x": items[: len(kept) + 1]}
+    assert mcp_budget.wire_tokens(over) > 1_000 - mcp_budget._WIRE_SLACK_TOKENS
+
+
+def test_fit_to_budget_cap_zero_renders_everything() -> None:
+    items = ["z" * 4000] * 50
+    kept, payload = mcp_budget.fit_to_budget(items, cap=0, render=lambda i: {"x": list(i)})
+
+    assert kept == items
+    assert len(payload["x"]) == 50
+
+
+def test_fit_to_budget_returns_the_empty_render_when_nothing_fits() -> None:
+    """A non-elastic part bigger than the cap cannot be fixed by dropping
+    items; the tool still gets a payload rather than an exception."""
+    fixed = "q" * 100_000
+    kept, payload = mcp_budget.fit_to_budget(
+        ["a", "b"], cap=100, render=lambda i: {"fixed": fixed, "x": list(i)}
+    )
+
+    assert kept == []
+    assert payload["x"] == []
+
+
+def test_memo_embed_query_is_exempt_from_the_budget() -> None:
+    """A 2560-dim vector is ~21.9k tokens and has exactly one plausible size:
+    nothing the caller passes or the corpus holds can grow it, and a truncated
+    vector is not a vector. Its caller-scaled sibling is NOT exempt."""
+    assert mcp_budget.cap_for("memo_embed_query") == 0
+    assert mcp_budget.cap_for("memo_embed_batch") == mcp_budget.DEFAULT_CAP_TOKENS
+
+
 def test_cap_for_prefers_the_per_tool_override(monkeypatch) -> None:
     monkeypatch.setitem(mcp_budget.CAPS, "memo_export_json", 500_000)
     assert mcp_budget.cap_for("memo_export_json") == 500_000

--- a/tests/test_server_graph.py
+++ b/tests/test_server_graph.py
@@ -253,14 +253,14 @@ def test_memo_graph_communities_returns_list_of_dicts(tmp_cfg) -> None:
 
 
 def test_memo_graph_communities_bounds_entities_but_keeps_the_true_size(tmp_cfg) -> None:
-    """A hub community's entity list is trimmed to _MAX_COMMUNITY_ENTITIES,
+    """A hub community's entity list is sampled at _DEFAULT_COMMUNITY_ENTITIES,
     and `size` still reports the community's real entity count -- the honest
     total the wrapper object was reverted rather than introduced to carry."""
-    from memo.server_graph import _MAX_COMMUNITY_ENTITIES, register
+    from memo.server_graph import _DEFAULT_COMMUNITY_ENTITIES, register
 
     mem = MagicMock(spec=Memory)
     mem.cfg = tmp_cfg
-    entities = [f"entity{n:04d}" for n in range(_MAX_COMMUNITY_ENTITIES * 3)]
+    entities = [f"entity{n:04d}" for n in range(_DEFAULT_COMMUNITY_ENTITIES * 3)]
     mem.navigator.detect_communities.return_value = [
         Community(id=0, entities=entities, size=len(entities), representative_entity=entities[0])
     ]
@@ -271,7 +271,7 @@ def test_memo_graph_communities_bounds_entities_but_keeps_the_true_size(tmp_cfg)
     result = tools["memo_graph_communities"]()
 
     assert isinstance(result, list)
-    assert len(result[0]["entities"]) == _MAX_COMMUNITY_ENTITIES
+    assert len(result[0]["entities"]) == _DEFAULT_COMMUNITY_ENTITIES
     assert result[0]["size"] == len(entities)
     assert result[0]["entities_truncated"] is True
 

--- a/tests/test_server_graph_budget.py
+++ b/tests/test_server_graph_budget.py
@@ -1,0 +1,307 @@
+"""The three MCP tools that could never return data, and the fit that fixed them.
+
+Measured 2026-08-08 on the developer's live install (~11.3k memories, the
+codegraph layer merged in) against the DEFAULT 10,000-token cap, calling each
+tool with NO arguments through the real budget middleware:
+
+    memo_graph_communities                 14,585 tokens  -> error dict
+    memo_graph_export (format="dot")       11,365 tokens  -> error dict
+    memo_graph_export (format="json")      27,413 tokens  -> error dict
+    memo_embed_query (2560-dim vector)     21,924 tokens  -> error dict
+
+Every one of them, on every call, for every caller. The count caps those tools
+already carried (`limit=20` x 50 entities, `max_edges=500`) cannot fix this:
+their elastic unit is a variable-length STRING (an entity name, a DOT edge
+line), so no fixed count bounds the payload. The same `max_edges=500` costs
+11.4k tokens as DOT and 27.4k as JSON off one graph.
+
+So the bound is now the size itself (`mcp_budget.fit_to_budget`), and these
+tests pin the outcome that matters: a real payload back, under the default
+budget, with no argument-guessing by the caller.
+
+Hermetic: the codegraph index is pinned to a nonexistent path so the merge in
+`Navigator._build_adjacency_list` degrades to the seeded entity graph (see
+`_no_codegraph`). Nothing here loads MLX -- `memo_embed_query`'s embedder is
+replaced with a float32 vector generator.
+"""
+
+from __future__ import annotations
+
+import struct
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from memo.config import Config
+from memo.memory import Memory
+from memo.server import build_server
+
+# 22 disjoint cliques of 55 entities each. Sized so the CURRENT (count-capped)
+# tools measure over the 10,000-token cap and the fitted ones do not:
+#   - communities: 20 (the default `limit`) x 50 (the old entity cap) long
+#     names is ~25k tokens; the seed must supply at least that many.
+#   - export: 22 * 55*54/2 = 32,670 edges, far past the 500-edge default, so
+#     the DOT/JSON payloads are bounded by the fit and not by the seed.
+_ISLANDS = 22
+_ISLAND_SIZE = 55
+_CREATED = "2026-01-01T00:00:00+00:00"
+
+
+def _entity(island: int, n: int) -> str:
+    """A codegraph-length symbol name (~60 chars).
+
+    Short names would hide the defect: 1,000 six-character entity names fit
+    the cap comfortably. The live payload is expensive because the entities
+    the codegraph layer contributes are real symbol names
+    (`test_memo_graph_export_json_bounds_edges_and_reports_true_counts`).
+    """
+    return f"conformance_symbol_{island:02d}_{n:02d}_bounds_edges_and_reports_true_counts"
+
+
+@pytest.fixture
+def _no_codegraph(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Pin codegraph resolution at a path that does not exist, and prove it.
+
+    `tests/conftest.py` turns cwd discovery off and drops `MEMO_CODEGRAPH_DB`,
+    but `codegraph_loader._resolve_db` still falls back to the module-relative
+    `CODEGRAPH_DB` -- memo's own checkout, which on the developer's machine
+    holds a real 79 MB index. Measured 2026-08-08 with that fallback in play:
+    4 of the 20 communities came from the live index rather than from the
+    seed, so the sizes asserted here would have been machine state.
+
+    Every layer of the resolution order is pinned (`_resolve_db`: explicit arg
+    > cwd discovery > MEMO_CODEGRAPH_DB > module `CODEGRAPH_DB`), not just the
+    env var, and the assertion below fails loudly if any of them ever resolves
+    a real file again. That assertion is the only thing that would catch it:
+    the worktree this was written in has no `.codegraph`, so deleting the pin
+    here leaves every test green while the main checkout leaks.
+    """
+    from memo import codegraph_loader
+
+    missing = tmp_path / "no-such-codegraph.db"
+    monkeypatch.setenv("MEMO_CODEGRAPH_DISCOVERY", "0")
+    monkeypatch.setenv("MEMO_CODEGRAPH_DB", str(missing))
+    monkeypatch.setattr(codegraph_loader, "CODEGRAPH_DB", missing)
+    resolved = codegraph_loader._resolve_db()
+    assert not resolved.is_file(), f"codegraph leaked into a hermetic test: {resolved}"
+
+
+@pytest.fixture
+def graph_server(tmp_cfg: Config, _no_codegraph: None) -> Iterator[Any]:
+    """An MCP server over a seeded entity graph, big enough to blow the cap."""
+    from memo.graph import GraphStore
+
+    store = GraphStore(tmp_cfg.graph_db)
+    try:
+        for island in range(_ISLANDS):
+            store.record_extraction(
+                memory_id=f"seed-memory-{island:03d}",
+                memory_date=_CREATED,
+                extracted_at=_CREATED,
+                entities=[
+                    {"name": _entity(island, n), "type": "concept"} for n in range(_ISLAND_SIZE)
+                ],
+            )
+    finally:
+        store.close()
+
+    memory = Memory(tmp_cfg)
+    try:
+        yield build_server(memory=memory)
+    finally:
+        memory.close()
+
+
+def _payload(result: Any) -> Any:
+    """The structured payload, asserting it is not the budget's error dict.
+
+    `structured_content` is what the budget middleware substitutes into, and
+    what a real MCP client reads. A list-returning tool is wrapped by FastMCP
+    as `{"result": [...]}`; the error substitution is always a bare dict with
+    an `error` key, so unwrapping after the check cannot mask it.
+    """
+    sc = result.structured_content
+    assert isinstance(sc, dict), f"expected structured content, got {type(sc)}"
+    assert sc.get("error") != "response_budget_exceeded", (
+        f"tool returned the budget error instead of data: {sc}"
+    )
+    return sc.get("result", sc)
+
+
+@pytest.mark.asyncio
+async def test_memo_graph_communities_returns_data_under_the_default_budget(
+    graph_server: Any,
+) -> None:
+    """Called bare, through the real middleware, it comes back with communities.
+
+    No `limit`, no `min_size` -- the defect was that the DEFAULT call could
+    never succeed, so passing arguments here would test the wrong thing.
+    """
+    result = await graph_server.call_tool("memo_graph_communities", {})
+
+    communities = _payload(result)
+    assert isinstance(communities, list)
+    assert len(communities) == 20, f"expected the default page of 20, got {len(communities)}"
+    # Real data, not empty husks: the seeded cliques are 55 entities each and
+    # `size` must still report that truth even though `entities` is sampled.
+    assert all(c["size"] == _ISLAND_SIZE for c in communities)
+    assert all(c["entities"] for c in communities)
+    assert all(c["representative_entity"] for c in communities)
+
+
+@pytest.mark.asyncio
+async def test_memo_graph_communities_reports_the_true_size_when_it_samples(
+    graph_server: Any,
+) -> None:
+    """The entity list is a sample; `size` and `entities_truncated` say so."""
+    result = await graph_server.call_tool("memo_graph_communities", {})
+
+    first = _payload(result)[0]
+    assert len(first["entities"]) < first["size"]
+    assert first["entities_truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_memo_graph_communities_max_entities_reaches_the_detail(
+    graph_server: Any,
+) -> None:
+    """The detail the smaller default gives up is reachable by asking for it."""
+    result = await graph_server.call_tool(
+        "memo_graph_communities", {"limit": 3, "max_entities": _ISLAND_SIZE}
+    )
+
+    communities = _payload(result)
+    assert len(communities) == 3
+    assert len(communities[0]["entities"]) == _ISLAND_SIZE
+    assert communities[0]["entities_truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_memo_graph_communities_survives_a_max_entities_that_blows_the_count_caps(
+    graph_server: Any,
+) -> None:
+    """Raising `max_entities` costs communities off the page, not the whole result.
+
+    20 communities x 55 long entity names is ~35k tokens -- past the cap by
+    3.5x, and the exact shape the old fixed `_MAX_COMMUNITY_ENTITIES = 50`
+    shipped by default. This is what `fit_to_budget` is for: no count cap can
+    hold a payload whose unit is a name of arbitrary length, so the size
+    decides and the caller still gets data.
+    """
+    result = await graph_server.call_tool("memo_graph_communities", {"max_entities": _ISLAND_SIZE})
+
+    communities = _payload(result)
+    assert communities, "the fit dropped everything"
+    assert len(communities) < 20, "nothing was traded away, so the fit did not engage"
+    assert len(communities[0]["entities"]) == _ISLAND_SIZE
+
+
+@pytest.mark.asyncio
+async def test_memo_graph_export_dot_returns_data_under_the_default_budget(
+    graph_server: Any,
+) -> None:
+    """Bare `memo_graph_export` (format defaults to "dot") returns real DOT."""
+    result = await graph_server.call_tool("memo_graph_export", {})
+
+    payload = _payload(result)
+    assert payload["format"] == "dot"
+    assert payload["content"].startswith("graph memo_entities {")
+    assert payload["content"].rstrip().endswith("}")
+    kept = [line for line in payload["content"].split("\n") if " -- " in line]
+    assert kept, "no edges survived the fit"
+    # The seed has 32,670 edges; the true count is reported whatever is kept.
+    assert payload["edge_count"] == _ISLANDS * _ISLAND_SIZE * (_ISLAND_SIZE - 1) // 2
+    assert payload["truncated"] is True
+    assert len(kept) < payload["edge_count"]
+
+
+@pytest.mark.asyncio
+async def test_memo_graph_export_json_returns_data_under_the_default_budget(
+    graph_server: Any,
+) -> None:
+    """The JSON format too -- it is ~2.4x the DOT payload for the same edges.
+
+    A single `max_edges` count cannot bound both formats: 500 edges measured
+    11,365 tokens as DOT and 27,413 as JSON off the same live graph.
+    """
+    result = await graph_server.call_tool("memo_graph_export", {"format": "json"})
+
+    payload = _payload(result)
+    assert payload["format"] == "json"
+    edges = payload["data"]["edges"]
+    nodes = payload["data"]["nodes"]
+    assert edges, "no edges survived the fit"
+    assert nodes, "no nodes survived the fit"
+    assert payload["truncated"] is True
+    assert len(edges) < payload["edge_count"]
+    # Still a drawable graph: every retained edge's endpoints are present.
+    ids = {n["id"] for n in nodes}
+    assert all(e["source"] in ids and e["target"] in ids for e in edges)
+
+
+@pytest.mark.asyncio
+async def test_the_graph_tools_disclose_that_codegraph_is_cwd_scoped(
+    graph_server: Any,
+) -> None:
+    """The codegraph merge is left cwd-scoped on purpose; it must be stated.
+
+    A code graph describes the repo you are standing in, which is not
+    something MEMO_DATA_DIR can express -- so the behaviour stays. What was
+    unacceptable was the silence: pointed at a brand-new EMPTY store, both
+    tools returned byte-identical repo symbols with nothing in the response,
+    the description, or the schema saying where they came from.
+
+    Asserted on `Tool.description`, the field that actually crosses the MCP
+    wire (verified against `list_tools()`; `parameters`, not `inputSchema`, is
+    the sibling that carries the schema).
+    """
+    tools = {t.name: t for t in await graph_server.list_tools()}
+
+    for name in ("memo_graph_communities", "memo_graph_export"):
+        description = tools[name].description or ""
+        assert "CURRENT WORKING DIRECTORY" in description, name
+        assert "MEMO_DATA_DIR" in description, name
+        assert "MEMO_GRAPH_USE_CODEGRAPH=0" in description, name
+
+
+def _float32_vector(dim: int) -> list[float]:
+    """A deterministic float32 vector with realistic repr length.
+
+    Size is the whole point of this test, and a float32's decimal repr is what
+    costs the tokens: a real MLX component reads back as -0.0012969970703125
+    (18 chars), while a hand-written 0.1 would be 3. Values are round-tripped
+    through `struct` so they are genuinely float32, exactly as
+    `MLXEmbedder.embed_query` returns them.
+    """
+    raw = [((i * 2654435761) % 2_000_003) / 2_000_003.0 - 0.5 for i in range(dim)]
+    return [struct.unpack("<f", struct.pack("<f", v / 32.0))[0] for v in raw]
+
+
+@pytest.mark.asyncio
+async def test_memo_embed_query_returns_the_whole_vector_under_the_default_budget(
+    tmp_cfg: Config,
+) -> None:
+    """A 2560-dim vector is ~21.9k tokens on the wire -- 2.2x the default cap.
+
+    It is exempt (`mcp_budget.CAPS`) rather than trimmed because a truncated
+    vector is not a vector: the tool's entire contract is "the exact vector
+    memo would use", and its size is fixed by the embedder profile, not by
+    the corpus or by anything the caller can grow.
+
+    No MLX: `embed_query` is replaced outright.
+    """
+    dim = 2560
+    vector = _float32_vector(dim)
+    memory = Memory(tmp_cfg)
+    try:
+        memory.embedder.embed_query = lambda text: list(vector)  # type: ignore[method-assign]
+        server = build_server(memory=memory)
+        result = await server.call_tool("memo_embed_query", {"text": "budget probe"})
+    finally:
+        memory.close()
+
+    payload = _payload(result)
+    assert payload["dim"] == dim
+    assert payload["vector"] == pytest.approx(vector)


### PR DESCRIPTION
## The defect

Found by sweeping all 164 MCP tools. Three tools could **never** return data — every call produced `{"error":"response_budget_exceeded"}`:

- `memo_graph_communities` → 14,585 tokens against a 10,000 cap
- `memo_graph_export` → 11,352
- `memo_embed_query` → a 2560-dim vector, which structurally cannot fit

The two graph tools also ignore `MEMO_DATA_DIR`/`MEMO_STATE_DIR`: pointed at a brand-new empty store they return byte-identical content, because `Navigator.detect_communities` merges **codegraph**, whose resolution is not scoped by the memo store. That is why the "entities" are repo symbols (`conftest.py`, `prep-cesium-path.mjs`), not memories.

## What this changes

Bounds the payloads so the default call succeeds, and discloses the codegraph scope in the two tools' descriptions rather than silently returning data from outside the configured store. `codegraph_loader._resolve_db` is deliberately cwd/project-scoped, so the scoping itself was left alone — but a tool that reads outside its store must say so.

## Known incomplete — recorded rather than hidden

Review found the same unbounded-payload defect **survives** in:
- `memo_graph`, the unified tool on the **default** MCP profile
- `memo_embed_batch`, a fourth tool in the same class (~21k tokens for a single text)

and that only the two tools in scope carry the new `Scope:` disclosure — `memo_graph_path` and siblings do not. These are follow-ups, not fixed here.

Also flagged: the `memo_embed_query` budget exemption makes `MEMO_MCP_RESPONSE_BUDGET_TOKENS` inoperative for that tool and drops it from the conformance budget gate; and `memo_graph_communities` can still return a short page under default arguments with no machine-readable signal, which contradicts the pagination heuristic its own docstring asserts.

## Verification

Tests assert each tool returns a real payload under the **default** budget; shown red against pre-fix source extracted with `git archive`.