### PR TITLE
fix: seven defects from a full QA sweep of the CLI + MCP surface

### DIFF
--- a/src/memo/asof.py
+++ b/src/memo/asof.py
@@ -1,0 +1,42 @@
+"""Valid-time ``as_of`` parsing at memo's user/agent boundaries.
+
+Its own module because ``memo.util`` is an enforced pure-stdlib leaf
+(``tests/test_architecture_boundaries.py``) and this raises a domain error.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from memo.errors import ValidationError
+
+
+def validate_as_of(as_of: str | None) -> str | None:
+    """Return ``as_of`` unchanged, or raise when it is not an ISO boundary.
+
+    The store layer is deliberately lenient about a bound it cannot parse:
+    ``store.bm25_queries._normalize_as_of`` falls back to the raw string and
+    ``memory.search_ops._passes_validity_gate`` keeps the row rather than
+    dropping it, so a garbled boundary never crashes a query mid-flight.
+
+    At the EDGE that leniency reads as a lie: a valid-time query with a typo
+    silently degrades to no filter at all and answers from the present while
+    echoing the bad bound back as if it had been honoured. Call this wherever
+    an ``as_of`` first arrives from a user or an agent, so the typo is refused
+    where it can still be corrected. Accepts exactly what ``_normalize_as_of``
+    understands — a bare ``YYYY-MM-DD``, a naive or offset-aware ISO 8601
+    datetime, and ``Z`` as an offset alias.
+    """
+    if as_of is None:
+        return None
+    candidate = as_of.strip()
+    try:
+        if not candidate:
+            raise ValueError("empty")
+        datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValidationError(
+            f"invalid --as-of value {as_of!r}: expected YYYY-MM-DD or a full ISO 8601 "
+            "timestamp (e.g. 2026-01-31 or 2026-01-31T14:00:00-03:00)"
+        ) from exc
+    return as_of

--- a/src/memo/cli_config.py
+++ b/src/memo/cli_config.py
@@ -357,12 +357,22 @@ def config_migrate(force: bool) -> None:
     storage = legacy.get("storage") if isinstance(legacy, dict) else {}
     if not isinstance(storage, dict) or not storage.get("data_dir"):
         raise click.ClickException("legacy config.toml has no [storage].data_dir to migrate")
+    # `write_default_config` refuses to clobber an existing Markdown config.
+    # Unhandled, that surfaced as a raw FileExistsError traceback (`config init`
+    # already translates the same failure), and the `pre-md-config` snapshot
+    # taken first left a backup of a migration that never happened. Write first,
+    # snapshot only once the migration has actually succeeded.
+    try:
+        written = write_default_config(
+            data_dir=Path(str(storage["data_dir"])),
+            vault_path=Path(str(storage["vault_path"])) if storage.get("vault_path") else None,
+            force=force,
+        )
+    except FileExistsError as exc:
+        raise click.ClickException(
+            f"config already exists: {exc}; use --force to overwrite"
+        ) from exc
     backup = snapshot_config_file(label="pre-md-config")
-    written = write_default_config(
-        data_dir=Path(str(storage["data_dir"])),
-        vault_path=Path(str(storage["vault_path"])) if storage.get("vault_path") else None,
-        force=force,
-    )
     console.print(f"[green]migrated[/green] legacy config to {len(written)} Markdown file(s)")
     if backup is not None:
         console.print(f"[dim]legacy backup: {backup}[/dim]")

--- a/src/memo/cli_doctor.py
+++ b/src/memo/cli_doctor.py
@@ -126,6 +126,31 @@ def _check_codegraph() -> None:
         console.print(f"[green]✓[/green] codegraph: CLI v{'.'.join(str(p) for p in cg_version)}")
 
 
+def _report_mcp_store_env() -> bool:
+    """Print MCP client store-path findings; return False when any is broken.
+
+    A store path in a client's `env` is the failure the CLI cannot feel: memo
+    creates whatever directory it is handed, so the MCP client answers from an
+    empty corpus while every other check here stays green.
+    """
+    findings = scan_mcp_store_env()
+    if not findings:
+        console.print("[green]✓[/green] mcp store env: no overrides pointing elsewhere")
+        return True
+    for finding in findings:
+        why = (
+            "resolves against the client's cwd"
+            if finding["issue"] == "relative"
+            else "does not exist — the server would create a new empty store"
+        )
+        console.print(
+            f"[red]✗[/red] mcp store env: {finding['config']} → "
+            f"{finding['var']}={finding['value']} "
+            f"[dim]({why}; set an absolute path or drop the override)[/dim]"
+        )
+    return False
+
+
 @click.command()
 @click.option("--gc", "do_gc", is_flag=True, help="Detect orphans between store and disk.")
 @click.option(
@@ -251,24 +276,7 @@ def doctor(
                     f"({_r['issue']}); shim {_r['suggestion']} missing — install runtime first"
                 )
 
-    # A store path in a client's env is the failure the CLI cannot feel: memo
-    # creates whatever directory it is handed, so the MCP client answers from an
-    # empty corpus while every check here stays green.
-    _store_env = scan_mcp_store_env()
-    if _store_env:
-        for _s in _store_env:
-            _why = (
-                "resolves against the client's cwd"
-                if _s["issue"] == "relative"
-                else "does not exist — the server would create a new empty store"
-            )
-            console.print(
-                f"[red]✗[/red] mcp store env: {_s['config']} → {_s['var']}={_s['value']} "
-                f"[dim]({_why}; set an absolute path or drop the override)[/dim]"
-            )
-        ok = False
-    else:
-        console.print("[green]✓[/green] mcp store env: no overrides pointing elsewhere")
+    ok = _report_mcp_store_env() and ok
 
     if cfg.data_dir.is_dir():
         console.print(f"[green]✓[/green] data_dir: {cfg.data_dir}")

--- a/src/memo/cli_doctor.py
+++ b/src/memo/cli_doctor.py
@@ -18,7 +18,7 @@ from memo.cli_diag import (
 )
 from memo.cli_runtime import _print_runtime_install_report, _runtime_install_report
 from memo.config import Config
-from memo.runtime.mcp_config import repair_mcp_configs, scan_mcp_configs
+from memo.runtime.mcp_config import repair_mcp_configs, scan_mcp_configs, scan_mcp_store_env
 
 # Codegraph doctor check — WARN-only (never fails doctor). Consumers of the
 # code graph degrade silently when the index is absent, but
@@ -250,6 +250,25 @@ def doctor(
                     f"[yellow]![/yellow] mcp config: {_r['config']} → {_r['command']} "
                     f"({_r['issue']}); shim {_r['suggestion']} missing — install runtime first"
                 )
+
+    # A store path in a client's env is the failure the CLI cannot feel: memo
+    # creates whatever directory it is handed, so the MCP client answers from an
+    # empty corpus while every check here stays green.
+    _store_env = scan_mcp_store_env()
+    if _store_env:
+        for _s in _store_env:
+            _why = (
+                "resolves against the client's cwd"
+                if _s["issue"] == "relative"
+                else "does not exist — the server would create a new empty store"
+            )
+            console.print(
+                f"[red]✗[/red] mcp store env: {_s['config']} → {_s['var']}={_s['value']} "
+                f"[dim]({_why}; set an absolute path or drop the override)[/dim]"
+            )
+        ok = False
+    else:
+        console.print("[green]✓[/green] mcp store env: no overrides pointing elsewhere")
 
     if cfg.data_dir.is_dir():
         console.print(f"[green]✓[/green] data_dir: {cfg.data_dir}")

--- a/src/memo/cli_search.py
+++ b/src/memo/cli_search.py
@@ -68,6 +68,20 @@ def _fact_badge(hit: dict) -> str:
     return f" facts:{len(facts)}" if isinstance(facts, list) and facts else ""
 
 
+def _require_valid_as_of(as_of: str | None) -> None:
+    """Refuse a malformed `--as-of` before the query runs.
+
+    The store keeps every row on a bound it cannot parse, so without this the
+    query answers from the PRESENT while looking like it honoured `--as-of`.
+    """
+    from memo.asof import validate_as_of
+
+    try:
+        validate_as_of(as_of)
+    except MemoError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
 def _default_search_json_body_chars() -> int:
     from memo.flags import flag_int
 
@@ -173,15 +187,7 @@ def search(
     """Top-k search — hybrid (semantic + keyword) by default."""
     import time
 
-    from memo.asof import validate_as_of
-
-    # Refuse a malformed boundary here: the store keeps every row on a bound it
-    # cannot parse, so without this the query answers from the PRESENT while
-    # looking like it honoured `--as-of`.
-    try:
-        validate_as_of(as_of)
-    except MemoError as exc:
-        raise click.ClickException(str(exc)) from exc
+    _require_valid_as_of(as_of)
 
     if body_chars is None:
         body_chars = _default_search_json_body_chars()

--- a/src/memo/cli_search.py
+++ b/src/memo/cli_search.py
@@ -18,6 +18,7 @@ from rich.table import Table
 from memo.cli_common import console, log_cli_consult
 from memo.cli_common import get_memory as _get_memory
 from memo.config import Config
+from memo.errors import MemoError
 from memo.memory.record import MemoryRecord
 
 
@@ -171,6 +172,16 @@ def search(
 ) -> None:
     """Top-k search — hybrid (semantic + keyword) by default."""
     import time
+
+    from memo.asof import validate_as_of
+
+    # Refuse a malformed boundary here: the store keeps every row on a bound it
+    # cannot parse, so without this the query answers from the PRESENT while
+    # looking like it honoured `--as-of`.
+    try:
+        validate_as_of(as_of)
+    except MemoError as exc:
+        raise click.ClickException(str(exc)) from exc
 
     if body_chars is None:
         body_chars = _default_search_json_body_chars()

--- a/src/memo/config.py
+++ b/src/memo/config.py
@@ -314,8 +314,39 @@ def _resolve_model_profile(
     _apply_selected_values(kwargs, md_values)
 
 
+def _reject_relative_store_env() -> None:
+    """Refuse a relative store path supplied through the environment.
+
+    An env-supplied store path is meant to name one exact directory, but a
+    relative one resolves against whatever cwd the process happens to inherit
+    — and the consequences diverge silently. A stale
+    ``MEMO_DATA_DIR="sweep/store_cli_2/data"`` in an MCP client's env resolved
+    under the home directory, so memo created a NEW EMPTY store there and every
+    MCP tool answered from an empty corpus while the CLI kept reading the real
+    one; the same string in a launchd plist (cwd ``/``) hit a read-only
+    filesystem and crash-looped with a readable error. Same misconfiguration,
+    and only the inherited cwd decided whether it was loud or invisible.
+
+    Scoped to the environment on purpose: ``_apply_repo_and_legacy_paths``
+    still sets relative ``data_dir``/``state_dir`` defaults for the zero-config
+    in-repo case, where the cwd IS the directory being described.
+    """
+    for env_key in ("MEMO_DATA_DIR", "MEMO_STATE_DIR"):
+        value = os.environ.get(env_key)
+        if not value:
+            continue
+        if not Path(value).expanduser().is_absolute():
+            raise MemoError(
+                f"{env_key}={value!r} is a relative path. It resolves against the "
+                "current working directory, which differs per client (a launchd "
+                "agent runs at '/'), so it can silently point at a different — or "
+                "empty — store. Use an absolute path (or a leading '~')."
+            )
+
+
 def _apply_environment_values(kwargs: dict[str, Any], md_values: dict[str, Any]) -> None:
     """Apply registered environment overrides and platform-aware toggles."""
+    _reject_relative_store_env()
     env_values = {
         field: value
         for env_key, field in _ENV_TO_FIELD.items()

--- a/src/memo/runtime/mcp_config.py
+++ b/src/memo/runtime/mcp_config.py
@@ -128,6 +128,64 @@ def scan_mcp_configs(
     return findings
 
 
+# Store paths handed to the server through the client's `env` block. Matched
+# in raw text so JSON, JSONC, TOML and YAML all work without a parser, the same
+# way the command scan does.
+_STORE_ENV_VARS: tuple[str, ...] = ("MEMO_DATA_DIR", "MEMO_STATE_DIR")
+_STORE_ENV_ASSIGNMENT = re.compile(
+    r"[\"']?(?P<var>MEMO_(?:DATA|STATE)_DIR)[\"']?\s*[:=]\s*[\"'](?P<value>[^\"']+)[\"']"
+)
+
+
+def scan_mcp_store_env(
+    config_paths: tuple[str, ...] = KNOWN_MCP_CONFIGS,
+) -> list[dict[str, str]]:
+    """Inspect known MCP configs for store paths that point somewhere else.
+
+    A wrong ``command`` fails loudly — the server does not start. A wrong
+    ``MEMO_DATA_DIR``/``MEMO_STATE_DIR`` does the opposite: memo opens (and
+    creates) whatever directory it is given, so the client answers every query
+    from an empty or foreign corpus while the CLI, reading the real store,
+    looks perfectly healthy. That gap is invisible from inside the CLI, which
+    is exactly why it belongs in ``memo doctor``.
+
+    Two issues are reported, both report-only — unlike a command path, memo
+    cannot know which corpus was intended, so there is nothing safe to rewrite:
+
+    - ``"relative"``: resolves against the client's cwd, which differs per
+      client (a launchd agent runs at ``/``).
+    - ``"missing"``: absolute but absent, so the server would create a new
+      empty store there on first open.
+    """
+    findings: list[dict[str, str]] = []
+    for cfg_str in config_paths:
+        cfg_path = Path(cfg_str).expanduser()
+        try:
+            if not cfg_path.exists():
+                continue
+            text = cfg_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for match in _STORE_ENV_ASSIGNMENT.finditer(text):
+            value = match.group("value")
+            resolved = Path(value).expanduser()
+            if not resolved.is_absolute():
+                issue = "relative"
+            elif not resolved.exists():
+                issue = "missing"
+            else:
+                continue
+            findings.append(
+                {
+                    "config": str(cfg_path),
+                    "var": match.group("var"),
+                    "value": value,
+                    "issue": issue,
+                }
+            )
+    return findings
+
+
 def _replace_bare_launch_command(text: str, command: str, suggestion: str) -> str:
     command_pattern = re.escape(command)
     scalar_pattern = re.compile(

--- a/src/memo/server_asof_valid.py
+++ b/src/memo/server_asof_valid.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from fastmcp import FastMCP
 
+from memo.asof import validate_as_of
 from memo.memory import Memory
 from memo.server_annotations import READ_ONLY, annotated_tool
 from memo.server_common import log_consult, now_ms
@@ -57,6 +58,7 @@ def register(server: FastMCP, memory: Memory) -> None:
         shape as ``memo_search`` items.
         """
         t0 = now_ms()
+        validate_as_of(as_of)
         records = memory.search(query, limit=limit, type_=type, mode=mode, as_of=as_of)
         results = [r.to_dict() for r in records]
         log_consult(
@@ -89,6 +91,7 @@ def register(server: FastMCP, memory: Memory) -> None:
         Returns: the ``memo_ask`` answer envelope plus an ``as_of`` echo.
         """
         t0 = now_ms()
+        validate_as_of(as_of)
         res = memory.ask(question, k=k, type_=type, as_of=as_of)
         cites = res.get("sources") or []
         hit_dicts = [c for c in cites if isinstance(c, dict)]

--- a/src/memo/server_collaborative.py
+++ b/src/memo/server_collaborative.py
@@ -23,7 +23,7 @@ def register(server: FastMCP, memory: Memory) -> None:
         entity_b: str,
         relationship: str,
         confidence: float = 0.7,
-    ) -> dict[str, str]:
+    ) -> dict[str, Any]:
         """Share a discovered connection with the community.
 
         Args:
@@ -81,7 +81,7 @@ def register(server: FastMCP, memory: Memory) -> None:
     def memo_collaborative_share_insight(
         user_id: str,
         content: str,
-    ) -> dict[str, str]:
+    ) -> dict[str, Any]:
         """Share an insight with the community.
 
         Args:

--- a/src/memo/server_write_coordinator.py
+++ b/src/memo/server_write_coordinator.py
@@ -13,6 +13,24 @@ from memo.errors import MemoError, QueueFullError, StorageError
 _log = logging.getLogger("memo.server")
 
 
+def _is_argument_error(exc: BaseException) -> bool:
+    """Whether ``exc`` describes the CALL rather than anything memo stores.
+
+    FastMCP raises its own ``ValidationError`` from ``FunctionTool.run`` when
+    pydantic cannot bind the arguments — before the tool body executes, so no
+    memory has been read or written yet. Its message lists missing/unexpected
+    parameter names and echoes back the arguments the caller itself just sent;
+    it cannot carry corpus content, and masking it leaves an agent with no way
+    to discover the signature it got wrong (the read-only tools, which never
+    pass through this coordinator, return exactly this detail).
+    """
+    try:
+        from fastmcp.exceptions import ValidationError as FastMCPValidationError
+    except ImportError:  # pragma: no cover - fastmcp is a hard dependency
+        return False
+    return isinstance(exc, FastMCPValidationError)
+
+
 @dataclass
 class _Job:
     run: Callable[[], Awaitable[Any]]
@@ -114,6 +132,8 @@ class McpWriteCoordinator:
                         job.future.set_exception(
                             cause
                             if isinstance(cause, MemoError)
+                            else e
+                            if _is_argument_error(e)
                             else StorageError(
                                 f"coordinated MCP write failed safely ({kind}) — "
                                 "details in the memo-mcp server log"

--- a/src/memo/sync_git.py
+++ b/src/memo/sync_git.py
@@ -815,6 +815,46 @@ def sync_pull(cfg: Config, store: VecStore, mem: Memory, *, remote: str = "origi
     return out
 
 
+# Memo's own derived state: a Tantivy segment directory and the sqlite
+# sidecars. `sync init` stages from `memory_dir.parent`, which contains
+# `state_dir` whenever both are pointed at one directory, so without this the
+# sweep races Tantivy's writer (`fatal: unable to stat '.tmpXXXXXX'`) and, when
+# it wins the race, commits a machine-local index into a cross-machine repo.
+# Markdown is the source of truth; the index is rebuildable from it.
+_SYNC_IGNORE_HEADER = "# memo: derived state, rebuildable from the markdown corpus"
+_SYNC_IGNORE_ENTRIES: tuple[str, ...] = (
+    "tantivy/",
+    "*.db-wal",
+    "*.db-shm",
+    "*.tmp*",
+)
+
+
+def ensure_sync_gitignore(root: Path) -> None:
+    """Append memo's derived-state ignores to ``root/.gitignore``, idempotently.
+
+    Only adds lines that are missing, so a hand-written ``.gitignore`` in the
+    sync repo survives untouched.
+    """
+    gitignore = root / ".gitignore"
+    try:
+        existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+    except OSError:
+        return
+    present = {line.strip() for line in existing.splitlines()}
+    missing = [entry for entry in _SYNC_IGNORE_ENTRIES if entry not in present]
+    if not missing:
+        return
+    block = "" if not existing or existing.endswith("\n") else "\n"
+    if _SYNC_IGNORE_HEADER not in existing:
+        block += f"{_SYNC_IGNORE_HEADER}\n"
+    block += "".join(f"{entry}\n" for entry in missing)
+    try:
+        gitignore.write_text(existing + block, encoding="utf-8")
+    except OSError:
+        return
+
+
 def sync_init_home(cfg: Config, private: bool = True) -> dict:
     """Initialize a new memo-sync repo: create GitHub repo + ensure local git + first push.
 
@@ -837,6 +877,7 @@ def sync_init_home(cfg: Config, private: bool = True) -> dict:
     # repo create --push` has nothing to push and _current_branch() fails.
     # Mirror the byo path — stage whatever exists and make a (possibly empty)
     # initial commit so HEAD is born before gh pushes.
+    ensure_sync_gitignore(root)
     if _git(root, "rev-parse", "HEAD", check=False).returncode != 0:
         _git(root, "add", "-A")
         _git(root, "commit", "--allow-empty", "-m", "memo: initial memory corpus")
@@ -891,6 +932,7 @@ def sync_init_home_byo(cfg: Config, url: str) -> dict:
     else:
         _git(root, "remote", "add", "origin", url)
 
+    ensure_sync_gitignore(root)
     _git(root, "add", "-A")
     # Even with no memories yet, make a real (possibly empty) initial commit so
     # HEAD is born — otherwise a brand-new user running the create path before

--- a/tests/test_as_of_validation.py
+++ b/tests/test_as_of_validation.py
@@ -1,0 +1,107 @@
+"""A malformed ``as_of`` must be refused at the boundary, not silently dropped.
+
+The store is deliberately lenient: ``_normalize_as_of`` falls back to the raw
+string and ``_passes_validity_gate`` returns True on a bound it cannot parse,
+so a garbled boundary never crashes a query mid-flight. That leniency is right
+where it lives and is unchanged here.
+
+What it cost at the EDGE was a lie. ``memo search "wal" --as-of not-a-date``
+exited 0 and printed today's records, and ``memo_search_valid_as_of`` echoed
+``{"as_of": "not-a-date"}`` beside present-day hits — a time-machine query
+answered from the present, presented as the past. The sibling surfaces already
+refuse the same input loudly (``memo_search_as_of``, ``memo_ask_as_of`` and
+``memo diff`` all raise ``Invalid isoformat string``), so the leniency was not
+even consistent.
+
+Boundary parsing accepts exactly what ``_normalize_as_of`` understands: a bare
+``YYYY-MM-DD`` date, a naive datetime, an offset-aware datetime, and ``Z`` as
+an offset alias.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memo.asof import validate_as_of
+from memo.config import Config
+from memo.errors import ValidationError
+
+ACCEPTED = [
+    "2026-01-01",
+    "2026-01-01T14:00:00",
+    "2026-01-01T14:00:00+00:00",
+    "2026-01-01T14:00:00Z",
+    "2026-01-01T14:00:00.123456-03:00",
+]
+
+REJECTED = [
+    "not-a-date",
+    "qa-as_of",
+    "2026-13-01",
+    "01/01/2026",
+    "yesterday",
+    "",
+    "   ",
+]
+
+
+@pytest.mark.parametrize("value", ACCEPTED)
+def test_validate_as_of_accepts_iso_bounds(value: str) -> None:
+    assert validate_as_of(value) == value
+
+
+def test_validate_as_of_passes_none_through() -> None:
+    """`None` means "no valid-time filter" and is not an error."""
+    assert validate_as_of(None) is None
+
+
+@pytest.mark.parametrize("value", REJECTED)
+def test_validate_as_of_rejects_garbage(value: str) -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        validate_as_of(value)
+    message = str(excinfo.value)
+    assert "as-of" in message.lower()
+    assert "YYYY-MM-DD" in message
+
+
+def test_validate_as_of_names_the_offending_value() -> None:
+    """The caller has to see WHICH string was refused to fix the typo."""
+    with pytest.raises(ValidationError, match="not-a-date"):
+        validate_as_of("not-a-date")
+
+
+def _env(tmp_cfg: Config) -> dict[str, str]:
+    return {
+        "MEMO_DATA_DIR": str(tmp_cfg.data_dir),
+        "MEMO_STATE_DIR": str(tmp_cfg.state_dir),
+        "MEMO_NONINTERACTIVE": "1",
+    }
+
+
+def test_cli_search_refuses_a_malformed_as_of(tmp_cfg: Config) -> None:
+    """`memo search --as-of garbage` must fail, not answer from the present."""
+    from click.testing import CliRunner
+
+    from memo.cli import cli
+
+    result = CliRunner().invoke(cli, ["search", "wal", "--as-of", "not-a-date"], env=_env(tmp_cfg))
+
+    assert result.exit_code != 0, result.output
+    assert "not-a-date" in result.output
+
+
+@pytest.mark.asyncio
+async def test_mcp_search_valid_as_of_refuses_a_malformed_bound(tmp_cfg: Config) -> None:
+    """The MCP twin must refuse it too instead of echoing it back as honoured."""
+    from memo.memory import Memory
+    from memo.server import build_server
+
+    memory = Memory(tmp_cfg)
+    try:
+        server = build_server(memory=memory)
+        with pytest.raises(Exception, match="not-a-date"):
+            await server.call_tool(
+                "memo_search_valid_as_of", {"query": "wal", "as_of": "not-a-date"}
+            )
+    finally:
+        memory.close()

--- a/tests/test_cli_config_migrate_errors.py
+++ b/tests/test_cli_config_migrate_errors.py
@@ -1,0 +1,72 @@
+"""`memo config migrate` reports a pre-existing config instead of crashing.
+
+`config init` and `config migrate` call the same `write_default_config`, which
+raises `FileExistsError` rather than clobber a Markdown config. `init` wrapped
+it in a `ClickException`; `migrate` did not, so on 2026-08-09 a plain
+`memo config migrate` on a machine that already had a config printed a raw
+traceback — and, because the legacy-config snapshot was taken FIRST, left a
+`pre-md-config` backup behind for a migration that never ran.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memo.cli import cli
+
+
+@pytest.fixture
+def config_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "xdg"
+    (home / "memo").mkdir(parents=True)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(home))
+    monkeypatch.setenv("MEMO_CONFIG_FILE", str(home / "memo" / "config.toml"))
+    # Per-test Markdown config home; the session default in tests/conftest.py is
+    # one shared tmp path, so two migrations in one run would see each other's.
+    monkeypatch.setenv("MEMO_CONFIG_DIR", str(home / "memo"))
+    monkeypatch.setenv("MEMO_NONINTERACTIVE", "1")
+    return home
+
+
+def _legacy_config(config_home: Path, data_dir: Path) -> None:
+    (config_home / "memo" / "config.toml").write_text(
+        f'[storage]\ndata_dir = "{data_dir}"\n', encoding="utf-8"
+    )
+
+
+def test_migrate_reports_an_existing_config_without_a_traceback(
+    config_home: Path, tmp_path: Path
+) -> None:
+    data_dir = tmp_path / "memorias"
+    data_dir.mkdir()
+    _legacy_config(config_home, data_dir)
+    runner = CliRunner()
+
+    first = runner.invoke(cli, ["config", "migrate"])
+    assert first.exit_code == 0, first.output
+
+    second = runner.invoke(cli, ["config", "migrate"])
+
+    assert second.exit_code != 0
+    assert "Traceback" not in second.output
+    assert "already exists" in second.output
+    assert "--force" in second.output
+
+
+def test_a_refused_migration_leaves_no_backup(config_home: Path, tmp_path: Path) -> None:
+    """The legacy snapshot is a record of a migration that happened."""
+    data_dir = tmp_path / "memorias"
+    data_dir.mkdir()
+    _legacy_config(config_home, data_dir)
+    runner = CliRunner()
+    first = runner.invoke(cli, ["config", "migrate"])
+    assert first.exit_code == 0, first.output
+
+    before = sorted(p.name for p in (config_home / "memo").glob("*pre-md-config*"))
+    runner.invoke(cli, ["config", "migrate"])
+    after = sorted(p.name for p in (config_home / "memo").glob("*pre-md-config*"))
+
+    assert after == before

--- a/tests/test_config_relative_store_env.py
+++ b/tests/test_config_relative_store_env.py
@@ -1,0 +1,71 @@
+"""A relative ``MEMO_DATA_DIR``/``MEMO_STATE_DIR`` from the environment is refused.
+
+Two incidents on 2026-08-09, one root cause. A QA sweep left
+``MEMO_DATA_DIR="sweep/store_cli_2/data"`` — a RELATIVE path — in two places:
+
+* ``~/.claude.json`` (the memo MCP server's ``env``). The client's cwd was the
+  home directory, so it resolved to a writable ``~/sweep/...``, memo created a
+  brand-new empty store there, and every one of the 41 MCP tools answered from
+  an empty corpus for days. ``memo_search`` returned zero hits in all three
+  modes, ``memo_profile`` reported ``available: false``. The CLI, reading the
+  real store, was fine — so nothing looked broken.
+* ``com.memo.watch.plist``. launchd runs agents with cwd ``/``, so the same
+  string resolved to ``/sweep``, a read-only filesystem, and the agent
+  crash-looped under ``KeepAlive`` with a clear ``RuntimeError``.
+
+The difference between "silently answers from an empty corpus" and "fails
+immediately with a readable error" was nothing but the cwd it happened to
+inherit. An environment-supplied store path is always meant to name one exact
+directory; when it is relative, the caller cannot know which one it got.
+
+Only the ENVIRONMENT is constrained. ``_apply_repo_and_legacy_paths`` still
+sets relative ``data_dir="memorias"`` / ``state_dir=".memo-state"`` for the
+zero-config in-repo case, where the cwd is the thing being described.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memo.config import Config
+from memo.errors import MemoError
+
+
+@pytest.mark.parametrize("var", ["MEMO_DATA_DIR", "MEMO_STATE_DIR"])
+def test_relative_store_env_is_refused(var: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(var, "sweep/store_cli_2/data")
+
+    with pytest.raises(MemoError) as excinfo:
+        Config.from_env()
+
+    message = str(excinfo.value)
+    assert var in message
+    assert "sweep/store_cli_2/data" in message
+    assert "absolute" in message.lower()
+
+
+@pytest.mark.parametrize("var", ["MEMO_DATA_DIR", "MEMO_STATE_DIR"])
+def test_absolute_store_env_is_accepted(
+    var: str, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(var, str(tmp_path))
+
+    cfg = Config.from_env()
+
+    assert str(getattr(cfg, {"MEMO_DATA_DIR": "data_dir", "MEMO_STATE_DIR": "state_dir"}[var]))
+
+
+@pytest.mark.parametrize("var", ["MEMO_DATA_DIR", "MEMO_STATE_DIR"])
+def test_tilde_store_env_is_accepted(var: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`~/...` names one exact directory regardless of cwd."""
+    monkeypatch.setenv(var, "~/memo-store")
+
+    Config.from_env()
+
+
+def test_zero_config_repo_relative_defaults_still_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The in-repo default is relative BY DESIGN and must keep working."""
+    monkeypatch.delenv("MEMO_DATA_DIR", raising=False)
+    monkeypatch.delenv("MEMO_STATE_DIR", raising=False)
+
+    Config.from_env()

--- a/tests/test_mcp_config_store_env.py
+++ b/tests/test_mcp_config_store_env.py
@@ -1,0 +1,97 @@
+"""`memo doctor` must see a store path in an MCP client's env, not just the binary.
+
+``scan_mcp_configs`` checks the launch COMMAND — that it is not a venv-internal
+path, not a bare name. It never looked at the ``env`` block, so on 2026-08-09,
+with ``~/.claude.json`` carrying ``MEMO_DATA_DIR="sweep/store_cli_2/data"`` and
+every MCP tool answering from an empty corpus, doctor printed::
+
+    ✓ mcp config paths: stable
+
+The command path was, in fact, stable. The store the server would open was not,
+and that is the failure the operator needed named: an MCP client reading a
+different corpus than the CLI is invisible from inside the CLI.
+
+Scanning stays format-agnostic (raw text, so JSON/JSONC/TOML/YAML all work) and
+report-only: unlike a command path, a wrong store directory has no safe
+mechanical repair — memo cannot know which corpus was meant.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from memo.runtime.mcp_config import scan_mcp_store_env
+
+
+def _write_claude_json(tmp_path: Path, env: dict[str, str]) -> Path:
+    cfg = tmp_path / "claude.json"
+    cfg.write_text(
+        json.dumps(
+            {"mcpServers": {"memo": {"command": "/Users/x/.local/bin/memo-mcp", "env": env}}}
+        ),
+        encoding="utf-8",
+    )
+    return cfg
+
+
+def test_relative_store_path_is_reported(tmp_path: Path) -> None:
+    cfg = _write_claude_json(tmp_path, {"MEMO_DATA_DIR": "sweep/store_cli_2/data"})
+
+    findings = scan_mcp_store_env((str(cfg),))
+
+    assert len(findings) == 1
+    assert findings[0]["config"] == str(cfg)
+    assert findings[0]["var"] == "MEMO_DATA_DIR"
+    assert findings[0]["value"] == "sweep/store_cli_2/data"
+    assert findings[0]["issue"] == "relative"
+
+
+def test_absolute_but_missing_store_path_is_reported(tmp_path: Path) -> None:
+    missing = tmp_path / "nope" / "data"
+    cfg = _write_claude_json(tmp_path, {"MEMO_STATE_DIR": str(missing)})
+
+    findings = scan_mcp_store_env((str(cfg),))
+
+    assert [f["issue"] for f in findings] == ["missing"]
+    assert findings[0]["var"] == "MEMO_STATE_DIR"
+
+
+def test_absolute_existing_store_path_is_clean(tmp_path: Path) -> None:
+    store = tmp_path / "memorias"
+    store.mkdir()
+    cfg = _write_claude_json(tmp_path, {"MEMO_DATA_DIR": str(store)})
+
+    assert scan_mcp_store_env((str(cfg),)) == []
+
+
+def test_config_without_store_env_is_clean(tmp_path: Path) -> None:
+    cfg = _write_claude_json(tmp_path, {"MEMO_MCP_PROFILE": "agent"})
+
+    assert scan_mcp_store_env((str(cfg),)) == []
+
+
+def test_both_vars_are_reported_independently(tmp_path: Path) -> None:
+    cfg = _write_claude_json(
+        tmp_path, {"MEMO_DATA_DIR": "sweep/data", "MEMO_STATE_DIR": "sweep/state"}
+    )
+
+    findings = scan_mcp_store_env((str(cfg),))
+
+    assert sorted(f["var"] for f in findings) == ["MEMO_DATA_DIR", "MEMO_STATE_DIR"]
+
+
+def test_toml_style_assignment_is_scanned(tmp_path: Path) -> None:
+    """Codex uses TOML; the scan is deliberately format-agnostic."""
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        '[mcp_servers.memo.env]\nMEMO_DATA_DIR = "sweep/store_cli_2/data"\n', encoding="utf-8"
+    )
+
+    findings = scan_mcp_store_env((str(cfg),))
+
+    assert [f["issue"] for f in findings] == ["relative"]
+
+
+def test_missing_config_file_is_skipped(tmp_path: Path) -> None:
+    assert scan_mcp_store_env((str(tmp_path / "absent.json"),)) == []

--- a/tests/test_server_collaborative_contract.py
+++ b/tests/test_server_collaborative_contract.py
@@ -1,0 +1,109 @@
+"""The collaborative MCP tools must satisfy the output schema they advertise.
+
+``tests/test_server_collaborative.py`` drives these tools with a MagicMock
+server, so FastMCP never derives an output schema from the return annotation
+and nothing ever compares the payload against it. That is the gap that let
+``-> dict[str, str]`` ship on two tools whose dataclasses carry ints, floats
+and lists (``SharedConnection.confidence: float``, ``.votes: int``,
+``CollectiveInsight.contributors: list[str]``, ``.upvotes/.downvotes: int``).
+
+The declared schema was ``{"additionalProperties": {"type": "string"}}``,
+which cannot describe those payloads. Measured 2026-08-09 over stdio against
+the installed 4.9.3 (fastmcp 3.4.6, which enforces the schema), every call to
+either tool came back as::
+
+    Output validation error: 0 is not of type 'string'
+
+— unconditionally, for every caller. Pinned by validating the real payload
+against the tool's OWN advertised schema rather than by calling and hoping:
+fastmcp 3.4.5 does not enforce output schemas, so a call-only test goes green
+on a lockfile that is one patch release behind the runtime users install.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from memo.config import Config
+from memo.memory import Memory
+from memo.server import build_server
+
+COLLABORATIVE_CALLS: list[tuple[str, dict[str, Any]]] = [
+    (
+        "memo_collaborative_share_connection",
+        {
+            "user_id": "user-a",
+            "entity_a": "Python",
+            "entity_b": "MLX",
+            "relationship": "used_with",
+            "confidence": 0.9,
+        },
+    ),
+    (
+        "memo_collaborative_share_insight",
+        {"user_id": "user-a", "content": "sqlite-vec beats a flat scan past ~10k rows"},
+    ),
+]
+
+
+@pytest.fixture
+def collab_server(tmp_cfg: Config, monkeypatch: pytest.MonkeyPatch) -> Iterator[Any]:
+    monkeypatch.setenv("MEMO_MCP_PROFILE", "full")
+    memory = Memory(tmp_cfg)
+    try:
+        yield build_server(memory=memory)
+    finally:
+        memory.close()
+
+
+async def _declared_schema(server: Any, name: str) -> dict[str, Any]:
+    tools = {t.name: t for t in await server._list_tools()}
+    assert name in tools, f"{name} is not registered under the full profile"
+    schema = tools[name].output_schema
+    assert schema is not None, f"{name} advertises no output schema"
+    return dict(schema)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool", "args"), COLLABORATIVE_CALLS, ids=lambda v: v if isinstance(v, str) else ""
+)
+async def test_payload_satisfies_the_advertised_output_schema(
+    collab_server: Any, tool: str, args: dict[str, Any]
+) -> None:
+    """What the tool returns must validate against what it says it returns."""
+    import jsonschema
+
+    schema = await _declared_schema(collab_server, tool)
+    result = await collab_server.call_tool(tool, args)
+    payload = result.structured_content
+    assert isinstance(payload, dict), f"expected structured content, got {type(payload)}"
+
+    jsonschema.validate(payload, schema)
+
+
+@pytest.mark.asyncio
+async def test_share_connection_keeps_its_numeric_fields(collab_server: Any) -> None:
+    """The payload is the point: a float confidence and an int vote count."""
+    result = await collab_server.call_tool(*COLLABORATIVE_CALLS[0])
+
+    conn = result.structured_content
+    assert conn["entity_a"] == "Python"
+    assert conn["relationship"] == "used_with"
+    assert conn["confidence"] == pytest.approx(0.9)
+    assert isinstance(conn["votes"], int)
+
+
+@pytest.mark.asyncio
+async def test_share_insight_keeps_its_list_and_counters(collab_server: Any) -> None:
+    """`contributors` stays a list and the vote counters stay ints."""
+    result = await collab_server.call_tool(*COLLABORATIVE_CALLS[1])
+
+    insight = result.structured_content
+    assert insight["content"] == "sqlite-vec beats a flat scan past ~10k rows"
+    assert isinstance(insight["contributors"], list)
+    assert isinstance(insight["upvotes"], int)
+    assert isinstance(insight["downvotes"], int)

--- a/tests/test_sync_init_gitignore.py
+++ b/tests/test_sync_init_gitignore.py
@@ -1,0 +1,115 @@
+"""`sync init` must not stage memo's own derived state.
+
+``sync_init_home`` / ``sync_init_home_byo`` run ``git add -A`` at
+``cfg.memory_dir.parent``. When ``state_dir`` lives under that root — which it
+does whenever both are pointed at one directory, the shape every isolated test
+store and scratch install uses — that sweep reaches the LIVE index: the Tantivy
+segment directory and the sqlite WAL/SHM sidecars.
+
+Two consequences, one of them observed. On 2026-08-09 a plain ``memo sync
+init`` against such a store died with::
+
+    git add -A failed: fatal: unable to stat 'state/tantivy/.tmp7nQlgN':
+    No such file or directory
+
+— Tantivy's writer had already replaced its temp file between git's readdir and
+its stat. The quieter one is worse: a successful run would commit a derived,
+machine-local index into the cross-machine sync repo, against memo's own
+contract that markdown is the source of truth and the index is rebuildable.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from memo.config import Config
+from memo.sync_git import ensure_sync_gitignore
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=root, capture_output=True, text=True, check=True
+    ).stdout
+
+
+@pytest.fixture
+def sync_root(tmp_path: Path) -> Path:
+    root = tmp_path / "store"
+    (root / "memorias").mkdir(parents=True)
+    (root / "state" / "tantivy").mkdir(parents=True)
+    (root / "state" / "tantivy" / ".tmpAbCdEf").write_text("scratch", encoding="utf-8")
+    (root / "state" / "memvec.db").write_text("index", encoding="utf-8")
+    (root / "state" / "memvec.db-wal").write_text("wal", encoding="utf-8")
+    (root / "memorias" / "note.md").write_text("# a real memory", encoding="utf-8")
+    _git(root, "init", "-b", "main")
+    return root
+
+
+def test_derived_state_is_not_staged(sync_root: Path) -> None:
+    ensure_sync_gitignore(sync_root)
+
+    _git(sync_root, "add", "-A")
+    staged = _git(sync_root, "diff", "--cached", "--name-only").splitlines()
+
+    assert "memorias/note.md" in staged
+    assert not [p for p in staged if p.startswith("state/tantivy/")]
+    assert not [p for p in staged if p.endswith(("-wal", "-shm"))]
+
+
+def test_the_markdown_corpus_is_still_staged(sync_root: Path) -> None:
+    """The ignore must be surgical — memories are the whole point of the repo."""
+    ensure_sync_gitignore(sync_root)
+
+    _git(sync_root, "add", "-A")
+    staged = _git(sync_root, "diff", "--cached", "--name-only").splitlines()
+
+    assert "memorias/note.md" in staged
+
+
+def test_it_is_idempotent(sync_root: Path) -> None:
+    ensure_sync_gitignore(sync_root)
+    first = (sync_root / ".gitignore").read_text(encoding="utf-8")
+    ensure_sync_gitignore(sync_root)
+
+    assert (sync_root / ".gitignore").read_text(encoding="utf-8") == first
+
+
+def test_it_preserves_a_hand_written_gitignore(sync_root: Path) -> None:
+    (sync_root / ".gitignore").write_text("# mine\nsecrets.txt\n", encoding="utf-8")
+
+    ensure_sync_gitignore(sync_root)
+
+    content = (sync_root / ".gitignore").read_text(encoding="utf-8")
+    assert "secrets.txt" in content
+    assert "tantivy/" in content
+
+
+def test_sync_init_byo_ignores_derived_state_before_staging(
+    sync_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The init path itself, not just the helper, must apply the ignore."""
+    from memo import sync_git
+
+    cfg = Config(
+        data_dir=sync_root / "memorias",
+        state_dir=sync_root / "state",
+        reranker_enabled=False,
+    )
+    pushed: list[tuple[str, ...]] = []
+    real_git = sync_git._git
+
+    def fake_git(root: Path, *args: str, **kwargs: object):
+        if args[:1] == ("push",) or args[:1] == ("remote",):
+            pushed.append(args)
+            return subprocess.CompletedProcess(args=list(args), returncode=0, stdout="", stderr="")
+        return real_git(root, *args, **kwargs)
+
+    monkeypatch.setattr(sync_git, "_git", fake_git)
+    sync_git.sync_init_home_byo(cfg, "https://github.com/example/memo-sync.git")
+
+    tracked = _git(sync_root, "ls-files").splitlines()
+    assert "memorias/note.md" in tracked
+    assert not [p for p in tracked if p.startswith("state/tantivy/")]

--- a/tests/test_sync_init_gitignore.py
+++ b/tests/test_sync_init_gitignore.py
@@ -45,6 +45,10 @@ def sync_root(tmp_path: Path) -> Path:
     (root / "state" / "memvec.db-wal").write_text("wal", encoding="utf-8")
     (root / "memorias" / "note.md").write_text("# a real memory", encoding="utf-8")
     _git(root, "init", "-b", "main")
+    # Repo-local identity: CI runners have no global user.name/user.email, and
+    # `sync_init_home_byo` makes a real commit.
+    _git(root, "config", "user.name", "memo tests")
+    _git(root, "config", "user.email", "tests@memo.invalid")
     return root
 
 

--- a/tests/test_write_coordinator_argument_errors.py
+++ b/tests/test_write_coordinator_argument_errors.py
@@ -1,0 +1,85 @@
+"""A write tool must tell the caller which argument it got wrong.
+
+The coordinator masks every non-``MemoError`` a write tool raises behind
+``coordinated MCP write failed safely (<Type>) — details in the memo-mcp
+server log``. Masking the MESSAGE is the right default: a storage or parsing
+failure can quote memory content, and the MCP client is not entitled to it.
+
+Argument-binding errors are different in kind. FastMCP raises
+``fastmcp.exceptions.ValidationError`` before the tool body runs, and its
+message describes only the CALL — which required argument is missing, which
+keyword is unexpected, echoing back arguments the caller itself just sent.
+Measured 2026-08-09 against the installed 4.9.3, ``memo_focus_set(focus=...,
+project=...)`` masked this::
+
+    2 validation errors for call[memo_focus_set]
+    summary   Missing required argument
+    focus     Unexpected keyword argument
+
+leaving the agent with nothing to correct and a server log it cannot read —
+while every READ-only tool (``memo_related``, ``memo_rerank``) returned that
+same pydantic detail in full. The write surface was undiscoverable by the
+agents it exists for.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from memo.config import Config
+from memo.memory import Memory
+from memo.server import build_server
+
+MASK = "failed safely"
+
+
+@pytest.fixture
+def server(tmp_cfg: Config, monkeypatch: pytest.MonkeyPatch) -> Iterator[Any]:
+    monkeypatch.setenv("MEMO_MCP_PROFILE", "full")
+    memory = Memory(tmp_cfg)
+    try:
+        yield build_server(memory=memory)
+    finally:
+        memory.close()
+
+
+@pytest.mark.asyncio
+async def test_missing_required_argument_names_the_argument(server: Any) -> None:
+    """`memo_focus_set` needs `summary`; the caller must be told exactly that."""
+    with pytest.raises(Exception) as excinfo:
+        await server.call_tool("memo_focus_set", {"project": "qa"})
+
+    message = str(excinfo.value)
+    assert MASK not in message, f"argument error was masked: {message}"
+    assert "summary" in message
+
+
+@pytest.mark.asyncio
+async def test_unexpected_keyword_argument_names_the_keyword(server: Any) -> None:
+    """A wrong keyword must come back as the wrong keyword, not as a type name."""
+    with pytest.raises(Exception) as excinfo:
+        await server.call_tool("memo_focus_set", {"project": "qa", "summary": "s", "focus": "typo"})
+
+    message = str(excinfo.value)
+    assert MASK not in message, f"argument error was masked: {message}"
+    assert "focus" in message
+
+
+@pytest.mark.asyncio
+async def test_a_failing_tool_body_stays_masked(server: Any, monkeypatch: Any) -> None:
+    """The privacy default is unchanged: a body failure still says nothing."""
+    from memo import server_write_coordinator
+
+    async def _boom() -> None:
+        raise RuntimeError("secret memory body: the deploy key is hunter2")
+
+    coordinator = server_write_coordinator.McpWriteCoordinator(capacity=4)
+    with pytest.raises(Exception) as excinfo:
+        await coordinator.submit(_boom)
+
+    message = str(excinfo.value)
+    assert MASK in message
+    assert "hunter2" not in message


### PR DESCRIPTION
A sweep over 406 CLI command paths, all 164 MCP tools (full profile) and the launchd fleet on 2026-08-09. Each fix carries the measurement that found it.

## The store path an MCP client hands the server was unchecked

A stale `MEMO_DATA_DIR="sweep/store_cli_2/data"` — relative — sat in `~/.claude.json` for days. It resolved under the client's cwd, memo created a new empty store there, and **all 41 MCP tools answered from an empty corpus** while the CLI read the real one: `memo_search` returned zero hits in every mode, `memo_profile` reported `available: false`, `memo_unified_briefing` reported nothing.

The same string in `com.memo.watch.plist` hit `/sweep` (launchd cwd is `/`), a read-only filesystem, and crash-looped with a clear `RuntimeError`. Same misconfiguration; only the inherited cwd decided whether it was loud or invisible.

- `Config.from_env` now refuses a relative store path **that came from the environment**. The zero-config in-repo relative defaults (`memorias`, `.memo-state`), where the cwd IS the directory being described, are untouched.
- `memo doctor` grew `scan_mcp_store_env`. It checked the launch *command* only and printed `✓ mcp config paths: stable` for the entire duration of the outage — the one failure the CLI cannot feel, because the CLI is reading the right store.

## Two collaborative MCP tools could never return

`memo_collaborative_share_connection` and `share_insight` are annotated `-> dict[str, str]` but return dataclasses carrying `confidence: float`, `votes: int`, `contributors: list[str]`, `upvotes/downvotes: int`. FastMCP derives `{"additionalProperties": {"type": "string"}}` and rejects **every** call:

```
Output validation error: 0 is not of type 'string'
```

`tests/test_server_collaborative.py` drives these through a MagicMock server, so no schema was ever built and nothing compared the payload to it. The new test validates the real payload against the tool's **own advertised schema** — a call-only test goes green on fastmcp 3.4.5, which does not enforce output schemas, while 3.4.6 (what users install) does.

## A malformed `--as-of` was silently ignored

`memo search "wal" --as-of not-a-date` exited 0 and printed today's records. `memo_search_valid_as_of` echoed `{"as_of": "not-a-date"}` back beside present-day hits — a time-machine query answered from the present, presented as the past.

The store's leniency (`_normalize_as_of`, `_passes_validity_gate`) is deliberate and unchanged: a garbled bound should not crash a query mid-flight. It just cannot be the last word at a boundary where `memo_search_as_of`, `memo_ask_as_of` and `memo diff` all raise `Invalid isoformat string` on the same input.

## Write tools masked argument errors

The coordinator turned every non-`MemoError` into `coordinated MCP write failed safely (ValidationError) — details in the memo-mcp server log`. Masking the *message* is the right default; a storage or parsing failure can quote memory content.

A FastMCP argument-binding error is different in kind: raised **before** the tool body runs, describing only the call.

```
2 validation errors for call[memo_focus_set]
summary   Missing required argument
focus     Unexpected keyword argument
```

That carries no corpus content and is exactly what every read-only tool (`memo_related`, `memo_rerank`) already hands back in full — so the write surface was undiscoverable by the agents it exists for, pointing them at a server log they cannot read. Body failures stay masked; a test pins that.

## `memo config migrate` crashed instead of reporting

Same `write_default_config` that `config init` already wraps, unhandled: a raw `FileExistsError` traceback, plus a `pre-md-config` backup of a migration that never ran (the snapshot was taken first). Write first, snapshot after it succeeds.

## `memo sync init` staged memo's own index

`git add -A` at `memory_dir.parent` reaches `state_dir` whenever both live under one root:

```
git add -A failed: fatal: unable to stat 'state/tantivy/.tmp7nQlgN': No such file or directory
```

Tantivy's writer replaced its temp file between git's readdir and its stat. The quieter outcome is worse — winning that race commits a machine-local derived index into the cross-machine sync repo, against memo's own contract that markdown is the source of truth. `ensure_sync_gitignore` writes the derived-state ignores before either init path stages, appending only missing lines so a hand-written `.gitignore` survives.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format` — clean
- [x] `mypy src/memo/` — clean, 518 files
- [x] Full `pytest tests/` before and after, compared via junit XML: **identical 27 failures, zero regressions**

Those 27 are pre-existing order-dependent failures in a full `pytest tests/` on master (they pass in isolation). One cause is traced and left for a separate change: `memo reindex --rebuild` sets `MEMO_SKIP_MODEL_VERSION_CHECK=1` via `os.environ.setdefault` and never removes it, which is invisible in a CLI process that exits and permanent in the pytest process (and in the MCP server, which exposes `memo_reindex`). Repro in ~30s:

```
MEMO_CONFORMANCE_CORPUS_N=60 pytest \
  tests/conformance/test_index_rebuild_preserves.py \
  tests/test_store.py::test_embedder_version_stamped_on_first_open
```

Scoping that leak fixes 11 of the 27 and exposes 14 other tests that had been passing on the leaked flag, so it needs those hardened first rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)