### PR TITLE
fix: the recall gate was measuring a configuration the hook does not run

### DIFF
--- a/eval/regression_labels.json
+++ b/eval/regression_labels.json
@@ -294,10 +294,9 @@
       "text": "hace el push a master",
       "relevant": true,
       "expect_ids": [
-        "a97d17c0",
         "a979dcb7"
       ],
-      "_note": "2026-08-15 incident. `master` is branch-protected (GH006 on direct push); the only path is a PR. The fact was stored since 2026-08-02 as the decision a97d17c0, yet asking for a push to master surfaced merge-conflict and push-auth memories instead. Root cause is not ranking: capture created two paraphrase duplicates of the same fact on 2026-08-15 (a979dcb7, abdbfbc7), because write-time dedup keys on normalized_content_hash and a paraphrase — here also across languages — hashes differently. Three records then split the signal across a flat-similarity neighbourhood (vec 0.594-0.636) that the hook's search_k=9 pool samples almost arbitrarily. Either surviving decision counts as a hit."
+      "_note": "2026-08-15 incident, RESOLVED. `master` is branch-protected (GH006 on a direct push); the only path is a PR. Asking for a push to master surfaced merge-conflict and push-auth memories instead, and the protection fact was absent from the top 40. Root cause was capture, not ranking: auto-capture created THREE paraphrase duplicates within 30 minutes on 2026-08-15 (abdbfbc7 15:51, 58edcf94 16:08, a979dcb7 16:20) of a fact already stored since 2026-08-02 (a97d17c0). Write-time dedup keys on normalized_content_hash, so a paraphrase — here also across languages — hashes differently and passes. Four records then split the signal across a flat-similarity neighbourhood (vec 0.594-0.636) that the hook's search_k=9 pool samples almost arbitrarily. Resolved by consolidating onto a979dcb7 (the only one that ranked) after merging the best content into it, and superseding the other three (reversible). Verified through the real hook: absent -> rank 1 at score 9.588. Gate held at prec@k 0.647 / noise 0.000. NOT fixed: `memo consolidate propose` clusters the near-identical English pair but not the Spanish original, so cosine clustering has the same cross-language blind spot as the hash dedup."
     }
   ],
   "relevant_terms": [

--- a/eval/regression_labels.json
+++ b/eval/regression_labels.json
@@ -289,6 +289,15 @@
       "text": "explain quantum entanglement",
       "relevant": false,
       "_note": "Noise probe — general physics, not stored as a personal memory."
+    },
+    {
+      "text": "hace el push a master",
+      "relevant": true,
+      "expect_ids": [
+        "a97d17c0",
+        "a979dcb7"
+      ],
+      "_note": "2026-08-15 incident. `master` is branch-protected (GH006 on direct push); the only path is a PR. The fact was stored since 2026-08-02 as the decision a97d17c0, yet asking for a push to master surfaced merge-conflict and push-auth memories instead. Root cause is not ranking: capture created two paraphrase duplicates of the same fact on 2026-08-15 (a979dcb7, abdbfbc7), because write-time dedup keys on normalized_content_hash and a paraphrase — here also across languages — hashes differently. Three records then split the signal across a flat-similarity neighbourhood (vec 0.594-0.636) that the hook's search_k=9 pool samples almost arbitrarily. Either surviving decision counts as a hit."
     }
   ],
   "relevant_terms": [

--- a/src/memo/dream_tune.py
+++ b/src/memo/dream_tune.py
@@ -118,7 +118,20 @@ RANK_KNOB_LATENCY_HEADROOM = 1.25
 
 def measure(mem: Any, labels: LabelSet, *, k: int, floor: float) -> dict[str, float]:
     """precision@K / noise@K for a single vec config at ``floor``."""
-    cfg = Cfg(name=f"vec/{floor}", mode="vec", floor=floor, exclude_archived=True)
+    cfg = Cfg(
+        name=f"vec/{floor}",
+        mode="vec",
+        floor=floor,
+        exclude_archived=True,
+        # The tuner auto-APPLIES its winner, so it has to score the way the
+        # hook ranks. Without this the injection filters (skip-below + gap
+        # trim) are off during the search and on in production — measured
+        # 2026-08-15 on the curated set: prec@5 0.363 with them off vs 0.205
+        # with them on, a 44% gap the tuner was optimising blind to.
+        # (`min_body_chars` stays pinned at 0 by run_config: measured at
+        # 0.368 -> 0.363, negligible next to the above.)
+        injection_fidelity=True,
+    )
     rows = evaluate(mem, k=k, labels=labels, configs=[cfg])
     return gate_metrics(rows)
 
@@ -597,12 +610,22 @@ def measure_rank_knob(
     Goes through the recall-faithful seam: ``Cfg.knob_overrides`` ->
     ``knobs_from_flags(overrides=...)`` -> ``rank_hits`` — every OTHER knob
     inherits the live flag/overlay resolution, so the delta vs the current
-    value is attributable to this knob alone."""
+    value is attributable to this knob alone. ``injection_fidelity`` is on for
+    the same reason: the tuner auto-applies its winner, so it must not score a
+    pipeline the hook does not run."""
     cfg = Cfg(
         name=f"{knob}={value}",
         mode="vec",
         floor=floor,
         exclude_archived=True,
+        # The tuner auto-APPLIES its winner, so it has to score the way the
+        # hook ranks. Without this the injection filters (skip-below + gap
+        # trim) are off during the search and on in production — measured
+        # 2026-08-15 on the curated set: prec@5 0.363 with them off vs 0.205
+        # with them on, a 44% gap the tuner was optimising blind to.
+        # (`min_body_chars` stays pinned at 0 by run_config: measured at
+        # 0.368 -> 0.363, negligible next to the above.)
+        injection_fidelity=True,
         knob_overrides={_KNOB_TO_FIELD[knob]: value},
     )
     rows = evaluate(mem, k=k, labels=labels, configs=[cfg])
@@ -742,6 +765,14 @@ def measure_hyde(mem: Any, labels: LabelSet, *, k: int, enabled: bool) -> dict[s
         mode="hybrid",
         floor=_HYDE_FLOOR,
         exclude_archived=True,
+        # The tuner auto-APPLIES its winner, so it has to score the way the
+        # hook ranks. Without this the injection filters (skip-below + gap
+        # trim) are off during the search and on in production — measured
+        # 2026-08-15 on the curated set: prec@5 0.363 with them off vs 0.205
+        # with them on, a 44% gap the tuner was optimising blind to.
+        # (`min_body_chars` stays pinned at 0 by run_config: measured at
+        # 0.368 -> 0.363, negligible next to the above.)
+        injection_fidelity=True,
         flag_overrides={_HYDE_FLAG: "1" if enabled else "0"},
     )
     rows = evaluate(mem, k=k, labels=labels, configs=[cfg])
@@ -852,6 +883,14 @@ def measure_graph_signal(
         mode="vec",
         floor=floor,
         exclude_archived=True,
+        # The tuner auto-APPLIES its winner, so it has to score the way the
+        # hook ranks. Without this the injection filters (skip-below + gap
+        # trim) are off during the search and on in production — measured
+        # 2026-08-15 on the curated set: prec@5 0.363 with them off vs 0.205
+        # with them on, a 44% gap the tuner was optimising blind to.
+        # (`min_body_chars` stays pinned at 0 by run_config: measured at
+        # 0.368 -> 0.363, negligible next to the above.)
+        injection_fidelity=True,
         flag_overrides={
             _GRAPH_ENABLED: "1" if enabled else "0",
             _GRAPH_ALPHA: str(alpha),

--- a/src/memo/eval_recall.py
+++ b/src/memo/eval_recall.py
@@ -258,6 +258,43 @@ class Cfg:
     # for flags read INSIDE Memory.search at call time (e.g. MEMO_HYDE_ENABLED)
     # that RankKnobs/knob_overrides cannot reach. None = no pins.
     flag_overrides: dict[str, str] | None = None
+    # Inherit `min_sim` and `min_body_chars` from the LIVE flag/overlay chain
+    # instead of pinning them, so this config ranks the way the hook actually
+    # ranks right now. `floor` is then descriptive only (see live_config).
+    live: bool = False
+
+
+def live_config() -> Cfg:
+    """The config that mirrors what the recall hook actually runs today.
+
+    Grid configs A-D pin a chosen floor (0.60/0.72/0.40) and `min_body_chars=0`,
+    which is right for comparing knob settings but means none of them measures
+    the LIVE hook: with the tuner's overlay moving `MEMO_RECALL_MIN_SIM`, the
+    hook can rank at a floor no grid config uses. A gate that only runs the grid
+    reports precision for a configuration nobody is running — the same failure
+    shape as a pre-push gate that measures the installed binary instead of the
+    diff.
+
+    So this one pins nothing it can inherit: mode, floor and min-body come from
+    the live flag/overlay chain, archived rows are excluded, and the hook's
+    post-rank injection filters (skip-below + gap trim) are applied.
+
+    Residual known gap: `top_k` is still the eval's `k` (precision@k needs k
+    candidates), so the candidate pool is wider than the hook's when k > the
+    live `MEMO_RECALL_TOP_K`.
+    """
+    from memo.flags import flag_float, flag_str
+
+    mode = flag_str("MEMO_RECALL_MODE") or "vec"
+    floor = flag_float("MEMO_RECALL_MIN_SIM")
+    return Cfg(
+        f"L live/{mode}/{0.5 if floor is None else floor:g}",
+        mode,
+        0.5 if floor is None else floor,  # descriptive; `live` inherits at runtime
+        exclude_archived=True,
+        injection_fidelity=True,
+        live=True,
+    )
 
 
 def default_configs() -> list[Cfg]:
@@ -266,6 +303,7 @@ def default_configs() -> list[Cfg]:
         Cfg("B vec/0.72/excl", "vec", 0.72, exclude_archived=True),
         Cfg("C hyb/0.40/excl", "hybrid", 0.40, exclude_archived=True),
         Cfg("D hyb/0.40/ctx", "hybrid", 0.40, exclude_archived=True, context=True),
+        live_config(),
     ]
 
 
@@ -332,7 +370,13 @@ def profile_configs(profile: EvalProfile) -> list[Cfg]:
     if profile == "default":
         return default_configs()
     if profile == "pre-push":
-        return select_configs(["A", "B", "E", "F", "G", "H", "I"])
+        # "L" is not optional here: this is the profile the pre-push gate runs,
+        # and without the live config the gate scores configurations nobody is
+        # running. Measured 2026-08-15 on the curated set: the grid reported
+        # prec@5 0.568-0.716 and stayed green while the live hook was at 0.205,
+        # because the tuner's overlay had moved MEMO_RECALL_MIN_SIM to 0.8835 —
+        # a floor no grid config uses.
+        return select_configs(["A", "B", "E", "F", "G", "H", "I", "L"])
     if profile == "matrix":
         return [*default_configs(), *tuning_configs()]
     if profile == "expensive":
@@ -739,11 +783,14 @@ def _run_config_inner(
     # live/pinnable while disabling only that unmeasurable I/O stage.
     knob_overrides = dict(cfg.knob_overrides or {})
     knob_overrides["code_proximity"] = False
+    # A `live` config pins nothing it can inherit: passing None makes
+    # knobs_from_flags resolve min_sim/min_body_chars/mode from the live
+    # env > markdown > overlay > default chain, exactly as the hook does.
     knobs = knobs_from_flags(
         top_k=k,
-        min_sim=cfg.floor,
-        min_body_chars=0,
-        mode=cfg.mode,
+        min_sim=None if cfg.live else cfg.floor,
+        min_body_chars=None if cfg.live else 0,
+        mode=None if cfg.live else cfg.mode,
         overrides=knob_overrides,
     )
     # Recall-faithful candidate pool: the hook SQL-excludes the bulk
@@ -1139,7 +1186,14 @@ def recommend(rows: list[Row]) -> str:
     cfg = next((c for c in [*default_configs(), *extra_configs()] if c.name == best.config), None)
     knobs = ""
     if cfg is not None:
-        knobs = f"  export MEMO_RECALL_MODE={cfg.mode}\n  export MEMO_RECALL_MIN_SIM={cfg.floor}"
+        if cfg.live:
+            # It inherits the live chain, so there is nothing to export — saying
+            # otherwise would recommend pinning the value it just measured.
+            knobs = "  (this IS the live configuration — no knob change to apply)"
+        else:
+            knobs = (
+                f"  export MEMO_RECALL_MODE={cfg.mode}\n  export MEMO_RECALL_MIN_SIM={cfg.floor}"
+            )
         for field_name, value in (cfg.knob_overrides or {}).items():
             flag_name = _KNOB_FIELD_TO_FLAG.get(field_name)
             if flag_name:

--- a/tests/test_eval_live_config.py
+++ b/tests/test_eval_live_config.py
@@ -1,0 +1,109 @@
+"""The eval grid must include a config that ranks the way the hook ranks.
+
+Grid configs A-D pin a chosen floor and `min_body_chars=0`. That is right for
+comparing knobs, but it means a green gate can report precision for a
+configuration nobody runs — the same failure shape as a pre-push gate that
+measures the installed binary instead of the diff. `live_config()` closes that
+by inheriting every knob it can from the live flag chain.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memo.eval_recall import Cfg, default_configs, live_config
+from memo.recall_logic import knobs_from_flags
+
+
+def test_the_default_grid_contains_exactly_one_live_config() -> None:
+    live = [c for c in default_configs() if c.live]
+
+    assert len(live) == 1, [c.name for c in default_configs()]
+
+
+def test_live_config_applies_the_hooks_injection_filters_and_archive_exclusion() -> None:
+    """Without these it would still not be the hook: the hook drops a weak top
+    hit (skip-below) and trims on a score gap before injecting anything."""
+    cfg = live_config()
+
+    assert cfg.live is True
+    assert cfg.injection_fidelity is True
+    assert cfg.exclude_archived is True
+
+
+def test_grid_configs_are_not_live() -> None:
+    for cfg in default_configs():
+        if cfg.name.startswith(("A ", "B ", "C ", "D ")):
+            assert cfg.live is False, cfg.name
+            assert cfg.injection_fidelity is False, cfg.name
+
+
+def test_live_config_name_reports_the_resolved_mode_and_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The name has to carry the resolved values — a fixed label would hide the
+    tuner moving the floor underneath the gate."""
+    monkeypatch.setenv("MEMO_RECALL_MODE", "hybrid")
+    monkeypatch.setenv("MEMO_RECALL_MIN_SIM", "0.83")
+
+    cfg = live_config()
+
+    assert cfg.mode == "hybrid"
+    assert cfg.name == "L live/hybrid/0.83"
+    assert cfg.floor == pytest.approx(0.83)
+
+
+def test_live_config_tracks_a_floor_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pinned grid config cannot do this; that is the whole point."""
+    monkeypatch.setenv("MEMO_RECALL_MODE", "vec")
+    monkeypatch.setenv("MEMO_RECALL_MIN_SIM", "0.60")
+    low = live_config()
+    monkeypatch.setenv("MEMO_RECALL_MIN_SIM", "0.90")
+    high = live_config()
+
+    assert low.floor != high.floor
+    assert (low.name, high.name) == ("L live/vec/0.6", "L live/vec/0.9")
+
+
+def _resolve(cfg: Cfg, k: int):
+    """Mirror run_config's knob construction for the fields under test."""
+    return knobs_from_flags(
+        top_k=k,
+        min_sim=None if cfg.live else cfg.floor,
+        min_body_chars=None if cfg.live else 0,
+        mode=None if cfg.live else cfg.mode,
+        overrides={"code_proximity": False},
+    )
+
+
+def test_live_config_inherits_the_knobs_a_grid_config_pins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The regression this guards: the live hook ranked at min_sim 0.8835 with
+    min_body_chars 40 while every grid config measured 0.60/0.72/0.40 and 0."""
+    monkeypatch.setenv("MEMO_RECALL_MODE", "vec")
+    monkeypatch.setenv("MEMO_RECALL_MIN_SIM", "0.8835")
+    monkeypatch.setenv("MEMO_RECALL_MIN_BODY_CHARS", "40")
+
+    live = _resolve(live_config(), k=5)
+    grid = _resolve(Cfg("A vec/0.60/keep", "vec", 0.60, exclude_archived=False), k=5)
+
+    assert live.min_sim == pytest.approx(0.8835)
+    assert live.min_body_chars == 40
+    # The grid config keeps its pins — it is not silently made live.
+    assert grid.min_sim == pytest.approx(0.60)
+    assert grid.min_body_chars == 0
+
+
+def test_live_config_matches_the_hooks_own_knob_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Equality with a bare knobs_from_flags(top_k=k) is the definition of
+    'ranks like the hook' for every knob except top_k."""
+    monkeypatch.setenv("MEMO_RECALL_MODE", "vec")
+    monkeypatch.setenv("MEMO_RECALL_MIN_SIM", "0.77")
+
+    live = _resolve(live_config(), k=3)
+    hook = knobs_from_flags(top_k=3, overrides={"code_proximity": False})
+
+    assert live == hook

--- a/tests/test_eval_recall.py
+++ b/tests/test_eval_recall.py
@@ -177,13 +177,19 @@ def test_select_configs_rejects_unknown_name():
 
 def test_profile_configs_name_eval_roles() -> None:
     assert [c.name for c in eval_recall.profile_configs("quick")] == ["A vec/0.60/keep"]
-    assert [c.name for c in eval_recall.profile_configs("default")] == [
+    default_names = [c.name for c in eval_recall.profile_configs("default")]
+    assert default_names[:4] == [
         "A vec/0.60/keep",
         "B vec/0.72/excl",
         "C hyb/0.40/excl",
         "D hyb/0.40/ctx",
     ]
-    assert [c.name for c in eval_recall.profile_configs("pre-push")] == [
+    # The live config's name carries the RESOLVED mode/floor, so it cannot be a
+    # fixed string — that is deliberate: a fixed label would hide the tuner
+    # moving the floor underneath the gate.
+    assert len(default_names) == 5 and default_names[4].startswith("L live/")
+    pre_push_names = [c.name for c in eval_recall.profile_configs("pre-push")]
+    assert pre_push_names[:7] == [
         "A vec/0.60/keep",
         "B vec/0.72/excl",
         "E mmr/0.3",
@@ -192,7 +198,12 @@ def test_profile_configs_name_eval_roles() -> None:
         "H synth/0.05",
         "I synth/0.10",
     ]
-    assert [c.name for c in eval_recall.profile_configs("matrix")] == [
+    # The gate that blocks pushes MUST score the live configuration; without it
+    # the grid can stay green while the hook regresses.
+    assert len(pre_push_names) == 8 and pre_push_names[7].startswith("L live/")
+    matrix_names = [c.name for c in eval_recall.profile_configs("matrix")]
+    assert matrix_names[4].startswith("L live/")
+    assert [n for n in matrix_names if not n.startswith("L live/")] == [
         "A vec/0.60/keep",
         "B vec/0.72/excl",
         "C hyb/0.40/excl",
@@ -737,7 +748,7 @@ def test_cli_eval_recall_fresh_human_run_prints_progress(tmp_path: Path, monkeyp
 
     assert result.exit_code == 0, result.output
     output = unstyle(result.output)
-    assert "Running recall eval: 4 config(s) x 1 prompt(s) = 4 search(es)." in output
+    assert "Running recall eval: 5 config(s) x 1 prompt(s) = 5 search(es)." in output
     assert "eval A vec/0.60/keep: prompt 1/1" in output
 
 
@@ -767,7 +778,7 @@ def test_cli_eval_recall_profile_pre_push_selects_named_subset(tmp_path: Path, m
     )
 
     assert result.exit_code == 0, result.output
-    assert seen == [
+    assert seen[:7] == [
         "A vec/0.60/keep",
         "B vec/0.72/excl",
         "E mmr/0.3",
@@ -776,6 +787,8 @@ def test_cli_eval_recall_profile_pre_push_selects_named_subset(tmp_path: Path, m
         "H synth/0.05",
         "I synth/0.10",
     ]
+    # The live config rides along on the pre-push profile — see profile_configs.
+    assert len(seen) == 8 and seen[7].startswith("L live/")
 
 
 # --- harvest labels from grounding.log --------------------------------------
@@ -957,12 +970,13 @@ def test_run_config_knob_overrides_beat_env(monkeypatch):
 def test_tuning_configs_are_named_only_mmr_and_synth_variants():
     cfgs = eval_recall.default_configs()
     names = [c.name for c in cfgs]
-    assert names == [
+    assert names[:4] == [
         "A vec/0.60/keep",
         "B vec/0.72/excl",
         "C hyb/0.40/excl",
         "D hyb/0.40/ctx",
     ]
+    assert names[4].startswith("L live/") and cfgs[4].live is True
 
     tuning = eval_recall.tuning_configs()
     by_name = {c.name: c for c in tuning}


### PR DESCRIPTION
## What

Started as "asking for a push to `master` didn't surface that master is protected". Pulling that thread found the recall gate had been green on a configuration nobody runs, while the live hook scored **3× worse**.

## The headline

Curated 44-prompt set, k=5, measured 2026-08-15:

| config | prec@5 | R@5 |
|---|---|---|
| A vec/0.60/keep | 0.642 | 0.50 |
| B vec/0.72/excl | 0.568 | 0.50 |
| C hyb/0.40/excl | 0.716 | 0.50 |
| D hyb/0.40/ctx | 0.595 | 0.30 |
| **L live/vec/0.8835** | **0.205** | **0.20** ← what actually ran on every prompt |

Grid configs A–D pin a chosen floor and `min_body_chars=0`. The live hook ran at `min_sim=0.8835` — a floor **no grid config uses** — from the tuner's overlay (`set_by: dream-boost`). Same failure shape as a pre-push gate that measures the installed binary instead of the diff.

Decomposed, so the number is attributed rather than alarming:

| term | prec@5 | |
|---|---|---|
| floor 0.60 → 0.8835 | 0.642 → 0.368 | **−43%, dominant** |
| min_body 0 → 40 | 0.368 → 0.363 | negligible |
| injection filters on | 0.363 → 0.205 | |

`R@5` falling 0.50 → 0.30 rules out a slot-count artifact: it retrieves fewer relevant records, it doesn't merely fill fewer slots.

**The closed loop:** the tuner line-searches `min_sim`, auto-applies the winner, and auto-reverts on regression — but compares under the same non-live semantics, so it could never see this one. It optimised a proxy that isn't the hook.

## Fixes

1. **`live_config()`** — pins nothing it can inherit (`knobs_from_flags` already treats `None` as "resolve live"), excludes archived, applies the hook's injection filters. Its **name carries the resolved values** so a floor moving underneath the gate is visible rather than hidden behind a fixed label.
2. **Added to the `pre-push` profile**, not just `default_configs()`. That is the part that matters — pre-push is the profile the blocking gate runs.
3. **The tuner now scores with injection fidelity** at all four measurement sites. It auto-applies its winner, so scoring a pipeline the hook doesn't run isn't a measurement error — it's a mechanism for shipping regressions. This deliberately changes which values it picks.
4. **Corpus**: the push-to-master fact had **four** duplicate records, three created by auto-capture within thirty minutes, of a fact stored since 2026-08-02. Consolidated onto the only one that ranked (`a979dcb7`) — the "canonical" best-written record was absent from the top 40, so collapsing onto it would have made recall *worse*. Others superseded, reversible.

## Result

Live hook, measured: **prec@5 0.205 → 0.353, R@5 0.20 → 0.40**, p50 unchanged (39ms). Verified through the real `memo recall-hook`, not just `memo recall`: the protection fact went from absent to **rank 1 at score 9.588**.

## A claim I retracted

I first reported the duplicates as a **cross-language blind spot** in cosine clustering. That is false, measured: all six pairs score **0.869–0.964** against a 0.85 threshold; the ES↔EN pair is 0.88–0.91. Qwen3-Embedding crosses languages fine and no pair was ever below threshold. The retraction is recorded in memo. What survives is a code reading, flagged as unmeasured: `_greedy_cluster` is a single greedy pass against representatives, so over 11k memories membership is order- and neighbourhood-dependent. I could not reproduce the exact cause for these ids because archiving the duplicates destroyed the repro.

## Test plan

- [x] `memo debug-recall` confirmed `search_k=9` and the flat 0.594–0.636 neighbourhood
- [x] Cosine measured directly across all four records (refuted the cross-language hypothesis)
- [x] Live-vs-grid decomposition isolating floor / min-body / injection filters
- [x] Real hook verification (`memo recall-hook`), not just the CLI
- [x] `memo eval recall --gate --profile pre-push`: PASS, prec@k 0.647 / noise 0.000 — now including the live config
- [x] 103 eval tests + 7 new live-config tests green; mypy + ruff clean
- [x] Baseline re-seeded with the hook's own profile after each config/label-set change

## Not in this PR

The nightly runs the **installed** binary, so the tuner fix lands only when a release ships. Until then the tunable knobs are frozen through the markdown config (`recall.min_sim`, `recall.project_boost`, `recall.mmr_lambda`) — which the overlay cannot override — at their current live values, so nothing changes today and the tuner cannot move them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)