### PR TITLE
fix: stop `eval memory --gate` comparing against recall's baseline

### DIFF
--- a/src/memo/cli_eval.py
+++ b/src/memo/cli_eval.py
@@ -40,10 +40,41 @@ def _cache_path(cfg: Config) -> Path:
     return cfg.state_dir / "eval" / "recall.json"
 
 
-def _baseline_path(cfg: Config) -> Path:
+# Which command a baseline belongs to. `eval memory` and `eval recall` measure
+# different pipelines and used to share ONE file. Only `eval recall` ever wrote
+# it, so the bug was on the READ side: `eval memory --gate` silently compared
+# its own pipeline against a baseline recorded from recall's. The k guard in
+# check_gate catches the case where the two ran at different top-K and nothing
+# else — at equal k the comparison looked healthy and meant nothing.
+#
+# `eval memory` therefore also gains `--update-baseline`; without it, refusing
+# the foreign baseline would leave its gate with no way to seed one at all.
+GATE_RECALL = "recall"
+GATE_MEMORY = "memory"
+
+
+def _baseline_path(cfg: Config, command: str = GATE_RECALL) -> Path:
     # Machine-local: the gate runs against THIS machine's live index, so the
     # baseline can't be a committed repo file — it lives under state_dir.
-    return cfg.state_dir / "eval" / "recall_baseline.json"
+    # `recall` keeps the historical filename so existing baselines stay valid.
+    name = "recall_baseline.json" if command == GATE_RECALL else f"{command}_baseline.json"
+    return cfg.state_dir / "eval" / name
+
+
+def _reject_foreign_baseline(baseline: dict, expected: str, path: Path) -> None:
+    """Refuse a baseline another command wrote.
+
+    Absent stamp = written before baselines were separated; those files only
+    ever came from `eval recall`, so treat them as such rather than forcing a
+    re-seed on upgrade.
+    """
+    owner = baseline.get("gate_command") or GATE_RECALL
+    if owner != expected:
+        raise click.ClickException(
+            f"baseline at {path} was written by `memo eval {owner}`, not "
+            f"`memo eval {expected}` — re-seed with "
+            f"`memo eval {expected} ... --update-baseline`"
+        )
 
 
 def _atomic_write_json(path: Path, payload: object) -> None:
@@ -93,9 +124,9 @@ def _save_cache(cfg: Config, cache: dict) -> None:
     p.write_text(json.dumps(cache, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
-def _load_baseline(cfg: Config) -> dict:
-    """Load the machine-local recall gate baseline, if one exists."""
-    p = _baseline_path(cfg)
+def _load_baseline(cfg: Config, command: str = GATE_RECALL) -> dict:
+    """Load the machine-local gate baseline for `command`, if one exists."""
+    p = _baseline_path(cfg, command)
     if not p.exists():
         return {}
     try:
@@ -174,6 +205,11 @@ def eval_repo_search_cmd(
 
 
 @eval_group.command(name="memory")
+@click.option(
+    "--update-baseline",
+    is_flag=True,
+    help="Record THIS run as the memory gate's baseline (its own file, never recall's).",
+)
 @click.option("--k", type=click.IntRange(min=1, max=50), default=5, show_default=True)
 @click.option(
     "--labels",
@@ -195,6 +231,7 @@ def eval_repo_search_cmd(
     "--gate", is_flag=True, help="Compare precision/noise with the saved recall baseline."
 )
 def eval_memory_cmd(
+    update_baseline: bool,
     k: int,
     labels_path: Path,
     eval_profile: str,
@@ -213,6 +250,9 @@ def eval_memory_cmd(
     mem = _get_memory(Config.from_env())
     try:
         rows = eval_recall.evaluate(mem, k=k, labels=labels, configs=configs)
+        # Taken while the store is open: check_gate uses it to tell a code
+        # regression apart from corpus drift.
+        corpus_fp = eval_recall.fingerprint_corpus(mem)
     finally:
         mem.close()
     payload: dict[str, Any] = {
@@ -238,11 +278,29 @@ def eval_memory_cmd(
             for row in rows
         ],
     }
+    if update_baseline:
+        _cfg = Config.from_env()
+        _payload = eval_recall.baseline_payload(
+            rows, k=k, labels_fingerprint=labels.fingerprint(), corpus_fingerprint=corpus_fp
+        )
+        _payload["gate_command"] = GATE_MEMORY
+        _bp = _baseline_path(_cfg, GATE_MEMORY)
+        _atomic_write_json(_bp, _payload)
+        console.print(f"[green]✓[/green] memory baseline saved → {_bp}")
+        return
+
     if gate:
-        baseline = _load_baseline(Config.from_env())
-        # Pass k so check_gate fails fast on a k mismatch — `eval memory` (k=5)
-        # and `eval recall` (k=3) share one recall_baseline.json, so a baseline
-        # seeded at a different top-K must not be compared silently.
+        _cfg = Config.from_env()
+        baseline = _load_baseline(_cfg, GATE_MEMORY)
+        if not baseline:
+            raise click.ClickException(
+                f"no memory gate baseline at {_baseline_path(_cfg, GATE_MEMORY)} — seed it "
+                "with `memo eval memory --update-baseline`. It deliberately no longer falls "
+                "back to `eval recall`'s baseline: that measured a different pipeline."
+            )
+        _reject_foreign_baseline(baseline, GATE_MEMORY, _baseline_path(_cfg, GATE_MEMORY))
+        # k is still passed so a baseline seeded at a different top-K is refused
+        # rather than compared silently.
         result = eval_recall.check_gate(
             rows, baseline, labels_fingerprint=labels.fingerprint(), k=k
         )
@@ -396,6 +454,7 @@ def _run_gate(
         baseline = json.loads(bp.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise click.ClickException(f"unreadable baseline {bp}: {exc}") from exc
+    _reject_foreign_baseline(baseline, GATE_RECALL, bp)
     return eval_recall.check_gate(
         rows,
         baseline,
@@ -740,7 +799,10 @@ def eval_recall_cmd(
             labels_fingerprint=labels.fingerprint(),
             corpus_fingerprint=corpus_fp,
         )
-        bp = _baseline_path(cfg)
+        # Stamp the owner so the other eval command's gate refuses this file
+        # instead of silently comparing against it.
+        payload["gate_command"] = GATE_RECALL
+        bp = _baseline_path(cfg, GATE_RECALL)
         _atomic_write_json(bp, payload)
         console.print(
             f"[green]✓[/green] baseline saved: config {metrics['config']!r} · "

--- a/tests/test_eval_baseline_ownership.py
+++ b/tests/test_eval_baseline_ownership.py
@@ -156,3 +156,88 @@ def test_gate_payload_round_trips_the_stamp(tmp_path: Path) -> None:
     _reject_foreign_baseline(loaded, GATE_MEMORY, path)
     with pytest.raises(click.ClickException):
         _reject_foreign_baseline(loaded, GATE_RECALL, path)
+
+
+def test_memory_gate_without_its_own_baseline_says_how_to_seed_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The refusal has to be actionable. Falling back to recall's baseline is
+    exactly what this change removes, so the error must name the remedy."""
+    from click.testing import CliRunner
+
+    from memo.cli import cli
+
+    _stub_eval(monkeypatch)
+    result = CliRunner().invoke(
+        cli,
+        ["eval", "memory", "--labels", str(_labels_file(tmp_path)), "--gate"],
+        env=_env(tmp_path),
+    )
+
+    assert result.exit_code != 0
+    assert "no memory gate baseline" in result.output
+    assert "--update-baseline" in result.output
+    assert "different pipeline" in result.output
+
+
+def test_memory_gate_runs_against_a_baseline_it_seeded_itself(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Seed then gate: the full loop the refusal above would otherwise block."""
+    from click.testing import CliRunner
+
+    from memo.cli import cli
+
+    _stub_eval(monkeypatch)
+    labels = _labels_file(tmp_path)
+    env = _env(tmp_path)
+
+    seeded = CliRunner().invoke(
+        cli, ["eval", "memory", "--labels", str(labels), "--update-baseline"], env=env
+    )
+    assert seeded.exit_code == 0, seeded.output
+
+    gated = CliRunner().invoke(
+        cli, ["eval", "memory", "--labels", str(labels), "--gate", "--json"], env=env
+    )
+
+    assert gated.exit_code == 0, gated.output
+    assert json.loads(gated.output)["gate"]["passed"] is True
+
+
+def test_memory_gate_refuses_a_baseline_recall_left_behind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The regression this whole change exists for: a recall-written file must
+    not be silently accepted just because it happens to sit in state_dir."""
+    from click.testing import CliRunner
+
+    from memo.cli import cli
+
+    _stub_eval(monkeypatch)
+    env = _env(tmp_path)
+    eval_dir = tmp_path / "state" / "eval"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    # Same filename the memory gate now reads, but stamped by the other command.
+    (eval_dir / "memory_baseline.json").write_text(
+        json.dumps({"gate_command": GATE_RECALL, "precision_at_k": 0.9, "k": 5}), "utf-8"
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["eval", "memory", "--labels", str(_labels_file(tmp_path)), "--gate"],
+        env=env,
+    )
+
+    assert result.exit_code != 0
+    assert "was written by `memo eval recall`" in result.output
+
+
+def test_load_baseline_reads_a_stored_payload(tmp_path: Path) -> None:
+    cfg = _Cfg(tmp_path)
+    path = _baseline_path(cfg, GATE_MEMORY)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"gate_command": GATE_MEMORY, "precision_at_k": 0.42}), "utf-8")
+
+    assert cli_eval._load_baseline(cfg, GATE_MEMORY)["precision_at_k"] == 0.42
+    assert cli_eval._load_baseline(cfg, GATE_RECALL) == {}

--- a/tests/test_eval_baseline_ownership.py
+++ b/tests/test_eval_baseline_ownership.py
@@ -1,0 +1,156 @@
+"""`eval memory` and `eval recall` must not share a gate baseline.
+
+They measure different pipelines. The file was shared and only `eval recall`
+ever wrote it, so `eval memory --gate` compared its own numbers against a
+baseline recorded from recall's — and `check_gate`'s k guard only catches that
+when the two happen to run at different top-K. At equal k the comparison looked
+healthy and meant nothing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from memo import cli_eval
+from memo.cli_eval import (
+    GATE_MEMORY,
+    GATE_RECALL,
+    _baseline_path,
+    _reject_foreign_baseline,
+)
+
+
+class _Cfg:
+    def __init__(self, state_dir: Path) -> None:
+        self.state_dir = state_dir
+
+
+def test_each_command_gets_its_own_baseline_file(tmp_path: Path) -> None:
+    cfg = _Cfg(tmp_path)
+
+    assert _baseline_path(cfg, GATE_RECALL) != _baseline_path(cfg, GATE_MEMORY)
+
+
+def test_recall_keeps_the_historical_filename(tmp_path: Path) -> None:
+    """Renaming it would silently invalidate every existing machine's baseline
+    and force a re-seed on upgrade."""
+    assert _baseline_path(_Cfg(tmp_path), GATE_RECALL).name == "recall_baseline.json"
+
+
+def test_default_command_is_recall(tmp_path: Path) -> None:
+    cfg = _Cfg(tmp_path)
+
+    assert _baseline_path(cfg) == _baseline_path(cfg, GATE_RECALL)
+
+
+def test_a_baseline_written_by_the_other_command_is_refused(tmp_path: Path) -> None:
+    path = tmp_path / "recall_baseline.json"
+
+    with pytest.raises(Exception, match="was written by `memo eval recall`"):
+        _reject_foreign_baseline({"gate_command": GATE_RECALL}, GATE_MEMORY, path)
+
+
+def test_a_baseline_from_the_same_command_is_accepted(tmp_path: Path) -> None:
+    _reject_foreign_baseline({"gate_command": GATE_MEMORY}, GATE_MEMORY, tmp_path / "b.json")
+    _reject_foreign_baseline({"gate_command": GATE_RECALL}, GATE_RECALL, tmp_path / "b.json")
+
+
+def test_an_unstamped_baseline_counts_as_recall(tmp_path: Path) -> None:
+    """Files written before the split only ever came from `eval recall`, so
+    treating them as recall keeps existing baselines valid across the upgrade
+    instead of forcing everyone to re-seed."""
+    _reject_foreign_baseline({"precision_at_k": 0.6}, GATE_RECALL, tmp_path / "b.json")
+
+    with pytest.raises(Exception, match="was written by `memo eval recall`"):
+        _reject_foreign_baseline({"precision_at_k": 0.6}, GATE_MEMORY, tmp_path / "b.json")
+
+
+def _labels_file(tmp_path: Path) -> Path:
+    path = tmp_path / "labels.json"
+    path.write_text(json.dumps({"prompts": [{"text": "where is memo", "relevant": True}]}), "utf-8")
+    return path
+
+
+def _stub_eval(monkeypatch: pytest.MonkeyPatch) -> None:
+    from memo import eval_recall
+
+    labels = eval_recall.LabelSet(prompts=[eval_recall.Prompt("where is memo", relevant=True)])
+    class _Mem:
+        def close(self) -> None:  # eval memory closes the store before scoring
+            pass
+
+    monkeypatch.setattr(cli_eval, "_get_memory", lambda cfg: _Mem())
+    monkeypatch.setattr(eval_recall, "load_labels", lambda path: labels)
+    monkeypatch.setattr(eval_recall, "fingerprint_corpus", lambda mem: "corpus")
+    monkeypatch.setattr(
+        eval_recall,
+        "evaluate",
+        lambda mem, *, k, labels, configs, progress=None: [
+            eval_recall.Row(config=configs[0].name, precision_at_k=1.0, noise_at_k=0.0)
+        ],
+    )
+
+
+def _env(tmp_path: Path) -> dict[str, str]:
+    return {
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_DATA_DIR": str(tmp_path / "data"),
+        "MEMO_STATE_DIR": str(tmp_path / "state"),
+    }
+
+
+def test_each_command_writes_only_its_own_file_and_stamps_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The real end-to-end check: seeding from one command must not produce or
+    touch the other's baseline, and the file must say who wrote it."""
+    from click.testing import CliRunner
+
+    from memo.cli import cli
+
+    _stub_eval(monkeypatch)
+    labels = _labels_file(tmp_path)
+    env = _env(tmp_path)
+    eval_dir = tmp_path / "state" / "eval"
+
+    for command, expected_file in (
+        (GATE_RECALL, "recall_baseline.json"),
+        (GATE_MEMORY, "memory_baseline.json"),
+    ):
+        for stale in eval_dir.glob("*_baseline.json"):
+            stale.unlink()
+        result = CliRunner().invoke(
+            cli,
+            ["eval", command, "--labels", str(labels), "--update-baseline"]
+            + (["--force"] if command == GATE_RECALL else []),
+            env=env,
+        )
+
+        assert result.exit_code == 0, result.output
+        written = sorted(p.name for p in eval_dir.glob("*_baseline.json"))
+        assert written == [expected_file], f"{command} wrote {written}"
+        payload = json.loads((eval_dir / expected_file).read_text(encoding="utf-8"))
+        assert payload["gate_command"] == command
+
+
+def test_eval_memory_exposes_update_baseline() -> None:
+    """Refusing the foreign baseline is only safe because `eval memory` can now
+    seed its own; otherwise its gate would have no remedy at all."""
+    names = {p.name for p in cli_eval.eval_memory_cmd.params}
+
+    assert "update_baseline" in names
+    assert "gate" in names
+
+
+def test_gate_payload_round_trips_the_stamp(tmp_path: Path) -> None:
+    path = tmp_path / "memory_baseline.json"
+    path.write_text(json.dumps({"gate_command": GATE_MEMORY, "precision_at_k": 0.5}), "utf-8")
+
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+
+    _reject_foreign_baseline(loaded, GATE_MEMORY, path)
+    with pytest.raises(Exception):
+        _reject_foreign_baseline(loaded, GATE_RECALL, path)

--- a/tests/test_eval_baseline_ownership.py
+++ b/tests/test_eval_baseline_ownership.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import click
 import pytest
 
 from memo import cli_eval
@@ -49,7 +50,7 @@ def test_default_command_is_recall(tmp_path: Path) -> None:
 def test_a_baseline_written_by_the_other_command_is_refused(tmp_path: Path) -> None:
     path = tmp_path / "recall_baseline.json"
 
-    with pytest.raises(Exception, match="was written by `memo eval recall`"):
+    with pytest.raises(click.ClickException, match="was written by `memo eval recall`"):
         _reject_foreign_baseline({"gate_command": GATE_RECALL}, GATE_MEMORY, path)
 
 
@@ -64,7 +65,7 @@ def test_an_unstamped_baseline_counts_as_recall(tmp_path: Path) -> None:
     instead of forcing everyone to re-seed."""
     _reject_foreign_baseline({"precision_at_k": 0.6}, GATE_RECALL, tmp_path / "b.json")
 
-    with pytest.raises(Exception, match="was written by `memo eval recall`"):
+    with pytest.raises(click.ClickException, match="was written by `memo eval recall`"):
         _reject_foreign_baseline({"precision_at_k": 0.6}, GATE_MEMORY, tmp_path / "b.json")
 
 
@@ -78,6 +79,7 @@ def _stub_eval(monkeypatch: pytest.MonkeyPatch) -> None:
     from memo import eval_recall
 
     labels = eval_recall.LabelSet(prompts=[eval_recall.Prompt("where is memo", relevant=True)])
+
     class _Mem:
         def close(self) -> None:  # eval memory closes the store before scoring
             pass
@@ -152,5 +154,5 @@ def test_gate_payload_round_trips_the_stamp(tmp_path: Path) -> None:
     loaded = json.loads(path.read_text(encoding="utf-8"))
 
     _reject_foreign_baseline(loaded, GATE_MEMORY, path)
-    with pytest.raises(Exception):
+    with pytest.raises(click.ClickException):
         _reject_foreign_baseline(loaded, GATE_RECALL, path)


### PR DESCRIPTION
## What

`memo eval memory` and `memo eval recall` measure different pipelines and shared one `recall_baseline.json`.

Only `eval recall` ever wrote it, so the defect is on the **read** side: `eval memory --gate` compared its own numbers against a baseline recorded from recall's run. `check_gate`'s `k` guard catches that only when the two happen to run at different top-K — at equal k the comparison looked healthy and meant nothing.

## Fix

Each command owns its baseline file, and the payload is stamped with the command that wrote it, so a mismatched one is refused instead of silently compared.

Two compatibility decisions:
- **`recall` keeps the historical filename** — no machine has to re-seed on upgrade.
- **An unstamped baseline counts as `recall`**, because before the split only `eval recall` could produce one.

`eval memory` also gains `--update-baseline`. Without it, refusing the foreign baseline would leave its gate with no way to seed one at all — a guard with no remedy is just a broken command.

## A correction to my own earlier report

I first described this as a **write** collision where either command could overwrite the other's file, and recorded that in memo. It is wrong: `eval memory` has no `--update-baseline` and never wrote anything.

The baseline revert I observed on 2026-08-15 (the recall gate's baseline going from 44 prompts / 0.647 back to 43 / 0.659 between two pushes) therefore **remains unexplained**. This PR does not claim to explain it. The memo note has been corrected.

## Test plan

- [x] 9 new tests in `tests/test_eval_baseline_ownership.py`, including an end-to-end one asserting each command writes **only** its own file and stamps it — reverting the split fails it
- [x] 391 eval tests pass
- [x] Config-mismatch guard verified still firing (`--profile quick` against a `pre-push`-seeded baseline is correctly refused)
- [x] `memo eval recall --against origin/master --profile pre-push`: **PASS, 0.647 vs 0.647, same corpus** — the code delta is exactly zero, so the pre-push gate drop was pure corpus drift (10643 → 10823 memories), and the re-seed is justified rather than papered over

🤖 Generated with [Claude Code](https://claude.com/claude-code)