### PR TITLE
fix: stop the tuner charging corpus drift to the knob it is judging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ### Fixed
 
+- **The nightly tuner confirmed a knob and rolled it back in the same pass.**
+  On 2026-08-27 one `dream` run CONFIRMED `MEMO_RECALL_MIN_SIM` 0.5 → 0.4 on
+  the online proof loop (0.0 → 0.9362, n=47) and reverted it minutes later.
+  The offline rollback guard compared a fresh measurement against
+  `eval/dream_baseline.json` written six days and thousands of memories
+  earlier, under `_regressed`'s 1e-9 tolerance — so it measured corpus drift
+  and charged it to the knob. `dream_baseline.json` now records the
+  `corpus_fingerprint` it describes (`recall_baseline.json` already did). The
+  guard trusts the stored snapshot only while it still describes the live
+  corpus; once it doesn't, it asks the comparable question instead — the
+  current floor against the floor it replaced, both measured on today's
+  corpus, which isolates the knob from the corpus entirely. Baselines written
+  before this field carry no fingerprint and are treated as not-comparable,
+  never as a match.
+
+||||||| parent of 693fe14a (fix: stop the tuner charging corpus drift to the knob it is judging)
 - **Read-only MCP tools stopped bypassing the write coordinator on MCP SDK v2.**
   The middleware read `ToolAnnotations.readOnlyHint`, which SDK v2 renamed to
   `read_only_hint` (PEP 8) and kept only as a deprecated alias that warns on

--- a/src/memo/dream_tune.py
+++ b/src/memo/dream_tune.py
@@ -171,6 +171,35 @@ def save_baseline(state_dir: Path, metrics: dict[str, float], *, mem: Any = None
     p.write_text(json.dumps(doc, indent=2), encoding="utf-8")
 
 
+def _live_floor_regressed(
+    state_dir: Path,
+    mem: Any,
+    labels: Any,
+    *,
+    baseline: dict[str, Any],
+    live: dict[str, float],
+    current: float,
+    k: int,
+    measure: Any,
+) -> bool:
+    """Has the applied min_sim floor actually regressed — as opposed to the corpus moving?
+
+    The stored baseline answers that only while it still describes the live
+    corpus. Once it doesn't, comparing against it measures corpus drift and
+    charges it to the knob, which is how one pass CONFIRMED 0.5 -> 0.4 on the
+    online proof loop and rolled it back minutes later. So when the stamp no
+    longer matches, ask the comparable question instead: the current floor
+    against the floor it replaced, both measured on today's corpus.
+    """
+    stamp = baseline.get("corpus_fingerprint")
+    if stamp and stamp == _corpus_fingerprint(mem):
+        return bool(_regressed(live, baseline))
+    prev_floor = _prev_floor(state_dir)
+    if prev_floor is None or prev_floor == current:
+        return False
+    return bool(_regressed(live, measure(mem, labels, k=k, floor=prev_floor)))
+
+
 def _prev_floor(state_dir: Path) -> float | None:
     """The min_sim value the live overlay replaced, i.e. what a rollback would
     restore. `None` when the overlay has no prior scalar for the knob — then
@@ -442,16 +471,16 @@ def run_tuning_pass(
         baseline = load_baseline(cfg.state_dir)
         if baseline is not None:
             live = measure(mem, labels, k=k, floor=current)
-            stamp = baseline.get("corpus_fingerprint")
-            if stamp and stamp == _corpus_fingerprint(mem):
-                worse = _regressed(live, baseline)
-            else:
-                prev_floor = _prev_floor(cfg.state_dir)
-                worse = (
-                    prev_floor is not None
-                    and prev_floor != current
-                    and _regressed(live, measure(mem, labels, k=k, floor=prev_floor))
-                )
+            worse = _live_floor_regressed(
+                cfg.state_dir,
+                mem,
+                labels,
+                baseline=baseline,
+                live=live,
+                current=current,
+                k=k,
+                measure=measure,
+            )
             if worse and not dry_run:
                 rolled = rollback_overlay(cfg.state_dir)
                 if rolled is not None:

--- a/src/memo/dream_tune.py
+++ b/src/memo/dream_tune.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Any
 
 from memo import dream_tune_online
+from memo.dream_utils import _corpus_fingerprint
 from memo.eval_recall import (
     Cfg,
     LabelSet,
@@ -151,10 +152,34 @@ def load_baseline(state_dir: Path) -> dict[str, float] | None:
         return None
 
 
-def save_baseline(state_dir: Path, metrics: dict[str, float]) -> None:
+def save_baseline(state_dir: Path, metrics: dict[str, float], *, mem: Any = None) -> None:
+    """Persist the offline gate metrics, stamped with the corpus they describe.
+
+    Without the stamp the baseline is a bare pair of numbers whose provenance
+    is lost the moment the corpus moves, and the rollback guard charges every
+    later corpus change to whatever knob it happens to be judging. `mem` is
+    optional so callers that have no Memory handy (and every baseline written
+    before this field existed) still work — the guard treats a missing
+    fingerprint as not-comparable, never as a match.
+    """
+    doc: dict[str, Any] = dict(metrics)
+    fingerprint = _corpus_fingerprint(mem) if mem is not None else None
+    if fingerprint:
+        doc["corpus_fingerprint"] = fingerprint
     p = _baseline_path(state_dir)
     p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+    p.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+
+def _prev_floor(state_dir: Path) -> float | None:
+    """The min_sim value the live overlay replaced, i.e. what a rollback would
+    restore. `None` when the overlay has no prior scalar for the knob — then
+    there is no applied change for the guard to second-guess."""
+    prev = read_overlay(state_dir).get("_meta", {}).get("prev")
+    if not isinstance(prev, dict):
+        return None
+    value = prev.get(_MIN_SIM)
+    return float(value) if isinstance(value, int | float) else None
 
 
 # --- labels ------------------------------------------------------------------
@@ -310,14 +335,19 @@ def _is_improved_change(
     ) > (before["precision_at_k"], -before["noise_at_k"])
 
 
-def _save_knob_baseline(state_dir: Path, knob: str, metrics: dict[str, float]) -> None:
-    """Persist the matching offline baseline when the knob has one."""
+def _save_knob_baseline(
+    state_dir: Path, knob: str, metrics: dict[str, float], *, mem: Any = None
+) -> None:
+    """Persist the matching offline baseline when the knob has one.
+
+    `mem` is threaded through so the saved baseline can record WHICH corpus it
+    describes; savers that have no use for it ignore it."""
     saver = _KNOB_BASELINE_SAVERS.get(knob)
     if saver is not None:
-        saver(state_dir, metrics)
+        saver(state_dir, metrics, mem)
 
 
-def _restore_online_revert(state_dir: Path, resolution: dict[str, Any]) -> None:
+def _restore_online_revert(state_dir: Path, resolution: dict[str, Any], *, mem: Any = None) -> None:
     """Restore every key managed by one reverted online experiment."""
     params = _scalar_overlay(state_dir)
     managed_before = resolution.get("managed_before")
@@ -330,7 +360,7 @@ def _restore_online_revert(state_dir: Path, resolution: dict[str, Any]) -> None:
     write_overlay(state_dir, params, {"set_by": "dream-online-revert"})
     saver = _KNOB_BASELINE_SAVERS.get(resolution["knob"])
     if saver is not None:
-        saver(state_dir, resolution["offline_before"])
+        saver(state_dir, resolution["offline_before"], mem)
     dream_tune_online.set_revert_cooldown(state_dir)
     pin_prev_to_current(state_dir)
 
@@ -382,7 +412,7 @@ def run_tuning_pass(
             )
             res["online"] = resolution
             if resolution["status"] == "reverted":
-                _restore_online_revert(cfg.state_dir, resolution)
+                _restore_online_revert(cfg.state_dir, resolution, mem=mem)
                 res["status"] = "online_reverted"
                 return res
             if resolution["status"] == "waiting":
@@ -393,11 +423,36 @@ def run_tuning_pass(
         current = flag_float(_MIN_SIM)
         current = 0.5 if current is None else current
 
-        # rollback guard: if the LIVE config already regressed vs baseline, revert first.
+        # rollback guard: if the LIVE config already regressed, revert first.
+        #
+        # "Regressed" has to mean "worse than the config it replaced", not
+        # "worse than a stored snapshot". The baseline is written once and the
+        # corpus grows every day, so a stale snapshot compared against a fresh
+        # measurement — under `_regressed`'s 1e-9 tolerance — reverts the knob
+        # for any drift at all. That is exactly what happened on 2026-08-27:
+        # one pass CONFIRMED min_sim 0.5->0.4 on the online proof loop
+        # (0.0 -> 0.9362, n=47) and rolled it back in the same pass, against a
+        # baseline six days and thousands of memories old.
+        #
+        # So: trust the snapshot only while it describes THIS corpus. Once it
+        # doesn't, ask the comparable question instead — measure the current
+        # floor against the floor it replaced, both on today's corpus. Costs a
+        # second measurement in a nightly pass, and isolates the knob from the
+        # corpus completely.
         baseline = load_baseline(cfg.state_dir)
         if baseline is not None:
             live = measure(mem, labels, k=k, floor=current)
-            if _regressed(live, baseline) and not dry_run:
+            stamp = baseline.get("corpus_fingerprint")
+            if stamp and stamp == _corpus_fingerprint(mem):
+                worse = _regressed(live, baseline)
+            else:
+                prev_floor = _prev_floor(cfg.state_dir)
+                worse = (
+                    prev_floor is not None
+                    and prev_floor != current
+                    and _regressed(live, measure(mem, labels, k=k, floor=prev_floor))
+                )
+            if worse and not dry_run:
                 rolled = rollback_overlay(cfg.state_dir)
                 if rolled is not None:
                     res["status"] = "rolled_back"
@@ -583,7 +638,7 @@ def run_tuning_pass(
                 "baseline_noise": w_after["noise_at_k"],
             },
         )
-        _save_knob_baseline(cfg.state_dir, knob, w_after)
+        _save_knob_baseline(cfg.state_dir, knob, w_after, mem=mem)
         dream_tune_online.record_pending(
             cfg.state_dir,
             knob=knob,
@@ -985,11 +1040,13 @@ def save_graph_baseline(state_dir: Path, metrics: dict[str, float]) -> None:
 # Lambda wrappers preserve late-binding: save_baseline / save_graph_baseline are
 # looked up in the module's global namespace at call time, not at dict-construction
 # time, so monkeypatching either function works correctly in tests.
+# `mem` defaults to None so a two-argument call still works: the rank-knob
+# savers ignore it, and only the min_sim baseline records a corpus fingerprint.
 _KNOB_BASELINE_SAVERS = {
-    _MIN_SIM: lambda sd, m: save_baseline(sd, m),
-    _GRAPH_ALPHA: lambda sd, m: save_graph_baseline(sd, m),
-    _MMR_LAMBDA: lambda sd, m: save_rank_knob_baseline(sd, _MMR_LAMBDA, m),
-    _SYNTHESIS_BOOST: lambda sd, m: save_rank_knob_baseline(sd, _SYNTHESIS_BOOST, m),
+    _MIN_SIM: lambda sd, m, mem=None: save_baseline(sd, m, mem=mem),
+    _GRAPH_ALPHA: lambda sd, m, mem=None: save_graph_baseline(sd, m),
+    _MMR_LAMBDA: lambda sd, m, mem=None: save_rank_knob_baseline(sd, _MMR_LAMBDA, m),
+    _SYNTHESIS_BOOST: lambda sd, m, mem=None: save_rank_knob_baseline(sd, _SYNTHESIS_BOOST, m),
 }
 
 

--- a/tests/test_dream_tune_knobs.py
+++ b/tests/test_dream_tune_knobs.py
@@ -491,3 +491,102 @@ def test_baseline_savers_registered_for_rank_knobs(tmp_path):
         saver = dt._KNOB_BASELINE_SAVERS[knob]
         saver(tmp_path, {"precision_at_k": 0.3, "noise_at_k": 0.0})
         assert dt.load_rank_knob_baseline(tmp_path, knob)["precision_at_k"] == 0.3
+
+
+# --- min_sim rollback guard: corpus drift must not be charged to the knob ----
+
+
+def test_min_sim_guard_does_not_roll_back_on_corpus_drift(tmp_path, monkeypatch):
+    """Live incident 2026-08-27: one nightly pass CONFIRMED min_sim 0.5->0.4 on
+    the online proof loop (0.0 -> 0.9362, n=47) and rolled it back in the same
+    pass. The offline guard compared a fresh measurement against
+    `eval/dream_baseline.json` written six days and thousands of memories
+    earlier, with `_regressed`'s 1e-9 tolerance — so any precision drift from a
+    growing corpus reverts the knob. The baseline is a snapshot of a corpus
+    that no longer exists; it cannot answer "is this knob worse".
+
+    The comparable question is the counterfactual on TODAY's corpus: the
+    current floor against the floor it replaced. When they measure the same,
+    the knob is innocent whatever the stale snapshot says."""
+    monkeypatch.setenv("MEMO_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(dt, "build_labels", lambda cfg, **k: _one_label())
+    # overlay history: min_sim moved 0.5 -> 0.4, so _meta.prev holds 0.5
+    dt.write_overlay(tmp_path, {"MEMO_RECALL_MIN_SIM": 0.5}, {"set_by": "dream"})
+    dt.write_overlay(tmp_path, {"MEMO_RECALL_MIN_SIM": 0.4}, {"set_by": "dream"})
+    # a stale baseline from a corpus that measured much better than today's
+    dt.save_baseline(tmp_path, {"precision_at_k": 0.9, "noise_at_k": 0.0})
+    # today both floors measure the same: the knob changed nothing
+    monkeypatch.setattr(dt, "measure", lambda *a, **k: _metrics(0.3))
+    _flat_min_sim(monkeypatch)
+
+    res = dt.run_tuning_pass(_cfg(tmp_path), _StubMem(), k=5)
+    assert res["status"] != "rolled_back"
+    assert dt.read_overlay(tmp_path)["MEMO_RECALL_MIN_SIM"] == 0.4
+
+
+def test_min_sim_guard_still_rolls_back_a_genuinely_worse_floor(tmp_path, monkeypatch):
+    """The counterfactual must not defang the guard: when the CURRENT floor
+    measures worse than the floor it replaced, on the same corpus and in the
+    same run, that is the knob's own doing and it still reverts."""
+    monkeypatch.setenv("MEMO_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(dt, "build_labels", lambda cfg, **k: _one_label())
+    dt.write_overlay(tmp_path, {"MEMO_RECALL_MIN_SIM": 0.5}, {"set_by": "dream"})
+    dt.write_overlay(tmp_path, {"MEMO_RECALL_MIN_SIM": 0.4}, {"set_by": "dream"})
+    dt.save_baseline(tmp_path, {"precision_at_k": 0.9, "noise_at_k": 0.0})
+    # current floor (0.4) is worse than its predecessor (0.5), measured now
+    monkeypatch.setattr(
+        dt, "measure", lambda mem, labels, *, k, floor: _metrics(0.1 if floor == 0.4 else 0.6)
+    )
+
+    def _boom(*a, **k):
+        raise AssertionError("no search may run after the rollback guard fires")
+
+    monkeypatch.setattr(dt, "search_min_sim", _boom)
+
+    res = dt.run_tuning_pass(_cfg(tmp_path), _StubMem(), k=5)
+    assert res["status"] == "rolled_back"
+    assert res["restored"] == {"MEMO_RECALL_MIN_SIM": 0.5}
+
+
+def test_min_sim_guard_trusts_a_baseline_from_the_same_corpus(tmp_path, monkeypatch):
+    """When the stored baseline carries the CURRENT corpus fingerprint it is a
+    valid comparison and stays the cheap path — one measurement, not two."""
+    monkeypatch.setenv("MEMO_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(dt, "build_labels", lambda cfg, **k: _one_label())
+    monkeypatch.setattr(dt, "_corpus_fingerprint", lambda mem: "42:2026-08-28")
+    dt.write_overlay(tmp_path, {"MEMO_RECALL_MIN_SIM": 0.5}, {"set_by": "dream"})
+    dt.write_overlay(tmp_path, {"MEMO_RECALL_MIN_SIM": 0.4}, {"set_by": "dream"})
+    dt.save_baseline(tmp_path, {"precision_at_k": 0.9, "noise_at_k": 0.0}, mem=_StubMem())
+
+    calls: list[float] = []
+
+    def _measure(mem, labels, *, k, floor):
+        calls.append(floor)
+        return _metrics(0.1)
+
+    monkeypatch.setattr(dt, "measure", _measure)
+
+    def _boom(*a, **k):
+        raise AssertionError("no search may run after the rollback guard fires")
+
+    monkeypatch.setattr(dt, "search_min_sim", _boom)
+
+    res = dt.run_tuning_pass(_cfg(tmp_path), _StubMem(), k=5)
+    assert res["status"] == "rolled_back"
+    assert calls == [0.4], "a same-corpus baseline needs no counterfactual measurement"
+
+
+def test_save_baseline_stamps_the_corpus_fingerprint(tmp_path, monkeypatch):
+    monkeypatch.setattr(dt, "_corpus_fingerprint", lambda mem: "7:2026-08-28T00:00:00")
+    dt.save_baseline(tmp_path, {"precision_at_k": 0.3, "noise_at_k": 0.0}, mem=_StubMem())
+    assert dt.load_baseline(tmp_path)["corpus_fingerprint"] == "7:2026-08-28T00:00:00"
+    # the metrics stay readable exactly as before
+    assert dt.load_baseline(tmp_path)["precision_at_k"] == 0.3
+
+
+def test_save_baseline_without_a_mem_stays_backward_compatible(tmp_path):
+    """Callers that have no Memory handy (and every baseline written before
+    this field existed) produce a baseline with no fingerprint, which the
+    guard must treat as not-comparable rather than as a match."""
+    dt.save_baseline(tmp_path, {"precision_at_k": 0.3, "noise_at_k": 0.0})
+    assert "corpus_fingerprint" not in dt.load_baseline(tmp_path)

--- a/tests/test_dream_tune_proof_loop.py
+++ b/tests/test_dream_tune_proof_loop.py
@@ -53,7 +53,9 @@ def test_online_reverted_restores_floor_before_and_baseline(tmp_path, monkeypatc
         "write_overlay",
         lambda sd, params, meta: calls.__setitem__("overlay", dict(params)),
     )
-    monkeypatch.setattr(dream_tune, "save_baseline", lambda sd, m: calls.__setitem__("baseline", m))
+    monkeypatch.setattr(
+        dream_tune, "save_baseline", lambda sd, m, **kw: calls.__setitem__("baseline", m)
+    )
     monkeypatch.setattr(
         dream_tune, "measure", lambda *a, **k: (_ for _ in ()).throw(AssertionError("no measure"))
     )
@@ -122,7 +124,7 @@ def test_graph_signal_revert_restores_atomic_config_and_baseline(tmp_path, monke
         dream_tune, "save_graph_baseline", lambda sd, m: calls.__setitem__("graph_baseline", m)
     )
     monkeypatch.setattr(
-        dream_tune, "save_baseline", lambda sd, m: calls.__setitem__("min_baseline", m)
+        dream_tune, "save_baseline", lambda sd, m, **kw: calls.__setitem__("min_baseline", m)
     )
     monkeypatch.setattr(
         dream_tune, "measure", lambda *a, **k: (_ for _ in ()).throw(AssertionError("no measure"))

--- a/tests/test_dream_tune_single_apply.py
+++ b/tests/test_dream_tune_single_apply.py
@@ -121,7 +121,7 @@ def test_tuning_pass_sets_cooldown_on_online_revert(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(dream_tune_online, "online_fraction", lambda sd, v, **k: (0.40, 50))
     monkeypatch.setattr(dream_tune, "write_overlay", lambda sd, params, meta: None)
-    monkeypatch.setattr(dream_tune, "save_baseline", lambda sd, m: None)
+    monkeypatch.setattr(dream_tune, "save_baseline", lambda sd, m, **kw: None)
     monkeypatch.setattr(
         dream_tune, "measure", lambda *a, **k: (_ for _ in ()).throw(AssertionError("no measure"))
     )


### PR DESCRIPTION
## The incident

On 2026-08-27 one nightly `dream` pass **confirmed** a knob and **rolled it back in the same pass**.

From `dream/last.json`:

- `.tuner.online` → `confirmed`, `MEMO_RECALL_MIN_SIM` 0.5 → 0.4, online 0.0 → **0.9362** (n=47)
- `.tuner.status` → `rolled_back`, `restored = {MEMO_RECALL_PROJECT_BOOST: 0.25}` — min_sim gone

## Why

In `run_tuning_pass`, a resolution of `reverted` or `waiting` returns early. `confirmed` **falls through** (the comment only names `none`/`expired`) into the min_sim rollback guard, which did:

```python
baseline = load_baseline(cfg.state_dir)          # eval/dream_baseline.json
if baseline is not None:
    live = measure(mem, labels, k=k, floor=current)
    if _regressed(live, baseline) and not dry_run:
        rolled = rollback_overlay(cfg.state_dir)
```

That baseline was written **six days earlier**, on a corpus thousands of memories smaller. `_regressed` uses a `1e-9` tolerance, i.e. effectively zero. The corpus grows daily, so a precision difference is guaranteed — and every one of them reverts the knob.

**The guard was measuring corpus drift and charging it to the knob.**

`recall_baseline.json` already carries a `corpus_fingerprint` for exactly this reason. `dream_baseline.json` did not, which is what let this through.

## The change

"Regressed" has to mean *worse than the config it replaced*, not *worse than a stored snapshot of a corpus that no longer exists*.

- `save_baseline` stamps `corpus_fingerprint` (the same `dream_utils._corpus_fingerprint`). `mem` is an optional keyword, so callers without a `Memory` — and every baseline written before this field — keep working.
- The guard trusts the stored snapshot **only while it still describes the live corpus**.
- Once it doesn't, it asks the comparable question instead: the **current floor against the floor it replaced** (`_meta.prev`), both measured on **today's** corpus. This isolates the knob from the corpus entirely.
- A missing fingerprint is treated as *not comparable*, never as a match, so pre-existing baselines take the counterfactual path rather than the stale one.

Cost: one extra `measure()` in a nightly pass, and only on the drifted path.

## What this does NOT change

The online proof loop and the offline guard keep their existing roles. This does not decide "who wins" between them — it makes the guard's question answerable, so the two stop contradicting each other for a reason that was never about the knob.

## Tests

4 new in `tests/test_dream_tune_knobs.py`.

- `test_min_sim_guard_does_not_roll_back_on_corpus_drift` reproduces the incident and failed RED with `assert 'rolled_back' != 'rolled_back'`.
- `test_min_sim_guard_still_rolls_back_a_genuinely_worse_floor` proves the counterfactual does not defang the guard: a floor that measures worse than its predecessor, same corpus same run, still reverts.
- `test_min_sim_guard_trusts_a_baseline_from_the_same_corpus` asserts the same-corpus path stays **one** measurement, not two (`calls == [0.4]`).
- Plus fingerprint stamping and the no-`mem` backward-compatible path.

Two test stubs patched `save_baseline` with a two-argument lambda and now accept the optional keyword; the production dispatch keeps a default so a two-argument call still works.

Full suite: **8086 passed / 21 skipped**. ruff, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)