### PR TITLE
fix: make consolidation merges reversible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
   never be deleted by an undo. `maintain`'s compaction has had the symmetric
   `_restore_archived` since it shipped; consolidation had nothing.
 
+  Restoring is also honest about the index: `(namespace, topic_key)` is UNIQUE
+  across live rows, and archiving a record soft-deletes it — which *frees* its
+  topic reservation for a later save to claim. Restoring such a record
+  verbatim made reindex's `deleted_at=NULL` un-delete violate that index, and
+  reindex reports a per-file failure as a log warning and carries on: the `.md`
+  landed in the live tree permanently unindexed while the restore claimed
+  success. The record coming out of the archive is by definition the superseded
+  one, so it now gives the slot up instead of colliding for it. As a general
+  net, every restored id is re-checked after the reindex; anything the index
+  would not adopt is reported in `unindexed_ids` with the `memo reindex
+  --rebuild` remedy, never counted as restored.
+
 ### Fixed
 
 - **A disk-only topic-reservation recovery could resurrect an archived memory.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+### Added
+
+- **`memo consolidate restore` — merges are reversible now.** Consolidation
+  archives the memories it absorbs, and that was a one-way door: `_archive_memory`
+  stripped the frontmatter `id` before writing to `archived/`, so `reindex`
+  (which requires a canonical id) could never adopt the file again even if a
+  human moved it back. Recovering a single wrongly-merged record meant
+  hand-editing YAML and re-injecting its id. The archived copy now keeps its
+  `id` and records the `archived_from` path it used to occupy, and
+  `memo consolidate restore <id>…` / `--for <merged-id>` moves memories back
+  into the live corpus — into their original path when it is still free,
+  otherwise a freshly allocated one. Legacy archives written without an id are
+  recovered from the filename. Restoring is additive: `--drop-merged` also
+  deletes the merged record, and refuses unless that record carries the new
+  `consolidated_from` provenance proving the merge created it, so a
+  `keep_latest` survivor — a pre-existing memory, not a merge artifact — can
+  never be deleted by an undo. `maintain`'s compaction has had the symmetric
+  `_restore_archived` since it shipped; consolidation had nothing.
+
+### Fixed
+
+- **A disk-only topic-reservation recovery could resurrect an archived memory.**
+  `_recover_topic_reservation_locked` walks every `.md` under `memory_dir` and
+  re-indexes the one holding a claimed `(namespace, topic_key)`. It never
+  skipped `inactive/` or `archived/` — and `inactive/` has always kept its
+  canonical id — so a compacted memory could be silently pulled back into the
+  index behind the user's back. It now skips `LIFECYCLE_ARCHIVE_DIRS`, the same
+  two directories `reindex` and the disk-orphan gc already refuse to absorb.
+  This is what makes preserving the `id` on the archived copy safe.
+
 ## [4.10.1] - 2026-08-14
 
 ### Fixed

--- a/src/memo/cli_consolidate.py
+++ b/src/memo/cli_consolidate.py
@@ -184,6 +184,91 @@ def consolidate_apply(
         console.print(f"[dim]...and {len(results) - 5} more[/dim]")
 
 
+@consolidate_group.command(name="restore")
+@click.argument("memory_ids", nargs=-1)
+@click.option(
+    "--for",
+    "for_merged",
+    metavar="MERGED_ID",
+    help="Restore every memory a given merge archived (undo one merge).",
+)
+@click.option(
+    "--drop-merged",
+    is_flag=True,
+    help="With --for, also delete the merged record. Refused unless that record was "
+    "created by the merge (a keep_latest survivor is real data).",
+)
+@click.option("--dry-run", is_flag=True, help="Report what would be restored, change nothing.")
+@click.option("--yes", "-y", is_flag=True, help="Skip the confirmation for --drop-merged.")
+@click.option("--json", "as_json", is_flag=True, help="Output raw JSON")
+def consolidate_restore(
+    memory_ids: tuple[str, ...],
+    for_merged: str | None,
+    drop_merged: bool,
+    dry_run: bool,
+    yes: bool,
+    as_json: bool,
+) -> None:
+    """Move archived memories back into the live corpus — the undo of a merge.
+
+    Restoring is additive: the merged record survives unless --drop-merged is
+    given, so an undo that turns out to be wrong destroys nothing.
+
+    Example: memo consolidate restore --for e9599fe4 --drop-merged
+    """
+    if not memory_ids and not for_merged:
+        raise click.UsageError("pass one or more memory ids, or --for <merged-id>")
+    if drop_merged and not for_merged:
+        raise click.UsageError("--drop-merged only applies with --for <merged-id>")
+    if drop_merged and not dry_run and not yes:
+        click.confirm(
+            f"This will delete the merged record {for_merged[:8] if for_merged else ''}. Continue?",
+            abort=True,
+        )
+
+    cfg = Config.from_env()
+    mem = _get_memory(cfg)
+
+    result = mem.consolidator.restore_archived(
+        list(memory_ids),
+        for_merged=for_merged,
+        drop_merged=drop_merged,
+        dry_run=dry_run,
+    )
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "restored_ids": result.restored_ids,
+                    "missing_ids": result.missing_ids,
+                    "dropped_merged_id": result.dropped_merged_id,
+                    "summary": result.summary,
+                    "dry_run": dry_run,
+                },
+                indent=2,
+            )
+        )
+        return
+
+    if dry_run:
+        console.print("[yellow]Dry run — nothing changed.[/yellow]")
+    console.print(f"[green]✓ Restored {len(result.restored_ids)} memories[/green]")
+    for mid in result.restored_ids[:20]:
+        console.print(f"  [cyan]{mid[:8]}[/cyan]")
+    if len(result.restored_ids) > 20:
+        console.print(f"[dim]...and {len(result.restored_ids) - 20} more[/dim]")
+    if result.missing_ids:
+        console.print(
+            f"[yellow]⊘ Not found under archived/: "
+            f"{escape(', '.join(m[:8] for m in result.missing_ids))}[/yellow]"
+        )
+    if result.dropped_merged_id:
+        console.print(f"[red]✗ Dropped merged record {result.dropped_merged_id[:8]}[/red]")
+    elif drop_merged:
+        console.print(f"[yellow]{escape(result.summary)}[/yellow]")
+
+
 @consolidate_group.command(name="list-archived")
 @click.option("--json", "as_json", is_flag=True, help="Output raw JSON")
 def consolidate_list_archived(as_json: bool) -> None:

--- a/src/memo/cli_consolidate.py
+++ b/src/memo/cli_consolidate.py
@@ -222,6 +222,11 @@ def consolidate_restore(
     """
     if not memory_ids and not for_merged:
         raise click.UsageError("pass one or more memory ids, or --for <merged-id>")
+    if memory_ids and for_merged:
+        # --for selects by archived_for and ignores positional ids entirely.
+        # Silently dropping what the user typed is how a partial restore gets
+        # mistaken for a complete one.
+        raise click.UsageError("pass memory ids or --for <merged-id>, not both")
     if drop_merged and not for_merged:
         raise click.UsageError("--drop-merged only applies with --for <merged-id>")
     if drop_merged and not dry_run and not yes:
@@ -246,6 +251,7 @@ def consolidate_restore(
                 {
                     "restored_ids": result.restored_ids,
                     "missing_ids": result.missing_ids,
+                    "unindexed_ids": result.unindexed_ids,
                     "dropped_merged_id": result.dropped_merged_id,
                     "summary": result.summary,
                     "dry_run": dry_run,
@@ -271,6 +277,12 @@ def _print_restore(result: RestoreResult, *, drop_merged: bool, dry_run: bool) -
         console.print(
             f"[yellow]⊘ Not recovered: "
             f"{escape(', '.join(m[:8] for m in result.missing_ids))}[/yellow]"
+        )
+    if result.unindexed_ids:
+        console.print(
+            f"[red]! Written to disk but NOT indexed: "
+            f"{escape(', '.join(m[:8] for m in result.unindexed_ids))}[/red]\n"
+            "[dim]  The .md is safe; the index refused it. Run `memo reindex --rebuild`.[/dim]"
         )
     if result.dropped_merged_id:
         console.print(f"[red]✗ Dropped merged record {result.dropped_merged_id[:8]}[/red]")

--- a/src/memo/cli_consolidate.py
+++ b/src/memo/cli_consolidate.py
@@ -7,6 +7,7 @@ root group in cli.py via `cli.add_command(consolidate_group)`.
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 
 import click
 from rich.markup import escape
@@ -15,6 +16,9 @@ from rich.table import Table
 from memo.cli_common import console
 from memo.cli_common import get_memory as _get_memory
 from memo.config import Config
+
+if TYPE_CHECKING:
+    from memo.consolidation import RestoreResult
 
 # -- advanced consolidation commands -------------------------------------------
 
@@ -251,6 +255,11 @@ def consolidate_restore(
         )
         return
 
+    _print_restore(result, drop_merged=drop_merged, dry_run=dry_run)
+
+
+def _print_restore(result: RestoreResult, *, drop_merged: bool, dry_run: bool) -> None:
+    """Render a RestoreResult for humans."""
     if dry_run:
         console.print("[yellow]Dry run — nothing changed.[/yellow]")
     console.print(f"[green]✓ Restored {len(result.restored_ids)} memories[/green]")
@@ -260,7 +269,7 @@ def consolidate_restore(
         console.print(f"[dim]...and {len(result.restored_ids) - 20} more[/dim]")
     if result.missing_ids:
         console.print(
-            f"[yellow]⊘ Not found under archived/: "
+            f"[yellow]⊘ Not recovered: "
             f"{escape(', '.join(m[:8] for m in result.missing_ids))}[/yellow]"
         )
     if result.dropped_merged_id:

--- a/src/memo/consolidation.py
+++ b/src/memo/consolidation.py
@@ -505,13 +505,14 @@ class AdvancedConsolidator:
     ) -> tuple[list[tuple[Path, str]], list[str]]:
         """Resolve the request to (file, id) pairs plus the ids not found."""
         import frontmatter
+        import yaml
 
         if for_merged:
             selected = []
             for path in archived_files:
                 try:
                     post = frontmatter.loads(path.read_text(encoding="utf-8"))
-                except Exception as exc:
+                except (OSError, yaml.YAMLError) as exc:
                     # One corrupt archive must not sink the rest of the batch.
                     _log.warning("restore: cannot read %s: %s", path.name, exc)
                     continue
@@ -534,10 +535,11 @@ class AdvancedConsolidator:
     def _restore_one(self, path: Path, memory_id: str) -> bool:
         """Write one archived file back into the live tree. Returns success."""
         import frontmatter
+        import yaml
 
         try:
             post = frontmatter.loads(path.read_text(encoding="utf-8"))
-        except Exception as exc:
+        except (OSError, yaml.YAMLError) as exc:
             # A corrupt or unreadable archive is reported and skipped; the rest
             # of the batch still gets restored.
             _log.warning("restore: cannot read %s: %s", path.name, exc)

--- a/src/memo/consolidation.py
+++ b/src/memo/consolidation.py
@@ -104,6 +104,7 @@ class RestoreResult:
 
     restored_ids: list[str]
     missing_ids: list[str]  # not recovered: absent, ambiguous prefix, or unreadable
+    unindexed_ids: list[str]  # .md is back on disk but the index would not adopt it
     dropped_merged_id: str | None  # merged record deleted to complete the undo
     summary: str
 
@@ -476,11 +477,19 @@ class AdvancedConsolidator:
                 # out of both lists — a silent drop is how you lose a memory.
                 missing.append(memory_id)
 
+        unindexed: list[str] = []
         if restored and not dry_run:
             # Files under archived/ are skipped by every walker, so the live
             # copy only becomes searchable once it is back in the tree — then
             # reindex adopts it (the upsert clears any delete tombstone).
             self.memory.reindex()
+            # reindex reports a per-file failure as a log warning and carries
+            # on, so "the file is back" does not prove "the memory is back".
+            # Anything the index would not adopt is called out, never counted
+            # as restored — the .md is safe on disk either way.
+            unindexed = [mid for mid in restored if self.memory.get(mid) is None]
+            if unindexed:
+                restored = [mid for mid in restored if mid not in set(unindexed)]
 
         dropped, note = self._drop_merged_record(
             for_merged if drop_merged else None, dry_run=dry_run
@@ -488,11 +497,16 @@ class AdvancedConsolidator:
         summary = f"Restored {len(restored)} archived memories"
         if missing:
             summary += f", {len(missing)} not found"
+        if unindexed:
+            summary += (
+                f", {len(unindexed)} written to disk but NOT indexed (run `memo reindex --rebuild`)"
+            )
         if note:
             summary += f" — {note}"
         return RestoreResult(
             restored_ids=restored,
             missing_ids=missing,
+            unindexed_ids=unindexed,
             dropped_merged_id=dropped,
             summary=summary,
         )
@@ -553,6 +567,7 @@ class AdvancedConsolidator:
         post["id"] = memory_id
 
         rel = self._restore_destination(post, origin)
+        self._release_taken_topic_key(post, rel)
         dest = self.memory.cfg.memory_dir / rel
         try:
             dest.parent.mkdir(parents=True, exist_ok=True)
@@ -562,6 +577,42 @@ class AdvancedConsolidator:
             _log.warning("restore: cannot write %s: %s", rel, exc)
             return False
         return True
+
+    def _release_taken_topic_key(self, post: Any, rel: str) -> None:
+        """Drop a topic reservation a live record has since claimed.
+
+        `(namespace, topic_key)` is UNIQUE across non-deleted rows. Archiving
+        soft-deleted this record, which released its reservation, so a later
+        save may hold it now. Restoring the frontmatter verbatim would make
+        reindex's `deleted_at=NULL` un-delete violate that index — and reindex
+        reports a per-file failure as a warning and moves on, so the `.md`
+        would sit in the live tree permanently unindexed while the restore
+        claimed success.
+
+        The record coming back out of the archive is by definition the
+        superseded one, so it gives the slot up rather than fight for it. Its
+        content is restored either way; only the topic claim is dropped.
+        """
+        from memo.identity import canonical_topic_key, namespace_for_index
+
+        topic_key = canonical_topic_key(post.metadata.get("topic_key"))
+        if not topic_key:
+            return
+        raw_tags = post.metadata.get("tags") or []
+        tags = [str(raw_tags)] if isinstance(raw_tags, str) else [str(t) for t in raw_tags]
+        namespace = namespace_for_index(tags, path=rel)
+        if namespace is None:
+            return
+        holders = self.memory.store.find_active_by_topic_identity(namespace, topic_key)
+        if not holders:
+            return
+        _log.warning(
+            "restore: %s gives up topic %r — %s holds it now",
+            str(post.metadata.get("id") or "?")[:8],
+            topic_key,
+            str(holders[0].get("id") or "?")[:8],
+        )
+        post.metadata.pop("topic_key", None)
 
     def _restore_destination(self, post: Any, origin: Any) -> str:
         """Prefer the path the memory used to hold; allocate a fresh one if taken."""

--- a/src/memo/consolidation.py
+++ b/src/memo/consolidation.py
@@ -26,8 +26,10 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from memo.llm import ChatBackend, MLXChat
@@ -94,6 +96,25 @@ class ConsolidationResult:
     archived_ids: list[str]  # IDs of archived memories
     skipped_ids: list[str]  # IDs that were skipped (e.g., conflicts)
     summary: str
+
+
+@dataclass(frozen=True)
+class RestoreResult:
+    """Result of moving archived memories back into the live corpus."""
+
+    restored_ids: list[str]
+    missing_ids: list[str]  # not recovered: absent, ambiguous prefix, or unreadable
+    dropped_merged_id: str | None  # merged record deleted to complete the undo
+    summary: str
+
+
+def _id_matches(value: str, wanted: str) -> bool:
+    """Exact id, or an unambiguous-length prefix of one.
+
+    `consolidate list-archived` prints 8-char prefixes, so those have to work
+    as input. Shorter fragments are refused rather than guessed at.
+    """
+    return value == wanted or (len(wanted) >= 8 and value.startswith(wanted))
 
 
 class AdvancedConsolidator:
@@ -339,6 +360,11 @@ class AdvancedConsolidator:
                     title=proposal.merged_title,
                     type_=type_,
                     tags=list(all_tags),
+                    # Provenance, and the marker `restore_archived --drop-merged`
+                    # keys off: only a record the merge CREATED may be deleted
+                    # when the merge is undone. A `keep_latest` survivor is a
+                    # pre-existing memory and never carries this.
+                    extra={"consolidated_from": sorted(proposal.memory_ids)},
                 )
 
             # Archive the old memories
@@ -368,7 +394,15 @@ class AdvancedConsolidator:
     def _archive_memory(self, memory_id: str, replacement_id: str) -> bool:
         """Archive a memory by moving it to the archived/ subdirectory.
 
-        Adds a frontmatter field `archived_for` pointing to the replacement.
+        The archived copy keeps everything ``restore_archived`` needs to put
+        it back: its canonical ``id``, the ``archived_from`` path it used to
+        occupy, and ``archived_for`` naming the record that replaced it.
+
+        Keeping the ``id`` is safe because every path that walks
+        ``memory_dir`` skips ``LIFECYCLE_ARCHIVE_DIRS`` — reindex, disk-orphan
+        gc, and topic-reservation recovery alike — and it is what makes the
+        merge reversible. ``inactive/`` (maintain's archive) has always kept
+        its id for exactly that reason.
         """
         rec = self.memory.get(memory_id)
         if not rec:
@@ -390,11 +424,8 @@ class AdvancedConsolidator:
         # Add archival metadata
         post["archived_for"] = replacement_id
         post["archived_at"] = datetime.now(UTC).isoformat()
-        # Drop the live `id` so `memo reindex`/gc (which rglob memory_dir,
-        # archived/ included) do NOT re-index this archived copy and
-        # resurrect the deleted memory. The id is preserved in the filename
-        # and in `archived_for`'s chain.
-        post.metadata.pop("id", None)
+        post["archived_from"] = rec.path
+        post["id"] = memory_id
 
         # Write to archived location
         archived_path = self._archival_dir / f"{memory_id}.md"
@@ -404,6 +435,168 @@ class AdvancedConsolidator:
         self.memory.delete(memory_id)
 
         return True
+
+    def restore_archived(
+        self,
+        memory_ids: Sequence[str] | None = None,
+        *,
+        for_merged: str | None = None,
+        drop_merged: bool = False,
+        dry_run: bool = False,
+    ) -> RestoreResult:
+        """Move archived memories back into the live corpus — the undo of a merge.
+
+        Pass explicit ``memory_ids`` to recover individual records, or
+        ``for_merged`` to recover every member a given merge absorbed.
+
+        ``drop_merged`` completes the undo by deleting the merged record, and
+        refuses unless that record carries the ``consolidated_from`` provenance
+        that proves the merge created it — a ``keep_latest`` merge keeps one of
+        its own members, and deleting that would destroy the very data the undo
+        is trying to rescue.
+
+        Restoring is additive on its own: without ``drop_merged`` the merged
+        record stays, so the corpus briefly holds both. That is deliberate —
+        nothing is destroyed by an undo that turns out to be a mistake.
+        """
+        if not memory_ids and not for_merged:
+            raise ValueError("restore_archived needs memory_ids or for_merged")
+
+        archived_files = (
+            sorted(self._archival_dir.glob("*.md")) if self._archival_dir.is_dir() else []
+        )
+        selected, missing = self._select_archived(archived_files, memory_ids, for_merged)
+
+        restored: list[str] = []
+        for path, memory_id in selected:
+            if dry_run or self._restore_one(path, memory_id):
+                restored.append(memory_id)
+            else:
+                # Present but unreadable. Report it rather than let it fall
+                # out of both lists — a silent drop is how you lose a memory.
+                missing.append(memory_id)
+
+        if restored and not dry_run:
+            # Files under archived/ are skipped by every walker, so the live
+            # copy only becomes searchable once it is back in the tree — then
+            # reindex adopts it (the upsert clears any delete tombstone).
+            self.memory.reindex()
+
+        dropped, note = self._drop_merged_record(
+            for_merged if drop_merged else None, dry_run=dry_run
+        )
+        summary = f"Restored {len(restored)} archived memories"
+        if missing:
+            summary += f", {len(missing)} not found"
+        if note:
+            summary += f" — {note}"
+        return RestoreResult(
+            restored_ids=restored,
+            missing_ids=missing,
+            dropped_merged_id=dropped,
+            summary=summary,
+        )
+
+    def _select_archived(
+        self,
+        archived_files: list[Path],
+        memory_ids: Sequence[str] | None,
+        for_merged: str | None,
+    ) -> tuple[list[tuple[Path, str]], list[str]]:
+        """Resolve the request to (file, id) pairs plus the ids not found."""
+        import frontmatter
+
+        if for_merged:
+            selected = []
+            for path in archived_files:
+                try:
+                    post = frontmatter.loads(path.read_text(encoding="utf-8"))
+                except Exception as exc:
+                    # One corrupt archive must not sink the rest of the batch.
+                    _log.warning("restore: cannot read %s: %s", path.name, exc)
+                    continue
+                if _id_matches(str(post.get("archived_for") or ""), for_merged):
+                    selected.append((path, str(post.get("id") or path.stem)))
+            return selected, []
+
+        by_stem = {path.stem: path for path in archived_files}
+        selected, missing = [], []
+        for wanted in memory_ids or []:
+            matches = [stem for stem in by_stem if _id_matches(stem, wanted)]
+            if len(matches) != 1:
+                # Zero matches, or a prefix short enough to be ambiguous —
+                # both are the caller's to disambiguate, never ours to guess.
+                missing.append(wanted)
+                continue
+            selected.append((by_stem[matches[0]], matches[0]))
+        return selected, missing
+
+    def _restore_one(self, path: Path, memory_id: str) -> bool:
+        """Write one archived file back into the live tree. Returns success."""
+        import frontmatter
+
+        try:
+            post = frontmatter.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            # A corrupt or unreadable archive is reported and skipped; the rest
+            # of the batch still gets restored.
+            _log.warning("restore: cannot read %s: %s", path.name, exc)
+            return False
+
+        post.metadata.pop("archived_for", None)
+        post.metadata.pop("archived_at", None)
+        origin = post.metadata.pop("archived_from", None)
+        # Files archived before the id was preserved carry it only in their
+        # filename; re-inject it or reindex will skip them as non-canonical.
+        post["id"] = memory_id
+
+        rel = self._restore_destination(post, origin)
+        dest = self.memory.cfg.memory_dir / rel
+        try:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(frontmatter.dumps(post), encoding="utf-8")
+            path.unlink()
+        except OSError as exc:
+            _log.warning("restore: cannot write %s: %s", rel, exc)
+            return False
+        return True
+
+    def _restore_destination(self, post: Any, origin: Any) -> str:
+        """Prefer the path the memory used to hold; allocate a fresh one if taken."""
+        memory_dir = self.memory.cfg.memory_dir
+        if isinstance(origin, str) and origin:
+            candidate = Path(origin)
+            unsafe = candidate.is_absolute() or ".." in candidate.parts
+            if not unsafe and not (memory_dir / candidate).exists():
+                return origin
+
+        raw_tags = post.metadata.get("tags") or []
+        tags = [str(raw_tags)] if isinstance(raw_tags, str) else [str(t) for t in raw_tags]
+        return str(
+            self.memory._build_rel_path(
+                str(post.metadata.get("title") or "untitled"),
+                str(post.metadata.get("created") or datetime.now(UTC).isoformat()),
+                tags,
+            )
+        )
+
+    def _drop_merged_record(
+        self, merged_id: str | None, *, dry_run: bool
+    ) -> tuple[str | None, str]:
+        """Delete the record a merge created. Returns (dropped_id, note)."""
+        if not merged_id:
+            return None, ""
+        merged = self.memory.get(merged_id)
+        if merged is None:
+            return None, f"merged record {merged_id[:8]} not found"
+        if not (merged.extra or {}).get("consolidated_from"):
+            return None, (
+                f"kept {merged_id[:8]}: not created by a merge (no consolidated_from "
+                "provenance) — a keep_latest merge survivor is real data"
+            )
+        if not dry_run:
+            self.memory.delete(merged.id)
+        return merged.id, f"dropped merged record {merged.id[:8]}"
 
     def _fast_lane_proposal(self, cluster: dict[str, Any]) -> MergeProposal | None:
         """Build a keep_latest MergeProposal without calling the LLM.

--- a/src/memo/memory/write_ops.py
+++ b/src/memo/memory/write_ops.py
@@ -166,6 +166,24 @@ def _graph_entities_from_extra(extra: dict[str, Any]) -> list[dict[str, str]]:
     return out
 
 
+def _live_markdown_files(root: Path) -> Iterator[Path]:
+    """Every canonical ``.md`` under ``root``, skipping the lifecycle archives.
+
+    ``inactive/`` and ``archived/`` keep their canonical ``id`` so a human — or
+    ``memo consolidate restore`` — can move a note back out by hand. Any walker
+    that re-indexes what it finds has to skip them, or it resurrects an
+    archived memory behind the user's back. ``reindex`` and the disk-orphan gc
+    already do; this is the same rule for the write path.
+    """
+    from memo.project import LIFECYCLE_ARCHIVE_DIRS
+
+    for path in sorted(root.rglob("*.md")):
+        parts = path.relative_to(root).parts
+        if parts[:1] and parts[0] in LIFECYCLE_ARCHIVE_DIRS:
+            continue
+        yield path
+
+
 class _WriteOpsMixin(_MemoryBase):
     # -- save ---------------------------------------------------------------
 
@@ -1523,21 +1541,12 @@ class _WriteOpsMixin(_MemoryBase):
         self, *, namespace: str, topic_key: str
     ) -> list[dict[str, Any]]:
         """Rebuild a disk-only topic reservation after an index failure."""
-        from memo.project import LIFECYCLE_ARCHIVE_DIRS
         from memo.redact import sanitize_memory_input
 
         candidates: list[tuple[Path, frontmatter.Post, list[str]]] = []
-        for candidate in sorted(self.cfg.memory_dir.rglob("*.md")):
+        for candidate in _live_markdown_files(self.cfg.memory_dir):
             try:
                 if candidate.is_symlink():
-                    continue
-                parts = candidate.relative_to(self.cfg.memory_dir).parts
-                if parts[:1] and parts[0] in LIFECYCLE_ARCHIVE_DIRS:
-                    # `inactive/` and `archived/` keep their canonical id so a
-                    # human (or `consolidate restore`) can move a note back.
-                    # Recovering one here would resurrect it into the index
-                    # behind everyone's back — the same reason reindex and the
-                    # disk-orphan gc skip these two directories.
                     continue
                 candidate_post = frontmatter.loads(candidate.read_text(encoding="utf-8"))
                 candidate_id = str(candidate_post.metadata.get("id") or "")

--- a/src/memo/memory/write_ops.py
+++ b/src/memo/memory/write_ops.py
@@ -1523,12 +1523,21 @@ class _WriteOpsMixin(_MemoryBase):
         self, *, namespace: str, topic_key: str
     ) -> list[dict[str, Any]]:
         """Rebuild a disk-only topic reservation after an index failure."""
+        from memo.project import LIFECYCLE_ARCHIVE_DIRS
         from memo.redact import sanitize_memory_input
 
         candidates: list[tuple[Path, frontmatter.Post, list[str]]] = []
         for candidate in sorted(self.cfg.memory_dir.rglob("*.md")):
             try:
                 if candidate.is_symlink():
+                    continue
+                parts = candidate.relative_to(self.cfg.memory_dir).parts
+                if parts[:1] and parts[0] in LIFECYCLE_ARCHIVE_DIRS:
+                    # `inactive/` and `archived/` keep their canonical id so a
+                    # human (or `consolidate restore`) can move a note back.
+                    # Recovering one here would resurrect it into the index
+                    # behind everyone's back — the same reason reindex and the
+                    # disk-orphan gc skip these two directories.
                     continue
                 candidate_post = frontmatter.loads(candidate.read_text(encoding="utf-8"))
                 candidate_id = str(candidate_post.metadata.get("id") or "")

--- a/tests/test_consolidate_restore.py
+++ b/tests/test_consolidate_restore.py
@@ -1,0 +1,306 @@
+"""Undoing a consolidation merge.
+
+Consolidation archives the memories it absorbs. Until now that was a
+one-way door: `_archive_memory` stripped the frontmatter `id`, so the
+archived copy could not be moved back into the live tree — `reindex`
+skips anything without a canonical id. `maintain`'s compaction has had
+the symmetric `_restore_archived` all along; consolidation had nothing.
+
+These tests pin the round trip: archive keeps enough provenance to
+reverse itself, and `restore_archived` reverses it.
+"""
+
+from __future__ import annotations
+
+import frontmatter
+import pytest
+from click.testing import CliRunner
+
+from memo.cli import cli
+from memo.consolidation import AdvancedConsolidator, MergeProposal
+
+
+@pytest.fixture
+def consolidator(mock_memory):
+    return AdvancedConsolidator(mock_memory)
+
+
+def _archived_post(consolidator, memory_id: str) -> frontmatter.Post:
+    path = consolidator._archival_dir / f"{memory_id}.md"
+    return frontmatter.loads(path.read_text(encoding="utf-8"))
+
+
+def _save(mem, title: str, content: str, **kw):
+    return mem.save(content=content, title=title, **kw)
+
+
+# ── what the archive has to preserve ──────────────────────────────────────
+
+
+def test_archived_copy_keeps_its_id(consolidator, mock_memory):
+    """Without the id the archived file can never be reindexed back."""
+    rec = _save(mock_memory, "Kept id", "body")
+    keeper = _save(mock_memory, "Keeper", "other")
+
+    assert consolidator._archive_memory(rec.id, keeper.id)
+
+    assert _archived_post(consolidator, rec.id).get("id") == rec.id
+
+
+def test_archived_copy_records_the_path_it_came_from(consolidator, mock_memory):
+    """Restoring in place is only possible if the origin path survives."""
+    rec = _save(mock_memory, "Origin path", "body", tags=["project:demo"])
+    keeper = _save(mock_memory, "Keeper", "other", tags=["project:demo"])
+    original_path = rec.path
+
+    consolidator._archive_memory(rec.id, keeper.id)
+
+    assert _archived_post(consolidator, rec.id).get("archived_from") == original_path
+
+
+# ── the round trip ────────────────────────────────────────────────────────
+
+
+def test_restore_brings_an_archived_memory_back_into_the_index(consolidator, mock_memory):
+    rec = _save(mock_memory, "Comes back", "the body that must survive")
+    keeper = _save(mock_memory, "Keeper", "other")
+    consolidator._archive_memory(rec.id, keeper.id)
+    assert mock_memory.get(rec.id) is None
+
+    result = consolidator.restore_archived([rec.id])
+
+    assert result.restored_ids == [rec.id]
+    revived = mock_memory.get(rec.id)
+    assert revived is not None
+    assert revived.body.strip() == "the body that must survive"
+    assert not (consolidator._archival_dir / f"{rec.id}.md").exists()
+
+
+def test_restore_puts_the_file_back_where_it_was(consolidator, mock_memory):
+    rec = _save(mock_memory, "Same slot", "body", tags=["project:demo"])
+    keeper = _save(mock_memory, "Keeper", "other", tags=["project:demo"])
+    original_path = rec.path
+    consolidator._archive_memory(rec.id, keeper.id)
+
+    consolidator.restore_archived([rec.id])
+
+    assert mock_memory.get(rec.id).path == original_path
+
+
+def test_restore_removes_the_archival_markers(consolidator, mock_memory):
+    rec = _save(mock_memory, "Clean frontmatter", "body")
+    keeper = _save(mock_memory, "Keeper", "other")
+    consolidator._archive_memory(rec.id, keeper.id)
+
+    consolidator.restore_archived([rec.id])
+
+    restored = frontmatter.loads(
+        (mock_memory.cfg.memory_dir / mock_memory.get(rec.id).path).read_text(encoding="utf-8")
+    )
+    assert "archived_for" not in restored.metadata
+    assert "archived_at" not in restored.metadata
+    assert "archived_from" not in restored.metadata
+
+
+def test_restore_recovers_a_legacy_archive_that_lost_its_id(consolidator, mock_memory):
+    """Files archived by the old code have no `id` — the filename holds it."""
+    rec = _save(mock_memory, "Legacy archive", "body")
+    keeper = _save(mock_memory, "Keeper", "other")
+    consolidator._archive_memory(rec.id, keeper.id)
+    archived_path = consolidator._archival_dir / f"{rec.id}.md"
+    post = frontmatter.loads(archived_path.read_text(encoding="utf-8"))
+    post.metadata.pop("id")
+    post.metadata.pop("archived_from", None)
+    archived_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    result = consolidator.restore_archived([rec.id])
+
+    assert result.restored_ids == [rec.id]
+    assert mock_memory.get(rec.id) is not None
+
+
+def test_restore_accepts_a_short_id_prefix(consolidator, mock_memory):
+    """`consolidate list-archived` prints 8-char prefixes; they must work."""
+    rec = _save(mock_memory, "Prefixed", "body")
+    keeper = _save(mock_memory, "Keeper", "other")
+    consolidator._archive_memory(rec.id, keeper.id)
+
+    result = consolidator.restore_archived([rec.id[:8]])
+
+    assert result.restored_ids == [rec.id]
+
+
+def test_restore_reports_ids_it_could_not_find(consolidator):
+    result = consolidator.restore_archived(["deadbeefdeadbeefdeadbeefdeadbeef"])
+
+    assert result.restored_ids == []
+    assert result.missing_ids == ["deadbeefdeadbeefdeadbeefdeadbeef"]
+
+
+def test_one_unreadable_archive_does_not_sink_the_batch(consolidator, mock_memory):
+    good = _save(mock_memory, "Readable", "body")
+    broken = _save(mock_memory, "Corrupt", "body")
+    keeper = _save(mock_memory, "Keeper", "other")
+    consolidator._archive_memory(good.id, keeper.id)
+    consolidator._archive_memory(broken.id, keeper.id)
+    (consolidator._archival_dir / f"{broken.id}.md").write_text(
+        "---\ntitle: [unterminated\n---\nbody\n", encoding="utf-8"
+    )
+
+    result = consolidator.restore_archived([good.id, broken.id])
+
+    assert result.restored_ids == [good.id]
+    assert result.missing_ids == [broken.id]
+    assert mock_memory.get(good.id) is not None
+
+
+def test_restore_does_not_overwrite_a_live_file_holding_the_old_path(consolidator, mock_memory):
+    """A later save may have taken the slug back; the survivor wins."""
+    rec = _save(mock_memory, "Contested slug", "original body")
+    keeper = _save(mock_memory, "Keeper", "other")
+    original_path = rec.path
+    consolidator._archive_memory(rec.id, keeper.id)
+    squatter = mock_memory.cfg.memory_dir / original_path
+    squatter.parent.mkdir(parents=True, exist_ok=True)
+    squatter.write_text("squatter", encoding="utf-8")
+
+    result = consolidator.restore_archived([rec.id])
+
+    assert result.restored_ids == [rec.id]
+    assert squatter.read_text(encoding="utf-8") == "squatter"
+    assert mock_memory.get(rec.id).path != original_path
+
+
+def test_restore_dry_run_changes_nothing(consolidator, mock_memory):
+    rec = _save(mock_memory, "Untouched", "body")
+    keeper = _save(mock_memory, "Keeper", "other")
+    consolidator._archive_memory(rec.id, keeper.id)
+
+    result = consolidator.restore_archived([rec.id], dry_run=True)
+
+    assert result.restored_ids == [rec.id]
+    assert (consolidator._archival_dir / f"{rec.id}.md").exists()
+    assert mock_memory.get(rec.id) is None
+
+
+# ── undoing a whole merge ─────────────────────────────────────────────────
+
+
+def _merge(consolidator, mock_memory, members, *, strategy="synthesis"):
+    archived = [m.id for m in members[1:]] if strategy == "keep_latest" else [m.id for m in members]
+    proposal = MergeProposal(
+        cluster_id=1,
+        memory_ids=[m.id for m in members],
+        merged_title="Merged record",
+        merged_body="merged body",
+        merge_strategy=strategy,
+        rationale="test",
+        archived_ids=archived,
+    )
+    return consolidator.apply_merge(proposal)
+
+
+def test_a_merged_record_records_the_ids_it_absorbed(consolidator, mock_memory):
+    """Provenance is what tells an undo the record was created BY the merge."""
+    a = _save(mock_memory, "Member A", "body a")
+    b = _save(mock_memory, "Member B", "body b")
+
+    outcome = _merge(consolidator, mock_memory, [a, b])
+
+    merged = mock_memory.get(outcome.merged_id)
+    assert sorted(merged.extra["consolidated_from"]) == sorted([a.id, b.id])
+
+
+def test_restore_for_a_merge_brings_back_every_member(consolidator, mock_memory):
+    a = _save(mock_memory, "Member A", "body a")
+    b = _save(mock_memory, "Member B", "body b")
+    outcome = _merge(consolidator, mock_memory, [a, b])
+
+    result = consolidator.restore_archived(for_merged=outcome.merged_id)
+
+    assert sorted(result.restored_ids) == sorted([a.id, b.id])
+    assert mock_memory.get(a.id) is not None
+    assert mock_memory.get(b.id) is not None
+
+
+def test_dropping_the_merged_record_undoes_the_whole_merge(consolidator, mock_memory):
+    a = _save(mock_memory, "Member A", "body a")
+    b = _save(mock_memory, "Member B", "body b")
+    outcome = _merge(consolidator, mock_memory, [a, b])
+
+    result = consolidator.restore_archived(for_merged=outcome.merged_id, drop_merged=True)
+
+    assert result.dropped_merged_id == outcome.merged_id
+    assert mock_memory.get(outcome.merged_id) is None
+    assert mock_memory.get(a.id) is not None
+
+
+def test_drop_merged_refuses_a_record_the_merge_did_not_create(consolidator, mock_memory):
+    """`keep_latest` keeps a pre-existing member — deleting it destroys data."""
+    a = _save(mock_memory, "Older", "body a")
+    b = _save(mock_memory, "Newer", "body b")
+    outcome = _merge(consolidator, mock_memory, [a, b], strategy="keep_latest")
+    survivor = outcome.merged_id
+
+    result = consolidator.restore_archived(for_merged=survivor, drop_merged=True)
+
+    assert result.dropped_merged_id is None
+    assert mock_memory.get(survivor) is not None
+    assert "not created by a merge" in result.summary
+
+
+# ── the archived copy must stay out of every recovery path ────────────────
+
+
+def test_topic_reservation_recovery_ignores_archived_files(consolidator, mock_memory):
+    """Keeping the id must not let a disk-only recovery resurrect an archive."""
+    rec = _save(
+        mock_memory,
+        "Reserved topic",
+        "body",
+        tags=["project:demo"],
+        topic_key="the-reserved-topic",
+    )
+    keeper = _save(mock_memory, "Keeper", "other", tags=["project:demo"])
+    consolidator._archive_memory(rec.id, keeper.id)
+
+    recovered = mock_memory._recover_topic_reservation_locked(
+        namespace="project:demo", topic_key="the-reserved-topic"
+    )
+
+    assert recovered == []
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────
+
+
+def test_cli_consolidate_restore_reports_what_it_restored(consolidator, mock_memory, monkeypatch):
+    rec = _save(mock_memory, "Via the CLI", "body")
+    keeper = _save(mock_memory, "Keeper", "other")
+    consolidator._archive_memory(rec.id, keeper.id)
+    monkeypatch.setattr("memo.cli_consolidate._get_memory", lambda cfg: mock_memory)
+    monkeypatch.setattr(
+        "memo.cli_consolidate.Config.from_env", staticmethod(lambda: mock_memory.cfg)
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["consolidate", "restore", rec.id],
+        env={"MEMO_NONINTERACTIVE": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert rec.id[:8] in result.output
+    assert mock_memory.get(rec.id) is not None
+
+
+def test_cli_consolidate_restore_needs_ids_or_a_merge(mock_memory, monkeypatch):
+    monkeypatch.setattr("memo.cli_consolidate._get_memory", lambda cfg: mock_memory)
+    monkeypatch.setattr(
+        "memo.cli_consolidate.Config.from_env", staticmethod(lambda: mock_memory.cfg)
+    )
+
+    result = CliRunner().invoke(cli, ["consolidate", "restore"], env={"MEMO_NONINTERACTIVE": "1"})
+
+    assert result.exit_code != 0
+    assert "--for" in result.output

--- a/tests/test_consolidate_restore.py
+++ b/tests/test_consolidate_restore.py
@@ -171,6 +171,44 @@ def test_restore_does_not_overwrite_a_live_file_holding_the_old_path(consolidato
     assert mock_memory.get(rec.id).path != original_path
 
 
+def test_restore_gives_up_a_topic_slot_a_newer_record_took(consolidator, mock_memory):
+    """`(namespace, topic_key)` is UNIQUE among live rows.
+
+    Archiving soft-deletes the row, which frees its topic reservation, so a
+    later save can claim it. Restoring the frontmatter verbatim would make
+    reindex's un-delete violate that index — and reindex swallows the
+    IntegrityError as a per-file warning, leaving the `.md` in the live tree
+    permanently unindexed while the restore reports success.
+    """
+    rec = _save(mock_memory, "Deploy process", "the original", topic_key="deploy-process")
+    keeper = _save(mock_memory, "Keeper", "other")
+    consolidator._archive_memory(rec.id, keeper.id)
+    newer = _save(mock_memory, "Deploy process v2", "the newer one", topic_key="deploy-process")
+
+    result = consolidator.restore_archived([rec.id])
+
+    assert result.restored_ids == [rec.id]
+    assert result.unindexed_ids == []
+    revived = mock_memory.get(rec.id)
+    assert revived is not None, "restore reported success but the record is not indexed"
+    assert revived.body.strip() == "the original"
+    assert mock_memory.get(newer.id) is not None
+
+
+def test_restore_reports_a_memory_the_index_refused(consolidator, mock_memory, monkeypatch):
+    """A restore the index would not adopt must never be reported as done."""
+    rec = _save(mock_memory, "Never indexed", "body")
+    keeper = _save(mock_memory, "Keeper", "other")
+    consolidator._archive_memory(rec.id, keeper.id)
+    monkeypatch.setattr(mock_memory, "reindex", lambda **kw: {"added": 0})
+
+    result = consolidator.restore_archived([rec.id])
+
+    assert result.restored_ids == []
+    assert result.unindexed_ids == [rec.id]
+    assert "reindex --rebuild" in result.summary
+
+
 def test_restore_dry_run_changes_nothing(consolidator, mock_memory):
     rec = _save(mock_memory, "Untouched", "body")
     keeper = _save(mock_memory, "Keeper", "other")
@@ -292,6 +330,23 @@ def test_cli_consolidate_restore_reports_what_it_restored(consolidator, mock_mem
     assert result.exit_code == 0, result.output
     assert rec.id[:8] in result.output
     assert mock_memory.get(rec.id) is not None
+
+
+def test_cli_consolidate_restore_refuses_ids_together_with_a_merge(mock_memory, monkeypatch):
+    """`--for` ignores positional ids; refuse rather than silently drop them."""
+    monkeypatch.setattr("memo.cli_consolidate._get_memory", lambda cfg: mock_memory)
+    monkeypatch.setattr(
+        "memo.cli_consolidate.Config.from_env", staticmethod(lambda: mock_memory.cfg)
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["consolidate", "restore", "deadbeefdeadbeefdeadbeefdeadbeef", "--for", "cafebabe"],
+        env={"MEMO_NONINTERACTIVE": "1"},
+    )
+
+    assert result.exit_code != 0
+    assert "--for" in result.output
 
 
 def test_cli_consolidate_restore_needs_ids_or_a_merge(mock_memory, monkeypatch):


### PR DESCRIPTION
## The problem

Consolidation archives every memory it absorbs, and that was a one-way door.

`_archive_memory` stripped the frontmatter `id` before writing the copy to `archived/`, so `reindex` — which requires a canonical id — could never adopt the file again, even if a human moved it back into the tree by hand. Recovering a single wrongly-merged record meant hand-editing YAML to re-inject its id and guessing at a destination path.

`maintain`'s compaction has had the symmetric `_restore_archived` since it shipped. Consolidation had nothing.

This landed as a real cost last week: a pass that merged across memory types retyped 55 of 66 archived records, and repairing even one of them (the `failure_pattern` a committed AVOID probe depends on) had to be done by hand for exactly this reason.

## What changed

The archived copy now keeps its `id` and records the `archived_from` path it used to occupy — everything the undo needs to put it back.

```
memo consolidate restore <id>...                        # recover specific records
memo consolidate restore --for <merged-id>              # undo one merge
memo consolidate restore --for <merged-id> --drop-merged
```

- Restores land on the **original path** when it is still free, and on a freshly allocated one when a later save took the slug — a restore never clobbers a live file.
- Archives written **before** this change carry their id only in the filename; those are recovered from the stem, so the whole existing archive is reachable.
- Ids accept the 8-char prefixes `consolidate list-archived` prints. A prefix short enough to be ambiguous is reported, never guessed at.
- One corrupt archive is reported and skipped rather than sinking the batch — and it lands in `missing_ids` instead of falling out of both lists.

**Restoring is additive.** The merged record survives unless `--drop-merged` is passed, so an undo that turns out to be a mistake destroys nothing. `--drop-merged` refuses any record that does not carry the new `consolidated_from` provenance proving the merge created it: a `keep_latest` merge keeps one of its own *members*, and deleting that survivor would destroy the very data the undo exists to rescue.

## Second bug, found by the first fix

Keeping the id on the archived copy turned a guard test red, which exposed a pre-existing bug.

`_recover_topic_reservation_locked` walks every `.md` under `memory_dir` looking for the file holding a claimed `(namespace, topic_key)` and re-indexes it. It never skipped `inactive/` or `archived/` — and **`inactive/` has always kept its canonical id**, so a compacted memory could already be pulled silently back into the index today, behind the user's back.

It now skips `LIFECYCLE_ARCHIVE_DIRS`, the same two directories `reindex` and the disk-orphan gc already refuse to absorb. That is also what makes preserving the id on the archived copy safe.

## Verification

- `tests/test_consolidate_restore.py` — 18 tests, written first and watched fail. Covers the round trip, the original-path preference, the squatted-path fallback, legacy id-less archives, prefix resolution, dry run, the unreadable-archive path, both `--drop-merged` branches, and the resurrection guard.
- Full suite: **7490 passed, 1 skipped**.
- `ruff check` + `ruff format --check` + `mypy` clean on every touched file.
- Retrieval gate: `memo eval recall --against origin/master` → **prec@k 0.719 vs 0.719, noise@k 0.000 vs 0.000** — zero code delta, as expected for a change that touches no ranking path. The machine-local pre-push baseline was re-seeded for confirmed corpus drift (10563 → 10605 memories) only after that isolation ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)