### PR TITLE
test: cover the receiver capability file and input rejections

### DIFF
--- a/tests/test_terminal_receiver.py
+++ b/tests/test_terminal_receiver.py
@@ -5,7 +5,12 @@ import time
 
 import pytest
 
-from memo.terminal_receiver import ReceiverClient, ReceiverSession, ReceiverSupervisor
+from memo.terminal_receiver import (
+    ReceiverClient,
+    ReceiverSession,
+    ReceiverSupervisor,
+    read_capability_file,
+)
 
 
 def _session():
@@ -85,3 +90,41 @@ def test_enter_and_conflicting_message_id_are_deterministic(tmp_path):
         assert write_conflict["error"] == "message_id conflict"
     finally:
         sup.close()
+
+
+def test_capability_file_requires_exact_owner_mode_and_content(tmp_path):
+    path = tmp_path / "cap"
+    path.write_text("secret\n", encoding="ascii")
+    path.chmod(0o600)
+    assert read_capability_file(path) == "secret"
+    path.write_text("", encoding="ascii")
+    with pytest.raises(ValueError, match="empty"):
+        read_capability_file(path)
+    path.write_text("secret", encoding="ascii")
+    path.chmod(0o640)
+    with pytest.raises(ValueError, match="0600"):
+        read_capability_file(path)
+
+
+def test_session_rejects_invalid_inputs_and_oversized_payload():
+    """The rejections a caller can actually trigger, in the order they fire.
+
+    Note the layering: `write` runs the message through terminal_live's 16 KiB
+    cap (TerminalValidationError) BEFORE the receiver's own 64 KiB "frame too
+    large" ValueError, so the terminal cap is the binding one for this path.
+    Asserting the receiver limit here would test a branch `write` cannot reach.
+    """
+    from memo.errors import TerminalValidationError
+
+    with pytest.raises(ValueError, match="invalid receiver"):
+        ReceiverSession(-1, 1)
+    s = _session()
+    try:
+        with pytest.raises(ValueError, match="string"):
+            s.write(123)  # type: ignore[arg-type]
+        with pytest.raises(TerminalValidationError, match="16 KiB"):
+            s.write("x" * (16 * 1024 + 1))
+        assert s.alive()
+    finally:
+        s.close()
+        s.close()


### PR DESCRIPTION
## What

Two tests left uncommitted in a stale worktree since 2026-08-02. The feature they cover shipped long ago — `terminal_receiver.py` and `read_capability_file` are both in master — so the tests were the only thing outstanding.

### The capability file is a security boundary with no coverage

`read_capability_file` requires mode exactly `0600` and non-empty content. Nothing asserted that. A `0640` capability file was accepted by the suite's *silence*, not by design.

### One assertion had drifted, and is corrected rather than copied

The oversized-payload test expected `ValueError("frame too large")` at 64 KiB. Against master it fails:

```
memo.errors.TerminalValidationError: terminal message exceeds 16 KiB
```

`write` runs the message through `terminal_live`'s 16 KiB cap **before** reaching the receiver's own 64 KiB frame limit. That receiver limit is real (`terminal_receiver.py:152`) but unreachable from `write` — copying the test as-written would have asserted a dead branch.

The test now documents the actual layering, which is the useful fact: the terminal cap is the binding one for this path.

## Test plan

- [x] `pytest tests/test_terminal_receiver.py` — 7 passed against master's implementation
- [x] `ruff check` + `ruff format --check` clean
- [x] Verified the covered symbols exist in master before landing the tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)