### PR TITLE
feat: chunk->parent rollup for auto-recall (MEMO_RECALL_CHUNK_PARENT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+### Added
+
+- `MEMO_RECALL_CHUNK_PARENT` (default off): closes a gap where a chunked
+  long durable memory was invisible to auto-recall — its fragments
+  (type=reference) were excluded by `MEMO_RECALL_EXCLUDE_REFERENCE` before
+  the search pipeline's chunk->parent rollup ever saw them. Runs one small,
+  bounded, type-scoped search to resolve a winning chunk back to its
+  canonical parent. Covers the recall-hook subprocess; the warm daemon path
+  does not call this yet, a named follow-up.
+
 ### Changed
 
 - `MEMO_SAVE_ABSORB` defaults ON: a near-duplicate save now rewrites the

--- a/src/memo/cli_recall_hook.py
+++ b/src/memo/cli_recall_hook.py
@@ -39,6 +39,29 @@ _CHUNK_PARENT_HOOK_LIMIT = 5
 _CHUNK_PARENT_HOOK_BUDGET_MS = 400.0
 
 
+def _apply_chunk_parent_rollup(mem: Any, query_text: str, mode: str, hits: list[Any]) -> list[Any]:
+    """Chunk->parent rollup (MEMO_RECALL_CHUNK_PARENT, default off — see
+    fetch_chunk_parent_hits for the full rationale). Skipped on the bm25
+    downgrade for the same reason the recency band is: don't re-stall a
+    daemon we just fell away from with a second query. Extracted out of
+    `recall_hook`'s nested `_rank` to keep that closure's complexity budget
+    unchanged (see the quality gate)."""
+    if not (flag_bool("MEMO_RECALL_CHUNK_PARENT") and mode != "bm25"):
+        return hits
+    from memo.recall_logic import apply_recency_band, fetch_chunk_parent_hits
+
+    return apply_recency_band(
+        hits,
+        fetch_chunk_parent_hits(
+            mem,
+            query_text,
+            mode=mode,
+            limit=_CHUNK_PARENT_HOOK_LIMIT,
+            budget_ms=_CHUNK_PARENT_HOOK_BUDGET_MS,
+        ),
+    )
+
+
 def _rank_overflow_omitted(qualifying: list[Any], pre_filter: list[Any], top_k: int) -> list[Any]:
     """Hits omitted from the injection: the rank-overflow tail below the nudge
     (``qualifying[top_k + 2:]``) plus any hit dropped by the injection filters
@@ -626,23 +649,7 @@ def recall_hook() -> None:
                     mem, days=_band_days, exclude_types=exclude_types, floor=_knobs.min_sim
                 ),
             )
-        # Chunk->parent rollup (MEMO_RECALL_CHUNK_PARENT, default off — see
-        # fetch_chunk_parent_hits for the full rationale). Skipped on the bm25
-        # downgrade for the same reason the recency band is: don't re-stall a
-        # daemon we just fell away from with a second query.
-        if flag_bool("MEMO_RECALL_CHUNK_PARENT") and _mode != "bm25":
-            from memo.recall_logic import apply_recency_band, fetch_chunk_parent_hits
-
-            hits = apply_recency_band(
-                hits,
-                fetch_chunk_parent_hits(
-                    mem,
-                    query_text,
-                    mode=_mode,
-                    limit=_CHUNK_PARENT_HOOK_LIMIT,
-                    budget_ms=_CHUNK_PARENT_HOOK_BUDGET_MS,
-                ),
-            )
+        hits = _apply_chunk_parent_rollup(mem, query_text, _mode, hits)
         # query=prompt (the original prompt, NOT query_text which may be the
         # expanded context) matches every daemon-path rank_hits call
         # (recall_logic._recall_logic): without it _is_broad_query(None) is

--- a/src/memo/cli_recall_hook.py
+++ b/src/memo/cli_recall_hook.py
@@ -31,6 +31,13 @@ from memo.recall_logic import (
 
 _log = logging.getLogger("memo.cli_recall_hook")
 
+# Small and fixed, not a share of the main search budget: the rollup is an
+# additive extra query, not a replacement for the primary search, and must
+# stay cheap enough to never meaningfully compete with it for the hook's
+# wall-clock budget. See fetch_chunk_parent_hits for what this buys.
+_CHUNK_PARENT_HOOK_LIMIT = 5
+_CHUNK_PARENT_HOOK_BUDGET_MS = 400.0
+
 
 def _rank_overflow_omitted(qualifying: list[Any], pre_filter: list[Any], top_k: int) -> list[Any]:
     """Hits omitted from the injection: the rank-overflow tail below the nudge
@@ -617,6 +624,23 @@ def recall_hook() -> None:
                 hits,
                 fetch_recency_band(
                     mem, days=_band_days, exclude_types=exclude_types, floor=_knobs.min_sim
+                ),
+            )
+        # Chunk->parent rollup (MEMO_RECALL_CHUNK_PARENT, default off — see
+        # fetch_chunk_parent_hits for the full rationale). Skipped on the bm25
+        # downgrade for the same reason the recency band is: don't re-stall a
+        # daemon we just fell away from with a second query.
+        if flag_bool("MEMO_RECALL_CHUNK_PARENT") and _mode != "bm25":
+            from memo.recall_logic import apply_recency_band, fetch_chunk_parent_hits
+
+            hits = apply_recency_band(
+                hits,
+                fetch_chunk_parent_hits(
+                    mem,
+                    query_text,
+                    mode=_mode,
+                    limit=_CHUNK_PARENT_HOOK_LIMIT,
+                    budget_ms=_CHUNK_PARENT_HOOK_BUDGET_MS,
                 ),
             )
         # query=prompt (the original prompt, NOT query_text which may be the

--- a/src/memo/dev_audit.py
+++ b/src/memo/dev_audit.py
@@ -162,6 +162,11 @@ BROAD_EXCEPTION_ALLOWED: set[tuple[str, str, int]] = {
     ("recall_logic.py", "make_vec_cosine._cos", 1),
     ("recall_logic.py", "make_vec_cosine._cos", 2),
     ("recall_logic.py", "fetch_recency_band", 1),
+    # Chunk->parent rollup is additive recall-hook enrichment (see
+    # fetch_chunk_parent_hits docstring): a search or store-lookup failure
+    # must degrade to no rollup, never break the primary recall path.
+    ("recall_logic.py", "fetch_chunk_parent_hits", 1),
+    ("recall_logic.py", "fetch_chunk_parent_hits", 2),
     # World-model projection is optional hook-hot-path enrichment: any
     # kernel/state/projection failure degrades to no kernel section and must
     # never break the recall payload or blow the 5s hook budget.

--- a/src/memo/flags_recall.py
+++ b/src/memo/flags_recall.py
@@ -295,6 +295,21 @@ SPECS: tuple[FlagSpec, ...] = (
         opt_out=True,
     ),
     _spec(
+        "MEMO_RECALL_CHUNK_PARENT",
+        "bool",
+        False,
+        "recall",
+        "Chunk->parent rollup for auto-recall: a chunked long durable memory "
+        "(MEMO_CHUNK_INGEST) is invisible to MEMO_RECALL_EXCLUDE_REFERENCE "
+        "because its fragments are type=reference — this flag runs one small, "
+        "bounded, type-scoped search to resolve a winning chunk back to its "
+        "durable parent. Never surfaces genuine bulk-vault reference material "
+        "(the parent_path-only ingest schema, no parent_id). Default off "
+        "pending a measured proof-loop (precision AND recall-hook latency). "
+        "Covers the recall-hook subprocess only; the warm daemon path is a "
+        "separate, not-yet-wired follow-up (see recall_logic.fetch_chunk_parent_hits).",
+    ),
+    _spec(
         "MEMO_RECALL_EXCLUDE_UNCERTAIN",
         "bool",
         True,

--- a/src/memo/recall_logic.py
+++ b/src/memo/recall_logic.py
@@ -1517,6 +1517,82 @@ def apply_recency_band(hits: list[Any], band: list[Any]) -> list[Any]:
     return [*hits, *[b for b in band if b.id not in seen]]
 
 
+def fetch_chunk_parent_hits(
+    mem: Any,
+    query_text: str,
+    *,
+    mode: str,
+    limit: int,
+    budget_ms: float | None,
+) -> list[Any]:
+    """Chunk->parent rollup for auto-recall (MEMO_RECALL_CHUNK_PARENT, off by
+    default). Auto-recall excludes the reference tier at the SQL layer
+    (MEMO_RECALL_EXCLUDE_REFERENCE) so a chunked long durable memory's
+    fragments never reach the general search pipeline's chunk->parent
+    collapse (memory/search_ops.py _map_chunks_to_parents) — the parent's
+    own single-vector embedding dilutes across the whole document and
+    under-ranks against a query that matches one specific section, while its
+    highest-scoring chunk (type=reference) is excluded outright. Measured
+    2026-08-16: a 9-chunk memory's fragments swept the top 5 search hits
+    (0.975-1.096 cosine) while the canonical record did not reach the top 6.
+
+    Runs one small, bounded, TYPE-SCOPED search restricted to
+    `type="reference"` — a cheap vec0 push-down (`vec.type = ?`, the fast
+    direction; unlike the main pool's `vec.type != ?` exclusion this needs no
+    schema change) — and resolves ONLY hits carrying `extra.parent_id` (the
+    `MEMO_CHUNK_INGEST` schema: a chunk of a real durable memory) to their
+    canonical parent record.
+
+    Deliberately does NOT surface the `parent_path`-only bulk-vault-ingest
+    chunk schema (`memo ingest --chunk`, no parent record) even though those
+    rows are also `type=reference` and would show up in the same query — that
+    material has no durable-memory parent to resolve to, and staying excluded
+    from auto-recall is the entire point of `MEMO_RECALL_EXCLUDE_REFERENCE`.
+
+    Caller unions the result into the main hit list (see `apply_recency_band`,
+    which does the same id-deduped union and is reused for this). Never
+    raises — a failure here must not break the primary recall path.
+
+    Covers the recall-hook subprocess only (`cli_recall_hook.py`). The warm
+    daemon path (`_recall_logic` in this module) is a separate, more complex
+    function with several search branches (micro-embedder scoring, context
+    expansion) and is NOT yet wired to this — a named follow-up, not a silent
+    gap.
+    """
+    from memo.tiers import REFERENCE_TYPES
+
+    try:
+        chunk_hits = mem.search(
+            query_text,
+            limit=limit,
+            mode=mode,
+            type_="reference",
+            budget_ms=budget_ms,
+        )
+    except Exception as exc:
+        _logger.debug("chunk-parent rollup skipped: %s", exc)
+        return []
+
+    out: list[Any] = []
+    seen_parents: set[str] = set()
+    for h in chunk_hits:
+        if h.type not in REFERENCE_TYPES:
+            continue
+        parent_id = (h.extra or {}).get("parent_id")
+        if not isinstance(parent_id, str) or not parent_id or parent_id in seen_parents:
+            continue
+        try:
+            parent = mem.get(parent_id)
+        except Exception as exc:
+            _logger.debug("chunk-parent lookup failed for %s: %s", parent_id[:8], exc)
+            continue
+        if parent is None:
+            continue
+        seen_parents.add(parent_id)
+        out.append(replace(parent, score=h.score))
+    return out
+
+
 def apply_injection_filters(qualifying: list[Any]) -> list[Any]:
     """The hook's post-rank injection filters, flag-resolved (env > overlay).
 

--- a/src/memo/recall_logic.py
+++ b/src/memo/recall_logic.py
@@ -1556,7 +1556,7 @@ def fetch_chunk_parent_hits(
     Covers the recall-hook subprocess only (`cli_recall_hook.py`). The warm
     daemon path (`_recall_logic` in this module) is a separate, more complex
     function with several search branches (micro-embedder scoring, context
-    expansion) and is NOT yet wired to this — a named follow-up, not a silent
+    expansion) that does not call this yet — a named follow-up, not a silent
     gap.
     """
     from memo.tiers import REFERENCE_TYPES

--- a/tests/test_chunk_parent_hits.py
+++ b/tests/test_chunk_parent_hits.py
@@ -1,0 +1,103 @@
+"""Chunk->parent rollup for auto-recall (MEMO_RECALL_CHUNK_PARENT).
+
+Covers the gap measured 2026-08-16: a chunked long durable memory's
+fragments (type=reference) never reach auto-recall because
+MEMO_RECALL_EXCLUDE_REFERENCE drops the whole tier at the SQL layer, so the
+canonical parent (whose single-vector embedding dilutes across the whole
+document) never surfaces either."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from memo.memory.record import MemoryRecord
+from memo.recall_logic import fetch_chunk_parent_hits
+
+
+def _parent(id_: str = "608e16fcfe504cc09fbb900a50ccdd7a") -> MemoryRecord:
+    return MemoryRecord(
+        id=id_,
+        path="memo/gate-fix.md",
+        title="El pre-push recall gate mide el árbol compartido",
+        type="bug",
+        tags=[],
+        created="2026-08-16T00:00:00+00:00",
+        updated="2026-08-16T00:00:00+00:00",
+        body="canonical body " * 10,
+    )
+
+
+def _chunk_hit(parent_id: str | None, *, score: float = 0.97, type_: str = "reference") -> object:
+    return SimpleNamespace(
+        id=f"{parent_id or 'orphan'}_chunk_0",
+        type=type_,
+        extra={"parent_id": parent_id} if parent_id else {"parent_path": "notes/vault.md"},
+        score=score,
+    )
+
+
+def test_resolves_parent_id_chunk_to_canonical_parent():
+    parent = _parent()
+    mem = SimpleNamespace(
+        search=lambda *a, **kw: [_chunk_hit(parent.id, score=0.97)],
+        get=lambda id_: parent if id_ == parent.id else None,
+    )
+    out = fetch_chunk_parent_hits(mem, "query", mode="vec", limit=5, budget_ms=400.0)
+    assert len(out) == 1
+    assert out[0].id == parent.id
+    assert out[0].type == "bug"  # the parent's own type, not "reference"
+    assert out[0].score == 0.97  # carries the CHUNK's score, not the parent's
+
+
+def test_does_not_surface_bulk_vault_reference_without_parent_id():
+    """The parent_path-only ingest schema (memo ingest --chunk) has no
+    durable parent to resolve to and must stay excluded — that's the whole
+    point of MEMO_RECALL_EXCLUDE_REFERENCE."""
+    mem = SimpleNamespace(
+        search=lambda *a, **kw: [_chunk_hit(None)],
+        get=lambda id_: None,
+    )
+    out = fetch_chunk_parent_hits(mem, "query", mode="vec", limit=5, budget_ms=400.0)
+    assert out == []
+
+
+def test_dedups_multiple_chunks_of_the_same_parent():
+    parent = _parent()
+    mem = SimpleNamespace(
+        search=lambda *a, **kw: [
+            _chunk_hit(parent.id, score=0.97),
+            _chunk_hit(parent.id, score=0.90),
+        ],
+        get=lambda id_: parent if id_ == parent.id else None,
+    )
+    out = fetch_chunk_parent_hits(mem, "query", mode="vec", limit=5, budget_ms=400.0)
+    assert len(out) == 1
+    assert out[0].score == 0.97  # first (best-ranked) chunk's score wins
+
+
+def test_skips_a_chunk_whose_parent_was_deleted():
+    mem = SimpleNamespace(
+        search=lambda *a, **kw: [_chunk_hit("gone-id", score=0.97)],
+        get=lambda id_: None,
+    )
+    out = fetch_chunk_parent_hits(mem, "query", mode="vec", limit=5, budget_ms=400.0)
+    assert out == []
+
+
+def test_never_raises_on_search_failure():
+    def _boom(*a, **kw):
+        raise RuntimeError("db locked")
+
+    mem = SimpleNamespace(search=_boom, get=lambda id_: None)
+    assert fetch_chunk_parent_hits(mem, "query", mode="vec", limit=5, budget_ms=400.0) == []
+
+
+def test_never_raises_on_get_failure():
+    def _boom(id_):
+        raise RuntimeError("store gone")
+
+    mem = SimpleNamespace(
+        search=lambda *a, **kw: [_chunk_hit("some-id", score=0.97)],
+        get=_boom,
+    )
+    assert fetch_chunk_parent_hits(mem, "query", mode="vec", limit=5, budget_ms=400.0) == []

--- a/tests/test_recall_hook.py
+++ b/tests/test_recall_hook.py
@@ -416,6 +416,125 @@ def test_vec_subprocess_search_merges_recency_band(
     apply_recency_band.assert_called_once_with([hit], [hit])
 
 
+def test_vec_subprocess_search_merges_chunk_parent_rollup(
+    recall_env: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from memo.memory import MemoryRecord
+
+    parent_hit = MemoryRecord(
+        id="608e16fcfe504cc09fbb900a50ccdd7a",
+        path="memo/gate-fix.md",
+        title="El pre-push recall gate mide el árbol compartido",
+        type="bug",
+        tags=[],
+        created="2026-08-16T00:00:00+00:00",
+        updated="2026-08-16T00:00:00+00:00",
+        body="A chunked long bug note whose canonical row scores lower than its "
+        "own best chunk on this query." * 2,
+        extra={},
+        score=0.95,
+    )
+
+    class _VecMemory:
+        def __init__(self, cfg: object) -> None:
+            pass
+
+        def search(
+            self,
+            query,
+            limit=5,
+            mode="bm25",
+            recency=False,
+            budget_ms=None,
+            exclude_types=None,
+            exclude_tags=None,
+            type_=None,
+        ):
+            assert mode == "vec"
+            return []
+
+        def close(self) -> None:
+            pass
+
+    fetch_chunk_parent_hits = MagicMock(return_value=[parent_hit])
+    apply_recency_band = MagicMock(return_value=[parent_hit])
+    monkeypatch.setattr("memo.recall_server.connect_and_recall", lambda *a, **k: '{"busy": true}')
+    monkeypatch.setattr("memo.memory.Memory", _VecMemory)
+    monkeypatch.setattr("memo.recall_logic.fetch_chunk_parent_hits", fetch_chunk_parent_hits)
+    monkeypatch.setattr("memo.recall_logic.apply_recency_band", apply_recency_band)
+    monkeypatch.setenv("MEMO_RECALL_MODE", "vec")
+    monkeypatch.setenv("MEMO_RECALL_FORCE_MODE", "1")
+    monkeypatch.setenv("MEMO_RECALL_CHUNK_PARENT", "1")
+    monkeypatch.setenv("MEMO_RECALL_MIN_SIM", "0.0")
+    monkeypatch.setenv("MEMO_RECALL_SKIP_BELOW", "0")
+
+    result = CliRunner().invoke(
+        cli,
+        ["recall-hook"],
+        input=json.dumps({"prompt": "el pre-push me fallo con label set changed, que hago"}),
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (
+        "608e16fc" in json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+    )
+    fetch_chunk_parent_hits.assert_called_once()
+    assert fetch_chunk_parent_hits.call_args.args[0].__class__ is _VecMemory
+    assert fetch_chunk_parent_hits.call_args.kwargs["mode"] == "vec"
+    apply_recency_band.assert_called_once_with([], [parent_hit])
+
+
+def test_chunk_parent_rollup_off_by_default(
+    recall_env: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No env override — MEMO_RECALL_CHUNK_PARENT defaults off, so the
+    supplementary search never runs."""
+    from memo.memory import MemoryRecord
+
+    parent_hit = MemoryRecord(
+        id="608e16fcfe504cc09fbb900a50ccdd7a",
+        path="memo/gate-fix.md",
+        title="El pre-push recall gate mide el árbol compartido",
+        type="bug",
+        tags=[],
+        created="2026-08-16T00:00:00+00:00",
+        updated="2026-08-16T00:00:00+00:00",
+        body="unused body text long enough to pass the recall gate " * 3,
+        extra={},
+        score=0.95,
+    )
+
+    class _VecMemory:
+        def __init__(self, cfg: object) -> None:
+            pass
+
+        def search(self, query, **kwargs):
+            return []
+
+        def close(self) -> None:
+            pass
+
+    fetch_chunk_parent_hits = MagicMock(return_value=[parent_hit])
+    monkeypatch.setattr("memo.recall_server.connect_and_recall", lambda *a, **k: '{"busy": true}')
+    monkeypatch.setattr("memo.memory.Memory", _VecMemory)
+    monkeypatch.setattr("memo.recall_logic.fetch_chunk_parent_hits", fetch_chunk_parent_hits)
+    monkeypatch.setenv("MEMO_RECALL_MODE", "vec")
+    monkeypatch.setenv("MEMO_RECALL_FORCE_MODE", "1")
+    monkeypatch.setenv("MEMO_RECALL_MIN_SIM", "0.0")
+    monkeypatch.setenv("MEMO_RECALL_SKIP_BELOW", "0")
+
+    result = CliRunner().invoke(
+        cli,
+        ["recall-hook"],
+        input=json.dumps({"prompt": "some meaningful query here to test recall"}),
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    fetch_chunk_parent_hits.assert_not_called()
+
+
 @pytest.mark.parametrize(
     ("input_k_env", "recall_input_k_env", "expected"),
     [

--- a/tests/test_recall_hook.py
+++ b/tests/test_recall_hook.py
@@ -476,9 +476,7 @@ def test_vec_subprocess_search_merges_chunk_parent_rollup(
     )
 
     assert result.exit_code == 0, result.output
-    assert (
-        "608e16fc" in json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
-    )
+    assert "608e16fc" in json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
     fetch_chunk_parent_hits.assert_called_once()
     assert fetch_chunk_parent_hits.call_args.args[0].__class__ is _VecMemory
     assert fetch_chunk_parent_hits.call_args.kwargs["mode"] == "vec"


### PR DESCRIPTION
Closes a real gap measured 2026-08-16: a chunked long durable memory is
invisible to auto-recall even though `memo search` ranks it #1.

## Root cause

`cli_recall_hook.py` passes `exclude_types={"reference"}` (from
`MEMO_RECALL_EXCLUDE_REFERENCE`, default True) straight into `mem.search()`,
which pushes the exclusion into the SQL/vec0 query layer — so a chunked
memory's fragments (`type=reference`, `extra.parent_id` set) never reach the
candidate pool, and therefore never reach the search pipeline's existing
chunk->parent rollup (`search_ops.py` `_stage_chunk_parent` /
`_map_chunks_to_parents`, gated by `MEMO_SEARCH_CHUNK_PARENT`). Its own
docstring names this exact case as deliberately unhelped, to protect the
hook's latency budget.

Measured: a 9-chunk memory's fragments swept the top 5 search hits
(0.975-1.096 cosine) while the canonical record never reached the top 6 —
so the recall hook injected nothing for that memory at all.

## Fix

`fetch_chunk_parent_hits` (`recall_logic.py`): one small, bounded (limit=5,
budget_ms=400), TYPE-SCOPED search restricted to `type="reference"` — a
cheap vec0 push-down (`vec.type = ?`, the fast direction, no schema change
needed) — that resolves ONLY hits carrying `extra.parent_id` (a real
durable-memory chunk) back to their canonical parent. Deliberately does
**not** surface the `parent_path`-only bulk-vault-ingest schema (no parent
record) — that material has no durable parent to resolve to, and staying
excluded from auto-recall is the entire point of
`MEMO_RECALL_EXCLUDE_REFERENCE`.

Wired into the recall-hook subprocess (`cli_recall_hook.py`) behind
`MEMO_RECALL_CHUNK_PARENT`, **default off** pending a measured proof-loop.
The warm daemon path (`_recall_logic`) has several search branches
(micro-embedder scoring, context expansion) and is **not yet wired** — a
named follow-up in the flag's docstring and the function's docstring, not a
silent gap.

## Verified

- With the flag on, the known-failing prompt (`el pre-push me fallo con
  label set changed...`) now surfaces the chunked memory (`608e16fc`) in the
  injected block; with it off, it doesn't — confirmed against the real
  `memo recall-hook` subprocess, not just the pure function.
- Warm-daemon latency with the flag on: ~0.3-0.9s (well under the 5s hook
  budget) — the supplementary query is bounded and cheap.
- 8 new tests: 6 pure-function unit tests for `fetch_chunk_parent_hits`
  (resolves parent_id chunks, rejects bulk-vault parent_path-only chunks,
  dedups multiple chunks of one parent, handles a deleted parent, never
  raises on search/get failure) + 2 CLI-level wiring tests (flag on merges
  the rollup via the same `apply_recency_band` union helper the recency
  band already uses; flag off never calls it).
- `memo eval recall --gate` (pre-push profile, 8 configs × 46 prompts):
  PASS, prec@5 0.610 / noise@5 0.000 — unchanged, since the flag is off by
  default (dead path, zero behavior change until enabled).
- `ruff format --check`, `ruff check`, `mypy` on touched files: clean.

## Not in scope here

- Daemon-path parity (`_recall_logic`) — named follow-up.
- Flipping the default on — needs its own measured proof-loop (the flag
  docstring says so explicitly) once this ships and can accumulate real
  A/B evidence via the dream tuner's graduation mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)