### PR TITLE
fix: close the emission-ledger review findings that touch live surfaces

### DIFF
--- a/docs/SPECS/2026-08-10-emission-ledger-design.md
+++ b/docs/SPECS/2026-08-10-emission-ledger-design.md
@@ -240,7 +240,7 @@ per-hit list to partition at all. Both are absent from
 | a tool would emit *more* of a memory than was emitted before (hook truncated to 400, `memo_ask` has room for 900) | re-emit full, replace the entry | monotonic-emission rule (`new_len <= n`) |
 | memory deleted | absent from hits | nothing needed |
 | auto-compaction | reset | PreCompact, already wired at `cli_hooks.py:98` |
-| `/clear` | reset | SessionStart |
+| `/clear` | reset | SessionStart — **NOT IMPLEMENTED** (see promotion blockers below) |
 | new session | new file | session-id partition |
 | two sessions, same cwd | separate files | session-id partition |
 | **subagent** | **inherits the parent ledger, has its own window** | see hazard 1 |
@@ -362,6 +362,34 @@ fully implemented, tested, and available behind the flag for anyone who sets
 `MEMO_EMITTED_LEDGER=1` explicitly (e.g. to start collecting the live data
 criterion 2 needs). The default stays off until a real session population
 supplies a measured `memo_get_after_digest` / `digests_served` ratio.
+
+### Promotion blockers (2026-08-17 adversarial review, confirmed on the shipped code)
+
+Beyond criterion 2, an adversarial review of the landed implementation
+confirmed gaps that must be fixed (or explicitly accepted here) before the
+default flips to `1`. None of them affect the shipped `0` default:
+
+1. **`/clear` reset was never implemented.** The invalidation table promises a
+   SessionStart-driven reset; the only `reset()` call site is the
+   PreCompact-driven `memo capture-tick --force` block. Post-`/clear`, a stale
+   ledger digests first-time emissions — and the stdio `memo-mcp` server
+   resolves its session id from its own frozen process env
+   (`server_session_patterns.py`), so even a new session id after `/clear`
+   does not reach already-running MCP tools. Needs a SessionStart(clear) reset
+   hook plus a per-request (not env-frozen) session id on the MCP side.
+2. **HTTP transport collapses all clients onto one ledger session** — client
+   A's emission digests client B's first read. Needs per-connection identity.
+3. **The counters sidecar `bump()` is an unlocked read-modify-write** with
+   truncate-in-place: concurrent calls lose deltas and a torn write zeroes the
+   counters criterion 2 depends on. Needs the same locking discipline as the
+   ledger file itself.
+4. **`MEMO_EMITTED_LEDGER_MAX=0` is accepted and disables both the FIFO trim
+   and the read-side cap** (unbounded file growth on the hook path);
+   an invalid-UTF-8 byte blinds the whole ledger rather than the torn line;
+   `_safe()` can collide two session ids onto one file (`a/b` vs `a_b`,
+   120-char truncation); hook-minted refs are dangling by construction (the
+   ref is minted after the context is printed). Small hardening items, listed
+   so promotion review re-checks them.
 
 ## Test plan
 

--- a/src/memo/dream_flags.py
+++ b/src/memo/dream_flags.py
@@ -62,7 +62,11 @@ CODE_REPAIR_FLAG = "MEMO_DREAM_CODE_REPAIR_ENABLED"
 # seam pins "0"/"1", e.g. 0.0 = off, 1.0 = full boost) or a bool whose name
 # doesn't end in `_ENABLED`. Explicit allowlist — most float knobs are tuner
 # territory, not graduation candidates.
-_DARK_SCALAR_FLAGS = ("MEMO_RECALL_CODE_PROXIMITY_BOOST", "MEMO_GRAPH_SEMANTIC_RELATIONS")
+_DARK_SCALAR_FLAGS = (
+    "MEMO_RECALL_CODE_PROXIMITY_BOOST",
+    "MEMO_GRAPH_SEMANTIC_RELATIONS",
+    "MEMO_EMITTED_LEDGER",
+)
 
 
 @dataclass(frozen=True)
@@ -208,6 +212,14 @@ GATES: dict[str, GateSpec] = dict(
             "surface, not recall-measurable",
         ),
         _g("MEMO_SECRET_STORAGE_ENABLED", "manual", "security opt-in; human-only, never auto"),
+        _g(
+            "MEMO_EMITTED_LEDGER",
+            "manual",
+            "promotion needs the live memo_get_after_digest/digests_served ratio "
+            "(criterion 2, unmeasurable by replay) plus the open invalidation "
+            "gaps closed — see docs/SPECS/2026-08-10-emission-ledger-design.md; "
+            "human-only",
+        ),
         _g(
             "MEMO_SAMPLING_SYNTH_ENABLED",
             "manual",

--- a/src/memo/flags.py
+++ b/src/memo/flags.py
@@ -287,6 +287,10 @@ def unknown_memo_vars(env: dict[str, str] | None = None) -> list[str]:
         # compatible for the lifetime of a process started before the upgrade.
         "MEMO_TERMINAL_ID",
         "MEMO_TERMINAL_REGISTRATION_ATTEMPTED",
+        # Per-session identity override read by identity._session_id() (and the
+        # emission ledger's per-session key). Env-only by nature — a session id
+        # in the markdown config would pin every session to one identity.
+        "MEMO_SESSION_ID",
         # User-facing banner toggle consumed by the bash shell shim
         # (runtime/shims.py). Env-only: the shim can't see the markdown-config
         # chain, so registering it as a flag would diverge silently.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -261,6 +261,12 @@ def memory_with_memories(tmp_cfg: Config, monkeypatch):
         "memo.embedder.MLXEmbedder.embed",
         lambda self, inputs: [[1.0, 0.0, 0.0, 0.0] for _ in inputs],
     )
+    # The constant stub makes the two seeds cosine-1.0 near-duplicates, so
+    # default-ON MEMO_SAVE_ABSORB would fire a REAL 30B LLM chat per setup on
+    # Apple Silicon (~15s each, 180s timeout under GPU contention) and, when
+    # that chat succeeds, absorb seed #2 INTO seed #1 — leaving one seeded
+    # memory instead of the two the "both hits for query=chat" premise needs.
+    monkeypatch.setenv("MEMO_SAVE_ABSORB", "0")
     mem = Memory(cfg)
     mem.save(content="Chat UI feedback loop and streaming design notes", title="Chat design notes")
     mem.save(content="Second chat memory used to exercise ledger dedup", title="Chat dedup memory")


### PR DESCRIPTION
A 4-dimension adversarial review (flag-off no-op / merge correctness / ledger module / conventions, every finding independently verified, 0 refuted) of the emission ledger that landed in PR #234 confirmed four issues. This lands everything that touches live surfaces; the rest is recorded as explicit promotion blockers in the spec.

## Fixes
- **tests/conftest.py — `memory_with_memories` fired a real 30B LLM chat per test setup**: the constant stub vector makes the two seeds cosine-1.0 near-duplicates, so default-ON `MEMO_SAVE_ABSORB` called `_absorb_into_existing` → real `llm.chat` on Apple Silicon (module: 436s → 17s measured) and, when the chat succeeded, merged seed #2 INTO seed #1 — nondeterministically breaking the fixture's two-hit premise. CI never saw it (Linux runners can't import mlx). Pinned `MEMO_SAVE_ABSORB=0`.
- **`MEMO_EMITTED_LEDGER` escaped the dark-flag graduation contract**: dark bool without the `_ENABLED` suffix, invisible to the automatic completeness check. Added to `_DARK_SCALAR_FLAGS` + a `manual` GateSpec pointing at the spec's promotion rule.
- **`MEMO_SESSION_ID` flagged as a typo by `memo config validate`**: env-only per-session identity, now excluded from `unknown_memo_vars`.
- **Spec honesty**: the invalidation table promised a `/clear` → SessionStart reset that was never implemented. Marked NOT IMPLEMENTED and recorded the confirmed gaps (`/clear` reset + env-frozen MCP session id, HTTP single-session collapse, counters-sidecar race, `_MAX=0` unbounded growth, UTF-8 blinding, `_safe()` collisions, dangling hook refs) as explicit promotion blockers.

## Verification
- `tests/test_dream_flags.py` + `tests/test_flags.py`: 54 passed
- `tests/test_emitted_ledger_integration.py`: 30 passed in 16.4s (was ~436s)
- ruff + mypy clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)