### PR TITLE
feat: enable MEMO_SAVE_ABSORB by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+### Changed
+
+- `MEMO_SAVE_ABSORB` defaults ON: a near-duplicate save now rewrites the
+  existing record (versioned, rollbackable) instead of creating a near-copy.
+  Measured 2026-08-16: absorbs correctly at cosine 0.9691/matching type,
+  ~24s per absorption (one bounded LLM call). Opt out with `=0`.
+
 ## [4.11.3] - 2026-08-16
 
 ### Fixed

--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -648,14 +648,17 @@ SPECS: tuple[FlagSpec, ...] = (
     _spec(
         "MEMO_SAVE_ABSORB",
         "bool",
-        False,
+        True,
         "misc",
         "Living canonical records: when a save hits a near-duplicate "
         "(MEMO_SAVE_DEDUP_THRESHOLD), rewrite the EXISTING record via one "
         "bounded LLM call + versioned update() (rollbackable) instead of "
         "creating a near-copy; proof_count grows in extra. Requires "
         "MEMO_SAVE_DEDUP_CHECK. Skipped in derived-save scope "
-        "(dream/consolidation). Never on the recall-hook path.",
+        "(dream/consolidation). Never on the recall-hook path. Default ON "
+        "(opt out with =0) — measured 2026-08-16: absorbs correctly at "
+        "cosine 0.9691/matching type, ~24s per absorption (one bounded "
+        "LLM call), reversible via memo version rollback.",
     ),
     _spec(
         "MEMO_INVALIDATE_PENALTY",

--- a/tests/test_dedup_scope.py
+++ b/tests/test_dedup_scope.py
@@ -46,7 +46,11 @@ def _dedup_records(caplog) -> list[logging.LogRecord]:
     return [r for r in caplog.records if _DEDUP_MSG in r.getMessage()]
 
 
-def test_dedup_warns_for_interactive_save(mem_const_embed, caplog):
+def test_dedup_warns_for_interactive_save(mem_const_embed, caplog, monkeypatch):
+    # This test is about the WARN path specifically — MEMO_SAVE_ABSORB=1
+    # (now the default) would silently rewrite the existing record instead
+    # of warning, which is a different mechanism covered by test_save_absorb.py.
+    monkeypatch.setenv("MEMO_SAVE_ABSORB", "0")
     mem_const_embed.save(content="seed body one", title="seed", type_="note")
     with caplog.at_level(logging.DEBUG, logger="memo.memory.record"):
         mem_const_embed.save(content="seed body two", title="dup", type_="note")

--- a/tests/test_memory_ask.py
+++ b/tests/test_memory_ask.py
@@ -51,6 +51,10 @@ def _assert_all_rag_calls_envelope_retrieved_data(
 
 
 def test_consolidate_clusters_near_duplicates(mem_with_stub: Memory, monkeypatch):
+    # This test is about the CONSOLIDATE pass clustering pre-existing near-dups
+    # after the fact — MEMO_SAVE_ABSORB=1 (now the default) would rewrite rec_a
+    # in place at save time, leaving nothing for consolidate to cluster.
+    monkeypatch.setenv("MEMO_SAVE_ABSORB", "0")
     monkeypatch.setattr(
         "memo.embedder.MLXEmbedder.embed",
         lambda self, inputs: [[1.0, 0.0, 0.0, 0.0] for _ in inputs],

--- a/tests/test_save_absorb.py
+++ b/tests/test_save_absorb.py
@@ -65,10 +65,20 @@ def test_absorb_is_versioned_and_rollbackable(mem_const, monkeypatch):
     assert versions  # pre-update snapshot exists → memo version rollback works
 
 
-def test_absorb_off_by_default_creates_new(mem_const):
+def test_absorb_on_by_default_rewrites_existing_record(mem_const):
+    """No monkeypatch.setenv here — proves the flag's own default (now True)
+    drives the absorb, not just an explicit override."""
+    mem_const._chat = _AbsorbChat()
     r1 = mem_const.save(content="El dashboard corre en el puerto 8765", title="Dashboard port")
     r2 = mem_const.save(content="Confirmado: dashboard en 8765", title="Dashboard port check")
-    assert r2.id != r1.id  # current warn-and-create behavior preserved
+    assert r2.id == r1.id
+
+
+def test_absorb_can_be_disabled(mem_const, monkeypatch):
+    monkeypatch.setenv("MEMO_SAVE_ABSORB", "0")
+    r1 = mem_const.save(content="El dashboard corre en el puerto 8765", title="Dashboard port")
+    r2 = mem_const.save(content="Confirmado: dashboard en 8765", title="Dashboard port check")
+    assert r2.id != r1.id  # opt-out preserved: warn-and-create behavior
 
 
 def test_absorb_falls_back_on_llm_failure(mem_const, monkeypatch):

--- a/tests/test_save_gate_wiring.py
+++ b/tests/test_save_gate_wiring.py
@@ -69,6 +69,9 @@ def test_balanced_near_dup_logs_warning(mock_memory, monkeypatch, caplog):
     # near-dup check and DOES emit the warning log.
     monkeypatch.delenv("MEMO_SAVE_GATE_PRESETS", raising=False)
     monkeypatch.setenv("MEMO_SAVE_DEDUP_CHECK", "1")
+    # This test is about the WARN path specifically — MEMO_SAVE_ABSORB=1
+    # (now the default) would silently rewrite instead of warning.
+    monkeypatch.setenv("MEMO_SAVE_ABSORB", "0")
     dup = _seed_and_dup(mock_memory, "note", exact=False)
     with caplog.at_level(logging.WARNING, logger="memo.memory.record"):
         dup()

--- a/tests/test_support_count.py
+++ b/tests/test_support_count.py
@@ -110,7 +110,10 @@ def mem_const(tmp_cfg, monkeypatch):
     mem.close()
 
 
-def test_near_dup_save_bumps_existing_support(mem_const):
+def test_near_dup_save_bumps_existing_support(mem_const, monkeypatch):
+    # Tests the warn-then-create corroboration path specifically —
+    # MEMO_SAVE_ABSORB=1 (now the default) would rewrite r1 in place instead.
+    monkeypatch.setenv("MEMO_SAVE_ABSORB", "0")
     r1 = mem_const.save(content="El dashboard corre en el puerto 8765", title="Dashboard port")
     r2 = mem_const.save(content="El dashboard escucha en 8765", title="Dashboard listens")
     assert r2.id != r1.id  # near-dup still only warns; record is created

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -99,6 +99,16 @@ def _force_close_embeddings(mem: Any) -> None:
     mem.embedder.embed_query = lambda query: unit
 
 
+@pytest.fixture(autouse=True)
+def _no_absorb(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every test here seeds 2+ near-identical records via mock_memory.save()
+    expecting them to stay distinct so synthesis has multiple sources to
+    cluster from. MEMO_SAVE_ABSORB=1 (now the default) would rewrite those
+    seeds into one record instead, defeating the whole file's testing
+    strategy — off by default here, not per-test."""
+    monkeypatch.setenv("MEMO_SAVE_ABSORB", "0")
+
+
 # ── synthesize_cross_cluster tests ──────────────────────────────────────────
 
 

--- a/tests/test_trust_states_fixture.py
+++ b/tests/test_trust_states_fixture.py
@@ -56,8 +56,15 @@ def real_mlx_memory(tmp_cfg: Config) -> Iterator[Memory]:
     mem.close()
 
 
-def _seed(mem: Memory) -> tuple[str, str, str]:
-    """Seed the fixture; return (distinct_id, older_id, newer_id)."""
+def _seed(mem: Memory, monkeypatch) -> tuple[str, str, str]:
+    """Seed the fixture; return (distinct_id, older_id, newer_id).
+
+    MEMO_SAVE_ABSORB=1 (now the default) would rewrite these near-duplicate
+    paraphrases and the older/newer contradiction pair into fewer records at
+    save time, defeating the crowding and contradiction scenarios this
+    fixture exists to build.
+    """
+    monkeypatch.setenv("MEMO_SAVE_ABSORB", "0")
     for i, text in enumerate(_PARAPHRASES):
         mem.save(content=text, title=f"deploy migrations {i}", type_="fact")
     distinct_id = mem.save(content=_DISTINCT, title="deploy cache warm", type_="fact").id
@@ -101,7 +108,7 @@ def test_dedup_collapse_rescues_distinct_fact_from_paraphrase_crowding(
     real_mlx_memory: Memory, monkeypatch
 ) -> None:
     mem = real_mlx_memory
-    distinct_id, _older, _newer = _seed(mem)
+    distinct_id, _older, _newer = _seed(mem, monkeypatch)
     prompt = Prompt(
         "what does the nightly deploy pipeline do after the rollout finishes",
         relevant=True,
@@ -126,7 +133,7 @@ def test_declare_disputes_surfaces_both_sides_of_open_pair(
     real_mlx_memory: Memory, monkeypatch
 ) -> None:
     mem = real_mlx_memory
-    _distinct, older_id, newer_id = _seed(mem)
+    _distinct, older_id, newer_id = _seed(mem, monkeypatch)
     prompt = Prompt(
         "what engine does the production database run",
         relevant=True,


### PR DESCRIPTION
Turns on living canonical records for near-duplicate saves: instead of
creating a near-copy, the existing record is rewritten in place via one
bounded LLM call + versioned `update()` (rollbackable via `memo version
rollback`).

## Measured (2026-08-16)

Isolated test stores, not just unit assertions:
- Same-language duplicate: absorbs correctly at cosine 0.9691, matching
  type. ~24s per absorption (one bounded LLM call).
- Cross-language paraphrase (0.87 cosine) does NOT absorb — below the
  0.88 `MEMO_SAVE_DEDUP_THRESHOLD`. That threshold is being measured
  separately (own PR, own proof), not touched here.
- On the 2026-08-15 real duplicate set, enabling ABSORB at default would
  have prevented 1 of 3 near-copies.

## Blast radius: 15 tests needed updating

Flipping this default broke test fixtures across the suite that relied on
`Memory.save()` producing DISTINCT records for near-duplicate content —
synthesis clustering, `consolidate()`, a contradiction-pair fixture,
dedup-warning tests, and a support-count test. Each now either:
- isolates the behavior it's actually testing with an explicit
  `MEMO_SAVE_ABSORB=0` (dedup-warning, support-count, consolidate,
  contradiction-pair — 6 tests), or
- in `test_synthesize.py`, where **14 of ~24 tests** shared the exact same
  root cause (seed loops needing 2-3 distinct near-identical records), via
  one file-scoped `autouse` fixture rather than repeating the same
  monkeypatch 14 times.

## Verified

- `test_synthesize.py`: 24/24 (was 24 passing on master's default-off, now
  24/24 on default-on with the autouse fixture).
- Targeted suite (`save|absorb|dedup|duplicate|synthesize|trust_states|consolidate`):
  441 passed, 1 skipped (MLX-gated).
- `memo eval recall --gate` (pre-push profile): PASS, prec@5 0.610 /
  noise@5 0.000 — unaffected (this is a save-time gate, not a retrieval
  scoring change).
- `ruff format --check`, `ruff check`, `mypy` on touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)