### PR TITLE
fix: make noise@k able to see the noise it measures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ### Fixed
 
+- **`noise@k` was structurally blind to the failure mode it is named for.**
+  `_hit_is_noise` fired only on a hit carrying a noise TAG, sitting under a
+  noise PATH fragment, or listed in the prompt's `avoid_ids`. The curated set
+  ships three prompts whose `_note` calls them "Noise probe" — culinary,
+  weather, physics — and none of them can produce such a hit: whatever comes
+  back is an ordinary dev memory with ordinary tags. So they scored zero noise
+  no matter what surfaced, and the gate read a clean `noise@5 0.000` while
+  `memo debug-recall "best pasta recipe for tonight"` injected 3 memories. The
+  new schema-additive `noise_probe` label makes the claim measurable: a prompt
+  that declares nothing in the corpus answers it counts every top-K hit as
+  noise. It is an explicit field rather than an inference from
+  `relevant=false and not expect_ids`, because the two ⛔ AVOID coverage probes
+  and the as-of probe share exactly that shape and their own labels state they
+  must never perturb precision@K / noise@K. Measured on the live index: `noise@5`
+  goes 0.000 → **0.041** at config `L live/vec/0.5` with `prec@5` unchanged at
+  0.530 — the recall did not regress, the instrument stopped lying. The
+  machine-local gate baseline must be reseeded (`--update-baseline`) for the
+  same reason.
+
 - **Read-only MCP tools stopped bypassing the write coordinator on MCP SDK v2.**
   The middleware read `ToolAnnotations.readOnlyHint`, which SDK v2 renamed to
   `read_only_hint` (PEP 8) and kept only as a deprecated alias that warns on

--- a/eval/regression_labels.json
+++ b/eval/regression_labels.json
@@ -278,17 +278,20 @@
     {
       "text": "best pasta recipe for tonight",
       "relevant": false,
-      "_note": "Noise probe — culinary content not in the developer's vault."
+      "_note": "Noise probe — culinary content not in the developer's vault.",
+      "noise_probe": true
     },
     {
       "text": "what is the weather tomorrow",
       "relevant": false,
-      "_note": "Noise probe — real-time query with no stored answer."
+      "_note": "Noise probe — real-time query with no stored answer.",
+      "noise_probe": true
     },
     {
       "text": "explain quantum entanglement",
       "relevant": false,
-      "_note": "Noise probe — general physics, not stored as a personal memory."
+      "_note": "Noise probe — general physics, not stored as a personal memory.",
+      "noise_probe": true
     },
     {
       "text": "hace el push a master",

--- a/src/memo/eval_recall.py
+++ b/src/memo/eval_recall.py
@@ -89,6 +89,13 @@ class Prompt:
     # Complements `avoid_ids` (ids that must stay OUT of normal recall — leakage).
     # Schema-additive on memo.eval_recall.labels.v1.
     expect_avoid_ids: list[str] = field(default_factory=list)
+    # A prompt with NO relevant answer anywhere in the corpus: every top-K hit
+    # it returns is noise. Explicit rather than inferred from
+    # `relevant=False and not expect_ids`, because the ⛔ AVOID coverage probes
+    # and the as-of probe share that exact shape and their labels state they
+    # must never perturb precision@K / noise@K — they score avoid@k only.
+    # Schema-additive on memo.eval_recall.labels.v1.
+    noise_probe: bool = False
 
 
 # Alias so tests/code can import `Label` as the per-prompt record type.
@@ -112,6 +119,7 @@ def _label_from_dict(d: dict) -> Label:
         avoid_ids=[str(x) for x in (d.get("avoid_ids") or [])],
         as_of=str(d["as_of"]) if d.get("as_of") else None,
         expect_avoid_ids=[str(x) for x in (d.get("expect_avoid_ids") or [])],
+        noise_probe=bool(d.get("noise_probe", False)),
     )
 
 
@@ -139,6 +147,7 @@ class LabelSet:
                         sorted(p.avoid_ids),
                         p.as_of,
                         sorted(p.expect_avoid_ids),
+                        p.noise_probe,
                     )
                     for p in self.prompts
                 ],
@@ -445,6 +454,23 @@ def _is_noise(rec: Any, labels: LabelSet) -> bool:
         return True
     p = (getattr(rec, "path", None) or "").lower()
     return any(frag in p for frag in labels.noise_path_fragments)
+
+
+def hit_is_noise(rec: Any, prompt: Prompt, labels: LabelSet) -> bool:
+    """Does this top-K hit count against ``noise@k`` for ``prompt``?
+
+    Three ways in. The first two are properties of the HIT — a noise tag or a
+    noise path fragment — and the third is the prompt's own ``avoid_ids``.
+    None of them can fire for an ordinary memory surfaced by a prompt that has
+    no right answer at all, which is why the curated set's three "Noise probe"
+    prompts scored a clean 0.000 while the live pipeline injected 3 memories
+    for `best pasta recipe for tonight`. A prompt marked ``noise_probe``
+    asserts that nothing in the corpus answers it, so anything it returns is
+    noise by the definition of the label.
+    """
+    if prompt.noise_probe:
+        return True
+    return _is_noise(rec, labels) or _id_matches(getattr(rec, "id", ""), prompt.avoid_ids)
 
 
 def _id_matches(hit_id: str, expect_ids: list[str]) -> bool:
@@ -878,8 +904,8 @@ def _run_config_inner(
         top = ranked[:k]
         quality_metrics = _quality_eval_metrics(top, k=k)
 
-        def _hit_is_noise(h: Any, _avoid_ids: list[str] = prompt.avoid_ids) -> bool:
-            return _is_noise(h, labels) or _id_matches(getattr(h, "id", ""), _avoid_ids)
+        def _hit_is_noise(h: Any, _prompt: Prompt = prompt) -> bool:
+            return hit_is_noise(h, _prompt, labels)
 
         for h in top:
             graph_eval_rows.append(

--- a/tests/test_eval_recall.py
+++ b/tests/test_eval_recall.py
@@ -1841,7 +1841,9 @@ def test_a_deliberately_unscored_prompt_is_not_a_noise_probe():
     they must NEVER perturb precision@K / noise@K — they score avoid@k only.
     Keying off that shape would have silently started scoring them, so the
     signal is an explicit field, not an inference."""
-    labels = LabelSet(prompts=[Prompt(text="let's cut a release now", expect_avoid_ids=["de5df482"])])
+    labels = LabelSet(
+        prompts=[Prompt(text="let's cut a release now", expect_avoid_ids=["de5df482"])]
+    )
     prompt = labels.prompts[0]
     hit = SimpleNamespace(id="deadbeef", tags=["project:memo"], path="/vault/notes/x.md")
     assert prompt.noise_probe is False

--- a/tests/test_eval_recall.py
+++ b/tests/test_eval_recall.py
@@ -1814,3 +1814,65 @@ def test_run_config_counts_type_marked_canonical_hit() -> None:
     )
 
     assert eval_recall.gate_metrics([row])["canonical_hit_at_k"] == 1.0
+
+
+def test_noise_probe_counts_every_hit_as_noise():
+    """`noise@k` was structurally blind to the failure mode it is named for.
+
+    `_hit_is_noise` only fired on a hit carrying a noise TAG, sitting under a
+    noise PATH fragment, or listed in the prompt's `avoid_ids`. The curated set
+    ships three prompts whose `_note` calls them "Noise probe" — culinary,
+    weather, physics — none of which can produce such a hit: whatever surfaces
+    is an ordinary dev memory with ordinary tags. So they scored 0 noise no
+    matter what came back, and `noise@k` read a clean 0.000 while
+    `memo debug-recall "best pasta recipe for tonight"` injected 3 memories.
+
+    A prompt declared a noise probe asserts that NOTHING is relevant to it, so
+    every top-k hit it returns is noise by definition of the label."""
+    labels = LabelSet(prompts=[Prompt(text="best pasta recipe", noise_probe=True)])
+    prompt = labels.prompts[0]
+    hit = SimpleNamespace(id="deadbeef", tags=["project:memo"], path="/vault/notes/x.md")
+    assert eval_recall.hit_is_noise(hit, prompt, labels) is True
+
+
+def test_a_deliberately_unscored_prompt_is_not_a_noise_probe():
+    """The two ⛔ AVOID coverage probes and the as-of probe share the noise
+    probes' shape (`relevant=false`, empty `expect_ids`) but their notes say
+    they must NEVER perturb precision@K / noise@K — they score avoid@k only.
+    Keying off that shape would have silently started scoring them, so the
+    signal is an explicit field, not an inference."""
+    labels = LabelSet(prompts=[Prompt(text="let's cut a release now", expect_avoid_ids=["de5df482"])])
+    prompt = labels.prompts[0]
+    hit = SimpleNamespace(id="deadbeef", tags=["project:memo"], path="/vault/notes/x.md")
+    assert prompt.noise_probe is False
+    assert eval_recall.hit_is_noise(hit, prompt, labels) is False
+
+
+def test_noise_probe_survives_the_json_round_trip():
+    p = eval_recall._label_from_dict({"text": "what is the weather tomorrow", "noise_probe": True})
+    assert p.noise_probe is True
+    assert eval_recall._label_from_dict({"text": "x"}).noise_probe is False
+
+
+def test_noise_probe_is_part_of_the_labels_fingerprint():
+    """The fingerprint keys the eval cache and the gate baseline. If flipping
+    a prompt to a noise probe left it unchanged, a stale cached result would
+    be served for a label set that now scores differently."""
+    base = LabelSet(prompts=[Prompt(text="q")])
+    probe = LabelSet(prompts=[Prompt(text="q", noise_probe=True)])
+    assert base.fingerprint() != probe.fingerprint()
+
+
+def test_curated_noise_probes_are_marked():
+    """The three prompts whose `_note` calls them noise probes carry the field
+    that makes that claim measurable."""
+    import json as _json
+    from pathlib import Path as _Path
+
+    path = _Path(__file__).resolve().parents[1] / "eval" / "regression_labels.json"
+    if not path.is_file():  # packaged checkouts without the curated set
+        return
+    prompts = _json.loads(path.read_text(encoding="utf-8"))["prompts"]
+    noted = [p for p in prompts if "noise probe" in (p.get("_note") or "").lower()]
+    assert noted, "curated set lost its noise probes"
+    assert all(p.get("noise_probe") for p in noted)


### PR DESCRIPTION
## The defect

`_hit_is_noise` had three ways to fire — all three are properties of the **hit**:

```python
def _hit_is_noise(h, _avoid_ids=prompt.avoid_ids) -> bool:
    return _is_noise(h, labels) or _id_matches(getattr(h, "id", ""), _avoid_ids)
```

...a noise **tag**, a noise **path** fragment, or the hit's id in the prompt's `avoid_ids`.

None of them can fire for a prompt that has **no right answer at all**. The curated set ships three prompts whose `_note` literally calls them noise probes:

- `best pasta recipe for tonight` — *"Noise probe — culinary content not in the developer's vault."*
- `what is the weather tomorrow` — *"Noise probe — real-time query with no stored answer."*
- `explain quantum entanglement` — *"Noise probe — general physics, not stored as a personal memory."*

Whatever they surface is an ordinary dev memory with ordinary tags under an ordinary path. So they scored **zero noise no matter what came back**.

That is why the gate read a clean `noise@5 0.000` while the live pipeline does this:

```
$ memo debug-recall "best pasta recipe for tonight"
mode=vec · min_sim=0.5 · top_k=3 · skip_below=0.45 · gap_threshold=0.5
9 candidates → 3 qualifying · ● = injected (top 3)
```

Three arbitrary memories injected for a question about dinner, and the gate that exists to catch exactly that waste could not see it.

## The change

A prompt marked `noise_probe` asserts that nothing in the corpus answers it, so **every top-K hit it returns is noise by the definition of the label**.

The field is explicit rather than inferred from `relevant=false and not expect_ids`, because the two ⛔ AVOID coverage probes and the as-of probe share exactly that shape — and their own notes say so:

> `relevant=false` + empty `expect_ids` so it **NEVER perturbs precision@K / noise@K** — it scores avoid@k (coverage) only.

Inferring from the shape would have silently started scoring them. A test pins that.

Also extracts the closure into a module-level `hit_is_noise(rec, prompt, labels)` so the predicate is testable and the harness cannot drift from it.

## Measured

Live index, config `L live/vec/0.5`:

| | before | after |
|---|---|---|
| `noise@5` | 0.000 | **0.041** |
| `prec@5` | 0.530 | 0.530 |

**Recall did not regress. The instrument stopped lying.** 0.041 × (49 × 5) ≈ 10 noise hits across 3 probes — about 3.3 injected memories per irrelevant prompt, matching `debug-recall`.

The machine-local gate baseline is reseeded for the same reason: `noise_probe` now participates in the labels fingerprint, so the old baseline no longer applies. Pre-push gate after reseeding: **PASS — prec@k 0.530 >= 0.530, noise@k 0.041 <= 0.041.**

This turns an unmeasurable complaint into a number that can be driven down.

## Tests

5 new, all RED first:

- every hit counts for a noise probe
- a deliberately-unscored probe stays unscored
- JSON round-trip of the new field
- the field participates in the labels fingerprint (otherwise a stale cached result is served for a set that now scores differently)
- the curated probes actually carry the marker

`pytest -k eval`: **412 passed**. ruff, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)