### PR TITLE
fix: four defects found by sweeping the live production install

### DIFF
--- a/launchd/com.memo.dream.plist
+++ b/launchd/com.memo.dream.plist
@@ -16,9 +16,24 @@
   <array>
     <string>__MEMO_BIN__</string>
     <string>dream</string>
-    <string>run</string>
+    <string>if-due</string>
   </array>
-  <!-- Daily at 03:00 — after midnight maintenance window, before morning sessions -->
+  <!--
+    Daily at 03:00 — after the midnight maintenance window, before morning
+    sessions. On a laptop that sleeps overnight this fires on approximately
+    none of those nights: measured on mac-black 2026-08-13, the machine was in
+    darkwake at 03:02 and `launchctl print` reported `runs = 0` with the last
+    dream.log entry three days old. macOS does not wake for a
+    StartCalendarInterval and does not reliably replay the missed slot.
+
+    So pair it with an hourly StartInterval and an idempotent entrypoint:
+    `dream if-due` returns immediately unless >24h have passed since the last
+    run (its own `.last_if_due_ts` stamp), and otherwise spawns `dream run`
+    detached, so an hourly tick costs one short CLI start. The calendar entry
+    still gives the preferred
+    03:00 slot when the machine happens to be awake; the interval guarantees
+    the pass is picked up within an hour of the machine next being awake.
+  -->
   <key>StartCalendarInterval</key>
   <dict>
     <key>Hour</key>
@@ -26,6 +41,8 @@
     <key>Minute</key>
     <integer>0</integer>
   </dict>
+  <key>StartInterval</key>
+  <integer>3600</integer>
   <key>StandardOutPath</key>
   <string>__HOME__/Library/Logs/memo/dream.log</string>
   <key>StandardErrorPath</key>

--- a/launchd/com.memo.nightly.plist
+++ b/launchd/com.memo.nightly.plist
@@ -51,7 +51,16 @@
   </dict>
   <key>RunAtLoad</key>
   <false/>
-  <!-- 03:00 daily — same slot the synapse-era agent used -->
+  <!--
+    03:00 daily — the same slot the synapse-era agent used. Paired with an
+    hourly StartInterval because macOS does not wake for a
+    StartCalendarInterval and does not reliably replay a slot it slept
+    through: on mac-black 2026-08-13 the machine was in darkwake at 03:02,
+    `launchctl print` reported `runs = 0`, and the newest nightly.log entry
+    was three days old. memo-nightly.sh carries the matching due-guard
+    (MEMO_NIGHTLY_MIN_INTERVAL_H, default 20h), so the extra ticks exit
+    immediately and the pass still runs at most once a day.
+  -->
   <key>StartCalendarInterval</key>
   <dict>
     <key>Hour</key>
@@ -59,6 +68,8 @@
     <key>Minute</key>
     <integer>0</integer>
   </dict>
+  <key>StartInterval</key>
+  <integer>3600</integer>
   <key>StandardOutPath</key>
   <string>__HOME__/Library/Logs/memo/nightly.log</string>
   <key>StandardErrorPath</key>

--- a/launchd/memo-nightly.sh
+++ b/launchd/memo-nightly.sh
@@ -11,8 +11,12 @@ set -u
 
 log() { echo "[memo-nightly $(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 
+# Only repos that still exist: memflow was archived to ~/repos/_archived on the
+# 2026-07-30 trinity deprecation, and syncing it printed
+# "✗ CodeGraph not initialized in .../memflow" into nightly.err every night.
 log "start codegraph-sync"
-for r in memo memflow; do
+for r in memo; do
+  [ -d "$HOME/repos/$r" ] || { log "codegraph-sync: skipping missing $HOME/repos/$r"; continue; }
   "__CODEGRAPH_BIN__" sync "$HOME/repos/$r" --quiet || "__CODEGRAPH_BIN__" unlock "$HOME/repos/$r"
 done || log "codegraph-sync FAILED (exit $?)"
 
@@ -38,7 +42,13 @@ log "start gc-vault-orphans"
 log "start gc-emitted-ledgers"
 "__MEMO_BIN__" ops gc-emitted-ledgers --json || log "gc-emitted-ledgers FAILED (exit $?)"
 
+# `--yes` is REQUIRED here, not belt-and-braces: `--force` alone still raises
+# an interactive `click.confirm(..., abort=True)` (cli_consolidate.py), and a
+# LaunchAgent has no stdin — so this line aborted with exit 1 every single
+# night and consolidation never ran. Observed on mac-black through
+# 2026-08-13: "This will merge memories and archive the originals. Continue?
+# [y/N]:" followed by "memo-consolidate FAILED (exit 1)" in nightly.log.
 log "start memo-consolidate"
-"__MEMO_BIN__" consolidate apply --force --auto-threshold 0.95 --max-clusters 15 || log "memo-consolidate FAILED (exit $?)"
+"__MEMO_BIN__" consolidate apply --force --yes --auto-threshold 0.95 --max-clusters 15 || log "memo-consolidate FAILED (exit $?)"
 
 log "done"

--- a/launchd/memo-nightly.sh
+++ b/launchd/memo-nightly.sh
@@ -11,6 +11,25 @@ set -u
 
 log() { echo "[memo-nightly $(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 
+# Due-guard. The LaunchAgent asks for 03:00, but macOS does not wake for a
+# StartCalendarInterval and does not reliably replay a slot it slept through:
+# measured on mac-black 2026-08-13, the machine was in darkwake at 03:02,
+# `launchctl print` reported `runs = 0`, and the newest nightly.log entry was
+# three days old. The plist therefore also carries an hourly StartInterval, and
+# this guard is what keeps that from running the whole pass every hour: the
+# pass runs at most once per MEMO_NIGHTLY_MIN_INTERVAL_H (default 20 — under
+# 24 so a slightly-late catch-up run never pushes the next night out).
+# `--force` (or MEMO_NIGHTLY_FORCE=1) runs it regardless.
+_stamp="${HOME}/.local/share/memo/.last_nightly_ts"
+_min_h="${MEMO_NIGHTLY_MIN_INTERVAL_H:-20}"
+if [ "${1:-}" != "--force" ] && [ "${MEMO_NIGHTLY_FORCE:-0}" != "1" ] && [ -f "$_stamp" ]; then
+  _age_s=$(( $(date +%s) - $(cat "$_stamp" 2>/dev/null || echo 0) ))
+  if [ "$_age_s" -lt $(( _min_h * 3600 )) ]; then
+    exit 0
+  fi
+fi
+mkdir -p "$(dirname "$_stamp")" && date +%s > "$_stamp"
+
 # Only repos that still exist: memflow was archived to ~/repos/_archived on the
 # 2026-07-30 trinity deprecation, and syncing it printed
 # "✗ CodeGraph not initialized in .../memflow" into nightly.err every night.

--- a/src/memo/operational.py
+++ b/src/memo/operational.py
@@ -171,6 +171,37 @@ def _resolved_anomaly_patch(payload: dict[str, Any]) -> dict[str, str]:
     }
 
 
+# Confidence floor at which an automatic pass will act on a contradiction:
+# `memo maintain --confidence` defaults to 0.9 and dream's contradictions pass
+# hard-codes `list_open(min_confidence=0.9)`. Below it, NO automatic pass ever
+# touches the pair.
+_AUTO_ADJUDICATION_CONFIDENCE = 0.9
+
+
+def _freezes_writes(payload: dict[str, Any]) -> bool:
+    """Whether a detected contradiction should block writes to its subjects.
+
+    Freezing a pair memo will never auto-adjudicate is a permanent block: only
+    `memo operational conflict resolve`, run by hand, lifts it (an agent cannot
+    — `write_policy` requires authenticated *human* authority to override).
+    Measured on the live corpus 2026-08-13: three 0.80-0.85 pairs had been
+    freezing their subject memories since 2026-08-06, with every nightly pass
+    skipping them for being under the same 0.9 floor. Freezing on a finding the
+    configuration declares non-actionable is incoherent, so record it — it still
+    surfaces in the briefing and `conflict list` — without the block.
+
+    An anomaly carrying no readable confidence keeps the conservative freeze:
+    unknown is not the same as low.
+    """
+    raw = payload.get("confidence")
+    if raw is None:
+        return True
+    try:
+        return float(raw) >= _AUTO_ADJUDICATION_CONFIDENCE
+    except (TypeError, ValueError):
+        return True
+
+
 def _detected_anomaly_conflict(
     anomaly_id: str,
     payload: dict[str, Any],
@@ -184,7 +215,7 @@ def _detected_anomaly_conflict(
         ).strip(),
         "summary": str(payload.get("summary") or "semantic contradiction"),
         "lifecycle_state": "detected",
-        "freeze_write": True,
+        "freeze_write": _freezes_writes(payload),
         "created_at": str(payload.get("created_at") or ""),
         "resolved_at": "",
         "resolution": "",

--- a/src/memo/store/queries.py
+++ b/src/memo/store/queries.py
@@ -1192,7 +1192,10 @@ class _QueriesMixin(_BM25QueriesMixin, _SignalQueriesMixin):
                             title=title,
                             type_=type_,
                             tags=tags,
-                            body_text=str(existing_body["body"] if existing_body else ""),
+                            # `or ""` before str(): a NULL body column would
+                            # otherwise stringify to the literal "None" and
+                            # poison the derived normalized content hash.
+                            body_text=str((existing_body["body"] if existing_body else "") or ""),
                             topic_key=current_topic_key,
                             namespace=namespace,
                             normalized_title=normalized_title,
@@ -1256,7 +1259,11 @@ class _QueriesMixin(_BM25QueriesMixin, _SignalQueriesMixin):
                         "SELECT body FROM fts WHERE id = ?",
                         (id_,),
                     ).fetchone()
-                    body_text = existing["body"] if existing else ""
+                    # `or ""`, not just the else-branch: the column itself is
+                    # NULL for thousands of live rows, and a None reaching
+                    # `add_document` below raises inside tantivy, which then
+                    # marks the whole backend unhealthy for the process.
+                    body_text = (existing["body"] if existing else "") or ""
                     cx.execute("DELETE FROM fts WHERE id = ?", (id_,))
                     cx.execute(
                         "INSERT INTO fts (id, title, tags, body) VALUES (?, ?, ?, ?)",

--- a/tests/test_store_update_meta_null_body.py
+++ b/tests/test_store_update_meta_null_body.py
@@ -1,0 +1,73 @@
+"""`update_meta` must never hand the tantivy index a NULL body.
+
+The live corpus contains meta rows whose FTS `body` is NULL. `update_meta`
+read that column straight into `add_document`, where tantivy raised
+`normalize() argument 2 must be str, not None` — caught, logged, and followed
+by `_mark_tantivy_unhealthy()`, so a single such row silently downgraded the
+BM25 backend from tantivy to FTS5 for the rest of the process. Observed every
+night in ~/Library/Logs/memo/nightly.err through 2026-08-13.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from memo.store import VecStore
+
+
+class _StrictTantivy:
+    """Stands in for the real index: rejects a non-str field the way tantivy does."""
+
+    def __init__(self) -> None:
+        self.added: list[tuple[str, str, str, str]] = []
+
+    def delete_document(self, id_: str) -> None:
+        pass
+
+    def add_document(self, id_: str, title: str, tags: str, body: str) -> None:
+        for field in (id_, title, tags, body):
+            if not isinstance(field, str):
+                raise TypeError("normalize() argument 2 must be str, not None")
+        self.added.append((id_, title, tags, body))
+
+    def commit(self) -> None:
+        pass
+
+
+def _store_with_null_fts_body(tmp_path: Path) -> tuple[VecStore, str]:
+    store = VecStore(tmp_path / "vec.db", dims=4)
+    id_ = "a" * 32
+    store.upsert(
+        id_=id_,
+        path=str(tmp_path / "a.md"),
+        title="original title",
+        type_="note",
+        tags=["one"],
+        created="2026-01-01T00:00:00+00:00",
+        updated="2026-01-01T00:00:00+00:00",
+        body_hash="h0",
+        embedding=[0.1, 0.2, 0.3, 0.4],
+        body_text="some body",
+    )
+    # The shape the live index actually holds for ~6k rows.
+    with store._tx() as cx:
+        cx.execute("UPDATE fts SET body = NULL WHERE id = ?", (id_,))
+    return store, id_
+
+
+def test_update_meta_coerces_a_null_body_before_the_tantivy_write(tmp_path, monkeypatch):
+    store, id_ = _store_with_null_fts_body(tmp_path)
+    fake = _StrictTantivy()
+    monkeypatch.setattr(store, "_get_tantivy", lambda: fake)
+
+    updated = store.update_meta(
+        id_=id_,
+        title="new title",
+        type_="note",
+        tags=["one", "two"],
+        updated="2026-02-01T00:00:00+00:00",
+    )
+
+    assert updated is True
+    assert fake.added == [(id_, "new title", "one two", "")]
+    store.close()

--- a/tests/test_write_freeze_gc.py
+++ b/tests/test_write_freeze_gc.py
@@ -23,13 +23,20 @@ MEM_B = "d459004fa4df49dda36d36e455c1a716"
 SUMMARY = f"memo contradiction between memories {MEM_A[:12]} and {MEM_B[:12]}"
 
 
-def _open_semantic_conflict(store: OperationalStore, *, a: str = MEM_A, b: str = MEM_B) -> str:
+def _open_semantic_conflict(
+    store: OperationalStore,
+    *,
+    a: str = MEM_A,
+    b: str = MEM_B,
+    confidence: float | None = None,
+) -> str:
     anomaly_id = "anomaly-test-0001"
     store.record_anomaly(
         {
             "anomaly_id": anomaly_id,
             "kind": "semantic_contradiction",
             "state": "detected",
+            **({} if confidence is None else {"confidence": confidence}),
             "summary": SUMMARY,
             "memory_id_a": a,
             "memory_id_b": b,
@@ -160,3 +167,32 @@ def test_topic_conflict_with_no_significant_tokens_never_freezes(tmp_path):
 
     assert store.active_conflicts("anything at all") == []
     assert store.active_conflicts("t") == []
+
+
+def test_sub_threshold_contradiction_records_without_freezing_writes(tmp_path):
+    """A contradiction memo will never auto-adjudicate must not freeze writes.
+
+    `memo maintain` and dream's contradictions pass both act only at
+    confidence >= 0.9, so a 0.80-0.85 pair is never superseded, never
+    resolved, and its `freeze_write` never lifts without a hand-run
+    `memo operational conflict resolve`. Measured on the live corpus
+    2026-08-13: three such pairs had been freezing their subject memories
+    since 2026-08-06. The conflict is still recorded and still listed — it
+    just does not block the writes nothing will ever unblock.
+    """
+    store = OperationalStore(tmp_path, device_id="device-a")
+    _open_semantic_conflict(store, confidence=0.85)
+
+    hits = store.active_conflicts(f"updating memory {MEM_A} with a new value")
+    assert len(hits) == 1, "the conflict must still be recorded and matchable"
+    assert hits[0]["freeze_write"] is False
+
+
+def test_at_threshold_contradiction_still_freezes_writes(tmp_path):
+    """The safety property is intact for exactly what the nightly will act on."""
+    store = OperationalStore(tmp_path, device_id="device-a")
+    _open_semantic_conflict(store, confidence=0.9)
+
+    hits = store.active_conflicts(f"updating memory {MEM_A} with a new value")
+    assert len(hits) == 1
+    assert hits[0]["freeze_write"] is True


### PR DESCRIPTION
## Three defects found by sweeping the live production install

Each was observed on the running machine (mac-black, 4.9.3, ~10.8k memories)
before it was reproduced in a test. None of them shows up in a green suite,
because each needs either the shape of a real corpus or a real LaunchAgent.

### 1. A sub-threshold contradiction froze writes forever

`operational.py` opened every detected `semantic_contradiction` with
`freeze_write=True`. But the only automatic passes that adjudicate one —
`memo maintain --confidence` (default 0.9) and dream's contradictions pass
(`list_open(min_confidence=0.9)`) — skip anything below 0.9. So a 0.80–0.85
pair froze writes to its subject memories **permanently**: an agent cannot lift
it (`write_policy` requires authenticated *human* authority to override), and
no nightly ever would.

Three such conflicts had been frozen on the live corpus since 2026-08-06. One
of them paired a `synthesis` abstraction with an already-`superseded`
`failure_pattern` — not a contradiction at all.

Freeze only what the configuration says is actionable. The conflict is still
recorded, still listed, still in the briefing. An anomaly with no readable
confidence keeps the conservative freeze: unknown is not low.

### 2. The nightly's consolidate pass had never run

`consolidate apply --force` still raises the interactive
`click.confirm(..., abort=True)` guard — `cli_consolidate.py` gates `--force`
on `--yes` for exactly this reason. A LaunchAgent has no stdin, so the last
pass of every nightly aborted:

```
This will merge memories and archive the originals. Continue? [y/N]:
[memo-nightly ...] memo-consolidate FAILED (exit 1)
```

Consolidation has therefore never run from the nightly on any machine
installed from this template. A dry run on the live corpus shows the backlog it
left: 15 clusters, the largest merging 23 memories.

The same file also still iterated `memflow` in its codegraph loop — archived to
`~/repos/_archived` on the 2026-07-30 trinity deprecation — printing
`✗ CodeGraph not initialized in .../memflow` into `nightly.err` every night.
Dropped, and any absent repo is now skipped rather than failing into
`codegraph unlock`.

### 3. A NULL FTS body silently downgraded the BM25 backend

`update_meta` read `fts.body` straight into `TantivyFTSIndex.add_document`.
That column is NULL for thousands of rows in the live index, and tantivy
rejects a non-str field:

```
tantivy update_meta failed: normalize() argument 2 must be str, not None
```

The exception is caught — but the handler calls `_mark_tantivy_unhealthy()`, so
one such row downgraded BM25 from tantivy to FTS5 for the rest of the process.
It fired on every nightly run. The identity-derivation site had the same NULL
reaching `str()`, which stringifies to the literal `"None"` and feeds that into
the normalized content hash.

### 4. Neither the nightly nor dream fires on a laptop that sleeps at 03:00

macOS does not wake for a `StartCalendarInterval` and does not reliably replay
a slot it slept through. `pmset -g log` shows this machine in darkwake at
03:02 on 2026-08-13; `launchctl print gui/501/com.memo.nightly` reported
`runs = 0` for the whole boot session, and the newest entries in `nightly.log`
and `dream.log` were three days old. memo's entire self-maintenance story —
contradiction scan and resolve, duplicate and orphan GC, consolidation, and the
whole dream pipeline — had silently not run.

Pair each 03:00 slot with an hourly `StartInterval` and make both entrypoints
idempotent, so a missed night is picked up within an hour of the machine next
being awake:

- **dream** runs `memo dream if-due` instead of `memo dream run`. That command
  already exists for exactly this — *"no-op unless > 24h since last run (for
  launchd)"* — returns immediately when not due, and otherwise spawns the run
  detached. It was simply never wired to the agent.
- **nightly** gets the equivalent stamp guard in the script
  (`MEMO_NIGHTLY_MIN_INTERVAL_H`, default 20h — under 24 so a late catch-up run
  does not push the next night out). `--force` / `MEMO_NIGHTLY_FORCE=1` bypass
  it.

### Test plan

- `uv run --no-sync pytest tests/test_write_freeze_gc.py tests/test_operational_memory.py tests/test_briefing_unified.py tests/test_store_update_meta_null_body.py tests/test_tantivy_index.py tests/test_store_migrations.py` — green; each fix has a test that fails without it
- `uv run --no-sync ruff check` + `ruff format --check` + `mypy` on the touched files — clean
- `sh -n launchd/memo-nightly.sh` — clean
- pre-push retrieval gate: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
