### PR TITLE
chore: point the Homebrew formula at the 4.11.3 sdist

### DIFF
--- a/docs/homebrew/mlx-memo.rb
+++ b/docs/homebrew/mlx-memo.rb
@@ -21,8 +21,8 @@ class MlxMemo < Formula
 
   desc "Local MCP memory for AI agents — MLX-native, sqlite-vec, markdown vault"
   homepage "https://github.com/jagoff/memo"
-  url "https://files.pythonhosted.org/packages/9d/e4/144a55602c4577d6f0a8500922ae6be708344acafb1044676378d9a10334/mlx_memo-4.11.2.tar.gz"
-  sha256 "f297b91b91e37968819a8a75e1cd026fbc89cbe50fc3c63f0a76f7a0bc510514"
+  url "https://files.pythonhosted.org/packages/2d/75/8f807ab0618e5c91f1131606f9252b5aaa28899005d1772bef7529c0c3b0/mlx_memo-4.11.3.tar.gz"
+  sha256 "451a0119241eb0d7221f50dccdcd33036a75560a49f50062a03a235d7ca9b21f"
   license "MIT"
 
   depends_on arch: :arm64


### PR DESCRIPTION
Closes the two `memo release check` warnings the 4.11.3 release PR (#257)
necessarily left open: the formula can only pin the sdist URL and sha256 once
PyPI has published, which happens on tag.

Same follow-up #254 did for 4.11.2.

## Verification

- `memo release check` → passed for 4.11.3, **no warnings** (was 2)
- sha256 verified by downloading the actual sdist and hashing it locally, not
  by trusting the PyPI JSON echo:
  `451a0119241eb0d7221f50dccdcd33036a75560a49f50062a03a235d7ca9b21f` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)