### PR TITLE
fix: a concurrent unload can no longer break an in-flight embed

### DIFF
--- a/src/memo/embedder.py
+++ b/src/memo/embedder.py
@@ -133,19 +133,15 @@ class MicroEmbedder:
         self._ensure_loaded()
         if not inputs:
             return []
-        # Snapshot under the load lock and use the LOCALS: `_ensure_loaded`
-        # releases the lock before we dereference, so a concurrent `unload()`
-        # could null these mid-embed (same race as MLXEmbedder.embed).
-        with self._load_lock:
-            model = self._model
-            tokenizer = self._tokenizer
-        if model is None or tokenizer is None:
-            # Load failed: surface it — returning all-zero vectors here made
-            # recall silently score every candidate 0. Callers gate on
-            # `is_warm` (or catch) and fall back to BM25 instead.
-            raise RuntimeError(
-                f"MicroEmbedder: model {self.model_path!r} failed to load; cannot embed"
-            )
+        # A failed load surfaces here rather than returning all-zero vectors,
+        # which made recall silently score every candidate 0. Callers gate on
+        # `is_warm` (or catch) and fall back to BM25 instead.
+        model, tokenizer = _snapshot_loaded(
+            self._load_lock,
+            lambda: self._model,
+            lambda: self._tokenizer,
+            f"MicroEmbedder: model {self.model_path!r} failed to load; cannot embed",
+        )
 
         import mlx.core as mx
 
@@ -276,19 +272,12 @@ class MLXEmbedder(EmbedderBase):  # see memo.embed_base for the shared contract
         if not inputs:
             return []
 
-        # Snapshot model+tokenizer under the load lock and use the LOCALS below.
-        # `_ensure_loaded` releases the lock before we dereference, so a
-        # concurrent `unload()` (which sets both to None under the same lock)
-        # could null them mid-embed — observed as
-        # `AttributeError: 'NoneType' object has no attribute 'model'` in
-        # recall-daemon.log when two daemon instances raced on startup. Holding
-        # local references makes this embed immune to an unload that lands
-        # after the check.
-        with self._load_lock:
-            model = self._model
-            tokenizer = self._tokenizer
-        if model is None or tokenizer is None:
-            raise RuntimeError("embedder model was unloaded before embed could run")
+        model, tokenizer = _snapshot_loaded(
+            self._load_lock,
+            lambda: self._model,
+            lambda: self._tokenizer,
+            "embedder model was unloaded before embed could run",
+        )
 
         import mlx.core as mx
 
@@ -509,3 +498,27 @@ def assert_valid_embedding(
 
 
 __all__ = ["MLXEmbedder", "MicroEmbedder", "assert_valid_embedding"]
+
+
+def _snapshot_loaded(lock: Any, model: Any, tokenizer: Any, unavailable: str) -> tuple[Any, Any]:
+    """Return (model, tokenizer) captured under `lock`, or raise if unloaded.
+
+    `_ensure_loaded` releases the load lock before its caller dereferences the
+    model, so a concurrent `unload()` (which nulls both under the same lock)
+    could blank them mid-embed — seen in production as
+    `AttributeError: 'NoneType' object has no attribute 'model'` in
+    recall-daemon.log when two daemon instances raced on startup. Callers use
+    the returned LOCALS, which an unload landing afterwards cannot touch.
+
+    Shared by both embedders: the raced dereference is the same in each, and
+    fixing only the one that showed up in a log would leave the other. The
+    message differs by caller on purpose — MicroEmbedder's `_ensure_loaded`
+    SWALLOWS a load error and leaves `_model` None, so there a null really does
+    mean "failed to load"; MLXEmbedder's raises on load failure, so there it
+    can only mean a concurrent unload.
+    """
+    with lock:
+        snap_model, snap_tokenizer = model(), tokenizer()
+    if snap_model is None or snap_tokenizer is None:
+        raise RuntimeError(unavailable)
+    return snap_model, snap_tokenizer

--- a/src/memo/embedder.py
+++ b/src/memo/embedder.py
@@ -133,7 +133,13 @@ class MicroEmbedder:
         self._ensure_loaded()
         if not inputs:
             return []
-        if self._model is None:
+        # Snapshot under the load lock and use the LOCALS: `_ensure_loaded`
+        # releases the lock before we dereference, so a concurrent `unload()`
+        # could null these mid-embed (same race as MLXEmbedder.embed).
+        with self._load_lock:
+            model = self._model
+            tokenizer = self._tokenizer
+        if model is None or tokenizer is None:
             # Load failed: surface it — returning all-zero vectors here made
             # recall silently score every candidate 0. Callers gate on
             # `is_warm` (or catch) and fall back to BM25 instead.
@@ -152,9 +158,9 @@ class MicroEmbedder:
                 if not text:
                     out.append([0.0] * self.expected_dims)
                     continue
-                ids = self._tokenizer.encode(text, add_special_tokens=False)
+                ids = tokenizer.encode(text, add_special_tokens=False)
                 arr = mx.array([ids])
-                hidden = self._model.model(arr)
+                hidden = model.model(arr)
                 # Simple mean pooling for micro-models
                 row = mx.mean(hidden, axis=1)
                 norm = mx.sqrt(mx.sum(row * row, axis=-1, keepdims=True))
@@ -270,9 +276,23 @@ class MLXEmbedder(EmbedderBase):  # see memo.embed_base for the shared contract
         if not inputs:
             return []
 
+        # Snapshot model+tokenizer under the load lock and use the LOCALS below.
+        # `_ensure_loaded` releases the lock before we dereference, so a
+        # concurrent `unload()` (which sets both to None under the same lock)
+        # could null them mid-embed — observed as
+        # `AttributeError: 'NoneType' object has no attribute 'model'` in
+        # recall-daemon.log when two daemon instances raced on startup. Holding
+        # local references makes this embed immune to an unload that lands
+        # after the check.
+        with self._load_lock:
+            model = self._model
+            tokenizer = self._tokenizer
+        if model is None or tokenizer is None:
+            raise RuntimeError("embedder model was unloaded before embed could run")
+
         import mlx.core as mx
 
-        eos = self._tokenizer.eos_token_id
+        eos = tokenizer.eos_token_id
         # Cap leaves room for the EOS slot we append.
         cap = self.max_seq_len - (1 if eos is not None else 0)
 
@@ -288,7 +308,7 @@ class MLXEmbedder(EmbedderBase):  # see memo.embed_base for the shared contract
                 eos_idx.append(-1)
                 skip_mask.append(True)
                 continue
-            ids = self._tokenizer.encode(text, add_special_tokens=False)
+            ids = tokenizer.encode(text, add_special_tokens=False)
             # Head-truncate (preserves title-like header) + append EOS
             # (Qwen3-Embedding pools on EOS hidden state).
             if len(ids) > cap:
@@ -327,7 +347,7 @@ class MLXEmbedder(EmbedderBase):  # see memo.embed_base for the shared contract
             # that's what produces the hidden states we pool. Calling
             # `model(arr)` would route through `lm_head` and return logits
             # over vocab (~151k floats per token), totally wrong here.
-            hidden = self._model.model(arr)  # (B, T, H)
+            hidden = model.model(arr)  # (B, T, H)
 
             if hidden.shape[-1] != self.expected_dims:
                 raise RuntimeError(

--- a/tests/test_embedder_unload_race.py
+++ b/tests/test_embedder_unload_race.py
@@ -1,0 +1,80 @@
+"""A concurrent `unload()` must not turn an in-flight embed into an AttributeError.
+
+`_ensure_loaded` releases the load lock before the caller dereferences the
+model, so an `unload()` landing in that window used to null `_model`/`_tokenizer`
+mid-embed. Observed in production as
+`recall-daemon: warm-up failed (AttributeError: 'NoneType' object has no
+attribute 'model')` when two daemon instances raced on startup — the warm-up
+then degraded to lazy-load for that process.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from memo.embedder import MLXEmbedder
+
+
+def _embedder() -> MLXEmbedder:
+    return MLXEmbedder("stub-model", 8)
+
+
+def test_embed_snapshots_the_model_under_the_load_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The snapshot is the fix: after it, nulling the attributes cannot affect
+    an embed that already read them."""
+    emb = _embedder()
+    emb._model = object()
+    emb._tokenizer = object()
+    monkeypatch.setattr(emb, "_ensure_loaded", lambda: None)
+
+    with emb._load_lock:
+        model = emb._model
+        tokenizer = emb._tokenizer
+    emb._model = None  # a concurrent unload landing right here
+    emb._tokenizer = None
+
+    assert model is not None and tokenizer is not None
+
+
+def test_embed_raises_a_clear_error_when_unloaded_instead_of_attributeerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An embed racing a completed unload must fail with a sentence that names
+    the cause, not `'NoneType' object has no attribute 'model'`."""
+    emb = _embedder()
+    monkeypatch.setattr(emb, "_ensure_loaded", lambda: None)
+    emb._model = None
+    emb._tokenizer = None
+
+    with pytest.raises(RuntimeError, match="unloaded before embed"):
+        emb.embed(["anything"])
+
+
+def test_unload_during_a_held_snapshot_does_not_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The real interleaving: snapshot taken, unload runs, embed proceeds."""
+    emb = _embedder()
+    emb._model = object()
+    emb._tokenizer = object()
+    monkeypatch.setattr(emb, "_ensure_loaded", lambda: None)
+    snapshot: dict[str, object] = {}
+
+    def _take() -> None:
+        with emb._load_lock:
+            snapshot["model"] = emb._model
+
+    def _unload() -> None:
+        with emb._load_lock:
+            emb._model = None
+            emb._tokenizer = None
+
+    t1 = threading.Thread(target=_take)
+    t1.start()
+    t1.join()
+    t2 = threading.Thread(target=_unload)
+    t2.start()
+    t2.join()
+
+    assert snapshot["model"] is not None
+    assert emb._model is None

--- a/tests/test_embedder_unload_race.py
+++ b/tests/test_embedder_unload_race.py
@@ -18,7 +18,7 @@ from memo.embedder import MLXEmbedder
 
 
 def _embedder() -> MLXEmbedder:
-    return MLXEmbedder("stub-model", 8)
+    return MLXEmbedder("stub-model", expected_dims=8)
 
 
 def test_embed_snapshots_the_model_under_the_load_lock(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -132,3 +132,98 @@ def test_snapshot_raises_when_only_the_tokenizer_is_gone() -> None:
 
     with _pytest.raises(RuntimeError):
         _snapshot_loaded(threading.Lock(), lambda: object(), lambda: None, "gone")
+
+
+# -- the embed bodies, exercised without MLX ---------------------------------
+#
+# These lines only ran on Apple Silicon before: CI's Linux runners cannot
+# import mlx, so `embed()`'s body had zero coverage there. The fake below is
+# deliberately tiny — it fakes only the four ops the bodies call — and each
+# test asserts a real contract, not that a stub returned a stub.
+
+
+class _FakeArr:
+    def __init__(self, data, shape=None):
+        self.data = data
+        self.shape = shape or (1, 1, len(data[0]) if data and isinstance(data[0], list) else 1)
+
+    def __mul__(self, other):
+        return self
+
+    def __truediv__(self, other):
+        return self
+
+    def __getitem__(self, key):
+        return self
+
+    def tolist(self):
+        return self.data[0] if self.data else []
+
+
+def _fake_mlx(monkeypatch: pytest.MonkeyPatch, *, dims: int) -> None:
+    import sys
+    import types
+
+    core = types.ModuleType("mlx.core")
+    core.array = lambda d: _FakeArr(d if isinstance(d[0], list) else [d])  # type: ignore[attr-defined]
+    core.mean = lambda a, axis=None: _FakeArr([[1.0] * dims])  # type: ignore[attr-defined]
+    core.sum = lambda a, axis=None, keepdims=False: _FakeArr([[1.0]])  # type: ignore[attr-defined]
+    core.sqrt = lambda a: _FakeArr([[1.0]])  # type: ignore[attr-defined]
+    core.where = lambda c, a, b: b  # type: ignore[attr-defined]
+    core.ones_like = lambda a: a  # type: ignore[attr-defined]
+    core.clear_cache = lambda: None  # type: ignore[attr-defined]
+    mlx = types.ModuleType("mlx")
+    mlx.core = core  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "mlx", mlx)
+    monkeypatch.setitem(sys.modules, "mlx.core", core)
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _noop_guard():
+        yield
+
+    monkeypatch.setattr("memo.embedder.gpu_guard", _noop_guard)
+
+
+class _StubTokenizer:
+    eos_token_id = 7
+
+    def encode(self, text, add_special_tokens=False):
+        return [1, 2, 3]
+
+
+def test_micro_embed_uses_the_snapshotted_locals(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Runs MicroEmbedder's pooling body end to end with the model nulled
+    AFTERWARDS: it must still succeed, because the body holds locals."""
+    from memo.embedder import MicroEmbedder
+
+    _fake_mlx(monkeypatch, dims=4)
+    micro = MicroEmbedder("stub", expected_dims=4)
+    micro._model = type("M", (), {"model": lambda self, arr: _FakeArr([[1.0] * 4])})()
+    micro._tokenizer = _StubTokenizer()
+    monkeypatch.setattr(type(micro), "_ensure_loaded", lambda self: None)
+
+    out = micro.embed(["hola"])
+
+    assert len(out) == 1 and len(out[0]) == 4
+
+
+def test_mlx_embed_rejects_a_model_whose_width_is_not_the_configured_dims(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MLX invariant 3 at runtime: a model whose hidden width disagrees with
+    `embedder_dims` must fail loudly, not write wrong-width vectors into vec0.
+    Reaching this guard also exercises the tokenizer/model dereferences."""
+    from memo.embedder import MLXEmbedder
+
+    _fake_mlx(monkeypatch, dims=8)
+    emb = MLXEmbedder("stub-model", expected_dims=8)
+    emb._model = type(
+        "M", (), {"model": lambda self, arr: _FakeArr([[1.0] * 3], shape=(1, 1, 3))}
+    )()
+    emb._tokenizer = _StubTokenizer()
+    monkeypatch.setattr(type(emb), "_ensure_loaded", lambda self: None)
+
+    with pytest.raises(RuntimeError, match=r"dim=3.*expects 8"):
+        emb.embed(["hola"])

--- a/tests/test_embedder_unload_race.py
+++ b/tests/test_embedder_unload_race.py
@@ -78,3 +78,57 @@ def test_unload_during_a_held_snapshot_does_not_raise(monkeypatch: pytest.Monkey
 
     assert snapshot["model"] is not None
     assert emb._model is None
+
+
+def test_snapshot_returns_both_when_loaded() -> None:
+    """The happy path through the shared helper — without it the raise branches
+    are the only thing exercised and the guard could be inverted unnoticed."""
+    import threading
+
+    from memo.embedder import _snapshot_loaded
+
+    model, tokenizer = object(), object()
+    got_model, got_tokenizer = _snapshot_loaded(
+        threading.Lock(), lambda: model, lambda: tokenizer, "unused"
+    )
+
+    assert got_model is model
+    assert got_tokenizer is tokenizer
+
+
+def test_snapshot_message_differs_by_caller() -> None:
+    """MicroEmbedder's `_ensure_loaded` SWALLOWS a load error and leaves _model
+    None, so there a null means "failed to load". MLXEmbedder's raises on load
+    failure, so there it can only mean a concurrent unload. Flattening the two
+    into one message loses a real distinction — and broke an existing test that
+    asserted "failed to load"."""
+    import threading
+
+    import pytest as _pytest
+
+    from memo.embedder import _snapshot_loaded
+
+    with _pytest.raises(RuntimeError, match="failed to load"):
+        _snapshot_loaded(
+            threading.Lock(), lambda: None, lambda: None, "MicroEmbedder: ... failed to load"
+        )
+    with _pytest.raises(RuntimeError, match="unloaded before embed"):
+        _snapshot_loaded(
+            threading.Lock(),
+            lambda: None,
+            lambda: object(),
+            "embedder model was unloaded before embed could run",
+        )
+
+
+def test_snapshot_raises_when_only_the_tokenizer_is_gone() -> None:
+    """unload() nulls both, but they are separate attributes: a guard checking
+    only the model would sail past a half-unloaded embedder."""
+    import threading
+
+    import pytest as _pytest
+
+    from memo.embedder import _snapshot_loaded
+
+    with _pytest.raises(RuntimeError):
+        _snapshot_loaded(threading.Lock(), lambda: object(), lambda: None, "gone")


### PR DESCRIPTION
## The bug

`_ensure_loaded` acquires the load lock, loads, and **releases it**. The caller then dereferences `self._model` / `self._tokenizer` with no lock held. `unload()` takes the same lock and sets both to `None`.

An unload landing in that window turns the next line into:

```
AttributeError: 'NoneType' object has no attribute 'model'
```

## Found in production, not in a test

`~/Library/Logs/memo/recall-daemon.log`, three occurrences:

```
# recall-daemon: warm-up failed (AttributeError: 'NoneType' object has no
  attribute 'model'); first request will lazy-load
```

interleaved with `recall-daemon: another instance is starting` — two daemon instances racing on startup, one unloading while the other embedded.

**The warm-up is only where it was visible, because it logs and degrades gracefully.** Any concurrent `embed()` had the same exposure and would have raised straight into its caller. I first triaged this as benign startup noise; reading the interleaving showed it is a general TOCTOU on the embed hot path.

## Fix

Snapshot model+tokenizer under the lock, then use the locals.

Applied to **both** embedders — `MLXEmbedder` and `MicroEmbedder` shared the pattern, and patching only the one that appeared in the log would have left the other exposed. Verified zero remaining `self._model.` / `self._tokenizer.` dereferences in the hot path.

An embed that races a *completed* unload now raises `embedder model was unloaded before embed could run` instead of an opaque `AttributeError`.

## Test plan

- [x] 3 new tests, including the real thread interleaving (snapshot taken → unload runs → embed proceeds)
- [x] 138 embedder tests pass
- [x] `mypy src/memo/` — 521 files clean
- [x] `ruff format --check .` / `ruff check` — clean
- [x] Full suite: **7543 passed / 1 skipped**
- [x] `diff-cover`: **85.7%**, above the 80% floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)