### PR TITLE
test: guard the two classes where recall injection drops a top-ranked memory

### DIFF
--- a/eval/regression_labels.json
+++ b/eval/regression_labels.json
@@ -297,6 +297,22 @@
         "a979dcb7"
       ],
       "_note": "2026-08-15 incident, RESOLVED. `master` is branch-protected (GH006 on a direct push); the only path is a PR. Asking for a push to master surfaced merge-conflict and push-auth memories instead, and the protection fact was absent from the top 40. Root cause was capture, not ranking: auto-capture created THREE paraphrase duplicates within 30 minutes on 2026-08-15 (abdbfbc7 15:51, 58edcf94 16:08, a979dcb7 16:20) of a fact already stored since 2026-08-02 (a97d17c0). Write-time dedup keys on normalized_content_hash, so a paraphrase — here also across languages — hashes differently and passes. Four records then split the signal across a flat-similarity neighbourhood (vec 0.594-0.636) that the hook's search_k=9 pool samples almost arbitrarily. Resolved by consolidating onto a979dcb7 (the only one that ranked) after merging the best content into it, and superseding the other three (reversible). Verified through the real hook: absent -> rank 1 at score 9.588. Gate held at prec@k 0.647 / noise 0.000. NOT fixed: `memo consolidate propose` clusters the near-identical English pair but not the Spanish original, so cosine clustering has the same cross-language blind spot as the hash dedup."
+    },
+    {
+      "text": "como maneja memo los casi-duplicados cuando guardo algo parecido",
+      "relevant": true,
+      "expect_ids": [
+        "4de6dd4168f1"
+      ],
+      "_note": "2026-08-16 incident: memo search ranks 4de6dd41 #1 (score 1.398, type=fact, no chunks) but the real recall-hook does NOT inject it. Refuted causes: the _uncertain tag is not a recall filter (2 of 3 control HITs carry it too; 243 memories have it), and MEMO_RECALL_TOKEN_BUDGET=4000 / MEMO_RECALL_TOP_K=15 produced byte-identical output (confounded: env vars may not reach the warm daemon path). Root cause still open. This prompt guards the class 'search ranks it first, injection drops it'."
+    },
+    {
+      "text": "el pre-push me fallo con label set changed, que hago",
+      "relevant": true,
+      "expect_ids": [
+        "608e16fcfe50"
+      ],
+      "_note": "2026-08-16 incident: a long durable memory is split into <id>_chunk_N rows typed 'reference'. The chunks swept the top 5 search hits (1.096->0.975) but auto-recall excludes the reference tier, so the hook can use none of them, and the canonical row does not even reach the top 6 (its embedding is diluted across the whole document). Perverse effect: the longer and better-chunked a durable memory, the LESS likely auto-recall surfaces it. Guards the chunk/tier class."
     }
   ],
   "relevant_terms": [


### PR DESCRIPTION
Two memories that `memo search` returns at rank 1 are **not injected** by the
real recall hook. Adds both as labeled prompts (44 → 46) so the classes are
measured, per the retrieval-regression discipline — no per-query patching.

Both are confirmed RED: the eval harness reproduces the miss, including
surfacing the same shallow lexical match the live hook injected instead
(`pr #246 opened with label and evidence`, 1.069). A harness that passed them
would have been unfaithful to the hook.

## The two classes

**`_uncertain` quarantine.** `recall_logic.uncertain_exclusion()` excludes
`_uncertain`-tagged auto-captures from recall (`MEMO_RECALL_EXCLUDE_UNCERTAIN`,
default on). 244 memories carry the tag; on a single recent day it was 37 of
259 captures (14%). Nothing graduates them — the graduation pass is not enabled
in the dream LaunchAgent — so they accumulate captured-but-unrecallable.

**Chunk/tier.** A long durable memory is split into `<id>_chunk_N` rows typed
`reference`. The chunks swept the top 5 search hits (1.096→0.975), but
auto-recall excludes the reference tier, so the hook can use none of them, and
the canonical row does not reach the top 6. Perverse effect: the longer and
better-chunked a durable memory, the less likely recall surfaces it. All 461
chunks carry `parent_id` (already indexed), so a chunk→parent rollup is
feasible — not attempted here.

## Measured, and deliberately NOT acted on

A/B on `MEMO_RECALL_EXCLUDE_UNCERTAIN` across all 46 prompts:

| config | on | off |
|---|---|---|
| grid A/E/F/G | 0.605 | 0.600 |
| H/I (best) | 0.610 | 0.605 |
| **L live** | 0.350 | **0.370** |

noise@5 stays 0.000 in every arm. Turning it off helps the config that models
the real hook (+0.020) but costs the grid (−0.005), so the gate's headline
number would drop and reject it. Not conclusive → the default is left alone.

Worth flagging separately: **L live scores 0.350 against the grid's 0.610** —
a ~0.25 gap between what the offline grid measures and what production
actually injects.

## Baseline

Re-seeded (machine-local) on the new 46-prompt set: `H synth/0.05`,
prec@5 0.61 / noise@5 0.0. The two new labels are counted as failing, so a
future fix ratchets the number up rather than needing another re-seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)