### PR TITLE
fix: replace greedy consolidation clustering with average-link (UPGMA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,28 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
   `MEMO_SAVE_ABSORB` is enabled, an absorb — can in principle match across
   memory types or projects; this pre-exists the threshold at 0.88 too.
 
+### Fixed
+
+- Consolidation clustering (`memo consolidate`) no longer splits above-threshold
+  near-duplicates across different proposed clusters. `_greedy_cluster` compared
+  each new memory only to each existing cluster's FIRST member (frozen forever
+  as its "representative"), never to members added afterwards — so two
+  near-duplicates could land in different clusters purely because of pull
+  order. Measured on the live corpus: 38.4% of above-threshold pairs (861 of
+  1450) split this way. Single-linkage (connected components of the threshold
+  graph) was tried and rejected as the fix: it transitively chains anything
+  reachable through a path of individually-strong pairs, and on the live
+  corpus one (project, type) bucket alone chained 157 of its 950 memories into
+  one unmergeable blob. Merge-consolidation (`_cluster_within_scope`) now uses
+  average-link (UPGMA) agglomerative clustering instead: two clusters merge
+  only when the AVERAGE similarity across every cross-pair clears the
+  threshold, which fixes the greedy split (previously-split near-duplicates
+  now co-cluster) without single-linkage's chaining (max cluster size stays
+  bounded — 6 vs. 157 on the same corpus). Hand-checked purity on real
+  title+body pairs roughly doubled (~30% -> ~55-60% correct near-duplicates)
+  versus greedy's proposals. `synthesize_cross_cluster` and
+  `dream_distill.run_distill` (read-only insight generation, not merges) still
+  use the original `_greedy_cluster`.
 ## [4.11.3] - 2026-08-16
 
 ### Fixed

--- a/src/memo/memory/consolidate_ops.py
+++ b/src/memo/memory/consolidate_ops.py
@@ -470,24 +470,48 @@ class _ConsolidateOpsMixin(_MemoryBase):
         threshold: float,
     ) -> builtins.list[builtins.list[int]]:
         """Bottom-up average-link merge of one threshold-graph component.
-        `members` indexes into `sim`; returns index groups still in that space."""
+        `members` indexes into `sim`; returns index groups still in that space.
+
+        Uses the Lance-Williams average-linkage update — when clusters A and B
+        merge, the new average similarity to any C is exactly
+        ``(|A|·sim(A,C) + |B|·sim(B,C)) / (|A|+|B|)`` — so each merge is an
+        O(k) row update plus an O(k^2) C-level argmax over the cluster-sim
+        matrix, O(k^3) total at C speed. The first version instead recomputed
+        every cross-cluster block mean per candidate pair per merge (an
+        O(k^2) *Python* pair loop of `np.ix_().mean()` calls, O(k^4) element
+        touches overall): fine on the live corpus (largest component 157), but
+        the corpus-scale conformance fixture — 20 topics of ~500 near-identical
+        vectors, so components of ~500 — turned `memo_consolidate` into ~2h of
+        GIL-holding work that also starved every later test in the process."""
         import numpy as _np
 
-        clusters: builtins.list[builtins.list[int]] = [[i] for i in range(len(members))]
-        sub = sim[_np.ix_(members, members)]
-        while len(clusters) > 1:
-            best_avg, best_a, best_b = -1.0, -1, -1
-            for a in range(len(clusters)):
-                for b in range(a + 1, len(clusters)):
-                    block = sub[_np.ix_(clusters[a], clusters[b])]
-                    avg = float(block.mean())
-                    if avg > best_avg:
-                        best_avg, best_a, best_b = avg, a, b
-            if best_avg < threshold:
+        k = len(members)
+        # Cluster-level sim matrix, float64: Lance-Williams accumulates
+        # weighted averages in place, and float32 drift could flip a
+        # near-threshold merge the pure-python (float) path accepts.
+        cs = sim[_np.ix_(members, members)].astype(_np.float64)
+        _np.fill_diagonal(cs, -_np.inf)
+        sizes = _np.ones(k, dtype=_np.int64)
+        # A merged-away cluster keeps its slot as [] (falsy) so live clusters
+        # never shift position — the argmax tie-break must stay stable.
+        clusters: builtins.list[builtins.list[int]] = [[i] for i in range(k)]
+        for _ in range(k - 1):
+            flat = int(_np.argmax(cs))
+            a, b = divmod(flat, k)
+            if cs[a, b] < threshold:
                 break
-            clusters[best_a] = clusters[best_a] + clusters[best_b]
-            del clusters[best_b]
-        return [[members[i] for i in c] for c in clusters]
+            if b < a:
+                a, b = b, a
+            row = (sizes[a] * cs[a, :] + sizes[b] * cs[b, :]) / (sizes[a] + sizes[b])
+            cs[a, :] = row
+            cs[:, a] = row
+            cs[a, a] = -_np.inf
+            cs[b, :] = -_np.inf
+            cs[:, b] = -_np.inf
+            sizes[a] += sizes[b]
+            clusters[a] = clusters[a] + clusters[b]
+            clusters[b] = []
+        return [[members[i] for i in c] for c in clusters if c]
 
     @staticmethod
     def _average_link_cluster_pure_python(
@@ -534,39 +558,41 @@ class _ConsolidateOpsMixin(_MemoryBase):
         members: builtins.list[int],
         threshold: float,
     ) -> builtins.list[builtins.list[int]]:
-        """`_upgma_merge_numpy` without numpy — same bottom-up average-link
-        merge of one threshold-graph component, over a plain nested-list
-        similarity matrix. `members`/`sim` index into the same original-item
-        space, so no local/global index remapping is needed here (unlike the
-        numpy path's `sim[np.ix_(...)]` submatrix)."""
+        """`_upgma_merge_numpy` without numpy — the same Lance-Williams
+        average-linkage merge (see that docstring for why the naive
+        recompute-every-block-mean version was replaced), over a local
+        cluster-level nested-list matrix built from `sim` for this component's
+        `members`."""
+        k = len(members)
+        cs = [[sim[members[a]][members[b]] for b in range(k)] for a in range(k)]
+        for i in range(k):
+            cs[i][i] = float("-inf")
+        sizes = [1] * k
         clusters: builtins.list[builtins.list[int]] = [[m] for m in members]
-        while len(clusters) > 1:
-            best_avg, best_a, best_b = -1.0, -1, -1
-            for a in range(len(clusters)):
-                for b in range(a + 1, len(clusters)):
-                    avg = _ConsolidateOpsMixin._cross_pair_avg(sim, clusters[a], clusters[b])
-                    if avg > best_avg:
-                        best_avg, best_a, best_b = avg, a, b
+        for _ in range(k - 1):
+            best_avg, best_a, best_b = float("-inf"), -1, -1
+            for a in range(k):
+                if not clusters[a]:
+                    continue
+                row = cs[a]
+                for b in range(k):
+                    if row[b] > best_avg:
+                        best_avg, best_a, best_b = row[b], a, b
             if best_avg < threshold:
                 break
-            clusters[best_a] = clusters[best_a] + clusters[best_b]
-            del clusters[best_b]
-        return clusters
-
-    @staticmethod
-    def _cross_pair_avg(
-        sim: builtins.list[builtins.list[float]],
-        cluster_a: builtins.list[int],
-        cluster_b: builtins.list[int],
-    ) -> float:
-        """Mean similarity over every (x in cluster_a, y in cluster_b) pair."""
-        total = 0.0
-        count = 0
-        for x in cluster_a:
-            for y in cluster_b:
-                total += sim[x][y]
-                count += 1
-        return total / count
+            a, b = (best_a, best_b) if best_a < best_b else (best_b, best_a)
+            na, nb = sizes[a], sizes[b]
+            for c in range(k):
+                merged = (na * cs[a][c] + nb * cs[b][c]) / (na + nb)
+                cs[a][c] = merged
+                cs[c][a] = merged
+                cs[b][c] = float("-inf")
+                cs[c][b] = float("-inf")
+            cs[a][a] = float("-inf")
+            sizes[a] = na + nb
+            clusters[a] = clusters[a] + clusters[b]
+            clusters[b] = []
+        return [c for c in clusters if c]
 
     @staticmethod
     def _cluster_within_scope(

--- a/src/memo/memory/consolidate_ops.py
+++ b/src/memo/memory/consolidate_ops.py
@@ -1,8 +1,11 @@
 """Consolidation + cross-cluster synthesis for `Memory`.
 
 `_ConsolidateOpsMixin` holds dedup/merge consolidation and LLM cross-cluster
-synthesis. They share the embedding-pull + greedy-cluster helpers, so they live
-together. Extracted from maintain_ops.py; composed into `Memory` in facade.py.
+synthesis. They share the embedding-pull helper and, historically, a greedy
+clustering pass; merge-consolidation now clusters via `_average_link_cluster`
+(`_cluster_within_scope`) while synthesis/distillation still use the original
+`_greedy_cluster` — see that method's docstring for why the merge path moved
+off it. Extracted from maintain_ops.py; composed into `Memory` in facade.py.
 """
 
 from __future__ import annotations
@@ -291,7 +294,13 @@ class _ConsolidateOpsMixin(_MemoryBase):
         threshold: float,
     ) -> builtins.list[builtins.list[int]]:
         """Greedy single-link clustering over L2-normalised embeddings (dot ==
-        cosine). Uses numpy for the O(N²) pass when available (1024-dim × 2000
+        cosine). Used by `synthesize_cross_cluster` and `dream_distill.run_distill`
+        — read-only insight generation, where an occasional split/chained group
+        just costs LLM budget, not data. The merge-consolidation path
+        (`_cluster_within_scope`) moved to `_average_link_cluster` instead; see
+        its docstring for the measured order-sensitivity/chaining tradeoffs that
+        make greedy the wrong choice when the output actually gets merged.
+        Uses numpy for the O(N²) pass when available (1024-dim × 2000
         in pure Python ≈ 400s; numpy < 1s), else a pure-Python fallback."""
         try:
             import numpy as _np
@@ -348,6 +357,218 @@ class _ConsolidateOpsMixin(_MemoryBase):
             return clusters
 
     @staticmethod
+    def _average_link_cluster(
+        items: builtins.list[dict[str, Any]],
+        threshold: float,
+    ) -> builtins.list[builtins.list[int]]:
+        """Average-link (UPGMA) agglomerative clustering, cut at cosine >= threshold.
+
+        The consolidation merge path used `_greedy_cluster` until this replaced
+        it (`_cluster_within_scope` is the only caller). Two failure modes,
+        measured on the live corpus at the default 0.85 threshold, motivated the
+        change — they are opposite ends of the same axis, not independent bugs:
+
+        - **Greedy under-merges, order-dependently.** `_greedy_cluster` compares
+          a new item only against each existing cluster's FIRST member, frozen
+          as its "representative" forever — never against members that joined
+          afterwards. Two near-duplicates above threshold therefore land in
+          different clusters whenever the first one to arrive gets buried inside
+          a cluster (stops being anyone's comparison target) before the second
+          is processed. Measured: 38.4% of above-threshold pairs (861/1450)
+          ended up split across different clusters.
+        - **Single-linkage over-merges via chaining.** Connected components of
+          the >=threshold graph transitively absorb anything reachable through a
+          path of individually-strong pairs, even when the path's endpoints
+          share nothing. Measured: one (project, type) bucket alone
+          (`memo`/`note`) chained 157 of its 950 memories into a single
+          component — unmergeable, unreviewable, and rejected for exactly this
+          reason when tried as a replacement.
+
+        Average-link sits between them: two clusters merge only when the
+        AVERAGE similarity across every cross-pair clears the threshold, so one
+        strong bridge is not enough on its own — it gets diluted the moment its
+        partner disagrees with the rest of the group. Clustering first restricts
+        to each connected component of the threshold graph (identical to the
+        single-linkage grouping) before running the O(k^3) HAC merge inside it;
+        that restriction is exact, not an approximation — two different
+        components share no >=threshold edge at all, so every cross-component
+        pairwise similarity is already < threshold, and the mean of values that
+        are all below a bound can never clear that bound either. On the live
+        corpus the largest such component was 157 (of a 950-item scope group);
+        the full corpus clustered in ~8s.
+
+        Purity, spot-checked by hand against real title+body pairs (n=15
+        clusters each): greedy proposals were correct near-duplicates in ~30%
+        of sampled pairs (topically-adjacent-but-distinct memories glued onto
+        an arbitrary first representative); average-link's were correct in
+        ~55-60% — a real quality gap the raw threshold can't see, since cosine
+        >= 0.85 alone conflates "same topic" with "same fact." Raw pair-recall
+        against that same blind threshold is actually a hair LOWER than
+        greedy's (58.8% vs 61.6%) — the difference is exactly the marginal,
+        mostly-false pairs greedy was matching that average-link correctly
+        declines.
+        """
+        if not items:
+            return []
+        try:
+            import numpy as _np
+
+            mat = _np.array([it["emb"] for it in items], dtype=_np.float32)
+            norms = _np.linalg.norm(mat, axis=1, keepdims=True)
+            norms[norms == 0] = 1.0
+            mat = mat / norms
+            sim = mat @ mat.T
+            n = sim.shape[0]
+            ii, jj = _np.where(_np.triu(sim, k=1) >= threshold)
+            components = _ConsolidateOpsMixin._union_find_components(
+                n, zip(ii.tolist(), jj.tolist(), strict=False)
+            )
+
+            out: builtins.list[builtins.list[int]] = []
+            for members in components:
+                if len(members) == 1:
+                    out.append(members)
+                    continue
+                out.extend(_ConsolidateOpsMixin._upgma_merge_numpy(sim, members, threshold))
+            return out
+        except ImportError:
+            return _ConsolidateOpsMixin._average_link_cluster_pure_python(items, threshold)
+
+    @staticmethod
+    def _union_find_components(
+        n: int,
+        edges: Any,
+    ) -> builtins.list[builtins.list[int]]:
+        """Connected components of the graph on `range(n)` formed by `edges`
+        (an iterable of `(i, j)` pairs). Every index 0..n-1 appears in exactly
+        one returned group, singletons included. Shared by the numpy and
+        pure-python paths of `_average_link_cluster` — this IS single-linkage's
+        own grouping step; average-link uses it only to bound which items are
+        even worth an O(k^3) UPGMA pass (see `_average_link_cluster`'s
+        docstring for why restricting to it is exact, not an approximation)."""
+        parent = list(range(n))
+
+        def find(x: int) -> int:
+            while parent[x] != x:
+                parent[x] = parent[parent[x]]
+                x = parent[x]
+            return x
+
+        for a, b in edges:
+            ra, rb = find(a), find(b)
+            if ra != rb:
+                parent[ra] = rb
+        components: dict[int, builtins.list[int]] = {}
+        for i in range(n):
+            components.setdefault(find(i), []).append(i)
+        return list(components.values())
+
+    @staticmethod
+    def _upgma_merge_numpy(
+        sim: Any,
+        members: builtins.list[int],
+        threshold: float,
+    ) -> builtins.list[builtins.list[int]]:
+        """Bottom-up average-link merge of one threshold-graph component.
+        `members` indexes into `sim`; returns index groups still in that space."""
+        import numpy as _np
+
+        clusters: builtins.list[builtins.list[int]] = [[i] for i in range(len(members))]
+        sub = sim[_np.ix_(members, members)]
+        while len(clusters) > 1:
+            best_avg, best_a, best_b = -1.0, -1, -1
+            for a in range(len(clusters)):
+                for b in range(a + 1, len(clusters)):
+                    block = sub[_np.ix_(clusters[a], clusters[b])]
+                    avg = float(block.mean())
+                    if avg > best_avg:
+                        best_avg, best_a, best_b = avg, a, b
+            if best_avg < threshold:
+                break
+            clusters[best_a] = clusters[best_a] + clusters[best_b]
+            del clusters[best_b]
+        return [[members[i] for i in c] for c in clusters]
+
+    @staticmethod
+    def _average_link_cluster_pure_python(
+        items: builtins.list[dict[str, Any]],
+        threshold: float,
+    ) -> builtins.list[builtins.list[int]]:
+        """`_average_link_cluster` without numpy — same algorithm, nested lists.
+        Only ever exercised on the small synthetic fixtures unit tests build;
+        the live corpus always has numpy available (it is the only path that
+        makes the O(N^2) similarity pass tractable at corpus scale)."""
+        n = len(items)
+        sim = _ConsolidateOpsMixin._cosine_matrix_pure_python(items)
+        edges = ((i, j) for i in range(n) for j in range(i + 1, n) if sim[i][j] >= threshold)
+        components = _ConsolidateOpsMixin._union_find_components(n, edges)
+
+        out: builtins.list[builtins.list[int]] = []
+        for members in components:
+            if len(members) == 1:
+                out.append(members)
+                continue
+            out.extend(_ConsolidateOpsMixin._upgma_merge_pure_python(sim, members, threshold))
+        return out
+
+    @staticmethod
+    def _cosine_matrix_pure_python(
+        items: builtins.list[dict[str, Any]],
+    ) -> builtins.list[builtins.list[float]]:
+        """Full N×N cosine similarity matrix over `items[i]["emb"]`, no numpy."""
+        n = len(items)
+        norms = [sum(x * x for x in it["emb"]) ** 0.5 or 1.0 for it in items]
+        sim: builtins.list[builtins.list[float]] = [[0.0] * n for _ in range(n)]
+        for i in range(n):
+            sim[i][i] = 1.0
+            for j in range(i + 1, n):
+                dot = sum(x * y for x, y in zip(items[i]["emb"], items[j]["emb"], strict=False))
+                cosine = dot / (norms[i] * norms[j])
+                sim[i][j] = cosine
+                sim[j][i] = cosine
+        return sim
+
+    @staticmethod
+    def _upgma_merge_pure_python(
+        sim: builtins.list[builtins.list[float]],
+        members: builtins.list[int],
+        threshold: float,
+    ) -> builtins.list[builtins.list[int]]:
+        """`_upgma_merge_numpy` without numpy — same bottom-up average-link
+        merge of one threshold-graph component, over a plain nested-list
+        similarity matrix. `members`/`sim` index into the same original-item
+        space, so no local/global index remapping is needed here (unlike the
+        numpy path's `sim[np.ix_(...)]` submatrix)."""
+        clusters: builtins.list[builtins.list[int]] = [[m] for m in members]
+        while len(clusters) > 1:
+            best_avg, best_a, best_b = -1.0, -1, -1
+            for a in range(len(clusters)):
+                for b in range(a + 1, len(clusters)):
+                    avg = _ConsolidateOpsMixin._cross_pair_avg(sim, clusters[a], clusters[b])
+                    if avg > best_avg:
+                        best_avg, best_a, best_b = avg, a, b
+            if best_avg < threshold:
+                break
+            clusters[best_a] = clusters[best_a] + clusters[best_b]
+            del clusters[best_b]
+        return clusters
+
+    @staticmethod
+    def _cross_pair_avg(
+        sim: builtins.list[builtins.list[float]],
+        cluster_a: builtins.list[int],
+        cluster_b: builtins.list[int],
+    ) -> float:
+        """Mean similarity over every (x in cluster_a, y in cluster_b) pair."""
+        total = 0.0
+        count = 0
+        for x in cluster_a:
+            for y in cluster_b:
+                total += sim[x][y]
+                count += 1
+        return total / count
+
+    @staticmethod
     def _cluster_within_scope(
         items: builtins.list[dict[str, Any]],
         threshold: float,
@@ -394,7 +615,7 @@ class _ConsolidateOpsMixin(_MemoryBase):
         out: builtins.list[builtins.list[int]] = []
         for member_idxs in groups.values():
             sub_items = [items[i] for i in member_idxs]
-            for cluster in _ConsolidateOpsMixin._greedy_cluster(sub_items, threshold):
+            for cluster in _ConsolidateOpsMixin._average_link_cluster(sub_items, threshold):
                 out.append([member_idxs[j] for j in cluster])
         return out
 
@@ -474,12 +695,10 @@ class _ConsolidateOpsMixin(_MemoryBase):
 
         Algorithm:
         1. Pull all stored embeddings (we have them already; no re-embed).
-        2. Greedy single-link clustering by cosine ≥ `threshold`, run
-           independently inside each (project scope, type) so the merge it
-           proposes is one the write path accepts and one that costs no
-           record its type (see `_cluster_within_scope`).
-           Each memory joins the first existing cluster it's
-           ≥-similar to, or starts a new one.
+        2. Average-link (UPGMA) agglomerative clustering by cosine ≥ `threshold`,
+           run independently inside each (project scope, type) so the merge it
+           proposes is one the write path accepts and one that costs no record
+           its type (see `_cluster_within_scope`, `_average_link_cluster`).
         3. Drop singletons. The remaining clusters are candidates.
         4. For each cluster, MLXChat 7B reads the bodies and emits a
            JSON `{summary, relationship, rationale}` per
@@ -495,7 +714,7 @@ class _ConsolidateOpsMixin(_MemoryBase):
         Qwen3-Embedding-0.6B vector space.
         """
         # 1) Pull all embeddings (already stored; no re-embed) and
-        # 2) greedy single-link cluster by cosine ≥ threshold.
+        # 2) average-link cluster by cosine ≥ threshold, scoped per (project, type).
         # Always exclude reference tier: reference memories are bulk-ingested
         # vault chunks whose paths resolve back to the user's Obsidian vault
         # files (via _resolve_existing's legacy fallback). Archiving them via

--- a/tests/test_ask_disputes_mlx.py
+++ b/tests/test_ask_disputes_mlx.py
@@ -39,8 +39,13 @@ _FILLERS = [
 
 
 @pytest.fixture
-def real_mlx_memory(tmp_cfg: Config) -> Iterator[Memory]:
-    """Release SQLite handles and Metal model/cache between slow cases."""
+def real_mlx_memory(tmp_cfg: Config, monkeypatch: pytest.MonkeyPatch) -> Iterator[Memory]:
+    """Release SQLite handles and Metal model/cache between slow cases.
+
+    ABSORB off: the fixture's whole point is a *contradiction pair* — two
+    distinct records for the same fact — and default-on absorb would merge
+    the second save into the first, collapsing the pair into one id."""
+    monkeypatch.setenv("MEMO_SAVE_ABSORB", "0")
     mem = Memory(tmp_cfg)
     yield mem
     mem.close()

--- a/tests/test_consolidate_average_link.py
+++ b/tests/test_consolidate_average_link.py
@@ -132,3 +132,36 @@ def test_average_link_singletons_pass_through_untouched():
 
 def test_average_link_empty_input_returns_empty():
     assert _ConsolidateOpsMixin._average_link_cluster([], threshold=0.85) == []
+
+
+def test_dense_component_clusters_in_bounded_time():
+    """One dense component of 500 near-identical vectors — the shape the
+    corpus-scale conformance fixture produces (20 topics × ~500 members whose
+    within-topic cosine is ~0.999). The first UPGMA implementation recomputed
+    every cross-cluster block mean per candidate pair per merge (O(k^4) element
+    touches), which turned `memo_consolidate` over that fixture into ~2h of
+    GIL-holding work — CI's conformance step timed out twice on it, and the
+    still-running FastMCP worker starved the *next* test in the process too.
+    Lance-Williams updates make the same merge O(k^3) at C speed (~0.1s).
+
+    The 30s bound is ~300× the measured time — loose enough for any CI runner,
+    tight enough that an O(k^4) regression (minutes at minimum) can never pass.
+    """
+    import random
+    import time
+
+    rng = random.Random(7)  # noqa: S311 — deterministic test fixture, not crypto
+    base = [rng.gauss(0, 1) for _ in range(64)]
+    items = []
+    for i in range(500):
+        v = [b + rng.gauss(0, 0.005) for b in base]
+        norm = math.sqrt(sum(x * x for x in v)) or 1.0
+        items.append({"id": str(i), "emb": [x / norm for x in v]})
+
+    start = time.monotonic()
+    clusters = _ConsolidateOpsMixin._average_link_cluster(items, threshold=0.85)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 30, f"dense-component clustering took {elapsed:.1f}s (O(k^4) regression?)"
+    # Near-identical vectors are one coherent cluster, not a shredded pile.
+    assert max(len(c) for c in clusters) == 500

--- a/tests/test_consolidate_average_link.py
+++ b/tests/test_consolidate_average_link.py
@@ -1,0 +1,134 @@
+"""Regression tests for `_ConsolidateOpsMixin._average_link_cluster` — the
+merge-consolidation clustering primitive that replaced `_greedy_cluster`
+(`_cluster_within_scope` is its only caller).
+
+Two failure modes drove the change, both reproduced here with hand-derived
+unit vectors (exact cosines, no floating-point guesswork):
+
+- `test_greedy_splits_an_above_threshold_pair_average_link_does_not`: greedy
+  compares a new item only to each existing cluster's FIRST member, frozen as
+  its "representative" forever. Q and R here are each other's best match
+  (cos ≈ 0.978), but Q gets folded into P's cluster before R arrives, and R is
+  only ever compared to P (cos ≈ 0.891, just under threshold) — so greedy
+  splits an above-threshold pair across two different clusters. Measured on
+  the live corpus: 38.4% of above-threshold pairs split this way.
+- `test_average_link_does_not_chain_like_single_linkage`: A-B and B-C are each
+  individually above threshold, but A and C share nothing (cos ≈ 0.61).
+  Single-linkage (connected components of the threshold graph) transitively
+  chains all three into one cluster through the B bridge — measured on the
+  live corpus, a single (project, type) bucket chained 157 of its 950 memories
+  this way. Average-link's cutoff is on the CLUSTER AVERAGE, so once A and B
+  merge (the stronger of the two edges — deliberately unequal so the merge
+  order is deterministic, not a near-tie the numpy vs pure-python cosine
+  rounding could break differently), C's average similarity to {A, B} (0.74)
+  dilutes below threshold and the merge stops.
+
+See `_average_link_cluster`'s docstring in
+`src/memo/memory/consolidate_ops.py` for the full empirical comparison
+(pair-recall / max-cluster-size / purity) against greedy and single-linkage.
+"""
+
+import math
+import sys
+
+from memo.memory.consolidate_ops import _ConsolidateOpsMixin
+
+
+def _unit(deg: float) -> list[float]:
+    rad = math.radians(deg)
+    return [math.cos(rad), math.sin(rad)]
+
+
+def _items(vectors: list[list[float]]) -> list[dict]:
+    return [{"id": str(i), "emb": v} for i, v in enumerate(vectors)]
+
+
+def test_greedy_splits_an_above_threshold_pair_average_link_does_not():
+    # P at 0°, Q at 15° (cos(P,Q)=0.966), R at 27° (cos(P,R)=0.891, cos(Q,R)=0.978).
+    # Threshold 0.9: P-Q and Q-R clear it; P-R does not.
+    vectors = [_unit(0), _unit(15), _unit(27)]
+    items = _items(vectors)
+    threshold = 0.9
+
+    greedy = _ConsolidateOpsMixin._greedy_cluster(items, threshold)
+    greedy_of = {i: ci for ci, cluster in enumerate(greedy) for i in cluster}
+    # The documented bug, reproduced: Q (1) and R (2) are each other's closest
+    # match and both clear the threshold, but greedy splits them because R is
+    # only ever compared to P's frozen representative.
+    assert greedy_of[1] != greedy_of[2], "expected the pre-existing greedy bug to reproduce"
+
+    avg_link = _ConsolidateOpsMixin._average_link_cluster(items, threshold)
+    avg_of = {i: ci for ci, cluster in enumerate(avg_link) for i in cluster}
+    assert avg_of[1] == avg_of[2], "average-link must keep the above-threshold Q,R pair together"
+
+
+def test_average_link_does_not_chain_like_single_linkage():
+    # A-B (cos=0.92) and B-C (cos=0.87) are each >= threshold, but deliberately
+    # unequal — a real tie between them (both exactly 0.9, say) would let the
+    # numpy matmul path and the pure-python dot-product path round to opposite
+    # winners and merge in a different order. A-C is cos=0.61, far below.
+    d_ab = math.degrees(math.acos(0.92))
+    d_bc = math.degrees(math.acos(0.87))
+    vectors = [_unit(0), _unit(d_ab), _unit(d_ab + d_bc)]
+    items = _items(vectors)
+    threshold = 0.85
+
+    clusters = _ConsolidateOpsMixin._average_link_cluster(items, threshold)
+    sizes = sorted(len(c) for c in clusters)
+    # NOT single-linkage's one chained cluster of 3 — A and C's shared
+    # dissimilarity (cos 0.61) drags the {A,B}-vs-C average (0.74) below
+    # threshold once A and B have merged, so the merge stops there.
+    assert sizes == [1, 2], f"expected a bounded {{A,B}},{{C}} split, got sizes {sizes}"
+
+    # The pair that IS above threshold on both sides (A,B) stays together;
+    # the unrelated pair (A,C) does not get chained in via the B bridge.
+    a_cluster = next(c for c in clusters if 0 in c)
+    assert 1 in a_cluster
+    assert 2 not in a_cluster
+
+
+def test_average_link_pure_python_fallback_matches_numpy_path(monkeypatch):
+    """The numpy-less fallback (exercised when numpy isn't installed — an
+    optional dependency, per pyproject's mypy-override comment) must produce
+    the same clustering as the numpy path for the same inputs.
+
+    The four consecutive similarities are deliberately unequal (0.93/0.88/0.91,
+    not a repeated 0.9): a near-exact tie between two candidate merge pairs
+    would let numpy's vectorised matmul and the pure-python manual dot product
+    round to opposite winners (this happened during development — an early
+    all-0.9 chain merged (0,1) first under one path and (1,2) first under the
+    other, diverging from there) and fail this assertion by construction,
+    not because either path is wrong."""
+    d1 = math.degrees(math.acos(0.93))
+    d2 = math.degrees(math.acos(0.88))
+    d3 = math.degrees(math.acos(0.91))
+    angles = [0.0, d1, d1 + d2, d1 + d2 + d3]
+    vectors = [_unit(a) for a in angles]
+    items = _items(vectors)
+    threshold = 0.85
+
+    numpy_result = _ConsolidateOpsMixin._average_link_cluster(items, threshold)
+
+    monkeypatch.setitem(sys.modules, "numpy", None)
+    fallback_result = _ConsolidateOpsMixin._average_link_cluster(items, threshold)
+
+    def _as_sets(clusters: list[list[int]]) -> set[frozenset[int]]:
+        return {frozenset(c) for c in clusters}
+
+    assert _as_sets(numpy_result) == _as_sets(fallback_result)
+
+
+def test_average_link_singletons_pass_through_untouched():
+    """Items with no above-threshold partner at all stay singleton clusters —
+    matching `_greedy_cluster`'s behaviour, so callers that drop clusters of
+    size 1 (`_consolidate_in_process`) see the same shape either way."""
+    vectors = [_unit(0), _unit(90), _unit(180)]
+    items = _items(vectors)
+
+    clusters = _ConsolidateOpsMixin._average_link_cluster(items, threshold=0.85)
+
+    assert sorted(len(c) for c in clusters) == [1, 1, 1]
+
+
+def test_average_link_empty_input_returns_empty():
+    assert _ConsolidateOpsMixin._average_link_cluster([], threshold=0.85) == []

--- a/tests/test_contradict.py
+++ b/tests/test_contradict.py
@@ -195,7 +195,12 @@ def test_resolve_accepts_competing_status(mock_memory):
 @pytest.fixture
 def mem_with_stub_embed(tmp_cfg: Config, monkeypatch) -> Memory:
     """Memory with a small deterministic embedder. Same body → same bucket
-    so we can stage near-duplicate clusters."""
+    so we can stage near-duplicate clusters.
+
+    ABSORB off: these tests seed *distinct* records that the stub maps to
+    identical vectors (cos=1.0) — exactly what default-on absorb merges into
+    one id, which would collapse every staged contradiction pair."""
+    monkeypatch.setenv("MEMO_SAVE_ABSORB", "0")
     cfg = Config(
         data_dir=tmp_cfg.data_dir,
         vault_path=tmp_cfg.vault_path,


### PR DESCRIPTION
## What

1. **Replace greedy consolidation clustering with average-link (UPGMA)** — `_cluster_within_scope` now clusters via `_average_link_cluster`. Greedy split 38.4% of above-threshold pairs (frozen-first-representative bug); single-linkage chained 157/950 memories through bridges. Average-link sits between: measured purity on real title+body pairs ~55-60% vs greedy's ~30%.
2. **Lance-Williams merge updates** (added after two CI hangs exposed it): the first UPGMA implementation recomputed every cross-cluster block mean per candidate pair per merge — O(k⁴). The corpus-scale conformance fixture (20 topics × ~500 near-identical vectors) turned `memo_consolidate` into ~2h of GIL-holding work: `test_mcp_response_budget` timed out inside it and the still-running FastMCP worker starved `test_output_paths` afterwards. Lance-Williams computes the exact same merge in O(k³) at C speed — 0.11s for the k=500 dense component; the two previously-hanging conformance tests now pass locally in 61s total. Regression test pins the dense-component shape with a 30s bound.
3. **Slow-suite ABSORB sweep**: 4 tests in 2 files (`test_ask_disputes_mlx.py`, `test_contradict.py`) staged contradiction pairs whose members default-on ABSORB (#262) now merges into one id → `ValidationError: a relation requires two distinct memory ids`. Invisible to fast CI (`-m "not slow"`). Fixtures now pin `MEMO_SAVE_ABSORB=0`; the other 6 pair-seeding files audited clean.

## Test plan
- [x] `tests/test_consolidate_average_link.py` (6 tests: greedy-split repro, no-chaining, numpy/pure-python equivalence, singletons, empty, dense-component time bound)
- [x] `tests/conformance/test_mcp_response_budget.py` + `test_output_paths.py` locally: 10 passed in 61s (previously 82min/2h19m CI hangs)
- [x] All 8 pair-seeding slow-suite files: 117 passed
- [x] quality gate, ruff, mypy, pre-push recall gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)