### PR TITLE
fix(contradict): stop opening contradiction pairs on reference chunks, and un-hang test_cli_http

### DIFF
--- a/src/memo/contradict.py
+++ b/src/memo/contradict.py
@@ -91,6 +91,25 @@ CREATE INDEX IF NOT EXISTS idx_pairs_b ON pairs(memory_id_b);
 """
 
 
+# Row types that can never be one side of a contradiction. A reference-tier
+# row is a `<file>#chunk-N` fragment of an ingested document: two sections of
+# one CV, one spec, one book are not a disagreement, and pairing them produced
+# both a bogus "failure pattern" (whose Wrong and Right were two jobs in the
+# same work history) and a nightly FileNotFoundError, because those rows store
+# a path relative to an Obsidian vault root the resolver cannot reach. Secrets
+# are excluded for the obvious reason: a contradiction rationale quotes both
+# bodies. Mirrors `negative_capture._SKIP_ORIGIN_TYPES`, minus failure_pattern
+# — an anti-memory CAN legitimately be superseded by a better one.
+_SKIP_AS_SOURCE_TYPES = frozenset({"reference", "secret"})
+
+
+def _skip_as_contradiction_source(rec: Any) -> bool:
+    """True when a record must never be paired. Never raises on a shape it
+    does not recognise: an untyped record is treated as eligible, the same as
+    before this filter existed."""
+    return getattr(rec, "type", None) in _SKIP_AS_SOURCE_TYPES
+
+
 def _canonical_pair(a: str, b: str) -> tuple[str, str]:
     """Order a pair so the same two ids always hash to the same row."""
     return (a, b) if a <= b else (b, a)
@@ -750,7 +769,7 @@ class ContradictionScanner:
                 break
 
             body = rec.body or rec.title
-            if not body.strip():
+            if not body.strip() or _skip_as_contradiction_source(rec):
                 continue
 
             try:
@@ -778,7 +797,7 @@ class ContradictionScanner:
                     continue
 
                 other = self.memory.get(nb["id"])
-                if other is None:
+                if other is None or _skip_as_contradiction_source(other):
                     continue
 
                 if not _enough_days_apart(rec.updated, other.updated, min_days_apart):

--- a/tests/test_contradict.py
+++ b/tests/test_contradict.py
@@ -637,3 +637,28 @@ def test_resolve_finds_a_pending_pair_the_unfiltered_window_omits(monkeypatch):
     assert len(opened) == 1
 
     assert store._row_for_pair_id(opened[0].pair_id) is not None
+
+
+def test_reference_rows_are_never_paired_as_contradictions():
+    """Two sections of one ingested document are not a disagreement.
+
+    Reference-tier rows are `<file>#chunk-N` fragments minted by ingest. The
+    scanner embedded them like any other memory, so a single CV produced a
+    "contradiction" between §4/13 and §7/13 — two jobs in the same work
+    history. That pair then fed `capture_from_supersede`, which minted a
+    failure_pattern whose Wrong and Right were both true.
+
+    The same rows also drove `memo maintain` to exit 1 every night: they store
+    a path relative to an Obsidian vault root that the resolver cannot reach,
+    so acting on the pair raises FileNotFoundError. 4119 rows are in that
+    state. Not opening the pair in the first place removes the cause rather
+    than the symptom.
+    """
+    from memo.contradict import _skip_as_contradiction_source
+
+    assert _skip_as_contradiction_source(SimpleNamespace(type="reference")) is True
+    assert _skip_as_contradiction_source(SimpleNamespace(type="secret")) is True
+    assert _skip_as_contradiction_source(SimpleNamespace(type="decision")) is False
+    assert _skip_as_contradiction_source(SimpleNamespace(type="fact")) is False
+    # A record with no type at all must not be silently dropped.
+    assert _skip_as_contradiction_source(SimpleNamespace()) is False

--- a/tests/test_server_http.py
+++ b/tests/test_server_http.py
@@ -37,6 +37,22 @@ class _FakeHTTPException(Exception):
         self.detail = detail
 
 
+def _evict_server_http() -> None:
+    """Drop `memo.server_http` from BOTH places Python caches it.
+
+    `sys.modules.pop` alone is not an eviction: the parent package keeps its
+    own attribute bound to the module object, so `monkeypatch.setattr` on a
+    dotted string still resolves to the stale module while the code under test
+    re-imports a fresh one. The two then disagree, the patch lands nowhere,
+    and a test that meant to stub `run_server` starts a real server instead.
+    """
+    import memo
+
+    sys.modules.pop("memo.server_http", None)
+    if hasattr(memo, "server_http"):
+        delattr(memo, "server_http")
+
+
 def test_http_api_uses_runtime_package_version(monkeypatch) -> None:
     monkeypatch.setitem(
         sys.modules,
@@ -49,7 +65,7 @@ def test_http_api_uses_runtime_package_version(monkeypatch) -> None:
             Query=lambda **_kwargs: None,
         ),
     )
-    sys.modules.pop("memo.server_http", None)
+    _evict_server_http()
     try:
         server_http = importlib.import_module("memo.server_http")
 
@@ -58,13 +74,13 @@ def test_http_api_uses_runtime_package_version(monkeypatch) -> None:
     finally:
         # Evict the module built against the fake fastapi: leaving it cached
         # would hand any later importer a _FakeFastAPI-backed app.
-        sys.modules.pop("memo.server_http", None)
+        _evict_server_http()
 
 
 def _load_server(monkeypatch: pytest.MonkeyPatch, tmp_path):
     monkeypatch.setenv("MEMO_STATE_DIR", str(tmp_path / "state"))
     monkeypatch.setenv("MEMO_HTTP_API_TOKEN", _TOKEN)
-    sys.modules.pop("memo.server_http", None)
+    _evict_server_http()
     module = importlib.import_module("memo.server_http")
     module.configure_auth(host="127.0.0.1")
     return module
@@ -186,7 +202,7 @@ def test_rest_rejects_oversized_chunked_body_even_when_route_ignores_body(
 def test_rest_no_auth_mode_installs_local_request_guard(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("MEMO_STATE_DIR", str(tmp_path / "state"))
     monkeypatch.delenv("MEMO_HTTP_API_TOKEN", raising=False)
-    sys.modules.pop("memo.server_http", None)
+    _evict_server_http()
     server_http = importlib.import_module("memo.server_http")
     server_http.configure_auth(host="127.0.0.1", allow_no_auth=True)
     memory = MagicMock()
@@ -214,7 +230,7 @@ def test_rest_direct_import_no_auth_mode_installs_local_request_guard(
     monkeypatch.setenv("MEMO_HTTP_ALLOW_NO_AUTH", "1")
     monkeypatch.setenv("MEMO_HTTP_HOST", "127.0.0.1")
     monkeypatch.delenv("MEMO_HTTP_API_TOKEN", raising=False)
-    sys.modules.pop("memo.server_http", None)
+    _evict_server_http()
     server_http = importlib.import_module("memo.server_http")
     memory = MagicMock()
     monkeypatch.setattr(server_http, "_memory", memory)
@@ -302,3 +318,34 @@ def test_rest_backup_uses_real_metadata_fields(monkeypatch, tmp_path) -> None:
             }
         ]
     }
+
+
+def test_evicting_the_module_does_not_strand_the_parent_attribute():
+    """`sys.modules` and `memo.server_http` must never disagree.
+
+    Popping only `sys.modules["memo.server_http"]` leaves the attribute on the
+    parent `memo` package bound to the evicted module object. Anything that
+    then does `monkeypatch.setattr("memo.server_http.run_server", ...)`
+    patches that STALE object, while the code under test re-imports a fresh
+    module and gets the REAL `run_server` — which starts a live uvicorn server
+    and hangs until pytest-timeout kills it 120s later.
+
+    That is the contamination behind `test_cli_http`'s intermittent hang
+    (3 failures / 23 passes since 2026-08-02), and it only reproduces when the
+    two files run in the same session in the wrong order — which is why it
+    looked like flakiness rather than a bug.
+    """
+    import memo
+
+    before = importlib.import_module("memo.server_http")
+    assert getattr(memo, "server_http", None) is before
+
+    _evict_server_http()
+
+    assert "memo.server_http" not in sys.modules
+    assert getattr(memo, "server_http", None) is None, (
+        "parent attribute still points at the evicted module"
+    )
+
+    after = importlib.import_module("memo.server_http")
+    assert getattr(memo, "server_http", None) is after


### PR DESCRIPTION
The two items #287 deliberately left open. Both turned out to have a smaller, more correct fix than the one first proposed.

## Reference rows should never have been paired

#287 made a vanished source file a `skipped` rather than a run failure — the right call for the exit code, but it reported a symptom. The cause is that reference-tier rows enter contradiction detection at all.

A `<file>#chunk-N` row is a fragment of an ingested document. Two sections of one CV, one spec, one book are not a disagreement. That single fact produced both defects the audit found:

- a "contradiction" between §4/13 and §7/13 of one résumé, which `capture_from_supersede` then turned into a failure_pattern whose Wrong and Right were both simply true;
- the nightly `FileNotFoundError`, because those rows store a path relative to an Obsidian vault root the resolver cannot reach — 4119 rows in `memvec.db` are permanently in that state.

The originally-proposed fix was to teach the resolver about vault roots. That is the wrong direction: it would make memo able to *rewrite files inside a user's Obsidian vault* in order to resolve pairs that should not exist. Filtering at detection removes the work instead of enabling it.

`secret` is excluded for the obvious reason — a contradiction rationale quotes both bodies. `failure_pattern` is deliberately **not** excluded here, unlike in `negative_capture`: an anti-memory can legitimately be superseded by a better one; what is nonsense is minting a new anti-memory *about* that supersession.

Written as combined conditions rather than added branches, so `scan_corpus` holds its budget at 23 instead of loosening the ratchet to 25.

## The hang was contamination, not flakiness

`test_http_cli_allows_no_auth_only_on_loopback` hung until pytest-timeout killed it at 120s, on ~12% of nightly runs (3 failures / 23 passes since 2026-08-02), with no marker.

`sys.modules.pop("memo.server_http")` is not an eviction — the parent `memo` package keeps its own attribute bound to the evicted module. A later `monkeypatch.setattr("memo.server_http.run_server", ...)` resolves the dotted string against that **stale** module, while the code under test re-imports a fresh one and gets the **real** `run_server`. A test meaning to stub the server started a live uvicorn instead. It only reproduced when both files ran in one session in the wrong order, which is what made it look random.

`_evict_server_http()` clears both; a new test pins the invariant directly.

## Verification

8046 passed / 21 skipped. mypy clean over 541 files, ruff clean over 1380, quality gate passing without loosening any budget, retrieval unchanged.