### PR TITLE
fix: lower MEMO_SAVE_DEDUP_THRESHOLD 0.88 -> 0.85, backed by a live-corpus census

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,22 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
   existing record (versioned, rollbackable) instead of creating a near-copy.
   Measured 2026-08-16: absorbs correctly at cosine 0.9691/matching type,
   ~24s per absorption (one bounded LLM call). Opt out with `=0`.
+- **`MEMO_SAVE_DEDUP_THRESHOLD` default lowered 0.88 → 0.85.** The save-time
+  near-duplicate cosine floor was measured against the live corpus in the
+  *real* regime the check actually runs in — `embed_query` on the new
+  candidate vs. the stored document embedding of each existing memory, not
+  symmetric document-document cosine, which scores meaningfully higher and
+  was masking the true precision of this band. A census of every real-regime
+  candidate whose top hit fell in the newly-caught [0.85, 0.88) window (28
+  pairs, not a sample — the whole population out of a 2,012-candidate scan)
+  came out 71% genuine duplicates vs. 18% distinct-fact false-positive risk,
+  dominated by same-session cross-language (es/en) and refined restatements;
+  the two pairs already caught at 0.88 today were both genuine duplicates
+  too. The event stays rare corpus-wide (~1.5% of candidates cross 0.85).
+  Separately (not changed by this PR): the save-time dedup search has no
+  type or project filter, so a near-duplicate hit — and, if
+  `MEMO_SAVE_ABSORB` is enabled, an absorb — can in principle match across
+  memory types or projects; this pre-exists the threshold at 0.88 too.
 
 ## [4.11.3] - 2026-08-16
 

--- a/src/memo/flags_misc.py
+++ b/src/memo/flags_misc.py
@@ -617,9 +617,16 @@ SPECS: tuple[FlagSpec, ...] = (
     _spec(
         "MEMO_SAVE_DEDUP_THRESHOLD",
         "float",
-        0.88,
+        0.85,
         "misc",
-        "Cosine similarity floor for near-duplicate detection on save (requires MEMO_SAVE_DEDUP_CHECK=1).",
+        "Cosine similarity floor for near-duplicate detection on save (requires "
+        "MEMO_SAVE_DEDUP_CHECK=1). Lowered from 0.88 (2026-08): a census of the "
+        "live-corpus [0.85, 0.88) query-vs-document band (the real asymmetric "
+        "regime this check runs in, not raw doc-doc cosine) found 71% true "
+        "duplicates vs 18% distinct-fact false-positive risk, dominated by "
+        "same-session cross-language (es/en) and refined restatements — and the "
+        "event is rare corpus-wide (~1.5% of candidates). See PR discussion for "
+        "the measurement.",
         min_val=0.0,
         max_val=1.0,
     ),

--- a/src/memo/memory/write_ops.py
+++ b/src/memo/memory/write_ops.py
@@ -684,7 +684,7 @@ class _WriteOpsMixin(_MemoryBase):
                 if _existing_sample:
                     _dedup_threshold_flag = flag_float("MEMO_SAVE_DEDUP_THRESHOLD")
                     _dedup_threshold = (
-                        0.88 if _dedup_threshold_flag is None else _dedup_threshold_flag
+                        0.85 if _dedup_threshold_flag is None else _dedup_threshold_flag
                     )
                     _dedup_q = f"{title}\n{content[:300]}"
                     _dedup_emb = self.embedder.embed_query(_dedup_q)

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -49,6 +49,10 @@ def test_flag_returns_default_when_unset(tmp_path: Path) -> None:
     assert flags.flag("MEMO_CONTRADICT_PENALTY_ENABLED", env=env) is False
     assert "MEMO_EMIT_LEDGER" not in flags.REGISTRY
     assert flags.flag_int("MEMO_DREAM_COMPRESS_THRESHOLD", env=env) == 0
+    # Lowered from 0.88 (2026-08): live-corpus measurement in the real
+    # query-vs-document regime found the [0.85, 0.88) band 71% true
+    # duplicates vs 18% distinct-fact risk — see flags_misc.py's help text.
+    assert flags.flag_float("MEMO_SAVE_DEDUP_THRESHOLD", env=env) == 0.85
 
 
 def test_graph_integration_flags_have_safe_defaults(tmp_path: Path) -> None:

--- a/tests/test_save_absorb.py
+++ b/tests/test_save_absorb.py
@@ -1,5 +1,6 @@
-"""C3 absorb-on-recurrence: a >=0.88 near-dup save rewrites the EXISTING
-record via versioned update() instead of creating a near-copy (flag-gated)."""
+"""C3 absorb-on-recurrence: a near-dup save (>= MEMO_SAVE_DEDUP_THRESHOLD,
+default 0.85) rewrites the EXISTING record via versioned update() instead of
+creating a near-copy (flag-gated)."""
 
 from __future__ import annotations
 

--- a/tests/test_support_count.py
+++ b/tests/test_support_count.py
@@ -90,8 +90,8 @@ def test_merge_signal_tolerates_old_payload_without_support(tmp_path: Path) -> N
 def mem_const(tmp_cfg, monkeypatch):
     """Memory with a constant-vector embedder: every text embeds to the same
     unit vector, so ANY two records are cosine-1.0 near-duplicates — the
-    near-dup path (threshold 0.88) fires deterministically. Dims pinned to
-    the stub's output via Config(embedder_dims=4)."""
+    near-dup path (default threshold 0.85) fires deterministically. Dims
+    pinned to the stub's output via Config(embedder_dims=4)."""
     from memo.memory import Memory
 
     cfg = Config(


### PR DESCRIPTION
## Summary

`MEMO_SAVE_DEDUP_THRESHOLD` (the cosine-similarity floor for save-time near-duplicate detection) is lowered from **0.88 to 0.85**, based on a measurement against the live corpus (10.7k memories) — not a blind flip.

## Why the original number was suspect

An earlier session's isolated-test-store measurement found cross-language paraphrase pairs (Spanish/English describing the same fact) scoring ~0.87, just under 0.88, so they never triggered dedup even though they're the same underlying fact.

## What was measured (methodology)

1. **First pass (discarded):** a symmetric document-document cosine scan across the live index. This over-estimates similarity relative to what the save path actually computes, because the save-time check is **asymmetric**: `embed_query()` (with the retrieval-instruction prefix) on the new candidate vs. the **stored** document embedding of each existing memory. A 6-pair spot-check confirmed the gap was large (real scores 0.02–0.18 lower than the symmetric proxy) and non-uniform — false-positive-risk pairs dropped more than true duplicates.
2. **Second pass (authoritative):** re-ran in the *real* regime. Subsampled up to 300 candidates per durable type (2,012 total across `fact/note/bug/decision/preference/procedure/failure_pattern/synthesis`), embedded each with `embed_query()`, and searched the **full** same-type corpus for its top hit (mirroring `store.search(limit=3)`).
   - Corpus-wide: only **30/2,012 (1.5%)** candidates have a top-hit score ≥ 0.85 at all; only **2/2,012 (0.1%)** already cross 0.88 today. This is a rare event either way.
   - **Full census** (not a sample) of every candidate whose top hit fell in the newly-caught **[0.85, 0.88)** window — 28 pairs — read and hand-classified against the actual memory content:

| | count | % |
|---|---|---|
| True duplicate (same fact, cross-language or refined restatement, overwhelmingly same-session) | 20 | 71% |
| Borderline | 3 | 11% |
| Distinct-fact false-positive risk | 5 | 18% |

   The two pairs **already caught at 0.88 today** were also both confirmed true duplicates — the corpus baseline behavior is sound, and lowering the floor extends the same precision into a slightly wider band rather than degrading it.

## What this doesn't fix (flagged, not touched)

The save-time dedup search (`write_ops.py`) has **no type or project filter** — it searches the whole index regardless of the new record's type. A near-duplicate hit (and, if `MEMO_SAVE_ABSORB` is enabled, an absorb) can in principle match a `bug` against a `decision`, or cross projects entirely. This pre-exists the threshold value at 0.88 too; a few sampled pairs surfaced cross-project matches (e.g. `memflow` vs `memo`) that a type/project-scoped search would have excluded from the candidate pool outright. Left as a follow-up since it's a different, more invasive change (touches the search call itself) and overlaps with the parallel `MEMO_SAVE_ABSORB` enablement work.

## Changes

- `src/memo/flags_misc.py` — default 0.88 → 0.85, help text documents the measurement.
- `src/memo/memory/write_ops.py` — fixed a stale `0.88` literal in the defensive fallback for when the flag resolves to `None` (dead in practice since the registry always has a default, but was silently inconsistent with the new default).
- `tests/test_flags.py` — asserts the new default.
- `tests/test_save_absorb.py`, `tests/test_support_count.py` — docstring updates (these tests use constant-vector embedders, so behavior is unaffected).
- `CHANGELOG.md` — entry under Unreleased.

## Test plan

- [x] `uv run --no-sync ruff check` + `ruff format --check` on touched files — clean
- [x] `uv run --no-sync mypy src/memo/flags_misc.py src/memo/memory/write_ops.py` — clean
- [x] `uv run --no-sync pytest tests/test_flags.py tests/test_save_absorb.py tests/test_support_count.py` — 52 passed
- [x] `uv run --no-sync pytest tests/` (full suite) — **7584 passed, 1 skipped, 0 failed**
- [x] `uv run --no-sync python scripts/quality_gate.py` — passed (178 complexity budgets, 190 exception budgets)
- [x] `memo eval recall --labels eval/regression_labels.json --k 5` against the live index — ran cleanly, normal numbers (this flag is save-time only, no retrieval-ranking code path touches it)
- [x] The repo's own pre-push hook ran `memo eval recall --gate` automatically and **passed**: `prec@k 0.610 >= 0.610, noise@k 0.000 <= 0.000`
- Note: a manual `--gate` invocation against my machine's saved baseline failed with an unrelated pre-existing mismatch (`gated config 'H synth/0.05' not evaluated this run`) — a stale baseline/config-set issue on this machine, not caused by this change (confirmed by the pre-push hook's own gate passing cleanly with its own config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)