### PR TITLE
chore: point the Homebrew formula at the 4.10.2 sdist

### DIFF
--- a/docs/homebrew/mlx-memo.rb
+++ b/docs/homebrew/mlx-memo.rb
@@ -21,8 +21,8 @@ class MlxMemo < Formula
 
   desc "Local MCP memory for AI agents — MLX-native, sqlite-vec, markdown vault"
   homepage "https://github.com/jagoff/memo"
-  url "https://files.pythonhosted.org/packages/33/1d/714d224e32c922160bba0cd884283b33e7333b44c0ee72ef71c5b4101c81/mlx_memo-4.10.1.tar.gz"
-  sha256 "ba2fea6e0c3666cf03904a52455af82ad1f41c5c53b41abbb29bd8a593012423"
+  url "https://files.pythonhosted.org/packages/17/e2/6e4e180c5aa56652dcf1068fe87e9797ff09979d1c6819fd47e8242926eb/mlx_memo-4.10.2.tar.gz"
+  sha256 "df7bf04fe88e0b6253bb4b27463bf8be52a1f404024c6ff98b64cf8901a60606"
   license "MIT"
 
   depends_on arch: :arm64


### PR DESCRIPTION
Follow-up to #243. The formula's `url`/`sha256` point at the PyPI **source distribution**, which only exists once `publish.yml` has run, so it cannot be bumped in the release PR itself — `memo release check` warns about exactly this gap until it lands.

Taken from `https://pypi.org/pypi/mlx-memo/4.10.2/json` → the `sdist` entry. `memo release check` → `✓ passed for 4.10.2` with no warnings.

The public tap `jagoff/homebrew-memo` is synced from this file separately; it has no branch protection and is updated by direct push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)