### PR TITLE
fix: read the tool read-only hint under both MCP SDK spellings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+### Fixed
+
+- **Read-only MCP tools stopped bypassing the write coordinator on MCP SDK v2.**
+  The middleware read `ToolAnnotations.readOnlyHint`, which SDK v2 renamed to
+  `read_only_hint` (PEP 8) and kept only as a deprecated alias that warns on
+  every access — so newer environments got a deprecation warning per tool call
+  now, and would serialise every query behind the write queue once the alias is
+  dropped. `server_annotations.read_only_hint()` now reads the PEP 8 name first
+  and falls back to the camelCase one for the mcp 1.x line. The probe uses a
+  sentinel rather than `is None`, because the field's own default IS `None`: an
+  SDK with `read_only_hint` merely unset would otherwise fall through to the
+  deprecated alias, warning on exactly the version the fix targets. Thanks
+  @PierrePrevostAvenel (#299).
+
 ## [4.14.4] - 2026-08-26
 
 ### Fixed

--- a/src/memo/server_annotations.py
+++ b/src/memo/server_annotations.py
@@ -43,6 +43,28 @@ NETWORK_WRITE: dict[str, Any] = {
 }
 
 
+_MISSING = object()
+
+
+def read_only_hint(annotations: Any) -> bool:
+    """Read a tool's read-only hint across both MCP SDK spellings.
+
+    MCP SDK v2 renamed `ToolAnnotations.readOnlyHint` to `read_only_hint`, and
+    kept the camelCase name as a deprecated alias that warns on every access.
+    Read the PEP 8 name first so we don't warn there, and fall back to the
+    camelCase one for the mcp 1.x line, which only has that spelling.
+
+    The probe is a sentinel rather than `is None` because the field's default
+    IS None: an SDK that has `read_only_hint` unset would otherwise fall
+    through to the deprecated alias — warning on exactly the version this
+    function exists to keep quiet.
+    """
+    value = getattr(annotations, "read_only_hint", _MISSING)
+    if value is _MISSING:
+        value = getattr(annotations, "readOnlyHint", None)
+    return bool(value)
+
+
 # Names of every tool registered with a NON read-only annotation. Populated at
 # registration time so the response-budget middleware can tell a mutation from a
 # query: a write commits BEFORE the middleware sizes its payload, so replacing

--- a/src/memo/server_write_coordinator.py
+++ b/src/memo/server_write_coordinator.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from memo.errors import MemoError, QueueFullError, StorageError
+from memo.server_annotations import read_only_hint
 
 _log = logging.getLogger("memo.server")
 
@@ -194,8 +195,7 @@ def make_write_coordinator_middleware(server: Any, coordinator: McpWriteCoordina
         async def on_call_tool(self, context: Any, call_next: Any) -> Any:
             name = str(getattr(context.message, "name", "") or "")
             tool = await server.get_tool(name)
-            annotations = getattr(tool, "annotations", None)
-            if annotations is not None and bool(getattr(annotations, "readOnlyHint", False)):
+            if read_only_hint(getattr(tool, "annotations", None)):
                 return await call_next(context)
             return await coordinator.submit(lambda: call_next(context))
 

--- a/tests/test_mcp_write_coordinator.py
+++ b/tests/test_mcp_write_coordinator.py
@@ -180,6 +180,34 @@ async def test_middleware_bypasses_read_only_and_coordinates_writes():
 
 
 @pytest.mark.asyncio
+async def test_middleware_bypasses_read_only_under_the_snake_case_sdk():
+    """MCP SDK v2 spells the hint `read_only_hint`; the bypass must still fire.
+
+    Reading only the camelCase name there would route every read-only tool
+    through the write coordinator, serialising queries behind mutations.
+    """
+    coordinator = McpWriteCoordinator(1)
+
+    class Server:
+        async def get_tool(self, name):
+            return SimpleNamespace(annotations=SimpleNamespace(read_only_hint=name == "read"))
+
+    middleware = make_write_coordinator_middleware(Server(), coordinator)
+
+    async def next_call(context):
+        return context.message.name
+
+    def context(name):
+        return SimpleNamespace(message=SimpleNamespace(name=name))
+
+    assert await middleware.on_call_tool(context("read"), next_call) == "read"
+    assert coordinator.snapshot()["submitted"] == 0
+    assert await middleware.on_call_tool(context("write"), next_call) == "write"
+    assert coordinator.snapshot()["submitted"] == 1
+    await coordinator.close()
+
+
+@pytest.mark.asyncio
 async def test_load_is_strict_fifo_and_leaves_no_pending_jobs():
     capacity = flag_int("MEMO_MCP_WRITE_QUEUE_SIZE") or 0
     assert capacity == 32

--- a/tests/test_server_annotations.py
+++ b/tests/test_server_annotations.py
@@ -104,3 +104,49 @@ def test_every_registered_tool_has_annotations(mem, monkeypatch):
     tools = asyncio.run(server.list_tools())
     missing = sorted(t.name for t in tools if t.annotations is None)
     assert missing == [], f"tools without annotations: {missing}"
+
+
+def test_read_only_hint_reads_the_snake_case_field():
+    """Newer MCP SDKs renamed `readOnlyHint` to `read_only_hint` (PEP 8).
+
+    A tool object from such an SDK carries only the snake_case spelling, so
+    reading the camelCase name would report every read-only tool as a write.
+    """
+    from types import SimpleNamespace
+
+    from memo.server_annotations import read_only_hint
+
+    assert read_only_hint(SimpleNamespace(read_only_hint=True)) is True
+    assert read_only_hint(SimpleNamespace(read_only_hint=False)) is False
+
+
+def test_read_only_hint_falls_back_to_the_camel_case_field():
+    """Current MCP SDKs (mcp 1.x) still spell it `readOnlyHint`."""
+    from types import SimpleNamespace
+
+    from memo.server_annotations import read_only_hint
+
+    assert read_only_hint(SimpleNamespace(readOnlyHint=True)) is True
+    assert read_only_hint(SimpleNamespace(readOnlyHint=False)) is False
+    assert read_only_hint(SimpleNamespace()) is False
+    assert read_only_hint(None) is False
+
+
+def test_read_only_hint_never_touches_the_deprecated_alias_when_the_new_one_exists():
+    """The camelCase alias emits a FastMCPDeprecationWarning on every access.
+
+    An unset `read_only_hint` is None, which must be read as "not read-only"
+    rather than as "field missing" — otherwise the fallback fires on exactly
+    the SDK whose warning this function exists to avoid.
+    """
+
+    class Annotations:
+        read_only_hint = None
+
+        @property
+        def readOnlyHint(self) -> bool:  # mirrors the SDK's own spelling
+            raise AssertionError("read the deprecated alias despite read_only_hint")
+
+    from memo.server_annotations import read_only_hint
+
+    assert read_only_hint(Annotations()) is False


### PR DESCRIPTION
Closes #299. Reported by @PierrePrevostAvenel.

## The problem

`_WriteCoordinatorMiddleware` decided whether to bypass the write queue by reading `ToolAnnotations.readOnlyHint`. MCP SDK v2 renamed that field to `read_only_hint` (PEP 8) and kept the camelCase name only as a deprecated alias that emits a `FastMCPDeprecationWarning` **on every access** — so on a newer SDK memo logs one warning per tool call, and once the alias is dropped `getattr` returns the default and every read-only tool loses its bypass, serialising queries behind the write queue.

## The fix

`server_annotations.read_only_hint()` reads the PEP 8 name first, falling back to camelCase for the mcp 1.x line (which only has that spelling — verified against the installed `mcp 1.29.1`, where `readOnlyHint` is still the only field).

One deviation from the fix suggested in the issue: the probe uses a **sentinel**, not `is None`.

```python
value = getattr(annotations, "read_only_hint", _MISSING)
if value is _MISSING:
    value = getattr(annotations, "readOnlyHint", None)
return bool(value)
```

`ToolAnnotations.readOnlyHint` is declared `bool | None = None`, so `None` means *unset*, not *absent*. Treating `None` as "field missing" would fall through to the deprecated alias on an SDK that has `read_only_hint` but leaves it unset — warning on exactly the version the fix exists to keep quiet. The sentinel distinguishes the two.

The write side is untouched: `annotated_tool` passes camelCase **dict keys**, which pydantic validates by alias, and camelCase is the MCP wire format, so it stays correct on both SDKs.

## Tests

Four new, RED before the fix:

- `read_only_hint` reads the snake_case field (SDK v2)
- falls back to camelCase (mcp 1.x), and handles a missing field / `None` annotations
- never touches the deprecated alias when the new name exists — asserted with a `readOnlyHint` property that raises
- middleware integration: read-only bypasses the coordinator, writes are queued, under the snake_case spelling

Full suite 8079 passed / 21 skipped · ruff · mypy · quality gate 185/205.

Note on the pre-push retrieval gate: it failed on a config-name change (`L live/vec/0.4` -> `0.5`) caused by machine-local tuner state, not this diff. Re-seeded from `origin/master` in an isolated worktree; master and this branch both measure prec@5 0.530 / noise 0.0.