### PR TITLE
fix: two ABSORB bugs found by adversarial cross-review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
   canonical parent. Covers the recall-hook subprocess; the warm daemon path
   does not call this yet, a named follow-up.
 
+### Fixed
+
+- Two bugs in `MEMO_SAVE_ABSORB` found by adversarial review right after it
+  shipped default-on:
+  - The absorb target's LLM merge call (up to `MEMO_CONSOLIDATE_TIMEOUT`,
+    default 180s) runs unlocked. If a concurrent nightly consolidation merge
+    archives+deletes the same target while the call is in flight, `update()`
+    silently resolved to `None` with zero logging and the caller fell
+    through to creating a brand-new near-duplicate record — undoing the
+    consolidation that just ran, invisibly. Now logs a warning naming the
+    likely cause, so the outcome is observable instead of a silent mystery.
+  - Absorb had no type-match check: a near-duplicate of a *different* type
+    (e.g. a `note` scoring >=0.88 against an existing `fact`) would still
+    rewrite the existing record's body via LLM merge while keeping its
+    original type label, silently blending cross-type content. Absorb now
+    only triggers on a same-type match; a type mismatch falls through to
+    the ordinary warn-and-create path.
+
 ### Changed
 
 - `MEMO_SAVE_ABSORB` defaults ON: a near-duplicate save now rewrites the

--- a/src/memo/memory/write_ops.py
+++ b/src/memo/memory/write_ops.py
@@ -724,13 +724,21 @@ class _WriteOpsMixin(_MemoryBase):
                                 )
                             if _dh.get("id") and not defer_to_identity:
                                 bump_support_if_enabled(self.store, [_dh["id"]])
-                            # C3: absorb-on-recurrence (flag-gated, default off).
+                            # C3: absorb-on-recurrence (flag-gated, default on).
                             # Never in derived-save scope — dream/consolidation
                             # batch saves are merged by the consolidate pass.
+                            # Same-type only: the LLM merge rewrites the
+                            # EXISTING record's body in place without touching
+                            # its type, so absorbing a differently-typed save
+                            # (e.g. a `note` into a `fact`) would silently
+                            # blend cross-type content under the original
+                            # type label. A type mismatch falls through to
+                            # the ordinary warn-and-create path below.
                             if (
                                 flag_bool("MEMO_SAVE_ABSORB")
                                 and not in_derived_save_scope()
                                 and _dh.get("id")
+                                and _dh.get("type") == type_
                             ):
                                 _absorbed = self._absorb_into_existing(_dh["id"], title, content)
                                 if _absorbed is not None:
@@ -1702,6 +1710,21 @@ class _WriteOpsMixin(_MemoryBase):
                     "save: absorbed near-duplicate into %s (proof_count=%d)",
                     existing_id[:8],
                     new_extra["proof_count"],
+                )
+            else:
+                # update() resolves the id fresh and returns None if it no
+                # longer exists — most likely the target was archived+deleted
+                # by a concurrent consolidation merge while this LLM call (up
+                # to MEMO_CONSOLIDATE_TIMEOUT, unlocked) was in flight. The
+                # caller falls back to creating a new record from the raw
+                # content, which is correct but must not be silent: without
+                # this log, that fallback looks identical to "absorb was
+                # never attempted."
+                _log.warning(
+                    "save: absorb target %s vanished before update() landed "
+                    "(likely archived by a concurrent consolidation merge) "
+                    "— falling back to a new record",
+                    existing_id[:8],
                 )
             return updated  # type: ignore[no-any-return]
         except Exception as exc:

--- a/tests/test_save_absorb.py
+++ b/tests/test_save_absorb.py
@@ -87,3 +87,52 @@ def test_absorb_falls_back_on_llm_failure(mem_const, monkeypatch):
     r1 = mem_const.save(content="El dashboard corre en el puerto 8765", title="Dashboard port")
     r2 = mem_const.save(content="Confirmado: dashboard en 8765", title="Dashboard port check")
     assert r2.id != r1.id  # graceful fallback — the save is never blocked
+
+
+def test_absorb_skips_cross_type_near_duplicate(mem_const, monkeypatch):
+    """A near-duplicate of a DIFFERENT type must never absorb — the LLM merge
+    rewrites the existing record's body without touching its type, so
+    absorbing across types would silently blend cross-type content under the
+    original type label."""
+    monkeypatch.setenv("MEMO_SAVE_ABSORB", "1")
+    mem_const._chat = _AbsorbChat()
+    r1 = mem_const.save(
+        content="El dashboard corre en el puerto 8765", title="Dashboard port", type_="fact"
+    )
+    r2 = mem_const.save(
+        content="Confirmado: dashboard en 8765", title="Dashboard port check", type_="note"
+    )
+    assert r2.id != r1.id  # type mismatch — falls back to warn-and-create
+    rec = mem_const.get(r1.id)
+    assert rec.body == "El dashboard corre en el puerto 8765"  # untouched by the merge
+    assert rec.type == "fact"
+
+
+class _AbsorbChatThatDeletesTarget:
+    """Stands in for the LLM merge call, and — as a side effect of that call
+    being in flight — deletes the absorb target. Reproduces the real race:
+    absorb's update() runs unlocked and can land after a concurrent
+    consolidation merge has already archived+deleted the same record."""
+
+    def __init__(self, mem, target_id):
+        self._mem = mem
+        self._target_id = target_id
+
+    def chat(self, model, messages, options=None):
+        self._mem.delete(self._target_id)
+        return {"message": {"content": "MERGED: puerto 8765 (confirmado 2x)"}}
+
+
+def test_absorb_warns_when_target_vanishes_mid_flight(mem_const, monkeypatch, caplog):
+    import logging
+
+    monkeypatch.setenv("MEMO_SAVE_ABSORB", "1")
+    r1 = mem_const.save(content="El dashboard corre en el puerto 8765", title="Dashboard port")
+    mem_const._chat = _AbsorbChatThatDeletesTarget(mem_const, r1.id)
+
+    with caplog.at_level(logging.WARNING, logger="memo.memory.record"):
+        r2 = mem_const.save(content="Confirmado: dashboard en 8765", title="Dashboard port check")
+
+    assert r2.id != r1.id  # target vanished mid-absorb — falls back to a new record
+    assert mem_const.get(r1.id) is None  # confirms the delete actually landed first
+    assert "vanished before update()" in caplog.text  # the race is now logged, not silent


### PR DESCRIPTION
An ultracode workflow (9 agents: 3 independent reviewers × 3 interaction
surfaces, each finding adversarially re-verified) reviewed the three
near-duplicate-handling changes landing this session — ABSORB default-on
(#262, merged), chunk-parent rollup (#260), average-link consolidation
(#261) — for interaction risks. It found two real, independently-verified
bugs in ABSORB, which is already live on master.

## Bug 1 — silent race with nightly consolidation (HIGH)

`_absorb_into_existing`'s LLM merge call (up to `MEMO_CONSOLIDATE_TIMEOUT`,
180s default) runs **unlocked**. If the nightly consolidation pass
archives+deletes the same target record while the call is in flight,
`update()`'s `resolve_id()` cleanly returns `None` — no exception — and the
only log line in that function was `if updated is not None: _log.info(...)`,
with **no else branch**. The caller falls through to creating a brand-new
near-duplicate record from the raw content, undoing the consolidation that
just ran, with zero operator-visible signal.

Fix: log a `_log.warning` naming the likely cause when `update()` returns
`None`, so the outcome is observable instead of a silent data-integrity
mystery. Doesn't (and can't cheaply) prevent the race — the LLM call can't
run under the write lock without blocking every other write for up to
180s — but makes it diagnosable.

## Bug 2 — no type-match check (MEDIUM)

The save-time dedup/absorb candidate search passes no `type_` filter, and
nothing in the trigger loop compared the candidate's type to the incoming
save's type. A `note` scoring >=0.88 against an existing `fact`/`decision`
would still trigger absorb, rewriting the existing record's body via LLM
merge while keeping its original type label — silently blending cross-type
content before average-link consolidation's type-partitioned clustering
(`_cluster_within_scope`) ever gets a chance to see it.

Fix: absorb now requires `_dh.get("type") == type_`; a type mismatch falls
through to the ordinary warn-and-create path.

## Also

Fixed a stale `# C3: absorb-on-recurrence (flag-gated, default off).`
comment at the call site — the flag flipped to default-on in #262 and
nothing else touches this line, so it stayed wrong.

## Verification

Two new regression tests reproduce both bugs directly, not just assert the
fix's mechanism:
- `test_absorb_skips_cross_type_near_duplicate` — same content, different
  types, asserts no absorb and the target's body/type stay untouched.
- `test_absorb_warns_when_target_vanishes_mid_flight` — the mocked LLM chat
  call **deletes the absorb target as a side effect**, genuinely
  reproducing the race window (not simulated via a mocked return value),
  then asserts the fallback happened AND the warning was logged.

```
tests/test_save_absorb.py: 7 passed (was 5; +2 new)
targeted suite (save|absorb|dedup|duplicate|synthesize|trust_states|consolidate): 443 passed, 1 skipped
ruff format --check / ruff check / mypy: clean
scripts/quality_gate.py: passed (178 complexity budgets, 190 exception budgets)
memo eval recall --gate (pre-push profile): PASS, prec@5 0.610 / noise@5 0.000
```

## Not fixed here — real but architectural, needs its own scoped pass

The same review surfaced three more findings, all independently verified,
none acted on here to avoid bolting unrelated architecture changes onto a
bugfix:

- **Chunk resync after absorb has no auto-heal.** `maybe_emit_chunks()`
  re-checks `MEMO_CHUNK_INGEST` live (ignoring whether stale chunk rows
  already exist) and wraps the re-chunk step in a blanket
  `except Exception` that only warns — the code's own "next reindex heals
  them" comment has no automated trigger, since nightly maintain never
  calls `Memory.reindex()`. Pre-existing behavior for any `update()`, not
  unique to absorb, but absorb makes it reachable more often.
- **Three uncoordinated near-duplicate thresholds**: `MEMO_SAVE_DEDUP_THRESHOLD`
  (0.88, flag-configurable, gates absorb) vs. `consolidate()`'s hardcoded
  0.85 default (what average-link's PR #261 measured its purity/chaining
  stats against) vs. the actual unattended nightly pass
  (`_run_consolidate_dups`, `auto_apply=True`) hardcoded to 0.9 with no flag
  at all. Tuning the save-time threshold has zero effect on nightly merge
  aggressiveness.
- **Average-link's measurement predates ABSORB's corpus-shrinking effect.**
  PR #261's stats were measured against a backlog accumulated under the old
  (pre-ABSORB) save behavior; going forward, most "obvious duplicate" pairs
  strong enough to reach nightly clustering (threshold 0.9) will already
  have been intercepted at save time (absorb threshold 0.88 < 0.9), so the
  population average-link actually processes will structurally differ from
  what it was tuned on. Never re-measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)