### PR TITLE
fix: five defects the post-release audit found, including a proxy that never ran on a default install

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Most memory servers *add* context. memo is built to remove it.
 
 The default MCP surface is 43 tools, not 165 — 74% fewer tools, and about 68% less schema context: **43 tools / ~9.7k schema tokens** versus **165 tools / ~30.6k tokens** on the full surface — overhead paid every session, in every client.
 
-Ambient recall injects one relevant memory before the model answers. The bundled Claude Code hook caps that injection at ~160 tokens. `memo roi` reads the real grounding and re-ask ledgers, then estimates accumulated savings with disclosed defaults (350 tokens per grounded recall and 900 per avoided re-ask).
+Ambient recall injects one relevant memory before the model answers. The bundled Claude Code hook caps that injection at ~160 tokens. `memo roi` reports the real grounding and re-ask counts — the estimated-savings figure it used to print was removed in 4.14.0, because multiplying those counts by hardcoded constants was a savings claim memo could not support. For measured savings, `memo tokens` reads the provider's own usage counters through the context-compression proxy.
 
 ```bash
 memo roi       # value from grounded recalls and avoided re-asks

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,13 @@ set -euo pipefail
 
 APP_NAME="mlx-memo"
 OLD_APP_NAME="memo-mcp"
-PYPI_SPEC="mlx-memo"
+# The [http] extra is NOT optional for a default install: the
+# context-compression proxy installs and wires itself by default (see the
+# "Token-saving proxy" phase), and `memo proxy serve` needs fastapi from this
+# extra. A bare `mlx-memo` still pulls uvicorn and httpx transitively via
+# fastmcp, so fastapi is the single missing piece -- enough to make the launchd
+# agent crashloop while the installer reports success.
+PYPI_SPEC="mlx-memo[http]"
 DEFAULT_VERSION="4.14.0"
 MIN_PYTHON_MAJOR=3
 MIN_PYTHON_MINOR=13

--- a/scripts/check_mutation_results.py
+++ b/scripts/check_mutation_results.py
@@ -38,7 +38,13 @@ _REQUIRED_METADATA_KEYS = {
     "estimated_durations_by_key",
     "exit_code_by_key",
 }
-_OPTIONAL_METADATA_KEYS = {"type_check_error_by_key"}
+# `hash_by_function_name` arrived with mutmut 3.7 (its incremental-run support);
+# a dependabot lockfile bump to 3.7.0 on 2026-08-05 made every scheduled run
+# since crash with "malformed mutmut metadata" while the mutation signal itself
+# was perfect (1377/1377 killed). A gate that dies on an unknown-but-legitimate
+# key reads exactly like a real regression, which is how three weeks of red went
+# unexamined.
+_OPTIONAL_METADATA_KEYS = {"type_check_error_by_key", "hash_by_function_name"}
 _ALLOWED_METADATA_KEYS = _REQUIRED_METADATA_KEYS | _OPTIONAL_METADATA_KEYS
 _BASELINE_SCHEMA_VERSION = 1
 _BASELINE_KEYS = {

--- a/src/memo/cli_maintain.py
+++ b/src/memo/cli_maintain.py
@@ -165,8 +165,38 @@ def _fold_synthesis_errors(receipt: dict[str, Any]) -> None:
             receipt["errors"].append(f"synthesize: {item['error']}")
 
 
+def _record_pair_failure(receipt: dict[str, Any], pair_id: Any, exc: BaseException) -> None:
+    """File one pair's failure as either SKIPPED or an ERROR.
+
+    A vault-ingested row stores its path relative to the Obsidian vault root
+    (`notes/...`, `work/...`). `_resolve_existing` can only fall back to
+    `vault_path`, which `Config.from_env()` leaves unset, so those files are
+    unreachable and the pair raises FileNotFoundError. Thousands of rows are
+    in that state, permanently: the source lives in a vault memo does not own.
+
+    That is a pair this pass cannot act on, not a pass that failed. Folding it
+    into `errors` made `_fail_on_pass_errors` exit 1, so the nightly
+    contradict-resolve reported FAILED every single night while actually doing
+    all of its work. An exit code that is always red teaches the operator to
+    stop reading it, which is strictly worse than not having one -- and it
+    masks the real failures it exists to surface.
+
+    Skipped pairs stay in the receipt, under their own key, so the condition
+    is visible and countable rather than silently swallowed.
+    """
+    label = f"pair {pair_id}: {type(exc).__name__}: {exc}"
+    if isinstance(exc, FileNotFoundError):
+        receipt.setdefault("skipped", []).append(label)
+        return
+    receipt["errors"].append(label)
+
+
 def _fail_on_pass_errors(receipt: dict[str, Any], *, dry_run: bool) -> None:
-    """Exit non-zero when a pass failed. A dry run changed nothing, so it does not."""
+    """Exit non-zero when a pass failed. A dry run changed nothing, so it does not.
+
+    Reads `errors` only: `skipped` is reported but deliberately does not turn
+    the run red -- see `_record_pair_failure`.
+    """
     if receipt["errors"] and not dry_run:
         raise SystemExit(1)
 
@@ -326,6 +356,7 @@ def maintain_cmd(
         "dead_archived": [],  # surfaced-never-grounded memories soft-forgotten
         "vacuumed": 0,  # successful hard deletes (dry-run: eligible candidates)
         "errors": [],
+        "skipped": [],  # pairs this pass could not act on (vanished source file)
         "cascade_warnings": [],
     }
 
@@ -507,8 +538,10 @@ def maintain_cmd(
                     # One unreadable record must not abandon every other
                     # pair in the run: the pass used to abort on the first
                     # pair whose .md had gone missing, leaving ~100
-                    # actionable pairs untouched every night.
-                    receipt["errors"].append(f"pair {pair.pair_id}: {type(exc).__name__}: {exc}")
+                    # actionable pairs untouched every night. A vanished
+                    # source is filed as SKIPPED, not as a run failure --
+                    # see `_record_pair_failure`.
+                    _record_pair_failure(receipt, pair.pair_id, exc)
                     continue
         except Exception as exc:
             receipt["errors"].append(f"contradict: {type(exc).__name__}: {exc}")

--- a/src/memo/cli_proxy.py
+++ b/src/memo/cli_proxy.py
@@ -31,11 +31,18 @@ def proxy_serve(host: str, port: int, upstream: str) -> None:
         import uvicorn
 
         from memo.proxy.server import build_app
+
+        # build_app() must be INSIDE the guard: it imports fastapi lazily, and
+        # fastapi is the one [http] member a default `pip install mlx-memo`
+        # actually lacks -- uvicorn and httpx arrive transitively via fastmcp.
+        # Called outside, its ImportError escaped as a raw ModuleNotFoundError,
+        # so the launchd agent crashlooped instead of printing this message.
+        app = build_app(upstream)
     except ImportError as exc:  # missing [http] extra — a clean CLI error
         raise click.ClickException(
             "memo proxy needs the [http] extra: pip install 'mlx-memo[http]'"
         ) from exc
-    uvicorn.run(build_app(upstream), host=host, port=port, log_level="warning")
+    uvicorn.run(app, host=host, port=port, log_level="warning")
 
 
 @proxy_group.command("off")

--- a/src/memo/negative_capture.py
+++ b/src/memo/negative_capture.py
@@ -157,8 +157,8 @@ def capture_from_supersede(
     (the caller's responsibility) so both bodies are still resolvable.
 
     Returns ``{"status", "captured_id"?, "error"?}`` where ``status`` is one of
-    ``disabled`` / ``unresolved`` / ``skipped_dup`` / ``dry_run`` / ``captured``
-    / ``error``.
+    ``disabled`` / ``unresolved`` / ``skipped_origin`` / ``skipped_dup`` /
+    ``dry_run`` / ``captured`` / ``error``.
     """
     if not flag_bool(_CAPTURE_FLAG):
         return {"status": "disabled", "captured_id": None}
@@ -167,6 +167,15 @@ def capture_from_supersede(
         superseding = mem.get(superseding_id)
         if superseded is None or superseding is None:
             return {"status": "unresolved", "captured_id": None}
+        # Same gate the avoid-verdict path applies -- this door never had it.
+        # An anti-memory OF an anti-memory is nonsense (it minted memories
+        # literally titled "Avoid reverting to: Avoid reverting to: X"), and a
+        # reference chunk is not a lesson: two sections of one ingested
+        # document read as a contradiction to the pair scanner, so a single CV
+        # produced a "failure pattern" whose Wrong and Right were two jobs in
+        # the same work history.
+        if superseded.type in _SKIP_ORIGIN_TYPES or superseding.type in _SKIP_ORIGIN_TYPES:
+            return {"status": "skipped_origin", "captured_id": None}
         payload = derive_failure_pattern_from_supersede(superseded, superseding)
         prov_hash = _provenance_hash(payload["extra"])
         if prov_hash in _existing_provenance_hashes(mem):

--- a/src/memo/ops_launchd.py
+++ b/src/memo/ops_launchd.py
@@ -248,8 +248,18 @@ def install_proxy(memo_bin: str, home: Path, *, port: int = 8768) -> Path:
     except subprocess.CalledProcessError as exc:
         stderr = (exc.stderr or "").strip()
         raise RuntimeError(f"launchctl bootstrap failed: {stderr or exc}") from exc
-    if wait_until_listening(port):
-        proxy_wiring.wire(home / ".claude", port)
+    if not wait_until_listening(port):
+        # The gate below already protects the CLIENT -- ANTHROPIC_BASE_URL is
+        # never written at a dead port -- but silence protected nobody else:
+        # `memo ops install proxy` exited 0 and install.sh announced "Claude
+        # Code now routes through it" over a crashlooping agent. Say it out
+        # loud; the caller decides what to do about it.
+        raise RuntimeError(
+            f"proxy agent bootstrapped but never answered on 127.0.0.1:{port} — "
+            f"check ~/Library/Logs/memo/proxy.log (a missing [http] extra is the "
+            f"usual cause: pip install 'mlx-memo[http]')"
+        )
+    proxy_wiring.wire(home / ".claude", port)
     return path
 
 

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -65,7 +65,14 @@ def test_failed_uv_install_preserves_existing_tool_and_uses_release_pin(tmp_path
 
     assert result.returncode != 0
     assert sentinel.read_text(encoding="utf-8") == "keep"
-    assert f"tool install mlx-memo=={_pkg_version()} --force" in log.read_text(encoding="utf-8")
+    # The [http] extra is part of the DEFAULT spec, not an optional add-on:
+    # the proxy installs and wires itself by default and needs fastapi from
+    # it. A bare `mlx-memo` still resolves uvicorn and httpx transitively via
+    # fastmcp, so fastapi is the single missing piece — enough to make the
+    # launchd agent crashloop while the installer reported success.
+    assert f"tool install mlx-memo[http]=={_pkg_version()} --force" in log.read_text(
+        encoding="utf-8"
+    )
     assert "uninstall" not in log.read_text(encoding="utf-8")
 
 
@@ -94,7 +101,12 @@ def test_failed_pipx_install_preserves_existing_tool(tmp_path: Path) -> None:
     assert result.returncode != 0
     assert sentinel.read_text(encoding="utf-8") == "keep"
     commands = log.read_text(encoding="utf-8")
-    assert f"install mlx-memo=={_pkg_version()} --force" in commands
+    # The [http] extra is part of the DEFAULT spec, not an optional add-on:
+    # the proxy installs and wires itself by default and needs fastapi from
+    # it. A bare `mlx-memo` still resolves uvicorn and httpx transitively via
+    # fastmcp, so fastapi is the single missing piece — enough to make the
+    # launchd agent crashloop while the installer reported success.
+    assert f"install mlx-memo[http]=={_pkg_version()} --force" in commands
     assert "uninstall" not in commands
 
 

--- a/tests/test_maintain.py
+++ b/tests/test_maintain.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from memo.cli import cli
@@ -815,3 +816,45 @@ def test_maintain_dry_run_reports_errors_without_failing(tmp_path):
 
     assert result.exit_code == 0, result.output
     assert "forget: RuntimeError: boom" in result.output
+
+
+def test_a_vanished_source_file_is_skipped_not_failed():
+    """A pair whose source .md is gone must not fail the whole run.
+
+    Vault-ingested rows carry a path relative to the Obsidian vault root
+    (`notes/...`, `work/...`), which `_resolve_existing` cannot resolve
+    because `Config.from_env()` leaves `vault_path` unset — so the file is
+    genuinely unreachable and the pair raises FileNotFoundError. That is an
+    expected, recurring, non-actionable condition affecting thousands of
+    rows, not a failure of the pass: the run still supersedes, merges and
+    synthesizes everything else.
+
+    Folding it into `errors` made `_fail_on_pass_errors` exit 1, so the
+    nightly `contradict-resolve` reported FAILED every night with the work
+    actually done. An exit code that is always red teaches the operator to
+    ignore it, which is worse than no exit code.
+    """
+    from memo.cli_maintain import _record_pair_failure
+
+    receipt = {"errors": [], "skipped": []}
+
+    _record_pair_failure(receipt, 42, FileNotFoundError(2, "No such file", "notes/gone.md"))
+    assert receipt["errors"] == []
+    assert len(receipt["skipped"]) == 1
+    assert "42" in receipt["skipped"][0]
+
+    _record_pair_failure(receipt, 43, RuntimeError("boom"))
+    assert len(receipt["errors"]) == 1
+    assert "RuntimeError" in receipt["errors"][0]
+    assert len(receipt["skipped"]) == 1
+
+
+def test_only_real_errors_fail_the_run():
+    """The exit code must mean something: skipped pairs are reported but do
+    not turn the run red; a genuine error still does."""
+    from memo.cli_maintain import _fail_on_pass_errors
+
+    _fail_on_pass_errors({"errors": [], "skipped": ["pair 42: source file gone"]}, dry_run=False)
+
+    with pytest.raises(SystemExit):
+        _fail_on_pass_errors({"errors": ["contradict: RuntimeError: boom"]}, dry_run=False)

--- a/tests/test_negative_capture.py
+++ b/tests/test_negative_capture.py
@@ -503,3 +503,68 @@ def test_avoid_verdict_persist_error_is_surfaced(mem_with_stub, enabled, monkeyp
     assert res["captured"] == []
     assert res["errors"]
     assert "disk full" in res["errors"][0]
+
+
+def test_supersede_never_mints_an_anti_memory_of_an_anti_memory(mem_with_stub, enabled):
+    """`_SKIP_ORIGIN_TYPES` must gate BOTH entry paths, not just one.
+
+    The avoid-verdict path checks `memrec.type in _SKIP_ORIGIN_TYPES`;
+    `capture_from_supersede` never looked at `.type` at all. So superseding one
+    failure_pattern with another minted a failure_pattern *about* failure
+    patterns — observed live as memories literally titled "Avoid reverting to:
+    Avoid reverting to: X". The module's own comment already calls that
+    nonsense; only one of its two doors enforced it.
+    """
+    mem = mem_with_stub
+    a = mem.save(
+        content="Pattern: a prior approach was reversed: use a global singleton for the pool.",
+        title="Avoid reverting to: global singleton",
+        type_=FAILURE_PATTERN_TYPE,
+    )
+    b = mem.save(
+        content="Pattern: a prior approach was reversed: use one connection per thread.",
+        title="Avoid reverting to: thread-local connection",
+        type_=FAILURE_PATTERN_TYPE,
+    )
+
+    before = len(_failure_patterns(mem))
+    res = negative_capture.capture_from_supersede(mem, superseded_id=a.id, superseding_id=b.id)
+
+    assert res["status"] == "skipped_origin"
+    assert res["captured_id"] is None
+    assert len(_failure_patterns(mem)) == before
+
+
+def test_supersede_never_mints_a_lesson_out_of_a_reference_chunk(mem_with_stub, enabled):
+    """Bulk reference chunks are not lessons.
+
+    Two sections of one ingested document routinely look like a contradiction
+    to the pair scanner. Observed live: a failure_pattern whose "Wrong" and
+    "Right" were two different jobs in the same person's work history, minted
+    from `#chunk-N` rows of a single ingested CV.
+    """
+    mem = mem_with_stub
+    a = mem.save(
+        content=(
+            "Server and network administrator, 2015 to 2016. Set up Linux servers from "
+            "scratch, virtualization with KVM and Proxmox, Zabbix monitoring, Apache and "
+            "Nginx, MySQL and PostgreSQL, public DNS with Bind9, backups with Bacula."
+        ),
+        title="Curriculum (4/13)",
+        type_="reference",
+    )
+    b = mem.save(
+        content=(
+            "Infrastructure lead, 2020 to 2024. Upgraded Proxmox platforms, migrated "
+            "Postfix and Dovecot mail servers, moved applications into Docker, migrated "
+            "servers to Huawei Cloud, centralized automation with Ansible AWX."
+        ),
+        title="Curriculum (7/13)",
+        type_="reference",
+    )
+
+    before = len(_failure_patterns(mem))
+    res = negative_capture.capture_from_supersede(mem, superseded_id=a.id, superseding_id=b.id)
+
+    assert res["status"] == "skipped_origin"
+    assert len(_failure_patterns(mem)) == before

--- a/tests/test_proxy_cli.py
+++ b/tests/test_proxy_cli.py
@@ -165,3 +165,34 @@ def test_serve_without_the_http_extra_is_a_clean_cli_error(tmp_path, monkeypatch
     assert result.exit_code != 0
     assert "pip install" in result.output or "extra" in result.output.lower()
     assert "Traceback" not in result.output
+
+
+def test_serve_with_only_fastapi_missing_is_a_clean_cli_error(tmp_path, monkeypatch):
+    """The variant that actually happens on a default install.
+
+    `pip install mlx-memo` (no extras) still pulls uvicorn and httpx in
+    transitively via fastmcp — only `fastapi` is absent. The pre-existing
+    regression test blocks fastapi, uvicorn AND httpx, and blocking *uvicorn*
+    is what makes the guard fire, so it passed over a configuration that
+    cannot occur while the one that always occurs went untested.
+
+    `build_app` imports fastapi lazily and was called OUTSIDE the try, so the
+    ImportError escaped the guard: the launchd agent died with a raw
+    ModuleNotFoundError and crashlooped, while `install.sh` reported the proxy
+    as installed and working.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "fastapi" or name.startswith("fastapi."):
+            raise ImportError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    result = CliRunner().invoke(proxy_group, ["serve"], env=_env(tmp_path))
+    assert result.exit_code != 0
+    assert "pip install" in result.output or "extra" in result.output.lower()
+    assert "Traceback" not in result.output
+    assert "ModuleNotFoundError" not in result.output

--- a/tests/test_proxy_wiring.py
+++ b/tests/test_proxy_wiring.py
@@ -191,3 +191,58 @@ def test_install_proxy_raises_when_the_listener_never_comes_up(tmp_path, monkeyp
     with pytest.raises(RuntimeError, match="never answered"):
         launchd.install_proxy("/usr/bin/memo", tmp_path, port=8768)
     assert wired == [], "settings.json must not be touched when the proxy never came up"
+
+
+def test_install_proxy_wires_the_client_once_the_listener_answers(tmp_path, monkeypatch):
+    """The success half of the gate: a proxy that came up DOES get wired,
+    and at the port it was actually installed on."""
+    import memo.ops_launchd as launchd
+
+    monkeypatch.setattr(launchd, "_port_owner", lambda _p: None)
+    monkeypatch.setattr(launchd, "_label_loaded", lambda _l: False)
+    monkeypatch.setattr(
+        launchd.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=0, stderr="")
+    )
+    monkeypatch.setattr(launchd, "wait_until_listening", lambda *a, **k: True)
+    seen: dict = {}
+    monkeypatch.setattr(
+        launchd.proxy_wiring,
+        "wire",
+        lambda claude_dir, port: seen.update(dir=claude_dir, port=port),
+    )
+
+    path = launchd.install_proxy("/usr/bin/memo", tmp_path, port=9123)
+
+    assert path.exists()
+    assert seen["port"] == 9123
+    assert seen["dir"] == tmp_path / ".claude"
+
+
+def test_proxy_serve_serves_the_app_build_app_returned(tmp_path, monkeypatch):
+    """`uvicorn.run` must receive the object `build_app` produced.
+
+    This is the line the fix moved: `build_app(upstream)` used to be
+    evaluated in the argument list, outside the ImportError guard. Pinning
+    that uvicorn is handed exactly that object keeps the guard from being
+    "fixed" back into an inline call.
+    """
+    import sys
+
+    import click.testing
+
+    from memo import cli_proxy
+
+    sentinel = object()
+    calls: dict = {}
+
+    fake_uvicorn = SimpleNamespace(run=lambda app, **kw: calls.update(app=app, **kw))
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+    monkeypatch.setattr("memo.proxy.server.build_app", lambda upstream: sentinel)
+
+    res = click.testing.CliRunner().invoke(
+        cli_proxy.proxy_group, ["serve", "--port", "9124"], env={"MEMO_NONINTERACTIVE": "1"}
+    )
+
+    assert res.exit_code == 0, res.output
+    assert calls["app"] is sentinel
+    assert calls["port"] == 9124

--- a/tests/test_proxy_wiring.py
+++ b/tests/test_proxy_wiring.py
@@ -6,6 +6,9 @@ that from happening by accident."""
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
+
+import pytest
 
 from memo.proxy_wiring import settings_path, unwire, wire, wired_port
 
@@ -141,3 +144,50 @@ def test_ops_install_proxy_defaults_to_the_proxy_port_not_the_chat_one(monkeypat
     res = click.testing.CliRunner().invoke(cli_ops.ops_group, ["install", "proxy"])
     assert res.exit_code == 0, res.output
     assert seen["port"] == 8768
+
+
+def test_ops_install_proxy_reports_failure_when_the_agent_never_answers(monkeypatch):
+    """The installer must not claim success for a proxy that did not start.
+
+    `install_proxy` bootstraps the agent and then gates the settings.json
+    wiring on `wait_until_listening`. That gate correctly protects the client
+    -- ANTHROPIC_BASE_URL is never written at a dead port -- but nothing told
+    the CALLER, so `memo ops install proxy` exited 0 and install.sh printed
+    "proxy installed — Claude Code now routes through it" over a launchd agent
+    that was crashlooping. A silent half-failure is worse than a loud one: the
+    user has no reason to look.
+    """
+    import click.testing
+
+    from memo import cli_ops
+
+    monkeypatch.setattr(
+        "memo.ops_launchd.install_proxy",
+        lambda *a, **k: (_ for _ in ()).throw(
+            RuntimeError("proxy agent bootstrapped but never answered on 127.0.0.1:8768")
+        ),
+    )
+    monkeypatch.setattr("shutil.which", lambda _n: "/usr/bin/memo")
+    res = click.testing.CliRunner().invoke(cli_ops.ops_group, ["install", "proxy"])
+    assert res.exit_code != 0
+    assert "never answered" in res.output
+    assert "Traceback" not in res.output
+
+
+def test_install_proxy_raises_when_the_listener_never_comes_up(tmp_path, monkeypatch):
+    """The unit behind it: a bootstrap that 'succeeded' but produced no
+    listener is a failed install, not a quiet one."""
+    import memo.ops_launchd as launchd
+
+    monkeypatch.setattr(launchd, "_port_owner", lambda _p: None)
+    monkeypatch.setattr(launchd, "_label_loaded", lambda _l: False)
+    monkeypatch.setattr(
+        launchd.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=0, stderr="")
+    )
+    monkeypatch.setattr(launchd, "wait_until_listening", lambda *a, **k: False)
+    wired = []
+    monkeypatch.setattr(launchd.proxy_wiring, "wire", lambda *a, **k: wired.append(a) or True)
+
+    with pytest.raises(RuntimeError, match="never answered"):
+        launchd.install_proxy("/usr/bin/memo", tmp_path, port=8768)
+    assert wired == [], "settings.json must not be touched when the proxy never came up"


### PR DESCRIPTION
An exhaustive audit ran after 4.14.0 shipped — six independent readers, each finding adversarially refuted before it counted. 8 items confirmed, 7 refuted. This PR closes five of them.

## The one that matters: the default install could not run the proxy

The proxy went default-on in #284, and had never worked on a default install.

`install.sh` installs `mlx-memo` with no extras; `fastapi` lives only in `[http]`. Verified against the **published artifact**, in clean venvs:

```
$ uv pip install 'mlx-memo==4.14.0' && python -c "import fastapi"
ModuleNotFoundError: No module named 'fastapi'
$ python -c "import uvicorn, httpx"      # present — they arrive via fastmcp
$ uv pip install 'mlx-memo[http]==4.14.0' && python -c "from memo.proxy.server import build_app; print(type(build_app('https://api.anthropic.com')).__name__)"
FastAPI
```

Three failures lined up:

1. **The dependency** — `PYPI_SPEC` is now `mlx-memo[http]`. Pillow deliberately not promoted: `pixel.py` catches its ImportError and degrades to None by design.
2. **The guard that did not guard** — `proxy_serve` wrapped its imports in `try/except ImportError` but called `build_app()` *outside* it, and `build_app` is where fastapi is imported lazily. The clean "needs the `[http]` extra" message could never fire for the one dependency that is ever missing.
3. **The test that tested the impossible case** — the existing regression test blocked fastapi, uvicorn **and** httpx, and blocking *uvicorn* is what made the guard fire. Green over a configuration that cannot occur, silent about the one that always does.

Blast radius was contained by the listener gate from #284: `ANTHROPIC_BASE_URL` is never written at a dead port, so Claude Code kept working. The result was a dead feature and a launchd crashloop, not an outage. But `install_proxy` told the caller nothing, so `memo ops install proxy` exited 0 and the installer printed *"proxy installed — Claude Code now routes through it"*. It now raises.

## The rest

| Fix | Why it mattered |
|---|---|
| **`maintain` exits 1 on a vanished source file** | Nightly contradict-resolve reported FAILED on 08-14/15/16 and all three runs today, with the work actually done. 4119 vault-ingested rows have unresolvable paths permanently. An exit code that is always red teaches the operator to stop reading it. Now filed under `skipped`; real errors still fail the run. Verified on the real corpus: exit 0, errors 0, skipped 1, still 3 superseded / 7 merged / 148 reconciled. |
| **`capture_from_supersede` ignored `_SKIP_ORIGIN_TYPES`** | The module says "an anti-memory OF an anti-memory is nonsense"; only one of its two entry paths enforced it. Live corpus had memories titled *"Avoid reverting to: Avoid reverting to: X"*, and one ingested CV produced a "failure pattern" whose Wrong and Right were two jobs in the same work history. These surface in the ⛔ AVOID block — a future session is handed self-referential noise, or a stranger's résumé, as a lesson to obey. |
| **`mutation-tests` red for three weeks** | Every scheduled run since 08-09 crashed with `unexpected key(s): hash_by_function_name` while the signal was perfect (1377/1377 killed). A dependabot bump to mutmut 3.7.0 introduced the key. Not urgent by gating (not a required check); urgent by attention — "the gate crashed" looks exactly like "mutants survived". |
| **README described a removed feature** | Still documented `memo roi`'s estimated savings and its hardcoded constants, which 4.14.0 deleted precisely because that was a claim memo could not support. |

## Verification

8038 passing before this branch's test updates; the two `test_install_script` failures were the *correct* tests catching the spec change and were updated with the reason. mypy clean over 541 files, ruff clean over 1380, quality gate passing, `bash -n install.sh` clean, retrieval unchanged (prec@k 0.642 vs 0.642, same corpus, both uncached).

## Not fixed here, deliberately

The underlying path-resolution gap behind the `maintain` skips. Making those 4119 rows resolvable means teaching the resolver about Obsidian vault roots — a larger change, and memo rewriting files inside a user's vault is not obviously desirable. Recorded rather than quietly patched over.
