### PR TITLE
chore: sync Homebrew formula to the 4.12.2 sdist

### DIFF
--- a/docs/homebrew/mlx-memo.rb
+++ b/docs/homebrew/mlx-memo.rb
@@ -21,8 +21,8 @@ class MlxMemo < Formula
 
   desc "Local MCP memory for AI agents — MLX-native, sqlite-vec, markdown vault"
   homepage "https://github.com/jagoff/memo"
-  url "https://files.pythonhosted.org/packages/77/d5/a73dfdcda894c06d20cdb145ae392c686d01814a424f7c638b4581488c98/mlx_memo-4.12.1.tar.gz"
-  sha256 "a3a5bcc7e2b23be36b5288065d36e14715ae43eca0a48e60685f7ee4a686a870"
+  url "https://files.pythonhosted.org/packages/e6/fe/a85f14d6fc05ddf2c27c6042ed665e705b96560e6c69509ae737361bd33f/mlx_memo-4.12.2.tar.gz"
+  sha256 "588a5b5c1adfca70bf8b6cd79dde114fdb7491d9edc4e7bc50be62e77a5ed045"
   license "MIT"
 
   depends_on arch: :arm64


### PR DESCRIPTION
Routine per-release formula sync (pattern of #254/#258): `docs/homebrew/mlx-memo.rb` now points at the published `mlx_memo-4.12.2.tar.gz` with its verified sha256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)