### PR TITLE
fix: judge the codegraph index against the code, not the clock

### DIFF
--- a/src/memo/cli_doctor.py
+++ b/src/memo/cli_doctor.py
@@ -54,6 +54,62 @@ def _codegraph_cli_version(timeout_s: float = 2.0) -> tuple[int, int, int] | Non
     return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
 
 
+def _newest_source_mtime(project_root: Path) -> float | None:
+    """Newest mtime among git-tracked files, or None when git cannot answer.
+
+    Tracked files only: an index is not stale because a build artifact or a
+    scratch file changed, and walking the whole tree would read node_modules.
+    """
+    import subprocess
+
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(project_root), "ls-files", "-z"],
+            capture_output=True,
+            timeout=10.0,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    newest: float | None = None
+    for raw in proc.stdout.split(b"\0"):
+        if not raw:
+            continue
+        try:
+            mtime = (project_root / raw.decode()).stat().st_mtime
+        except OSError:
+            continue
+        if newest is None or mtime > newest:
+            newest = mtime
+    return newest
+
+
+def codegraph_staleness(db_path: Path, *, newest_source_mtime: float | None) -> str | None:
+    """Return a staleness warning for the codegraph index, or None if current.
+
+    Staleness is "behind the code", not "old". Comparing the index's age
+    against a flat 24-hour window warned on every repo nobody had touched for a
+    day, and `codegraph sync` answered "Already up to date" — a warning the
+    documented remedy could not clear, which trains the operator to ignore the
+    line and takes the real signal with it.
+
+    ``newest_source_mtime`` is None when git cannot enumerate the tree; there
+    is nothing to compare against, so age remains the best guess available.
+    """
+    import time
+
+    index_mtime = db_path.stat().st_mtime
+    if newest_source_mtime is not None:
+        if index_mtime >= newest_source_mtime:
+            return None
+        return "index is behind the working tree — run `codegraph sync`"
+    if time.time() - index_mtime > _CODEGRAPH_FRESH_MAX_AGE_S:
+        return "index older than 24h and freshness unverifiable — run `codegraph sync`"
+    return None
+
+
 def _check_codegraph() -> None:
     """Codegraph index health — WARN-only, never flips doctor's `ok`.
 
@@ -83,7 +139,6 @@ def _check_codegraph() -> None:
     else:
         try:
             import sqlite3 as cg_sqlite3
-            import time as cg_time
 
             cg_conn = cg_sqlite3.connect(f"file:{cg_db}?mode=ro", uri=True)
             try:
@@ -92,20 +147,22 @@ def _check_codegraph() -> None:
                 cg_edges = int(cg_conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0])
             finally:
                 cg_conn.close()
-            cg_age_s = cg_time.time() - cg_db.stat().st_mtime
             cg_warnings: list[str] = []
             if cg_journal != "wal":
                 cg_warnings.append(f"journal_mode={cg_journal} (expected wal)")
             if cg_nodes == 0 or cg_edges == 0:
                 cg_warnings.append(f"index empty (nodes={cg_nodes} edges={cg_edges})")
-            if cg_age_s > _CODEGRAPH_FRESH_MAX_AGE_S:
-                cg_warnings.append("index older than 24h — run `codegraph sync`")
+            cg_stale = codegraph_staleness(
+                cg_db, newest_source_mtime=_newest_source_mtime(cg_db.parent.parent)
+            )
+            if cg_stale:
+                cg_warnings.append(cg_stale)
             if cg_warnings:
                 console.print(f"[yellow]![/yellow] codegraph: {'; '.join(cg_warnings)}")
             else:
                 console.print(
                     f"[green]✓[/green] codegraph: index ok "
-                    f"(nodes={cg_nodes} edges={cg_edges}, wal, fresh <24h)"
+                    f"(nodes={cg_nodes} edges={cg_edges}, wal, current with the tree)"
                 )
         except Exception as exc:
             console.print(f"[yellow]![/yellow] codegraph: index unreadable: {exc}")

--- a/tests/test_doctor_codegraph_freshness.py
+++ b/tests/test_doctor_codegraph_freshness.py
@@ -20,9 +20,52 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
-from memo.cli_doctor import codegraph_staleness
+from memo.cli_doctor import _newest_source_mtime, codegraph_staleness
 
 DAY = 24 * 3600.0
+
+
+def _git(root: Path, *args: str) -> None:
+    import subprocess
+
+    subprocess.run(["git", *args], cwd=root, capture_output=True, check=True)
+
+
+def test_newest_source_mtime_reads_tracked_files(tmp_path: Path) -> None:
+    """The comparison point: the newest file git knows about."""
+    import os
+
+    _git(tmp_path, "init", "-b", "main")
+    old = tmp_path / "old.py"
+    new = tmp_path / "new.py"
+    old.write_text("a = 1", encoding="utf-8")
+    new.write_text("b = 2", encoding="utf-8")
+    _git(tmp_path, "add", "old.py", "new.py")
+    stamp = time.time() - 3 * DAY
+    os.utime(old, (stamp, stamp))
+    os.utime(new, (stamp + DAY, stamp + DAY))
+
+    assert _newest_source_mtime(tmp_path) == stamp + DAY
+
+
+def test_newest_source_mtime_ignores_untracked_files(tmp_path: Path) -> None:
+    """A build artifact is not a reason to call the index stale."""
+    import os
+
+    _git(tmp_path, "init", "-b", "main")
+    tracked = tmp_path / "mod.py"
+    tracked.write_text("a = 1", encoding="utf-8")
+    _git(tmp_path, "add", "mod.py")
+    stamp = time.time() - 2 * DAY
+    os.utime(tracked, (stamp, stamp))
+    (tmp_path / "artifact.bin").write_text("fresh", encoding="utf-8")
+
+    assert _newest_source_mtime(tmp_path) == stamp
+
+
+def test_newest_source_mtime_is_none_outside_a_repo(tmp_path: Path) -> None:
+    """`git ls-files` fails; there is nothing to compare against."""
+    assert _newest_source_mtime(tmp_path / "not-a-repo") is None
 
 
 def test_index_newer_than_sources_is_fresh(tmp_path: Path) -> None:

--- a/tests/test_doctor_codegraph_freshness.py
+++ b/tests/test_doctor_codegraph_freshness.py
@@ -1,0 +1,83 @@
+"""Codegraph staleness is "behind the code", not "old".
+
+The check compared the index file's mtime against a flat 24-hour window, so a
+repo nobody has touched in two days reported::
+
+    ! codegraph: index older than 24h — run `codegraph sync`
+
+and running the sync answered "Already up to date" — measured 2026-08-09 on a
+1,202-file index. A permanent warning that the documented remedy cannot clear
+teaches the operator to ignore the line, which costs the real signal: an index
+that is genuinely behind the source.
+
+Staleness is now relative to the newest tracked source file. Age alone is only
+reported when that comparison is unavailable (no git, unreadable tree), where
+the old heuristic is still the best guess on offer.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from memo.cli_doctor import codegraph_staleness
+
+DAY = 24 * 3600.0
+
+
+def test_index_newer_than_sources_is_fresh(tmp_path: Path) -> None:
+    source = tmp_path / "mod.py"
+    source.write_text("x = 1", encoding="utf-8")
+    db = tmp_path / "codegraph.db"
+    db.write_text("index", encoding="utf-8")
+
+    assert codegraph_staleness(db, newest_source_mtime=source.stat().st_mtime) is None
+
+
+def test_an_old_but_current_index_is_fresh(tmp_path: Path) -> None:
+    """The regression: untouched repo, week-old index, nothing to do."""
+    db = tmp_path / "codegraph.db"
+    db.write_text("index", encoding="utf-8")
+    week_ago = time.time() - 7 * DAY
+    import os
+
+    os.utime(db, (week_ago, week_ago))
+
+    assert codegraph_staleness(db, newest_source_mtime=week_ago - DAY) is None
+
+
+def test_index_behind_the_source_is_stale(tmp_path: Path) -> None:
+    db = tmp_path / "codegraph.db"
+    db.write_text("index", encoding="utf-8")
+    import os
+
+    old = time.time() - 2 * DAY
+    os.utime(db, (old, old))
+
+    message = codegraph_staleness(db, newest_source_mtime=time.time())
+
+    assert message is not None
+    assert "codegraph sync" in message
+    assert "behind" in message
+
+
+def test_falls_back_to_age_when_sources_are_unknown(tmp_path: Path) -> None:
+    """No git / unreadable tree: age is the only signal left."""
+    db = tmp_path / "codegraph.db"
+    db.write_text("index", encoding="utf-8")
+    import os
+
+    old = time.time() - 2 * DAY
+    os.utime(db, (old, old))
+
+    message = codegraph_staleness(db, newest_source_mtime=None)
+
+    assert message is not None
+    assert "24h" in message
+
+
+def test_recent_index_with_unknown_sources_is_fresh(tmp_path: Path) -> None:
+    db = tmp_path / "codegraph.db"
+    db.write_text("index", encoding="utf-8")
+
+    assert codegraph_staleness(db, newest_source_mtime=None) is None


### PR DESCRIPTION
`memo doctor` compared the codegraph index file's mtime to a flat 24-hour window:

```
! codegraph: index older than 24h — run `codegraph sync`
```

Running the documented remedy answered `Already up to date`. Measured 2026-08-09 on a 1,202-file / 24,431-node index that was, in fact, current — the repo simply had not been touched in two days.

A warning the remedy cannot clear is worse than no warning: it trains the operator to skip the line, and takes the real signal with it — an index that is genuinely behind the source, which is exactly what the check exists to catch (`MEMO_GRAPH_USE_CODEGRAPH` is default-on, so a stale graph quietly degrades path/neighbors/impact).

Staleness is now the index mtime against the newest **git-tracked** file. Tracked only: an index is not stale because a build artifact changed, and walking the whole tree would read `node_modules`. When git cannot enumerate the tree, there is nothing to compare against — the age heuristic remains as the fallback and the message says so rather than implying a sync will help.

## Test plan

- [x] `pytest tests/test_doctor_codegraph_freshness.py tests/test_cli_doctor.py` — 12 passed, including the regression (week-old index, older sources, reports fresh)
- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/memo/` — clean, 518 files
- [x] `scripts/quality_gate.py` — 178 complexity / 187 exception budgets pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)