### PR TITLE
fix: copy eval/ into the Docker build context (docker-publish red since 4.11.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY src ./src
 COPY .agents ./.agents
 COPY .claude-plugin ./.claude-plugin
 COPY commands ./commands
+COPY eval ./eval
 COPY hooks ./hooks
 COPY plugins ./plugins
 COPY skills ./skills

--- a/Dockerfile.glama
+++ b/Dockerfile.glama
@@ -10,6 +10,7 @@ COPY src ./src
 COPY .agents ./.agents
 COPY .claude-plugin ./.claude-plugin
 COPY commands ./commands
+COPY eval ./eval
 COPY hooks ./hooks
 COPY plugins ./plugins
 COPY skills ./skills


### PR DESCRIPTION
`docker-publish` has failed on every tag since v4.11.2 with `FileNotFoundError: Forced include not found: /src/eval/regression_labels.json`: the wheel force-includes `eval/regression_labels.json`, but both Dockerfiles' explicit COPY allowlists (documented as "keep aligned with hatch force-include") were never updated when that include landed, so the in-image `uv build --wheel` fails.

One-line fix per Dockerfile: `COPY eval ./eval`.

After merge, re-publishing 4.12.0's image needs a re-run against a ref containing this fix (the tag itself predates it) — or it simply ships with the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)