### PR TITLE
fix(proxy): a shrunk tool_result no longer deletes its image, and 1h cache writes bill at 2x

### DIFF
--- a/src/memo/cli_tokens.py
+++ b/src/memo/cli_tokens.py
@@ -161,8 +161,9 @@ def _proxy_panel(proxy: dict) -> Panel:
         colour = "green" if frac >= 0 else "red"
         verb = "saved" if frac >= 0 else "cost"
         # The headline is now a weighted PROMPT COST ratio (input_tokens +
-        # 1.25x cache-creation + 0.1x cache-read — see meter.py's weight
-        # constants), not a bare input_tokens ratio: real traffic bills
+        # cache-creation weighted BY TIER, 1.25x for a 5m write and 2x for a
+        # 1h one, + 0.1x cache-read — see meter.py's weight constants), not a
+        # bare input_tokens ratio: real traffic bills
         # almost the whole prompt through the two cache counters, so
         # input_tokens alone is a ratio of noise. The raw input_tokens
         # means stay visible alongside it.

--- a/src/memo/proxy/meter.py
+++ b/src/memo/proxy/meter.py
@@ -23,7 +23,7 @@ _HOLDOUT_BUCKETS = 10_000
 # Weights that turn the three Messages-API usage counters into one
 # "prompt cost" in token-equivalents, from Anthropic's prompt-caching
 # pricing (https://docs.claude.com/en/docs/build-with-claude/prompt-caching,
-# 5-minute cache tier, the default): an uncached input token bills at the
+# by tier -- 5m writes at 1.25x, 1h writes at 2x): an uncached input token bills at the
 # base rate (1x); writing a new block into the cache costs a one-time
 # CACHE_CREATION_WEIGHT premium; reading a block already in the cache costs
 # only CACHE_READ_WEIGHT. `input_tokens` alone is the UNCACHED REMAINDER
@@ -34,6 +34,13 @@ _HOLDOUT_BUCKETS = 10_000
 # (e.g. `toolschemas`, zone=ZONE_PREFIX) edits the cached HEAD and so its
 # entire effect lands in the two counters that ratio ignores.
 CACHE_CREATION_WEIGHT = 1.25
+# A 1-hour cache write bills at 2x base input, not 1.25x. This is not an edge
+# case: measured on this machine's own traffic, 15,543,652 tokens were written
+# at the 1h tier and ZERO at 5m, so weighting every write at 1.25 understated
+# the cache-creation term for 100% of observed requests. The tier is the
+# CLIENT's choice (the proxy never touches cache_control), so both weights
+# have to exist and the row has to say which one applies.
+CACHE_CREATION_1H_WEIGHT = 2.0
 CACHE_READ_WEIGHT = 0.1
 
 
@@ -52,6 +59,11 @@ class Record:
     input_tokens: int = 0
     output_tokens: int = 0
     cache_creation_tokens: int = 0
+    # Per-tier split of the write above. Absent (0/0) on rows written before
+    # the tiers were recorded -- `_prompt_cost` falls back to the 5m weight
+    # for those rather than inventing a tier for history it cannot see.
+    cache_creation_5m_tokens: int = 0
+    cache_creation_1h_tokens: int = 0
     cache_read_tokens: int = 0
     retrieved: int = 0
     # Per-transform share of est_saved_tokens (from TransformPlan.saved_by) —
@@ -87,10 +99,23 @@ def usage_from_response(body: dict) -> dict[str, int]:
         value = usage.get(key)
         return value if isinstance(value, int) else 0
 
+    # The Messages API reports the cache-write total flat AND broken down by
+    # tier. Record both: the flat field stays the authoritative total (it is
+    # exactly the sum of the tiers), while the breakdown is what lets
+    # `_prompt_cost` bill a 1h write at 2x instead of assuming 1.25x.
+    breakdown = usage.get("cache_creation")
+    breakdown = breakdown if isinstance(breakdown, dict) else {}
+
+    def _tier(key: str) -> int:
+        value = breakdown.get(key)
+        return value if isinstance(value, int) else 0
+
     return {
         "input_tokens": _int("input_tokens"),
         "output_tokens": _int("output_tokens"),
         "cache_creation_tokens": _int("cache_creation_input_tokens"),
+        "cache_creation_5m_tokens": _tier("ephemeral_5m_input_tokens"),
+        "cache_creation_1h_tokens": _tier("ephemeral_1h_input_tokens"),
         "cache_read_tokens": _int("cache_read_input_tokens"),
     }
 
@@ -174,9 +199,18 @@ def _mean(rows: list[dict], key: str) -> float | None:
 def _prompt_cost(row: dict) -> float:
     """One row's whole prompt, in token-equivalents -- see the module's weight
     constants for where CACHE_CREATION_WEIGHT/CACHE_READ_WEIGHT come from."""
+    total_write = _num(row, "cache_creation_tokens")
+    tier_1h = _num(row, "cache_creation_1h_tokens")
+    tier_5m = _num(row, "cache_creation_5m_tokens")
+    # Anything the breakdown does not account for keeps the 5m weight: an
+    # older row has no tiers at all, and guessing one for it would turn a
+    # uniform bias into a time-dependent confound in the very arm comparison
+    # this ledger exists to compute.
+    untiered = max(0, total_write - tier_1h - tier_5m)
     return (
         _num(row, "input_tokens")
-        + CACHE_CREATION_WEIGHT * _num(row, "cache_creation_tokens")
+        + CACHE_CREATION_1H_WEIGHT * tier_1h
+        + CACHE_CREATION_WEIGHT * (tier_5m + untiered)
         + CACHE_READ_WEIGHT * _num(row, "cache_read_tokens")
     )
 

--- a/src/memo/proxy/transforms/delta.py
+++ b/src/memo/proxy/transforms/delta.py
@@ -49,6 +49,12 @@ from memo.flags import flag_bool
 from memo.mcp_budget import est_tokens
 from memo.proxy import ccr
 from memo.proxy.plan import ZONE_LIVE, Context
+
+# `_set_block_text` is imported, not re-implemented: three identical copies
+# existed and all three deleted any image or document block travelling with
+# the text. One canonical version lives in the module that owns tool_result
+# rewriting.
+from memo.proxy.transforms.toolresults import _set_block_text
 from memo.proxy.zones import Zones, whole_history_scope
 
 _log = logging.getLogger(__name__)
@@ -129,13 +135,6 @@ def _block_text(block: dict) -> str:
         ]
         return "\n".join(parts)
     return ""
-
-
-def _set_block_text(block: dict, text: str) -> None:
-    if isinstance(block.get("content"), list):
-        block["content"] = [{"type": "text", "text": text}]
-    else:
-        block["content"] = text
 
 
 def _read_tool_paths(messages: list) -> dict[str, str]:

--- a/src/memo/proxy/transforms/jsoncrush.py
+++ b/src/memo/proxy/transforms/jsoncrush.py
@@ -71,6 +71,12 @@ from typing import Any
 from memo.flags import flag_bool
 from memo.mcp_budget import est_tokens
 from memo.proxy.plan import ZONE_LIVE, Context
+
+# `_set_block_text` is imported, not re-implemented: three identical copies
+# existed and all three deleted any image or document block travelling with
+# the text. One canonical version lives in the module that owns tool_result
+# rewriting.
+from memo.proxy.transforms.toolresults import _set_block_text
 from memo.proxy.zones import Zones, scan_scope
 
 _log = logging.getLogger(__name__)
@@ -126,13 +132,6 @@ def _block_text(block: dict) -> str:
         ]
         return "\n".join(parts)
     return ""
-
-
-def _set_block_text(block: dict, text: str) -> None:
-    if isinstance(block.get("content"), list):
-        block["content"] = [{"type": "text", "text": text}]
-    else:
-        block["content"] = text
 
 
 class JsonCrush:

--- a/src/memo/proxy/transforms/toolresults.py
+++ b/src/memo/proxy/transforms/toolresults.py
@@ -475,10 +475,38 @@ def _block_text(block: dict) -> str:
 
 
 def _set_block_text(block: dict, text: str) -> None:
-    if isinstance(block.get("content"), list):
-        block["content"] = [{"type": "text", "text": text}]
-    else:
+    """Write the rewritten text back, KEEPING every non-text block.
+
+    This used to assign ``[{"type": "text", ...}]`` over the whole content
+    list, which silently deleted any image or document travelling with the
+    text -- and unlike every other cut in this package, that one had no way
+    back: ``_rewrite_block`` stashes the joined TEXT for CCR, so
+    ``memo_crush_retrieve`` cannot return the base64. The model never saw the
+    screenshot it asked for, and nothing said so.
+
+    The trigger is ordinary, not exotic: Claude Code's own ``Read`` of a
+    .ipynb returns cells as text PLUS the figure as an image, and a notebook
+    with one matplotlib plot clears the 4000-char fallback threshold easily.
+
+    The replacement text takes the position of the FIRST text block, so a
+    picture that preceded the text stays in front of it.
+    """
+    content = block.get("content")
+    if not isinstance(content, list):
         block["content"] = text
+        return
+    rebuilt: list = []
+    placed = False
+    for part in content:
+        if isinstance(part, dict) and part.get("type") == "text":
+            if not placed:
+                rebuilt.append({"type": "text", "text": text})
+                placed = True
+            continue
+        rebuilt.append(part)
+    if not placed:
+        rebuilt.append({"type": "text", "text": text})
+    block["content"] = rebuilt
 
 
 class ToolResults:

--- a/tests/test_proxy_meter.py
+++ b/tests/test_proxy_meter.py
@@ -36,10 +36,14 @@ def test_usage_reads_all_four_provider_fields():
             "cache_read_input_tokens": 40,
         }
     }
+    # The two tier keys read 0 here because this body has no `cache_creation`
+    # breakdown -- the flat total is all the provider gave us.
     assert usage_from_response(body) == {
         "input_tokens": 10,
         "output_tokens": 20,
         "cache_creation_tokens": 30,
+        "cache_creation_5m_tokens": 0,
+        "cache_creation_1h_tokens": 0,
         "cache_read_tokens": 40,
     }
 
@@ -49,6 +53,8 @@ def test_usage_of_a_bodyless_response_is_all_zeroes():
         "input_tokens": 0,
         "output_tokens": 0,
         "cache_creation_tokens": 0,
+        "cache_creation_5m_tokens": 0,
+        "cache_creation_1h_tokens": 0,
         "cache_read_tokens": 0,
     }
 
@@ -434,3 +440,53 @@ def test_by_transform_against_a_real_registry_plan_not_a_hand_written_row(tmp_pa
         if name not in plan.saved_by:
             assert by[name]["est_saved_tokens"] == 0
             assert by[name]["share"] in (0.0, None)
+
+
+def test_cache_write_tiers_are_weighted_separately():
+    """A 1h cache write bills at 2.0x base input, a 5m write at 1.25x.
+
+    `usage_from_response` read only the flat `cache_creation_input_tokens`
+    and every write was weighted 1.25. Measured on this machine's real
+    traffic: 15,543,652 tokens written at the 1h tier and **zero** at 5m —
+    so the constant was wrong for 100% of observed writes, not for an edge
+    case. The module comment claiming "5-minute cache tier, the default" is
+    a true statement about the API and a false one about this traffic.
+    """
+    from memo.proxy.meter import usage_from_response
+
+    tiered = usage_from_response(
+        {
+            "usage": {
+                "input_tokens": 3,
+                "output_tokens": 7,
+                "cache_creation_input_tokens": 1000,
+                "cache_read_input_tokens": 50,
+                "cache_creation": {
+                    "ephemeral_5m_input_tokens": 400,
+                    "ephemeral_1h_input_tokens": 600,
+                },
+            }
+        }
+    )
+    assert tiered["cache_creation_tokens"] == 1000, "the flat total must still be recorded"
+    assert tiered["cache_creation_5m_tokens"] == 400
+    assert tiered["cache_creation_1h_tokens"] == 600
+
+    # No breakdown: the tier is unknown, and guessing one is what caused this.
+    flat = usage_from_response({"usage": {"cache_creation_input_tokens": 900}})
+    assert flat["cache_creation_tokens"] == 900
+    assert flat["cache_creation_5m_tokens"] == 0
+    assert flat["cache_creation_1h_tokens"] == 0
+
+
+def test_prompt_cost_bills_a_1h_write_at_double():
+    from memo.proxy.meter import _prompt_cost
+
+    row_1h = {"cache_creation_tokens": 100, "cache_creation_1h_tokens": 100}
+    row_5m = {"cache_creation_tokens": 100, "cache_creation_5m_tokens": 100}
+    untiered = {"cache_creation_tokens": 100}
+
+    assert _prompt_cost(row_1h) == 200.0
+    assert _prompt_cost(row_5m) == 125.0
+    # An untiered row keeps the old assumption rather than inventing a tier.
+    assert _prompt_cost(untiered) == 125.0

--- a/tests/test_proxy_toolresults.py
+++ b/tests/test_proxy_toolresults.py
@@ -481,3 +481,63 @@ def test_bracket_expressions_with_a_literal_close_bracket_are_not_false_positive
     (tmp_path / "f.yaml").write_text(_filter_yaml_with_pattern(pattern))
     filters = load_filters(tmp_path)
     assert len(filters) == 1, f"{pattern!r} was falsely rejected at load"
+
+
+def test_a_shrunk_tool_result_keeps_its_image_block(tmp_path):
+    """Cutting the text must not delete the picture.
+
+    `_set_block_text` replaced the whole `content` list with one text block,
+    so a tool_result carrying [text, image] lost the image. It is the only
+    cut in this package with NO recovery path: `_rewrite_block` stashes the
+    joined TEXT for CCR, so `memo_crush_retrieve` cannot bring the base64
+    back. The model simply never sees the screenshot it asked for, and
+    nothing anywhere says so.
+
+    Reproduced live: Claude Code's own `Read` of a .ipynb returns cells as
+    text PLUS the figure as an image, and any notebook with a matplotlib plot
+    clears the 4000-char fallback threshold easily. So the trigger is not
+    exotic multimodal MCP servers — it is reading a notebook.
+    """
+    from memo.proxy.transforms.toolresults import _set_block_text
+
+    image = {
+        "type": "image",
+        "source": {"type": "base64", "media_type": "image/png", "data": "iVBOR"},
+    }
+    doc = {"type": "document", "source": {"type": "text", "data": "d"}}
+    block = {"type": "tool_result", "content": [{"type": "text", "text": "x" * 9000}, image, doc]}
+
+    _set_block_text(block, "cut")
+
+    kinds = [b.get("type") for b in block["content"]]
+    assert kinds == ["text", "image", "document"], kinds
+    assert block["content"][0]["text"] == "cut"
+    assert block["content"][1] is image, "the image object itself must survive untouched"
+    assert block["content"][2] is doc
+
+
+def test_the_replacement_text_lands_where_the_first_text_block_was(tmp_path):
+    """Order matters: an image that preceded the text must stay in front of
+    it, or the model reads the result in the wrong sequence."""
+    from memo.proxy.transforms.toolresults import _set_block_text
+
+    image = {"type": "image", "source": {"data": "x"}}
+    block = {
+        "type": "tool_result",
+        "content": [image, {"type": "text", "text": "a"}, {"type": "text", "text": "b"}],
+    }
+
+    _set_block_text(block, "cut")
+
+    assert [b.get("type") for b in block["content"]] == ["image", "text"]
+    assert block["content"][0] is image
+    assert block["content"][1]["text"] == "cut"
+
+
+def test_a_string_content_block_is_still_replaced_wholesale(tmp_path):
+    """The non-list form has nothing to preserve."""
+    from memo.proxy.transforms.toolresults import _set_block_text
+
+    block = {"type": "tool_result", "content": "plain string"}
+    _set_block_text(block, "cut")
+    assert block["content"] == "cut"


### PR DESCRIPTION
Two findings from the QA that survived adversarial refutation. Both are measurement-or-data-loss bugs in shipped, on-by-default code.

## 1. Shrinking a tool_result deleted its image — silently and unrecoverably

`_set_block_text` assigned `[{"type": "text", ...}]` over the whole content list, so a tool_result carrying `[text, image]` lost the image the moment the text crossed the 4000-char fallback threshold.

Every other cut in this package is recoverable — `ccr.py` opens with *"nothing is cut without being recoverable"*. This one was not: `_rewrite_block` stashes the joined **text** for CCR, so `memo_crush_retrieve` returns the text and the base64 is gone.

**The trigger is ordinary.** Claude Code's own `Read` of a `.ipynb` returns cells as text **plus** figures as image blocks, and one matplotlib plot clears 4000 chars easily. Verified against a real captured tool_result from this machine's transcripts: before `['text','image']`, after `['text']`, image on the wire `False`.

Characterized before fixing, since the behaviour is shape-dependent:

| input | result |
|---|---|
| big text + image | **LOST** image |
| image + big text | **LOST** image (order irrelevant) |
| big text + image + document | **LOST** both |
| image only | safe (no text to rewrite) |
| short text + image | safe (under threshold) |
| big text + second text block | safe (join is lossless) |

Now only text blocks are replaced, collapsed to one at the position of the **first** of them, with every other block spliced back in original order.

Three byte-identical copies of the helper existed (toolresults, delta, jsoncrush) and all three had the bug; structmap already imported the toolresults one. Now they all do. Since two of those transforms ship off, worth stating the reachability: on a clean env the enabled set is toolschemas, delta, structmap, toolresults — and **both** structmap and toolresults use this helper, so the bug was live on the default configuration.

End-to-end through the real registry: text cut, blocks after `['text','image']`, image on the wire `True`.

No test anywhere asserted a pre-existing non-text block survives. The 42 existing toolresults tests were green and blind to it.

## 2. A 1-hour cache write billed at 1.25x instead of 2x

`_prompt_cost` weighted every cache-creation token at the 5-minute-tier multiplier. Measured on this machine's own transcripts: **15,543,652 tokens written at the 1h tier and zero at 5m** — so the constant was wrong for 100% of observed writes, not for an edge case. The module comment saying "5-minute cache tier, the default" is true about the API and false about the traffic, which is exactly how it went unnoticed; that comment and its twin in `cli_tokens.py` are corrected here.

`usage_from_response` now records the `cache_creation` tier breakdown the API already returns. Rows written before the tiers were recorded keep the 5m weight rather than having a tier guessed for them — assuming 2x for history would turn a uniform, self-cancelling bias into a time-dependent confound in the very treated-vs-holdout comparison the ledger exists to compute.

**Direction of the error:** the flat 1.25 *understated* the savings. Recomputed over this session's 764 pre-proxy and 1066 post-proxy cache-hit requests, the measured cut goes from 47.2% to **51.8%**.

## Verification

8051 passed / 21 skipped. mypy clean over 541 files, ruff clean over 1380, quality gate passing without loosening a budget, retrieval unchanged (prec@k 0.642 vs 0.642).