### PR TITLE
fix: report the real corpus total in aggregate proactive nudges

### DIFF
--- a/src/memo/memory/facade.py
+++ b/src/memo/memory/facade.py
@@ -53,6 +53,29 @@ from memo.temporal import TemporalAnalyzer
 
 _log = logging.getLogger(__name__)
 
+# Shared FROM/WHERE tails for the proactive-nudge reads below, so the capped
+# `*_ids` query and its uncapped `*_count` sibling can never drift apart and
+# report on two different populations.
+_LOW_CONFIDENCE_FROM = (
+    "FROM memory_health mh JOIN meta m ON m.id = mh.id "
+    "WHERE mh.confidence < ? AND (m.deleted_at IS NULL OR m.deleted_at = '')"
+)
+
+
+def _dead_memory_from(durable_types: frozenset[str]) -> str:
+    """FROM/WHERE tail for never-accessed durable memories.
+
+    Built rather than a constant because the `IN (...)` list needs one `?` per
+    durable type; the caller binds `durable_types` in the same order.
+    """
+    placeholders = ",".join("?" for _ in durable_types)
+    return (
+        "FROM meta m LEFT JOIN access a ON a.id = m.id "
+        "WHERE COALESCE(a.access_count, 0) = 0 "
+        f"AND m.type IN ({placeholders}) "
+        "AND (m.deleted_at IS NULL OR m.deleted_at = '')"
+    )
+
 
 class Memory(
     _WriteOpsMixin,
@@ -538,20 +561,28 @@ class Memory(
         (`MEMO_SOFT_DELETE` leaves `memory_health` rows around for up to 90
         days after `meta.deleted_at` is stamped — see `dead_memory_ids` for
         the same deleted-filter idiom) so a deleted memory never gets cited.
+
+        Capped by `limit`: pair with `low_confidence_count` when you need to
+        report how many there really are.
         """
         rows = self.store._conn.execute(
-            """
-            SELECT mh.id
-              FROM memory_health mh
-              JOIN meta m ON m.id = mh.id
-             WHERE mh.confidence < ?
-               AND (m.deleted_at IS NULL OR m.deleted_at = '')
-             ORDER BY mh.confidence ASC
-             LIMIT ?
-            """,
+            f"SELECT mh.id {_LOW_CONFIDENCE_FROM} ORDER BY mh.confidence ASC LIMIT ?",
             (threshold, limit),
         ).fetchall()
         return [str(r["id"]) for r in rows]
+
+    def low_confidence_count(self, *, threshold: float = 0.4) -> int:
+        """How many live memories sit below `threshold` — the uncapped total.
+
+        `low_confidence_ids` truncates to `limit`, so its length is the
+        evidence cap rather than the backlog; a nudge that reports `len(ids)`
+        silently understates a corpus with more than `limit` of them.
+        """
+        row = self.store._conn.execute(
+            f"SELECT count(*) AS n {_LOW_CONFIDENCE_FROM}",
+            (threshold,),
+        ).fetchone()
+        return int(row["n"]) if row else 0
 
     def dead_memory_ids(self, *, limit: int = 50) -> list[str]:
         """Durable memory ids with zero recorded access (`access` table).
@@ -559,24 +590,31 @@ class Memory(
         Never surfaced since creation — candidates the proactive ROI
         detector flags for pruning. Reference/secret types are excluded
         (only `tiers.DURABLE_TYPES` counts as a "dead" memory).
+
+        Capped by `limit`: pair with `dead_memory_count` when you need to
+        report how many there really are.
         """
         from memo.tiers import DURABLE_TYPES
 
-        placeholders = ",".join("?" for _ in DURABLE_TYPES)
         rows = self.store._conn.execute(
-            f"""
-            SELECT m.id
-              FROM meta m
-              LEFT JOIN access a ON a.id = m.id
-             WHERE COALESCE(a.access_count, 0) = 0
-               AND m.type IN ({placeholders})
-               AND (m.deleted_at IS NULL OR m.deleted_at = '')
-             ORDER BY m.created ASC
-             LIMIT ?
-            """,  # noqa: S608 — placeholders are '?' marks, not interpolated values
+            f"SELECT m.id {_dead_memory_from(DURABLE_TYPES)} ORDER BY m.created ASC LIMIT ?",
             (*DURABLE_TYPES, limit),
         ).fetchall()
         return [str(r["id"]) for r in rows]
+
+    def dead_memory_count(self) -> int:
+        """How many durable memories have never been surfaced — the real total.
+
+        `dead_memory_ids` truncates to `limit`, so on a corpus with thousands
+        of never-accessed memories its length reports the cap, not the backlog.
+        """
+        from memo.tiers import DURABLE_TYPES
+
+        row = self.store._conn.execute(
+            f"SELECT count(*) AS n {_dead_memory_from(DURABLE_TYPES)}",
+            tuple(DURABLE_TYPES),
+        ).fetchone()
+        return int(row["n"]) if row else 0
 
     def recurring_pattern_pairs(
         self, *, limit: int = 5, min_count: int = 2

--- a/src/memo/proactive/detectors/_totals.py
+++ b/src/memo/proactive/detectors/_totals.py
@@ -1,0 +1,33 @@
+"""Best-effort corpus totals for aggregate nudges.
+
+An aggregate detector cites at most `limit` ids as evidence, so `len(ids)` is
+the evidence cap — not how many there are. These detectors read the real count
+from a separate facade query, but `mem` is duck-typed (`Any`): a source that
+predates the count method must still get its nudge rather than lose it to the
+detector's outer guard. Hence this narrower fallback, called from *inside* that
+guard so anything unforeseen still degrades to no nudge instead of raising.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from collections.abc import Callable
+
+_log = logging.getLogger(__name__)
+
+
+def total_or(count: Callable[[], int], fallback: int) -> int:
+    """`count()`, or `fallback` when the source can't answer.
+
+    Catches the three ways a duck-typed source fails to produce a count — no
+    such method (`AttributeError`), a different signature or a non-numeric
+    return (`TypeError`/`ValueError`), or the underlying store erroring
+    (`sqlite3.Error`) — because the count only sharpens a nudge's wording and
+    must never cost the nudge itself.
+    """
+    try:
+        return int(count())
+    except (AttributeError, TypeError, ValueError, sqlite3.Error) as exc:
+        _log.debug("proactive: corpus count unavailable (%s)", exc)
+        return fallback

--- a/src/memo/proactive/detectors/health.py
+++ b/src/memo/proactive/detectors/health.py
@@ -1,8 +1,10 @@
 """Health detector — low-confidence memories as an aggregate nudge.
 
-Emits ONE `KIND_HEALTH` `Nudge` citing every low-confidence memory, sourced
-from `mem.low_confidence_ids()`. Guarded: any exception returns `[]` — this
-detector must never sink a proactive-surface call.
+Emits ONE `KIND_HEALTH` `Nudge` for low-confidence memories, sourced from
+`mem.low_confidence_ids()`. Evidence is capped at `limit` ids while the title
+reports the real corpus total (`mem.low_confidence_count()`). Guarded: any
+exception returns `[]` — this detector must never sink a proactive-surface
+call.
 """
 
 from __future__ import annotations
@@ -11,6 +13,7 @@ import logging
 from typing import Any
 
 from ..nudge import KIND_HEALTH, Nudge
+from ._totals import total_or
 
 _log = logging.getLogger(__name__)
 
@@ -18,6 +21,7 @@ _log = logging.getLogger(__name__)
 def detect_health(mem: Any, *, now: str, limit: int = 10) -> list[Nudge]:
     try:
         ids = mem.low_confidence_ids(threshold=0.4, limit=limit)
+        total = total_or(lambda: mem.low_confidence_count(threshold=0.4), len(ids))
     except Exception as exc:  # guarded — never sink a surface
         _log.debug("proactive.health failed: %s", exc)
         return []
@@ -29,7 +33,7 @@ def detect_health(mem: Any, *, now: str, limit: int = 10) -> list[Nudge]:
             subject_id="low-confidence",
             urgency=0.2,
             value=0.5,
-            title=f"{len(ids)} low-confidence memories — worth reviewing",
+            title=f"{total} low-confidence memories — worth reviewing",
             evidence=tuple(ids),
             action="memo maintain",
             created_at=now,

--- a/src/memo/proactive/detectors/roi.py
+++ b/src/memo/proactive/detectors/roi.py
@@ -1,7 +1,9 @@
 """ROI detector — dead memories (never accessed) as an aggregate nudge.
 
-Emits ONE `KIND_ROI` `Nudge` citing every durable memory with zero recorded
-access, sourced from `mem.dead_memory_ids()`. Guarded: any exception returns
+Emits ONE `KIND_ROI` `Nudge` for durable memories with zero recorded access,
+sourced from `mem.dead_memory_ids()`. Evidence is capped at `limit` ids while
+the title reports the real corpus total (`mem.dead_memory_count()`), so a
+backlog of thousands never renders as the cap. Guarded: any exception returns
 `[]` — this detector must never sink a proactive-surface call.
 """
 
@@ -11,6 +13,7 @@ import logging
 from typing import Any
 
 from ..nudge import KIND_ROI, Nudge
+from ._totals import total_or
 
 _log = logging.getLogger(__name__)
 
@@ -18,6 +21,7 @@ _log = logging.getLogger(__name__)
 def detect_roi(mem: Any, *, now: str, limit: int = 10) -> list[Nudge]:
     try:
         ids = mem.dead_memory_ids(limit=limit)
+        total = total_or(lambda: mem.dead_memory_count(), len(ids))
     except Exception as exc:  # guarded — never sink a surface
         _log.debug("proactive.roi failed: %s", exc)
         return []
@@ -29,7 +33,7 @@ def detect_roi(mem: Any, *, now: str, limit: int = 10) -> list[Nudge]:
             subject_id="dead-memories",
             urgency=0.1,
             value=0.4,
-            title=f"{len(ids)} memories never surfaced — candidates to prune",
+            title=f"{total} memories never surfaced — candidates to prune",
             evidence=tuple(ids),
             created_at=now,
         )

--- a/tests/test_proactive_health.py
+++ b/tests/test_proactive_health.py
@@ -53,3 +53,40 @@ def test_low_confidence_ids_excludes_soft_deleted_memory(mock_memory):
     ids = mock_memory.low_confidence_ids(threshold=0.4)
 
     assert rec.id not in ids
+
+
+def test_health_title_reports_the_true_total_not_the_evidence_cap():
+    """Same truncation bug as the ROI detector: `len(ids)` is the evidence cap,
+    not the corpus count, so the title understated a large backlog."""
+
+    class _TruncatedMem:
+        def low_confidence_ids(self, *, threshold, limit):
+            return [f"low{i}" for i in range(limit)]
+
+        def low_confidence_count(self, *, threshold):
+            return 42
+
+    n = detect_health(_TruncatedMem(), now="2026-07-21T00:00:00Z", limit=10)[0]
+
+    assert "42 low-confidence" in n.title
+    assert len(n.evidence) == 10
+
+
+def test_health_falls_back_to_evidence_length_when_count_is_unavailable():
+    class _NoCountMem:
+        def low_confidence_ids(self, *, threshold, limit):
+            return ["low1", "low2"]
+
+    n = detect_health(_NoCountMem(), now="2026-07-21T00:00:00Z")[0]
+
+    assert "2 low-confidence" in n.title
+
+
+def test_real_facade_low_confidence_count_matches_unlimited_ids(mock_memory):
+    for i in range(3):
+        rec = mock_memory.save(content=f"shaky note {i}", type_="note")
+        mock_memory.store.set_confidence_batch([(rec.id, 0.2)])
+
+    assert mock_memory.low_confidence_count(threshold=0.4) == len(
+        mock_memory.low_confidence_ids(threshold=0.4, limit=999)
+    )

--- a/tests/test_proactive_roi.py
+++ b/tests/test_proactive_roi.py
@@ -39,3 +39,42 @@ def test_real_facade_dead_memory_ids_finds_never_accessed_durable_memory(mock_me
     ids = mock_memory.dead_memory_ids()
 
     assert rec.id in ids
+
+
+def test_roi_title_reports_the_true_total_not_the_evidence_cap():
+    """The title used to report `len(ids)`, which equals `limit` whenever the
+    corpus has more dead memories than the evidence cap — so a corpus with
+    1645 never-surfaced memories rendered as "10 memories never surfaced".
+    Evidence stays capped; the count must be the real one."""
+
+    class _TruncatedMem:
+        def dead_memory_ids(self, *, limit):
+            return [f"dead{i}" for i in range(limit)]
+
+        def dead_memory_count(self):
+            return 1645
+
+    n = detect_roi(_TruncatedMem(), now="2026-07-21T00:00:00Z", limit=10)[0]
+
+    assert "1645 memories never surfaced" in n.title
+    assert len(n.evidence) == 10
+
+
+def test_roi_falls_back_to_evidence_length_when_count_is_unavailable():
+    """`mem` is duck-typed: a source without the newer count method must still
+    emit its nudge rather than silently losing it to the guard."""
+
+    class _NoCountMem:
+        def dead_memory_ids(self, *, limit):
+            return ["dead1", "dead2"]
+
+    n = detect_roi(_NoCountMem(), now="2026-07-21T00:00:00Z")[0]
+
+    assert "2 memories never surfaced" in n.title
+
+
+def test_real_facade_dead_memory_count_matches_unlimited_ids(mock_memory):
+    for i in range(3):
+        mock_memory.save(content=f"fact {i} nobody ever looked up", type_="fact")
+
+    assert mock_memory.dead_memory_count() == len(mock_memory.dead_memory_ids(limit=999))


### PR DESCRIPTION
## Problem

`detect_roi` and `detect_health` titled their nudge with `len(ids)` — but `ids` comes back capped at the detector's `limit` (10). On any corpus larger than the cap, the title reported **the cap, not the backlog**.

On this machine:

```
digest antes:  "10 memories never surfaced — candidates to prune"
real:          1645 never-accessed durable memories
```

A 164× understatement of the exact number the nudge exists to communicate — and it reads as a complete count, so nothing hinted it was truncated.

## Fix

- Evidence stays capped (a nudge shouldn't carry 1645 ids); the **title** now uses a separate uncapped count.
- New `Memory.low_confidence_count()` / `Memory.dead_memory_count()`. Each shares its `FROM`/`WHERE` tail with its `*_ids` sibling (`_LOW_CONFIDENCE_FROM`, `_dead_memory_from`) so the capped list and the total can never drift onto different populations.
- `total_or` keeps the count best-effort: `mem` is duck-typed (`Any`), so a source without the newer method falls back to `len(ids)` and still emits its nudge. It catches only the concrete failure modes (`AttributeError` / `TypeError` / `ValueError` / `sqlite3.Error`) and is called from **inside** each detector's existing guard, so anything unforeseen degrades to no nudge rather than raising — no new broad-except site, gate unchanged at 185/205.

The other three detectors (`dejavu`, `reliability`, `continuity`) emit per-item nudges with no aggregate count, so they never had this bug.

## Verification

Against a read-only copy of the live index (10,495 live memories):

```
low-confidence: count=6     ids_capped=6
dead durable:   count=1645  ids_capped=10
```

The underlying signal checks out — 4,695 of 6,340 durable memories *have* been accessed (74%), so "1645 never surfaced" is a real backlog, not a broken instrument.

## Tests

6 new, TDD (4 red first):
- title reports the true total while evidence stays at the cap (both detectors)
- fallback to `len(ids)` when the source has no count method (both detectors)
- `*_count()` matches `len(*_ids(limit=999))` against a real store (both)

Full suite **8075 passed / 21 skipped**; mypy 542 files; ruff clean; quality gate 185 complexity / 205 exception budgets.

Retrieval gate: `prec@k 0.530 >= 0.530, noise@k 0.000 <= 0.000` — this diff touches no retrieval code, and the numbers match master's exactly.