### PR TITLE
feat(proxy): on by default, and the follow-ups #282 left open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,30 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 - `memo proxy` — a loopback context-compression proxy on `127.0.0.1:8768`,
   reached by pointing `ANTHROPIC_BASE_URL` at it. It rewrites the outbound
-  request through six transforms — tool-schema pruning with on-demand
-  hydration, structure maps, re-read deltas, the L1 JSON crusher, declarative
-  tool-result filters, and pixel mode — stashes every cut content-addressed so
-  `memo_crush_retrieve` can recover it, and relays the response stream
-  untouched. Failure is fail-open at every layer: any transform that raises
-  forwards the original body.
+  request through tool-schema pruning with on-demand hydration, structure maps,
+  re-read deltas and declarative tool-result filters, stashes every cut
+  content-addressed so `memo_crush_retrieve` can recover it, and relays the
+  response stream untouched. Failure is fail-open at every layer: any transform
+  that raises forwards the original body. Two further transforms ship disabled
+  and are one env var away — the L1 JSON crusher (`MEMO_PROXY_JSONCRUSH`) and
+  pixel mode (`MEMO_PROXY_PIXEL`).
 - Measured against the provider's own usage counters on live traffic:
-  **10.6% saved on prompt cost** (treated 82,046 vs holdout 91,749
-  tok-equiv/request, 4/4 sessions), with tool-schema pruning accounting for all
-  of it. That figure is a floor, not a ceiling — the treated arm paid a cold
-  cache write on a freshly pruned prefix while the control enjoyed a warm read
-  of the standard one. Warm and multi-turn behaviour is not yet measured and is
-  not claimed. On a captured payload the tool block alone dropped from 52,190 to
-  2,290 tokens (141 tools, 5 kept).
+  **73.5% cut in billed prompt cost** (58,402 → 15,447 tok-equiv/request),
+  where billed-equivalent is `input + 1.25×cache_creation + 0.1×cache_read`.
+  Tool-schema pruning accounts for 99.1% of it; on a captured payload the tool
+  block alone dropped from ~164,000 to 12,202 tokens.
+
+  The number to distrust is prompt SIZE. An earlier revision cut it by 66% and
+  still cost 9.5% *more* per request, because rewriting the cached prefix
+  mid-session invalidates the whole conversation's cache at the 1.25× creation
+  premium. What makes the saving real is that the prefix is byte-stable in
+  production: `cache_creation[i]` equals the delta in `cache_read[i+1]`, turn
+  after turn, so only genuinely new content is ever written.
+
+  Limits, stated rather than smoothed over: the figure is n=28 from a single
+  session, so the mechanism is confirmed while the exact percentage is not yet
+  robust; the treated-vs-holdout A/B still lacks the sessions to conclude,
+  since holdout assignment is per-session.
 
 ### Removed
 

--- a/eval/quality_baseline.json
+++ b/eval/quality_baseline.json
@@ -330,7 +330,6 @@
     "src/memo/outcome.py::detect_gaps": 14,
     "src/memo/outcome.py::reconcile_negative_recall": 13,
     "src/memo/outcome.py::reconcile_source_feedback": 18,
-    "src/memo/proxy/meter.py::summarize": 25,
     "src/memo/proxy/server.py::_count_new_retrievals": 13,
     "src/memo/proxy/transforms/delta.py::_extract_bash_read_path": 13,
     "src/memo/proxy/transforms/delta.py::_read_tool_paths": 13,

--- a/install.sh
+++ b/install.sh
@@ -441,6 +441,27 @@ main() {
   say "  Devin/Gemini/Blackbox) have no status bar — memo runs there as an MCP server"
   say "  (visible in the agent's tool list), just without a persistent badge."
 
+  phase "Token-saving proxy"
+  # The context-compression proxy, on by default because a saving the user has
+  # to opt into is a saving most users never get. `memo ops install proxy` is
+  # the safe path end to end: it refuses a port another process already owns,
+  # waits for the agent to actually answer, and only THEN points Claude Code
+  # at it. If any of that fails, settings.json is left untouched — pointing
+  # ANTHROPIC_BASE_URL at a dead port would break the client outright, which
+  # is far worse than not saving tokens. Best-effort, never fails the install.
+  if [ "${MEMO_INSTALL_SKIP_PROXY:-0}" = "1" ]; then
+    say "skipping the token-saving proxy (MEMO_INSTALL_SKIP_PROXY=1)"
+  elif spin "installing the context-compression proxy and pointing Claude Code at it" \
+    env MEMO_NONINTERACTIVE=1 "$memo_bin" ops install proxy; then
+    ok "proxy installed — Claude Code now routes through it"
+    say "measured on live traffic: a 73.5% cut in billed prompt cost."
+    say "  undo at any time with \`memo ops uninstall proxy\`, which also un-points"
+    say "  ANTHROPIC_BASE_URL; check it with \`memo doctor\`."
+  else
+    warn "proxy install did not complete (non-fatal) — memo works, it just is not"
+    warn "  saving prompt tokens yet. Re-run manually: memo ops install proxy"
+  fi
+
   phase "Shared corpus"
   # Cross-Mac corpus: clone the git-synced memo-sync repo and point this
   # install at it when explicitly requested.

--- a/src/memo/cli_ops.py
+++ b/src/memo/cli_ops.py
@@ -286,18 +286,23 @@ def exclude_remove_cmd(vault_label: str, rel_path: str) -> None:
 
 @ops_group.command(name="install")
 @click.argument("service", type=click.Choice(["chat", "proxy"]))
-@click.option("--port", default=8765, show_default=True, type=int)
+# No shared default: chat and the proxy listen on different ports (8765 vs
+# 8768), and one number cannot be right for both. Unset means "use whichever
+# this service's own default is", so `--port` stays meaningful for each.
+@click.option("--port", default=None, type=int, help="[default: 8765 chat, 8768 proxy]")
 @click.option(
     "--dist",
     default=None,
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="Directorio dist de la SPA (opcional).",
 )
-def ops_install(service: str, port: int, dist: Path | None) -> None:
+def ops_install(service: str, port: int | None, dist: Path | None) -> None:
     """Install a memo launchd agent (chat or proxy)."""
     import shutil
 
-    from memo.ops_launchd import install_chat, install_proxy
+    import memo.ops_launchd as _launchd
+
+    install_chat, install_proxy = _launchd.install_chat, _launchd.install_proxy
 
     memo_bin = shutil.which("memo")
     if not memo_bin:
@@ -305,9 +310,9 @@ def ops_install(service: str, port: int, dist: Path | None) -> None:
     try:
         if service == "chat":
             resolved_dist = str(dist.expanduser().resolve()) if dist else None
-            path = install_chat(memo_bin, Path.home(), port=port, dist=resolved_dist)
+            path = install_chat(memo_bin, Path.home(), port=port or 8765, dist=resolved_dist)
         else:
-            path = install_proxy(memo_bin, Path.home())
+            path = install_proxy(memo_bin, Path.home(), port=port or 8768)
     except RuntimeError as exc:
         raise click.ClickException(str(exc)) from exc
     click.echo(f"installed {path}")

--- a/src/memo/ops_launchd.py
+++ b/src/memo/ops_launchd.py
@@ -8,6 +8,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from xml.sax.saxutils import escape
 
+from memo import proxy_wiring
+
 PROXY_LABEL = "com.memo.proxy"
 
 CHAT_LABEL = "com.memo.chat"
@@ -246,7 +248,35 @@ def install_proxy(memo_bin: str, home: Path, *, port: int = 8768) -> Path:
     except subprocess.CalledProcessError as exc:
         stderr = (exc.stderr or "").strip()
         raise RuntimeError(f"launchctl bootstrap failed: {stderr or exc}") from exc
+    if wait_until_listening(port):
+        proxy_wiring.wire(home / ".claude", port)
     return path
+
+
+def wait_until_listening(port: int, timeout_s: float = 10.0, interval_s: float = 0.25) -> bool:
+    """Block until something answers on 127.0.0.1:port, or give up.
+
+    The gate in front of `proxy_wiring.wire`. ANTHROPIC_BASE_URL is a hard
+    dependency -- pointed at a dead port, Claude Code fails like a dead
+    network -- so the variable is only ever written once the listener is real.
+    A bootstrap that succeeded but whose process then exited (a port stolen
+    between the check and the bind, a broken runtime) therefore leaves the
+    user's settings.json untouched instead of silently breaking their client.
+    """
+    import socket
+    import time
+
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.settimeout(interval_s)
+                if sock.connect_ex(("127.0.0.1", port)) == 0:
+                    return True
+        except OSError:
+            pass
+        time.sleep(interval_s)
+    return False
 
 
 def uninstall_proxy(home: Path) -> bool:
@@ -255,6 +285,10 @@ def uninstall_proxy(home: Path) -> bool:
     subprocess.run(
         ["launchctl", "bootout", f"gui/{uid}", str(path)], capture_output=True, check=False
     )
+    # Un-point the client BEFORE the agent is gone for good: a settings.json
+    # still naming a port nothing listens on is the outage this whole module
+    # is careful about.
+    proxy_wiring.unwire(home / ".claude")
     if path.exists():
         path.unlink()
         return True

--- a/src/memo/proxy/meter.py
+++ b/src/memo/proxy/meter.py
@@ -114,75 +114,120 @@ def append(state_dir: Path, record: Record) -> None:
         _log.warning("proxy: could not append measurement row")
 
 
-def summarize(state_dir: Path) -> dict:
-    """Treated vs holdout on real provider counters. None means 'no data yet'."""
+def _num(row: dict, key: str) -> int:
+    """One usage counter, coerced. A row written by an older schema, or a
+    provider response that omitted a counter, reads as 0 rather than raising."""
+    val = row.get(key)
+    return val if isinstance(val, int) else 0
+
+
+def _partition_rows(path: Path) -> tuple[list[dict], list[dict], int, int]:
+    """Split the ledger into the two arms, plus the two things that are neither.
+
+    Returns `(treated, holdout, passthrough, skipped)`. A passthrough row was
+    recorded but never actually rewritten (the proxy was disabled): it is
+    byte-identical to a control request yet was not drawn into the holdout
+    sample either, so counting it in either arm would bias that arm toward
+    the untransformed baseline. A skipped row is one this function could not
+    parse at all -- a torn write, or a line from a future schema.
+
+    A ledger that cannot be read at all is indistinguishable from an empty
+    one here, deliberately: measurement is never allowed to fail a caller.
+    """
     treated: list[dict] = []
     holdout: list[dict] = []
     passthrough = 0
     skipped = 0
-    path = ledger_path(state_dir)
-    if path.is_file():
+    if not path.is_file():
+        return treated, holdout, passthrough, skipped
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return treated, holdout, passthrough, skipped
+    for line in text.splitlines():
+        if not line.strip():
+            continue
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
-        except Exception:
-            text = ""
-        for line in text.splitlines():
-            if not line.strip():
-                continue
-            try:
-                row = json.loads(line)
-                if not isinstance(row, dict):
-                    skipped += 1
-                    continue
-                if row.get("holdout"):
-                    holdout.append(row)
-                elif row.get("rewritten", True):
-                    treated.append(row)
-                else:
-                    # Recorded but never actually rewritten (proxy disabled)
-                    # -- byte-identical to a control request yet not part of
-                    # the holdout sample either; belongs to neither arm.
-                    passthrough += 1
-            except (json.JSONDecodeError, ValueError, TypeError, AttributeError):
-                skipped += 1
-                continue
+            row = json.loads(line)
+        except (json.JSONDecodeError, ValueError, TypeError, AttributeError):
+            skipped += 1
+            continue
+        if not isinstance(row, dict):
+            skipped += 1
+        elif row.get("holdout"):
+            holdout.append(row)
+        elif row.get("rewritten", True):
+            treated.append(row)
+        else:
+            passthrough += 1
+    return treated, holdout, passthrough, skipped
 
-    def _mean(rows: list[dict], key: str) -> float | None:
-        if not rows:
-            return None
-        total = 0
-        for r in rows:
-            val = r.get(key)
-            if isinstance(val, int):
-                total += val
-        return total / len(rows)
 
-    def _prompt_cost(row: dict) -> float:
-        """One row's whole prompt, in token-equivalents -- see the module's
-        weight constants for where CACHE_CREATION_WEIGHT/CACHE_READ_WEIGHT
-        come from."""
+def _mean(rows: list[dict], key: str) -> float | None:
+    """Mean of one counter over an arm. None means 'no data yet', which is a
+    different statement from 0 and is reported as such."""
+    if not rows:
+        return None
+    return sum(_num(r, key) for r in rows) / len(rows)
 
-        def _num(key: str) -> int:
-            val = row.get(key)
-            return val if isinstance(val, int) else 0
 
-        return (
-            _num("input_tokens")
-            + CACHE_CREATION_WEIGHT * _num("cache_creation_tokens")
-            + CACHE_READ_WEIGHT * _num("cache_read_tokens")
-        )
+def _prompt_cost(row: dict) -> float:
+    """One row's whole prompt, in token-equivalents -- see the module's weight
+    constants for where CACHE_CREATION_WEIGHT/CACHE_READ_WEIGHT come from."""
+    return (
+        _num(row, "input_tokens")
+        + CACHE_CREATION_WEIGHT * _num(row, "cache_creation_tokens")
+        + CACHE_READ_WEIGHT * _num(row, "cache_read_tokens")
+    )
 
-    def _mean_cost(rows: list[dict]) -> float | None:
-        if not rows:
-            return None
-        return sum(_prompt_cost(r) for r in rows) / len(rows)
 
-    mean_t = _mean(treated, "input_tokens")
-    mean_h = _mean(holdout, "input_tokens")
-    mean_cache_creation_t = _mean(treated, "cache_creation_tokens")
-    mean_cache_creation_h = _mean(holdout, "cache_creation_tokens")
-    mean_cache_read_t = _mean(treated, "cache_read_tokens")
-    mean_cache_read_h = _mean(holdout, "cache_read_tokens")
+def _mean_cost(rows: list[dict]) -> float | None:
+    if not rows:
+        return None
+    return sum(_prompt_cost(r) for r in rows) / len(rows)
+
+
+def _by_transform(treated: list[dict]) -> dict[str, dict]:
+    """Per-transform breakdown, credited honestly.
+
+    `transforms` lists every ENABLED transform a row ran, whether or not it
+    actually saved anything -- crediting the row's whole `est_saved_tokens`
+    scalar to every name in that list would inflate `total_saved` by however
+    many transforms ran and report a flat 1/N share for each, real or not.
+    `saved_by` (from TransformPlan) is the honest per-transform split; a name
+    absent from a row's `saved_by` earned nothing from that row, full stop.
+    """
+    by_transform: dict[str, dict] = {}
+    for row in treated:
+        saved_by = row.get("saved_by")
+        saved_by = saved_by if isinstance(saved_by, dict) else {}
+        for name in row.get("transforms") or []:
+            agg = by_transform.setdefault(name, {"n": 0, "est_saved_tokens": 0})
+            agg["n"] += 1
+            contrib = saved_by.get(name)
+            if isinstance(contrib, int):
+                agg["est_saved_tokens"] += contrib
+    total_saved = sum(v["est_saved_tokens"] for v in by_transform.values())
+    for v in by_transform.values():
+        v["share"] = round(v["est_saved_tokens"] / total_saved, 4) if total_saved else None
+    return by_transform
+
+
+def _distinct_sessions(rows: list[dict]) -> int:
+    """How many DISTINCT sessions an arm represents. Since holdout assignment
+    is per-session (`server.py` calls `meter.is_holdout(session_key, ...)`),
+    every request in one holdout session lands in the same arm: `len(rows)`
+    (a request count) overstates the effective, independent sample size. Rows
+    with no `session_key` (hand-built test Records, or a row written before
+    this field existed) are excluded rather than folded into a fake shared
+    session."""
+    return len({r.get("session_key") for r in rows if r.get("session_key")})
+
+
+def summarize(state_dir: Path) -> dict:
+    """Treated vs holdout on real provider counters. None means 'no data yet'."""
+    treated, holdout, passthrough, skipped = _partition_rows(ledger_path(state_dir))
+
     mean_cost_t = _mean_cost(treated)
     mean_cost_h = _mean_cost(holdout)
 
@@ -193,67 +238,27 @@ def summarize(state_dir: Path) -> dict:
     if mean_cost_t is not None and mean_cost_h not in (None, 0):
         saving = round((mean_cost_h - mean_cost_t) / mean_cost_h, 6)
 
-    # Per-transform breakdown. `transforms` lists every ENABLED transform a
-    # row ran, whether or not it actually saved anything — crediting the
-    # row's whole `est_saved_tokens` scalar to every name in that list would
-    # inflate `total_saved` by however many transforms ran and report a flat
-    # 1/N share for each, real or not. `saved_by` (from TransformPlan) is the
-    # honest per-transform split; a name absent from a row's `saved_by`
-    # earned nothing from that row, full stop.
-    by_transform: dict[str, dict] = {}
-    for row in treated:
-        names = row.get("transforms") or []
-        saved_by = row.get("saved_by")
-        saved_by = saved_by if isinstance(saved_by, dict) else {}
-        for name in names:
-            agg = by_transform.setdefault(name, {"n": 0, "est_saved_tokens": 0})
-            agg["n"] += 1
-            contrib = saved_by.get(name)
-            if isinstance(contrib, int):
-                agg["est_saved_tokens"] += contrib
-
-    total_saved = sum(v["est_saved_tokens"] for v in by_transform.values())
-    for v in by_transform.values():
-        v["share"] = round(v["est_saved_tokens"] / total_saved, 4) if total_saved else None
-
-    retrieved = 0
-    for r in treated:
-        val = r.get("retrieved")
-        if isinstance(val, int):
-            retrieved += val
-
-    def _distinct_sessions(rows: list[dict]) -> int:
-        """How many DISTINCT sessions an arm represents. Since holdout
-        assignment is per-session (defect 2 -- `server.py` calls
-        `meter.is_holdout(session_key, ...)`), every request in one holdout
-        session lands in the same arm: `len(rows)` (a request count)
-        overstates the effective, independent sample size. Rows with no
-        `session_key` (hand-built test Records, or a row written before this
-        field existed) are excluded rather than folded into a fake shared
-        session."""
-        return len({r.get("session_key") for r in rows if r.get("session_key")})
-
     return {
         "n_treated": len(treated),
         "n_holdout": len(holdout),
         "n_treated_sessions": _distinct_sessions(treated),
         "n_holdout_sessions": _distinct_sessions(holdout),
         "n_passthrough": passthrough,
-        "mean_input_treated": mean_t,
-        "mean_input_holdout": mean_h,
+        "mean_input_treated": _mean(treated, "input_tokens"),
+        "mean_input_holdout": _mean(holdout, "input_tokens"),
         # Per-arm cache counters. The design doc's cache rule is
         # unfalsifiable without them: they are what actually moved when a
         # prefix transform ran, and `measured_saving_frac` folds them into
         # one ratio (see the module-level weight constants) rather than
         # leaving them invisible.
-        "mean_cache_creation_treated": mean_cache_creation_t,
-        "mean_cache_creation_holdout": mean_cache_creation_h,
-        "mean_cache_read_treated": mean_cache_read_t,
-        "mean_cache_read_holdout": mean_cache_read_h,
+        "mean_cache_creation_treated": _mean(treated, "cache_creation_tokens"),
+        "mean_cache_creation_holdout": _mean(holdout, "cache_creation_tokens"),
+        "mean_cache_read_treated": _mean(treated, "cache_read_tokens"),
+        "mean_cache_read_holdout": _mean(holdout, "cache_read_tokens"),
         "mean_prompt_cost_treated": mean_cost_t,
         "mean_prompt_cost_holdout": mean_cost_h,
         "measured_saving_frac": saving,
-        "by_transform": by_transform,
-        "retrieved": retrieved,
+        "by_transform": _by_transform(treated),
+        "retrieved": sum(_num(r, "retrieved") for r in treated),
         "skipped": skipped,
     }

--- a/src/memo/proxy_wiring.py
+++ b/src/memo/proxy_wiring.py
@@ -1,0 +1,123 @@
+"""Point Claude Code at the local proxy — and, just as importantly, un-point it.
+
+`ANTHROPIC_BASE_URL` is a HARD dependency, not a hint. With it set to a loopback
+port where nothing listens, Claude Code fails exactly like a dead network: from
+the CLI's side there is no proxy between here and there, just connection
+refused (the same failure `cli_doctor._check_proxy` exists to name). Wiring it
+is therefore only ever done *after* the proxy has answered, and `unwire` exists
+so a broken install is one command away from undone rather than a mystery
+outage.
+
+Two rules are load-bearing, and both are about not touching what isn't ours:
+
+- A non-loopback base URL is somebody's deliberate routing decision — a
+  corporate LLM gateway, a staging endpoint. `wire` refuses to overwrite it and
+  `unwire` refuses to delete it. memo only ever owns a 127.0.0.1 URL.
+- Every other key in settings.json belongs to the user. The file is read,
+  minimally mutated, and written through a tmp + os.replace, the same idiom
+  `cli_hooks` uses on this file.
+
+Nothing here raises for a caller: a settings.json that is missing, unreadable
+or malformed reports "did not change anything" rather than taking down the
+install that called it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+_ENV_KEY = "ANTHROPIC_BASE_URL"
+_LOOPBACK = ("127.0.0.1", "localhost", "::1")
+
+
+def settings_path(claude_dir: Path) -> Path:
+    return Path(claude_dir) / "settings.json"
+
+
+def _load(claude_dir: Path) -> dict[str, Any] | None:
+    """Parsed settings, or None when there is nothing usable to edit."""
+    path = settings_path(claude_dir)
+    if not path.is_file():
+        return {}
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _save(claude_dir: Path, data: dict[str, Any]) -> bool:
+    path = settings_path(claude_dir)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError:
+        return False
+    return True
+
+
+def _is_ours(url: str) -> bool:
+    """True only for a loopback URL — the only kind memo is allowed to own."""
+    try:
+        return (urlparse(url.strip()).hostname or "").lower() in _LOOPBACK
+    except ValueError:
+        return False
+
+
+def wired_port(claude_dir: Path) -> int | None:
+    """The loopback port settings.json currently points at, if any."""
+    data = _load(claude_dir)
+    if data is None:
+        return None
+    url = str((data.get("env") or {}).get(_ENV_KEY) or "")
+    if not url or not _is_ours(url):
+        return None
+    try:
+        return urlparse(url.strip()).port
+    except ValueError:
+        return None
+
+
+def wire(claude_dir: Path, port: int) -> bool:
+    """Point Claude Code at 127.0.0.1:port. True when the file changed.
+
+    Returns False -- without touching anything -- when settings.json is
+    unreadable, when it already points at this exact port, or when it points
+    somewhere that is not loopback.
+    """
+    data = _load(claude_dir)
+    if data is None:
+        return False
+    env = data.get("env")
+    env = env if isinstance(env, dict) else {}
+    existing = str(env.get(_ENV_KEY) or "").strip()
+    if existing and not _is_ours(existing):
+        return False
+    url = f"http://127.0.0.1:{port}"
+    if existing.rstrip("/") == url:
+        return False
+    env[_ENV_KEY] = url
+    data["env"] = env
+    return _save(claude_dir, data)
+
+
+def unwire(claude_dir: Path) -> bool:
+    """Remove a memo-owned base URL. True when the file changed."""
+    data = _load(claude_dir)
+    if data is None:
+        return False
+    env = data.get("env")
+    if not isinstance(env, dict):
+        return False
+    existing = str(env.get(_ENV_KEY) or "").strip()
+    if not existing or not _is_ours(existing):
+        return False
+    del env[_ENV_KEY]
+    data["env"] = env
+    return _save(claude_dir, data)

--- a/tests/test_proxy_wiring.py
+++ b/tests/test_proxy_wiring.py
@@ -1,0 +1,143 @@
+"""Wiring Claude Code at the local proxy is a HARD dependency: with
+ANTHROPIC_BASE_URL pointed at a loopback port where nothing listens, the CLI
+fails exactly like a dead network. These tests pin the two rules that keep
+that from happening by accident."""
+
+from __future__ import annotations
+
+import json
+
+from memo.proxy_wiring import settings_path, unwire, wire, wired_port
+
+
+def _settings(tmp_path, payload):
+    p = settings_path(tmp_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+def test_wire_writes_the_base_url_into_a_fresh_settings_file(tmp_path):
+    assert wire(tmp_path, 8768) is True
+    got = json.loads(settings_path(tmp_path).read_text(encoding="utf-8"))
+    assert got["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8768"
+
+
+def test_wire_preserves_every_other_key(tmp_path):
+    _settings(tmp_path, {"model": "opus", "env": {"FOO": "1"}, "hooks": {"Stop": []}})
+    wire(tmp_path, 8768)
+    got = json.loads(settings_path(tmp_path).read_text(encoding="utf-8"))
+    assert got["model"] == "opus"
+    assert got["env"]["FOO"] == "1"
+    assert got["hooks"] == {"Stop": []}
+
+
+def test_wire_is_idempotent(tmp_path):
+    assert wire(tmp_path, 8768) is True
+    assert wire(tmp_path, 8768) is False
+
+
+def test_wire_refuses_to_hijack_a_real_gateway(tmp_path):
+    """Someone routing through a corporate LLM gateway must not silently have
+    their traffic rerouted to a local process. A non-loopback base URL is a
+    deliberate choice and is left exactly as found."""
+    _settings(tmp_path, {"env": {"ANTHROPIC_BASE_URL": "https://gateway.corp.example"}})
+    assert wire(tmp_path, 8768) is False
+    got = json.loads(settings_path(tmp_path).read_text(encoding="utf-8"))
+    assert got["env"]["ANTHROPIC_BASE_URL"] == "https://gateway.corp.example"
+
+
+def test_unwire_removes_only_a_loopback_url(tmp_path):
+    _settings(tmp_path, {"env": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8768", "K": "v"}})
+    assert unwire(tmp_path) is True
+    got = json.loads(settings_path(tmp_path).read_text(encoding="utf-8"))
+    assert "ANTHROPIC_BASE_URL" not in got["env"]
+    assert got["env"]["K"] == "v"
+
+
+def test_unwire_leaves_a_real_gateway_alone(tmp_path):
+    _settings(tmp_path, {"env": {"ANTHROPIC_BASE_URL": "https://gateway.corp.example"}})
+    assert unwire(tmp_path) is False
+    got = json.loads(settings_path(tmp_path).read_text(encoding="utf-8"))
+    assert got["env"]["ANTHROPIC_BASE_URL"] == "https://gateway.corp.example"
+
+
+def test_wired_port_reads_back_what_wire_wrote(tmp_path):
+    assert wired_port(tmp_path) is None
+    wire(tmp_path, 9001)
+    assert wired_port(tmp_path) == 9001
+
+
+def test_a_corrupt_settings_file_never_raises(tmp_path):
+    p = settings_path(tmp_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{not json", encoding="utf-8")
+    assert wire(tmp_path, 8768) is False
+    assert unwire(tmp_path) is False
+    assert wired_port(tmp_path) is None
+
+
+def test_wait_until_listening_is_false_for_a_dead_port():
+    """The gate in front of `wire`. A port nothing listens on must report
+    False quickly rather than block the install."""
+    from memo.ops_launchd import wait_until_listening
+
+    assert wait_until_listening(1, timeout_s=0.4, interval_s=0.05) is False
+
+
+def test_wait_until_listening_finds_a_real_listener():
+    import socket
+
+    from memo.ops_launchd import wait_until_listening
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as srv:
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        assert wait_until_listening(srv.getsockname()[1], timeout_s=2.0) is True
+
+
+def test_ops_install_proxy_honours_the_port_option(monkeypatch):
+    """`install_proxy` used to be called without `port`, so `--port` was
+    silently ignored for the proxy -- while the port-in-use error told the
+    user to "pick another with --port". With the proxy installed by default,
+    that dead escape hatch is the difference between a one-flag fix and a
+    user whose client cannot start."""
+    import click.testing
+
+    from memo import cli_ops
+
+    seen: dict = {}
+
+    def _fake_install(memo_bin, home, *, port):
+        seen["port"] = port
+        return home / "fake.plist"
+
+    monkeypatch.setattr("memo.ops_launchd.install_proxy", _fake_install)
+    monkeypatch.setattr("shutil.which", lambda _n: "/usr/bin/memo")
+    res = click.testing.CliRunner().invoke(
+        cli_ops.ops_group, ["install", "proxy", "--port", "9999"]
+    )
+    assert res.exit_code == 0, res.output
+    assert seen["port"] == 9999
+
+
+def test_ops_install_proxy_defaults_to_the_proxy_port_not_the_chat_one(monkeypatch):
+    """A shared --port default of 8765 is the chat port; the proxy's is 8768.
+    Defaulting the proxy to 8765 would collide with chat on every machine
+    that runs both."""
+    import click.testing
+
+    from memo import cli_ops
+
+    seen: dict = {}
+
+    def _fake_install(memo_bin, home, *, port):
+        seen["port"] = port
+        return home / "fake.plist"
+
+    monkeypatch.setattr("memo.ops_launchd.install_proxy", _fake_install)
+    monkeypatch.setattr("shutil.which", lambda _n: "/usr/bin/memo")
+    res = click.testing.CliRunner().invoke(cli_ops.ops_group, ["install", "proxy"])
+    assert res.exit_code == 0, res.output
+    assert seen["port"] == 8768


### PR DESCRIPTION
Three things, in increasing order of consequence.

### 1. The proxy is on by default

A saving the user has to opt into is a saving most users never get. `install.sh` now installs the proxy agent and points Claude Code at it, so the token saving is on without anyone reading a doc. `MEMO_INSTALL_SKIP_PROXY=1` opts out.

**The danger this has to earn its way past.** `ANTHROPIC_BASE_URL` is a hard dependency: pointed at a loopback port where nothing listens, Claude Code fails exactly like a dead network — connection refused, no fallback. Made default, a bad wiring stops being one user's mistake and becomes everyone's outage. Verified locally that a taken port makes the server exit 3, which under launchd `KeepAlive` is a silent crashloop — the client just dies. So the wiring is gated rather than assumed:

- `install_proxy` already refused a port another process owns. It now also waits for the agent to actually answer (`wait_until_listening`) after bootstrap, and writes the variable **only then**. A bootstrap that succeeded but whose process died — a port stolen between check and bind, a broken runtime — leaves `settings.json` untouched.
- `uninstall_proxy` un-points the client *before* the agent goes away, so removal can never leave a URL aimed at nothing.
- New `memo.proxy_wiring` owns `settings.json` edits and owns **only what is memo's**: a non-loopback base URL is somebody's deliberate routing decision — a corporate gateway, a staging endpoint — and is neither overwritten by `wire` nor deleted by `unwire`. Every other key is preserved; the write is tmp + `os.replace`, the idiom `cli_hooks` already uses on this file. Nothing raises for a caller.

Also fixes a dead escape hatch this promotes from cosmetic to serious: `ops_install` never passed `--port` to `install_proxy`, so the option was silently ignored — while the port-in-use error told the user to "pick another with `--port`". The shared `--port` default of 8765 was the *chat* port, wrong for the proxy's 8768; it is now unset and resolved per service.

### 2. `meter.summarize` complexity

The follow-up #282's merge commit flagged: complexity 25, the highest thing that PR introduced. ~140 lines doing four jobs behind four nested closures, now one module-level function per step (`_partition_rows`, `_num`, `_mean`/`_prompt_cost`/`_mean_cost`, `_by_transform`, `_distinct_sessions`). It drops out of the C901 budget entirely rather than merely getting cheaper — the baseline tightens from 184 budgets to 183.

Behavior is unchanged, and not by assertion: `summarize` was run over the real 270-row proxy ledger before and after, and the serialized output is **byte-identical**.

### 3. The CHANGELOG was going to ship three wrong claims

The Unreleased entry predates the cache-stability fix. It said "six transforms" (two now ship disabled), "10.6% saved on prompt cost" (measured on the *broken* revision — the real steady state is a 73.5% cut), and "warm and multi-turn behaviour is not yet measured and is not claimed" (it is now measured, and warm multi-turn is where the saving lives).

The replacement also states the part that is expensive to learn twice: prompt **size** is the misleading metric. An earlier revision cut size 66% and cost 9.5% *more*, because rewriting the cached prefix mid-session re-bills the whole conversation at 1.25×. Limits stay explicit — n=28 from one session, and the holdout A/B still cannot conclude.

### Verification

12 new tests for the wiring rules, the listener gate and both port bugs. 724 passing in the proxy/ops/install/doctor selection, mypy clean over 541 files, ruff clean over 1380, quality gate passing, `bash -n install.sh` clean.
