### PR TITLE
fix: consolidate within (project, type) instead of on cosine alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
   memories stay untagged rather than being absorbed into one. A record
   carrying two `project:` tags of its own is left out entirely — no partner
   makes its union writable.
+- **Consolidation silently retyped what it merged.** The merged record takes
+  the type of its newest member, so a cross-type cluster retypes everyone
+  else — and type decides which surface a memory appears on:
+  `failure_pattern` feeds the recall hook's ⛔ AVOID block, `procedure` feeds
+  procedure promotion, `preference`/`feedback` get their own recall boost
+  tier. One live pass merged `decision`, `procedure`, `failure_pattern`,
+  `preference` and `note` into a single `decision`; across that pass 55 of 66
+  archived records lost their type, and the committed retrieval label set
+  caught it as an AVOID probe that stopped resolving (avoid@k 1.000 → 0.500).
+  Clustering is now partitioned by type as well as by project scope: records
+  that are near-identical in wording but differ in type are not duplicates,
+  they are the same topic seen through different lenses. Measured on the same
+  corpus, this trades 106 merged memories per pass for 79 — and 0 retyped
+  instead of 57.
 
 ## [4.10.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+### Fixed
+
+- **Consolidation proposed merges the write path then refused.** Clusters were
+  built on cosine alone, but `apply_merge` saves the merged record with the
+  *union* of its members' tags and `identity.namespace_for_write` rejects a
+  union carrying more than one `project:` slug. Every cluster that spanned two
+  projects was proposed, attempted, and lost to `memory identity conflict:
+  ambiguous_namespace` — measured on a 6,135-memory corpus at the default
+  threshold, **14 of 15 clusters died that way**, so the nightly pass looked
+  like it ran while merging 9 memories instead of 138. Clustering now runs
+  independently inside each project scope (`identity.cluster_scope`), which
+  keeps every proposal writable *and* leaves project attribution untouched: a
+  memory is only ever merged with memories of its own project, and untagged
+  memories stay untagged rather than being absorbed into one. A record
+  carrying two `project:` tags of its own is left out entirely — no partner
+  makes its union writable.
+
 ## [4.10.0] - 2026-08-13
 
 ### Added

--- a/src/memo/identity.py
+++ b/src/memo/identity.py
@@ -155,6 +155,25 @@ def namespace_for_write(tags: Sequence[str], *, auto_project: bool) -> str:
     return UNSCOPED_NAMESPACE if auto_project else GLOBAL_NAMESPACE
 
 
+def cluster_scope(tags: Sequence[str]) -> str | None:
+    """Scope key for grouping records that may legally be merged together.
+
+    A merged record carries the UNION of its members' tags, so any grouping
+    done ahead of a merge has to agree with :func:`namespace_for_write` or the
+    write is refused as ``ambiguous_namespace``. Records sharing this key
+    always produce a writable union; ``None`` marks a record that is already
+    ambiguous on its own and therefore cannot be merged with anything.
+
+    Untagged records get their own ``""`` scope rather than joining a project:
+    the write path would accept the union, but the merge would silently
+    reassign them to that project.
+    """
+    slugs, invalid = _project_slugs(tags)
+    if invalid or len(slugs) > 1:
+        return None
+    return slugs[0] if slugs else ""
+
+
 def namespace_for_index(tags: Sequence[str], *, path: str) -> str | None:
     """Derive namespace for an existing Markdown/index row.
 

--- a/src/memo/memory/consolidate_ops.py
+++ b/src/memo/memory/consolidate_ops.py
@@ -352,28 +352,44 @@ class _ConsolidateOpsMixin(_MemoryBase):
         items: builtins.list[dict[str, Any]],
         threshold: float,
     ) -> builtins.list[builtins.list[int]]:
-        """Cluster inside each project scope, never across it.
+        """Cluster inside each (project scope, memory type), never across either.
 
-        `apply_merge` writes the merged record with the UNION of its members'
-        tags, and `identity.namespace_for_write` refuses a union carrying more
-        than one `project:` slug. Clustering on cosine alone ignores that, so a
-        cross-project cluster was proposed and then rejected at apply time
+        Cosine similarity is blind to two things a merge cannot ignore:
+
+        **Project.** `apply_merge` writes the merged record with the UNION of
+        its members' tags, and `identity.namespace_for_write` refuses a union
+        carrying more than one `project:` slug. A cross-project cluster was
+        therefore proposed and then rejected at apply time
         (`ambiguous_namespace`) — on the live corpus that killed 14 of 15
         clusters, leaving consolidation looking like it ran while doing ~7% of
-        the work. Partitioning first makes every proposal writable, and keeps
-        project attribution exactly where it was: a memory is only ever merged
-        with memories of its own scope.
+        the work.
+
+        **Type.** The merged record takes the type of its newest member, so a
+        cross-type merge silently retypes everyone else — and type decides
+        which surface a memory appears on: `failure_pattern` feeds the recall
+        hook's ⛔ AVOID block, `procedure` feeds procedure promotion,
+        `preference`/`feedback` get their own recall boost tier. One measured
+        pass merged `decision`, `procedure`, `failure_pattern`, `preference`
+        and `note` into a single `decision`; across the pass 57 records lost
+        their type, and the retrieval label set caught it as an AVOID probe
+        that stopped resolving. Records that are near-identical in wording but
+        differ in type are not duplicates — they are the same topic seen
+        through different lenses.
+
+        Partitioning on both keeps every proposal writable and lossless: a
+        memory is only ever merged with memories of its own project and its own
+        type, so nothing changes attribution or leaves its surface.
         """
         from memo.identity import cluster_scope
 
-        groups: dict[str, builtins.list[int]] = {}
+        groups: dict[tuple[str, str], builtins.list[int]] = {}
         for idx, item in enumerate(items):
             scope = cluster_scope(item.get("tags") or [])
             if scope is None:
                 # Already ambiguous by itself: no partner makes the union
                 # writable, so it can never be a merge candidate.
                 continue
-            groups.setdefault(scope, []).append(idx)
+            groups.setdefault((scope, str(item.get("type") or "")), []).append(idx)
 
         out: builtins.list[builtins.list[int]] = []
         for member_idxs in groups.values():
@@ -459,8 +475,9 @@ class _ConsolidateOpsMixin(_MemoryBase):
         Algorithm:
         1. Pull all stored embeddings (we have them already; no re-embed).
         2. Greedy single-link clustering by cosine ≥ `threshold`, run
-           independently inside each project scope so the merge it proposes
-           is one the write path accepts (see `_cluster_within_scope`).
+           independently inside each (project scope, type) so the merge it
+           proposes is one the write path accepts and one that costs no
+           record its type (see `_cluster_within_scope`).
            Each memory joins the first existing cluster it's
            ≥-similar to, or starts a new one.
         3. Drop singletons. The remaining clusters are candidates.

--- a/src/memo/memory/consolidate_ops.py
+++ b/src/memo/memory/consolidate_ops.py
@@ -348,6 +348,41 @@ class _ConsolidateOpsMixin(_MemoryBase):
             return clusters
 
     @staticmethod
+    def _cluster_within_scope(
+        items: builtins.list[dict[str, Any]],
+        threshold: float,
+    ) -> builtins.list[builtins.list[int]]:
+        """Cluster inside each project scope, never across it.
+
+        `apply_merge` writes the merged record with the UNION of its members'
+        tags, and `identity.namespace_for_write` refuses a union carrying more
+        than one `project:` slug. Clustering on cosine alone ignores that, so a
+        cross-project cluster was proposed and then rejected at apply time
+        (`ambiguous_namespace`) — on the live corpus that killed 14 of 15
+        clusters, leaving consolidation looking like it ran while doing ~7% of
+        the work. Partitioning first makes every proposal writable, and keeps
+        project attribution exactly where it was: a memory is only ever merged
+        with memories of its own scope.
+        """
+        from memo.identity import cluster_scope
+
+        groups: dict[str, builtins.list[int]] = {}
+        for idx, item in enumerate(items):
+            scope = cluster_scope(item.get("tags") or [])
+            if scope is None:
+                # Already ambiguous by itself: no partner makes the union
+                # writable, so it can never be a merge candidate.
+                continue
+            groups.setdefault(scope, []).append(idx)
+
+        out: builtins.list[builtins.list[int]] = []
+        for member_idxs in groups.values():
+            sub_items = [items[i] for i in member_idxs]
+            for cluster in _ConsolidateOpsMixin._greedy_cluster(sub_items, threshold):
+                out.append([member_idxs[j] for j in cluster])
+        return out
+
+    @staticmethod
     def _split_oversized_clusters(
         items: builtins.list[dict[str, Any]],
         clusters: builtins.list[builtins.list[int]],
@@ -423,7 +458,9 @@ class _ConsolidateOpsMixin(_MemoryBase):
 
         Algorithm:
         1. Pull all stored embeddings (we have them already; no re-embed).
-        2. Greedy single-link clustering by cosine ≥ `threshold`.
+        2. Greedy single-link clustering by cosine ≥ `threshold`, run
+           independently inside each project scope so the merge it proposes
+           is one the write path accepts (see `_cluster_within_scope`).
            Each memory joins the first existing cluster it's
            ≥-similar to, or starts a new one.
         3. Drop singletons. The remaining clusters are candidates.
@@ -455,7 +492,7 @@ class _ConsolidateOpsMixin(_MemoryBase):
             items = self._pull_embeddings(exclude_types={"reference"} | SENSITIVE_TYPES)
         if not items:
             return []
-        clusters = self._greedy_cluster(items, threshold)
+        clusters = self._cluster_within_scope(items, threshold)
 
         # 3) Drop singletons; rank by size (then by most-recent updated).
         candidate_clusters = [c for c in clusters if len(c) >= 2]

--- a/tests/test_consolidate_namespace_clustering.py
+++ b/tests/test_consolidate_namespace_clustering.py
@@ -12,11 +12,16 @@ import pytest
 from memo.identity import IdentityConflictError, cluster_scope, namespace_for_write
 
 
-def _item(mid: str, tags: list[str], emb: list[float] | None = None) -> dict:
+def _item(
+    mid: str,
+    tags: list[str],
+    emb: list[float] | None = None,
+    type_: str = "note",
+) -> dict:
     return {
         "id": mid,
         "title": f"title {mid}",
-        "type": "note",
+        "type": type_,
         "tags": tags,
         "path": f"{mid}.md",
         "updated": "2026-01-01T00:00:00+00:00",
@@ -101,6 +106,36 @@ def test_a_record_that_is_ambiguous_by_itself_is_never_proposed(mock_memory, mon
 
     assert len(clusters) == 1
     assert {m["id"] for m in clusters[0]["members"]} == {"memo0", "memo1"}
+
+
+def test_types_never_get_merged_together(mock_memory, monkeypatch):
+    """The merged record takes the type of its newest member, so a cross-type
+    merge retypes everyone else — and type decides which surface a memory shows
+    up on (`failure_pattern` → the recall hook's ⛔ AVOID block, `procedure` →
+    procedure promotion). A live pass merged five types into one `decision` and
+    a labelled AVOID probe stopped resolving."""
+    mem = mock_memory
+    items = [
+        _item("d1", ["project:memo"], type_="decision"),
+        _item("d2", ["project:memo"], type_="decision"),
+        _item("p1", ["project:memo"], type_="procedure"),
+        _item("p2", ["project:memo"], type_="procedure"),
+        _item("f1", ["project:memo"], type_="failure_pattern"),
+    ]
+
+    monkeypatch.setattr(mem, "_pull_embeddings", lambda **kwargs: items)
+    monkeypatch.setattr(mem, "_read_body", lambda path: f"body:{path}")
+
+    clusters = mem.consolidate(threshold=0.85, max_clusters=10, skip_llm=True)
+
+    for cluster in clusters:
+        assert len({m["type"] for m in cluster["members"]}) == 1
+    # The lone failure_pattern has no same-type partner, so it is not proposed
+    # at all rather than being folded into the decisions it resembles.
+    assert {frozenset(m["id"] for m in c["members"]) for c in clusters} == {
+        frozenset({"d1", "d2"}),
+        frozenset({"p1", "p2"}),
+    }
 
 
 def test_every_proposed_cluster_survives_namespace_for_write(mock_memory, monkeypatch):

--- a/tests/test_consolidate_namespace_clustering.py
+++ b/tests/test_consolidate_namespace_clustering.py
@@ -1,0 +1,129 @@
+"""Consolidation must propose only merges the write path will accept.
+
+A merged record carries the UNION of its members' tags, and
+`identity.namespace_for_write` refuses a union holding more than one `project:`
+slug (`ambiguous_namespace`). Clustering purely by cosine happily mixes
+projects, so the proposals were generated and then rejected at apply time —
+measured on the live corpus, 14 of 15 clusters died that way.
+"""
+
+import pytest
+
+from memo.identity import IdentityConflictError, cluster_scope, namespace_for_write
+
+
+def _item(mid: str, tags: list[str], emb: list[float] | None = None) -> dict:
+    return {
+        "id": mid,
+        "title": f"title {mid}",
+        "type": "note",
+        "tags": tags,
+        "path": f"{mid}.md",
+        "updated": "2026-01-01T00:00:00+00:00",
+        "emb": emb or [1.0, 0.0, 0.0, 0.0],
+    }
+
+
+def _project_slugs_of(cluster: dict) -> set[str]:
+    slugs = set()
+    for member in cluster["members"]:
+        for tag in member["tags"]:
+            if tag.startswith("project:"):
+                slugs.add(tag)
+    return slugs
+
+
+@pytest.mark.parametrize(
+    ("tags", "expected"),
+    [
+        ([], ""),
+        (["note"], ""),
+        (["project:memo"], "memo"),
+        (["Project:Memo", "note"], "memo"),
+        (["project:memo", "project:memflow"], None),
+        (["project:"], None),
+    ],
+)
+def test_cluster_scope_agrees_with_the_write_path(tags, expected):
+    assert cluster_scope(tags) == expected
+    if expected is None:
+        with pytest.raises(IdentityConflictError):
+            namespace_for_write(tags, auto_project=False)
+    else:
+        namespace_for_write(tags, auto_project=False)
+
+
+def test_identical_bodies_in_different_projects_cluster_separately(mock_memory, monkeypatch):
+    """Same embedding, different `project:` tag — one cosine cluster today, and
+    every merge it proposes is refused. Split it by project instead."""
+    mem = mock_memory
+    items = [_item(f"memo{i}", ["project:memo"]) for i in range(3)]
+    items += [_item(f"flow{i}", ["project:memflow"]) for i in range(2)]
+
+    monkeypatch.setattr(mem, "_pull_embeddings", lambda **kwargs: items)
+    monkeypatch.setattr(mem, "_read_body", lambda path: f"body:{path}")
+
+    clusters = mem.consolidate(threshold=0.85, max_clusters=10, skip_llm=True)
+
+    assert [c["size"] for c in clusters] == [3, 2]
+    assert [_project_slugs_of(c) for c in clusters] == [{"project:memo"}, {"project:memflow"}]
+
+
+def test_untagged_memories_never_get_absorbed_into_a_project(mock_memory, monkeypatch):
+    """Untagged records are mergeable with anything as far as the write path is
+    concerned, but folding them into a project cluster would silently reassign
+    them (and, under MEMO_STORE_BY_PROJECT, move their file and change the
+    recall project boost). Keep them in their own scope."""
+    mem = mock_memory
+    items = [_item(f"memo{i}", ["project:memo"]) for i in range(2)]
+    items += [_item(f"loose{i}", []) for i in range(2)]
+
+    monkeypatch.setattr(mem, "_pull_embeddings", lambda **kwargs: items)
+    monkeypatch.setattr(mem, "_read_body", lambda path: f"body:{path}")
+
+    clusters = mem.consolidate(threshold=0.85, max_clusters=10, skip_llm=True)
+
+    assert len(clusters) == 2
+    assert [_project_slugs_of(c) for c in clusters] == [{"project:memo"}, set()]
+
+
+def test_a_record_that_is_ambiguous_by_itself_is_never_proposed(mock_memory, monkeypatch):
+    """Two `project:` slugs on ONE record poison any cluster it joins — the union
+    stays ambiguous no matter who it merges with. Leave it out."""
+    mem = mock_memory
+    items = [_item(f"memo{i}", ["project:memo"]) for i in range(2)]
+    items.append(_item("mixed", ["project:memo", "project:memflow"]))
+
+    monkeypatch.setattr(mem, "_pull_embeddings", lambda **kwargs: items)
+    monkeypatch.setattr(mem, "_read_body", lambda path: f"body:{path}")
+
+    clusters = mem.consolidate(threshold=0.85, max_clusters=10, skip_llm=True)
+
+    assert len(clusters) == 1
+    assert {m["id"] for m in clusters[0]["members"]} == {"memo0", "memo1"}
+
+
+def test_every_proposed_cluster_survives_namespace_for_write(mock_memory, monkeypatch):
+    """The invariant, stated directly: the union of a proposal's tags must be
+    writable. This is what `apply_merge` hands to `Memory.save`."""
+    mem = mock_memory
+    items = [
+        _item("a", ["project:memo", "note"]),
+        _item("b", ["project:memo", "decision"]),
+        _item("c", ["project:memo-spec"]),
+        _item("d", ["project:memo-spec", "note"]),
+        _item("e", []),
+        _item("f", ["note"]),
+    ]
+
+    monkeypatch.setattr(mem, "_pull_embeddings", lambda **kwargs: items)
+    monkeypatch.setattr(mem, "_read_body", lambda path: f"body:{path}")
+
+    clusters = mem.consolidate(threshold=0.85, max_clusters=10, skip_llm=True)
+
+    assert clusters
+    for cluster in clusters:
+        union: set[str] = set()
+        for member in cluster["members"]:
+            union.update(member["tags"])
+        namespace_for_write(sorted(union), auto_project=False)


### PR DESCRIPTION
## Problem

Consolidation clustered on cosine similarity alone, ignoring two dimensions a merge cannot ignore. Both defects are invisible from the repo — they only show up when you run the pass against a real corpus and read what it actually did.

### 1. Cross-project clusters were proposed and then refused

`apply_merge` saves the merged record with the **union** of its members' tags, and `identity.namespace_for_write` rejects a union carrying more than one `project:` slug. Any cluster spanning two projects was proposed, attempted, and lost to:

```
Merge failed: memory identity conflict: ambiguous_namespace
```

Measured on the live corpus (6,135 memories) at the default `0.85` threshold the LLM pass uses:

| | clusters | writable | rejected | memories merged |
|---|---|---|---|---|
| before | 15 | 1 | **14** | 9 |
| after | 15 | 15 | 0 | 138 |

The nightly pass looked like it ran while doing ~7% of the work, and reported success — a rejected merge comes back as a skipped proposal, not an error.

### 2. Cross-type clusters silently retyped their members

The merged record takes the type of its **newest** member, so every other member is retyped. Type decides which surface a memory appears on:

- `failure_pattern` → the recall hook's ⛔ AVOID block
- `procedure` → procedure promotion
- `preference` / `feedback` → their own recall boost tier

Applying the first commit against the live corpus merged `decision`, `procedure`, `failure_pattern`, `preference` and `note` into a single `decision`. Across that one pass **55 of 66 archived records lost their type**. The committed retrieval label set caught it: an AVOID probe stopped resolving and `avoid@k` went 1.000 → 0.500.

## Fix

`identity.cluster_scope()` names the grouping key that agrees with the write path, and `_cluster_within_scope()` runs the existing greedy clustering independently inside each `(project scope, type)`.

Two deliberate choices:

- **Untagged records get their own scope** instead of joining a project. The write path would accept the union, but the merge would reassign them — and under `MEMO_STORE_BY_PROJECT` that also moves the file into the project bucket and changes the recall project boost.
- **A record carrying two `project:` tags of its own is left out entirely.** No partner makes its union writable, so proposing it can only waste an LLM call and a merge attempt.

Cost on the same corpus at 0.85: 79 memories merged per pass instead of 106, and 0 records retyped instead of 57. Records near-identical in wording but differing in type are not duplicates — they are the same topic seen through different lenses.

Partitioning is also strictly cheaper: the O(N²) pass now runs per scope.

## Verification

- `uv run --no-sync pytest tests/` — 7467 passed, 1 skipped
- `mypy` / `ruff check` / `ruff format --check` clean on the touched files
- Live `memo consolidate apply --force --yes`: 0 `ambiguous_namespace`, 0 failures
- `memo eval recall --against origin/master`: prec@5 0.681 vs 0.681, noise 0.000 vs 0.000 — zero retrieval delta, as expected for a maintenance-path change
- Pre-push retrieval gate: PASS (prec@5 0.681 ≥ 0.670, noise@k 0.000), no baseline reseed

## Follow-up worth filing

Consolidation's archive is **not reversible in practice**. `_archive_memory` strips the frontmatter `id` before writing to `archived/` and soft-deletes the row, and there is no `consolidate restore` counterpart to `maintain`'s `_restore_archived`. Repairing the retyped records from the pass above meant hand-reinjecting the id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)