### PR TITLE
fix: withhold the proxy A/B ratio below the sample floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ### Fixed
 
+- **`memo tokens` printed a proxy saving of "386295.8% cost".** The holdout
+  A/B panel rendered its headline ratio at any sample size, qualifying a thin
+  one with the word "provisional" but printing the number anyway. Because the
+  control arm is drawn per *session* at `MEMO_PROXY_HOLDOUT_FRAC`, it fills far
+  slower than the treated arm, and live traffic put 2 holdout requests worth 5
+  tok-equiv (one short, atypical session) against 4984 treated worth 19320 —
+  a ratio wrong by four orders of magnitude, in bold, above a grey caveat no
+  reader weighs against it. Below the existing `_MIN_PROXY_SAMPLE` floor the
+  panel now withholds the ratio and falls into the "not enough data to compare
+  arms yet" branch that already existed, reporting request AND session counts
+  plus the floor so the shortfall is legible. This is the instrument every
+  proxy savings claim is measured against, so a wrong number here discredits
+  all of them. Note the residual: 30 requests drawn from a single session are
+  still one correlated sample, which is why the session counts are now shown
+  next to the request counts.
+
 - **Read-only MCP tools stopped bypassing the write coordinator on MCP SDK v2.**
   The middleware read `ToolAnnotations.readOnlyHint`, which SDK v2 renamed to
   `read_only_hint` (PEP 8) and kept only as a deprecated alias that warns on

--- a/src/memo/cli_tokens.py
+++ b/src/memo/cli_tokens.py
@@ -146,11 +146,28 @@ def _transcript_panel(measured: dict) -> Panel:
 def _proxy_panel(proxy: dict) -> Panel:
     frac = proxy["measured_saving_frac"]
     n_t, n_h = proxy["n_treated"], proxy["n_holdout"]
-    if frac is None:
+    # Defect 2: holdout is assigned per SESSION, not per request, so n_t/n_h
+    # (request counts) overstate the effective sample size — every request in
+    # one holdout session is correlated, not an independent draw. Report the
+    # distinct-session count beside the request count rather than hiding that
+    # the unit changed.
+    n_ts = proxy.get("n_treated_sessions") or 0
+    n_hs = proxy.get("n_holdout_sessions") or 0
+    sessions_note = f", {n_ts}/{n_hs} sessions" if (n_ts or n_hs) else ""
+    # A sample too thin to compare is not a measurement with a caveat — it is
+    # not a measurement. Because the control arm is drawn per session at
+    # MEMO_PROXY_HOLDOUT_FRAC, it fills ~1/frac times slower than the treated
+    # one, and its first entries can be a single atypical session: live
+    # traffic once put 2 holdout requests worth 5 tok-equiv against 4984
+    # treated worth 19320 and rendered "386295.8% cost" in bold. Withhold the
+    # ratio below the floor instead of shipping it with a "provisional" word.
+    thin = min(n_t, n_h) < _MIN_PROXY_SAMPLE
+    if frac is None or thin:
         if n_t or n_h:
             body = (
                 f"[dim]not enough data to compare arms yet[/dim] "
-                f"([dim]{n_t} treated / {n_h} holdout requests[/dim])"
+                f"([dim]{n_t} treated / {n_h} holdout requests{sessions_note}"
+                f" — need {_MIN_PROXY_SAMPLE} per arm[/dim])"
             )
         else:
             body = "[dim]no measured data yet — the proxy has not logged any requests[/dim]"
@@ -171,21 +188,11 @@ def _proxy_panel(proxy: dict) -> Panel:
         cost_h = proxy["mean_prompt_cost_holdout"]
         mean_in_t = proxy["mean_input_treated"]
         mean_in_h = proxy["mean_input_holdout"]
-        thin = min(n_t, n_h) < _MIN_PROXY_SAMPLE
-        # Defect 2: holdout is now assigned per SESSION, not per request, so
-        # n_t/n_h (request counts) overstate the effective sample size —
-        # every request in one holdout session is correlated, not an
-        # independent draw. Report the distinct-session count beside the
-        # request count rather than hiding that the unit changed.
-        n_ts = proxy.get("n_treated_sessions") or 0
-        n_hs = proxy.get("n_holdout_sessions") or 0
-        sessions_note = f", {n_ts}/{n_hs} sessions" if (n_ts or n_hs) else ""
         body = (
             f"[bold {colour}]{abs(frac) * 100:.1f}% {verb}[/bold {colour}] on prompt cost "
             f"(treated {cost_t:.0f} vs holdout {cost_h:.0f} tok-equiv/request; "
             f"raw input_tokens {mean_in_t:.0f} vs {mean_in_h:.0f}) "
-            f"[dim](n={n_t} treated / {n_h} holdout requests{sessions_note}"
-            f"{' · provisional, thin sample' if thin else ''})[/dim]"
+            f"[dim](n={n_t} treated / {n_h} holdout requests{sessions_note})[/dim]"
         )
     if proxy.get("retrieved"):
         body += f"\n[dim]{proxy['retrieved']} recovered originals (cost their tokens twice)[/dim]"

--- a/tests/test_proxy_reporting.py
+++ b/tests/test_proxy_reporting.py
@@ -80,16 +80,16 @@ def test_measured_panel_reports_treated_vs_holdout_when_data_exists(tmp_path):
     only `verb`/`colour` carry the sign, and nothing asserted them. Assert
     the actual claim."""
     state_dir = tmp_path / "state"
-    for i in range(10):
+    for i in range(30):
         _seed(state_dir, [_record(f"t{i}", holdout=False, input_tokens=500)])
-    for i in range(10):
+    for i in range(30):
         _seed(state_dir, [_record(f"h{i}", holdout=True, input_tokens=1000)])
     result = CliRunner().invoke(tokens_cmd, [], env=_env(tmp_path))
     assert result.exit_code == 0, result.output
     assert "no measured data" not in result.output.lower()
     assert "50.0% saved" in result.output
     assert "treated 500 vs holdout 1000" in result.output
-    assert "n=10 treated / 10 holdout" in result.output
+    assert "n=30 treated / 30 holdout" in result.output
     # The panel label is "on prompt cost" unconditionally now (defect 1's
     # relabel), so a bare "cost" substring check would trip on the noun in
     # every panel, saved or not -- assert the VERB specifically stayed
@@ -102,9 +102,9 @@ def test_passthrough_rows_are_reported_but_excluded_from_the_treated_count(tmp_p
     (`rewritten=False`) must not inflate n=treated, but it also must not
     just silently vanish — the panel says how many were excluded and why."""
     state_dir = tmp_path / "state"
-    for i in range(10):
+    for i in range(30):
         _seed(state_dir, [_record(f"t{i}", holdout=False, input_tokens=500)])
-    for i in range(10):
+    for i in range(30):
         _seed(state_dir, [_record(f"h{i}", holdout=True, input_tokens=1000)])
     _seed(
         state_dir,
@@ -112,7 +112,7 @@ def test_passthrough_rows_are_reported_but_excluded_from_the_treated_count(tmp_p
     )
     result = CliRunner().invoke(tokens_cmd, [], env=_env(tmp_path))
     assert result.exit_code == 0, result.output
-    assert "n=10 treated / 10 holdout" in result.output
+    assert "n=30 treated / 30 holdout" in result.output
     assert "1 passthrough request" in result.output
 
 
@@ -142,17 +142,25 @@ def test_json_reports_no_data_as_none_not_zero(tmp_path):
     assert data["proxy"]["n_treated"] == 0
 
 
-def test_proxy_panel_flags_a_thin_sample(tmp_path):
-    """Round-2 (item 6): the sibling transcript panel applies a
+def test_proxy_panel_withholds_a_thin_sample(tmp_path):
+    """Round-2 (item 6) originally: the sibling transcript panel applies a
     _MIN_COHORT_TURNS=30 floor and marks a thin cohort as provisional; the
     proxy panel applied none, so a n=1-vs-n=1 fluke could print e.g. "33.3%
-    saved" in bold green with no qualifier at all."""
+    saved" in bold green with no qualifier at all. That round added the word
+    "provisional" and kept the number.
+
+    Round-3 (2026-08-28): annotating was not enough — live traffic rendered
+    "386295.8% cost" WITH the provisional marker attached, and a reader takes
+    the bold four-order-of-magnitude number, not the grey caveat. Below the
+    floor the panel now withholds the ratio entirely."""
     state_dir = tmp_path / "state"
     _seed(state_dir, [_record("t0", holdout=False, input_tokens=500)])
     _seed(state_dir, [_record("h0", holdout=True, input_tokens=1000)])
     result = CliRunner().invoke(tokens_cmd, [], env=_env(tmp_path))
     assert result.exit_code == 0, result.output
-    assert "provisional" in result.output.lower()
+    assert "not enough data" in result.output.lower()
+    assert "% saved" not in result.output
+    assert "% cost" not in result.output
 
 
 def test_proxy_panel_no_thin_marker_at_a_healthy_sample(tmp_path):
@@ -238,3 +246,46 @@ def test_by_transform_has_no_dead_retrieval_rate_column(tmp_path):
     assert result.exit_code == 0, result.output
     assert "retrieval rate" not in result.output.lower()
     assert "over-cutting" not in result.output.lower()
+
+
+def test_a_thin_holdout_suppresses_the_percentage_instead_of_annotating_it(tmp_path):
+    """Live defect (2026-08-28): `memo tokens` printed "386295.8% cost" —
+    treated 19320 vs holdout 5 tok-equiv/request off n=4984 treated / 2
+    holdout requests in ONE holdout session.
+
+    Holdout is assigned per session at MEMO_PROXY_HOLDOUT_FRAC=0.05, so ~20
+    sessions must elapse before one lands in the control arm, and the one
+    that did was a 2-request session that never carried a real prompt. The
+    `thin` flag already caught this and only appended a "provisional" word
+    to a bold headline that was wrong by four orders of magnitude. A sample
+    too thin to compare is not a measurement with a caveat; it is not a
+    measurement. Suppress the number, keep the counts.
+    """
+    state_dir = tmp_path / "state"
+    for i in range(40):
+        _seed(state_dir, [_record(f"t{i}", holdout=False, input_tokens=19320, session_key="s-t")])
+    for i in range(2):
+        _seed(state_dir, [_record(f"h{i}", holdout=True, input_tokens=5, session_key="s-h")])
+    result = CliRunner().invoke(tokens_cmd, [], env=_env(tmp_path))
+    assert result.exit_code == 0, result.output
+    out = result.output.lower()
+    assert "not enough data" in out
+    # The bogus headline and its verb must both be gone, not merely qualified.
+    assert "%" not in result.output.split("memo · proxy")[-1].split("╰")[0]
+    # The counts stay visible so the user can see why it is withheld.
+    assert "40" in result.output and "2" in result.output
+
+
+def test_suppressed_headline_still_reports_the_session_counts(tmp_path):
+    """The effective sample unit is the session, not the request (holdout is
+    assigned per session), so the withheld-measurement line must show it —
+    otherwise "40 treated / 2 holdout requests" reads as a near-miss on the
+    30-request floor when the real shortfall is 1 control session."""
+    state_dir = tmp_path / "state"
+    for i in range(40):
+        _seed(state_dir, [_record(f"t{i}", holdout=False, input_tokens=19320, session_key="s-t")])
+    for i in range(2):
+        _seed(state_dir, [_record(f"h{i}", holdout=True, input_tokens=5, session_key="s-h")])
+    result = CliRunner().invoke(tokens_cmd, [], env=_env(tmp_path))
+    assert result.exit_code == 0, result.output
+    assert "session" in result.output.lower()


### PR DESCRIPTION
## The defect

`memo tokens` rendered this for the proxy holdout panel:

```
386295.8% cost on prompt cost (treated 19320 vs holdout 5 tok-equiv/request;
raw input_tokens 12 vs 5) (n=4979 treated / 2 holdout requests, 6/1 sessions
· provisional, thin sample)
```

Measured from the live ledger:

| | |
|---|---|
| `n_treated` | 4984 requests / 6 sessions |
| `n_holdout` | **2 requests / 1 session** |
| `mean_prompt_cost_treated` | 19312.6 |
| `mean_prompt_cost_holdout` | **5.0** |
| `measured_saving_frac` | **−3861.5** |

## Why the arm was starved

Holdout is assigned per **session** — `server.py` calls
`meter.is_holdout(session_key, ...)` — at `MEMO_PROXY_HOLDOUT_FRAC=0.05`. The
control arm therefore fills roughly `1/frac` times slower than the treated one,
and its first entries can be one atypical session. Here that session made 2
requests averaging 5 tok-equiv, which is not a real Claude Code prompt.

## Why annotating wasn't enough

`_proxy_panel` already computed `thin = min(n_t, n_h) < _MIN_PROXY_SAMPLE`, but
used it only to append a grey `· provisional, thin sample` to a bold headline.
The number above was wrong by four orders of magnitude. A reader takes the bold
figure, not the caveat.

A sample too thin to compare is not a measurement with a qualifier. It is not a
measurement.

## The change

Below the floor the panel now falls into the `not enough data to compare arms
yet` branch that already existed (`cli_tokens.py:148`), and reports request
counts, session counts, and the floor so the shortfall is legible:

```
not enough data to compare arms yet (5003 treated / 2 holdout requests,
6/1 sessions — need 30 per arm)
```

This is not cosmetic: the holdout A/B is the instrument every proxy savings
claim is measured against, so a number wrong by 4 OOM discredits all of them.

## Residual, deliberately left

30 requests drawn from a single session are still one correlated sample — the
`_distinct_sessions` docstring already says so. A session-level floor would be
more correct statistically but would silence the panel for weeks, so the
session counts are printed beside the request counts instead, and a reader can
judge for themselves.

## Tests

RED first: `test_a_thin_holdout_suppresses_the_percentage_instead_of_annotating_it`
reproduced the live shape and failed with the exact number, `386300.0% cost`.

Three existing tests encoded the superseded contract:

- `test_proxy_panel_flags_a_thin_sample` asserted the `provisional` word →
  rewritten as `test_proxy_panel_withholds_a_thin_sample`, docstring records
  both rounds of the contract.
- `test_measured_panel_reports_treated_vs_holdout_when_data_exists` and
  `test_passthrough_rows_are_reported_but_excluded_from_the_treated_count`
  test headline math and passthrough exclusion, subjects unrelated to the
  floor; they seeded 10/10 and now seed 30/30 so they keep exercising the
  headline they were written for.

`pytest -k "proxy or token"`: **539 passed**. ruff, ruff format, mypy clean.
Pre-push recall gate: PASS (prec@k 0.530 >= 0.530, noise@k 0.000 <= 0.000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)