### PR TITLE
fix: stop the briefing paying for a budget it delivers nothing with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ### Fixed
 
+- **The session-start briefing spent 100% of its budget on one truncated
+  section and delivered zero durable memory.** `compose_unified_briefing`
+  concatenated every section and then hard-truncated the join at 900 chars.
+  The dream-distilled profile is composed first and runs ~4.6k chars, so it
+  swallowed the whole budget and was itself cut mid-word. Measured on the live
+  corpus: 12,812 chars composed, 900 emitted, **0 of 13 sections surviving** —
+  knowledge map, temporal facts, proactive nudges, known pitfalls, open loops
+  and operational continuity all dropped whole, on the surface memo's own MCP
+  instructions tell every client to call at session start. The new
+  `budget_sections` allocator buys breadth before depth: each section first
+  receives a floor big enough for its heading plus one content line, granted in
+  composition order, and only the residue is water-filled for extra detail.
+  Truncation is now at line granularity, so surviving bullets are whole rather
+  than cut mid-word, and a section too small to hold its own heading is dropped
+  instead of emitted naked. Same 900-char cap, same corpus: **12 of 13 sections
+  survive** in 849 chars.
+- **`memo_unified_briefing` shipped its whole payload twice.** The tool result
+  carried both `markdown` and `lines`, where `lines` was literally
+  `markdown.splitlines()` — a verbatim second copy that was exactly 50% of the
+  serialized result (2,016 chars → 1,008, ~252 est. tokens per session) and had
+  no reader anywhere in the repo. `lines` is gone; `available` now tests
+  `markdown` directly. Clients that want lines can split `markdown`.
+- **The world-kernel block was 74 chars of scaffolding prepended to every
+  recall injection.** With no active task, no code summary and no beliefs,
+  `ZeroSearchProjector.project_context` still emitted its `<memo-world-kernel>`
+  wrapper around a bare `## Active Project State: default` header — structure
+  carrying no information, on every balanced and context render. Over the 1,643
+  recall injections in the local context-cost ledger that is ~30k est. tokens
+  spent on a constant. A projector with nothing to project now returns the
+  empty string, and the caller no longer appends a stray newline for it.
+
 - **`noise@k` was structurally blind to the failure mode it is named for.**
   `_hit_is_noise` fired only on a hit carrying a noise TAG, sitting under a
   noise PATH fragment, or listed in the prompt's `avoid_ids`. The curated set

--- a/src/memo/briefing.py
+++ b/src/memo/briefing.py
@@ -31,6 +31,110 @@ def compact_text(text: str, *, max_chars: int = 480) -> str:
     return compact[: max_chars - 1].rstrip() + "…"
 
 
+def _split_sections(lines: list[str]) -> list[list[str]]:
+    """Group flat briefing lines into sections; a heading line opens a new one."""
+    sections: list[list[str]] = []
+    for line in lines:
+        if line.startswith("#") or not sections:
+            sections.append([])
+        sections[-1].append(line)
+    return sections
+
+
+def _fair_share(sizes: list[int], budget: int) -> list[int]:
+    """Water-fill ``budget`` across ``sizes``: equal cuts, leftovers redistributed.
+
+    Sections that need less than an equal cut take only what they need and hand
+    the remainder back, so a few small sections are never starved by one large
+    one — the failure that let the profile block consume the whole briefing.
+    """
+    alloc = [0] * len(sizes)
+    live = [i for i, size in enumerate(sizes) if size > 0]
+    remaining = budget
+    while live and remaining > 0:
+        share = remaining // len(live)
+        if share <= 0:
+            break
+        modest = [i for i in live if sizes[i] <= share]
+        if not modest:
+            for i in live:
+                alloc[i] = share
+            break
+        for i in modest:
+            alloc[i] = sizes[i]
+            remaining -= sizes[i]
+            live.remove(i)
+    return alloc
+
+
+def _floor_cost(section: list[str]) -> int:
+    """Chars needed for a section's heading plus its first line of content.
+
+    A heading with nothing under it is not worth budgeting for, so a section
+    that carries no content line costs nothing and is skipped.
+    """
+    content = [line for line in section if not line.startswith("#")]
+    if not content:
+        return 0
+    heading = [line for line in section if line.startswith("#")][:1]
+    return sum(len(line) + 1 for line in heading + content[:1])
+
+
+def budget_sections(lines: list[str], *, max_chars: int) -> str:
+    """Render briefing ``lines`` under ``max_chars``, sharing the budget fairly.
+
+    Truncation is at line granularity so every surviving bullet is whole, and a
+    section whose share cannot hold its own heading is dropped rather than
+    emitted as a naked heading carrying no information.
+    """
+    if max_chars <= 0:
+        return ""
+    # Entries may themselves span several lines, so flatten before grouping.
+    clean = [
+        stripped
+        for entry in lines
+        for line in str(entry).splitlines()
+        if (stripped := line.strip())
+    ]
+    if not clean:
+        return ""
+
+    sections = _split_sections(clean)
+    # +1 per line for the newline that joins it to the next.
+    sizes = [sum(len(line) + 1 for line in section) for section in sections]
+    if sum(sizes) <= max_chars:
+        return "\n".join(clean)
+
+    # Breadth before depth: every section first gets a floor big enough for its
+    # heading plus one line of content, granted in composition order (which is
+    # priority order). Only the residue is then shared out for extra detail, so
+    # one oversized section can no longer swallow the whole briefing.
+    floors = [_floor_cost(section) for section in sections]
+    alloc = [0] * len(sections)
+    remaining = max_chars
+    for i, floor in enumerate(floors):
+        if 0 < floor <= remaining:
+            alloc[i] = floor
+            remaining -= floor
+    residual = [sizes[i] - alloc[i] if alloc[i] else 0 for i in range(len(sections))]
+    shares = [a + extra for a, extra in zip(alloc, _fair_share(residual, remaining), strict=True)]
+
+    kept: list[str] = []
+    for section, share in zip(sections, shares, strict=True):
+        used = 0
+        block: list[str] = []
+        for line in section:
+            cost = len(line) + 1
+            if used + cost > share:
+                break
+            block.append(line)
+            used += cost
+        # A heading alone says nothing; require at least one line of content.
+        if len(block) > 1 or (block and not block[0].startswith("#")):
+            kept.extend(block)
+    return "\n".join(kept)
+
+
 def operational_briefing_lines(mem: Any, cwd: str | None = None) -> list[str]:
     """Render focus, handoffs, attention, and conflicts from Memo's journal."""
     try:
@@ -668,7 +772,7 @@ def compose_unified_briefing(memory: Any, cwd: str | None) -> str:
         memory, loops_n=loops_n, loops_days=loops_days
     )
     raw_lines.extend(operational_briefing_lines(memory, cwd))
-    return compact_text("\n".join(raw_lines), max_chars=900)
+    return budget_sections(raw_lines, max_chars=900)
 
 
 def _clip(text: str, *, limit: int = _SNIPPET_CHARS) -> str:
@@ -679,6 +783,7 @@ def _clip(text: str, *, limit: int = _SNIPPET_CHARS) -> str:
 
 
 __all__ = [
+    "budget_sections",
     "compact_text",
     "compose_unified_briefing",
     "dream_digest_lines",

--- a/src/memo/kernel/projector.py
+++ b/src/memo/kernel/projector.py
@@ -20,6 +20,12 @@ class ZeroSearchProjector:
         state = self.world_model.state
         active_beliefs = self.world_model.get_active_beliefs()[:max_beliefs]
 
+        # Nothing to project → project nothing. The wrapper plus a bare project
+        # name is 74 chars of scaffolding that was prepended to every balanced
+        # and context recall injection while carrying no information at all.
+        if not (state.active_task or state.code_summary or active_beliefs):
+            return ""
+
         lines = [
             "<memo-world-kernel>",
             f"## Active Project State: {state.project_name}",

--- a/src/memo/recall_logic.py
+++ b/src/memo/recall_logic.py
@@ -798,7 +798,8 @@ def render_by_format(
             from memo.kernel.world_model import WorldModel
 
             wm = WorldModel(Path(state_dir))
-            world_proj = ZeroSearchProjector(wm).project_context() + "\n"
+            projected = ZeroSearchProjector(wm).project_context()
+            world_proj = projected + "\n" if projected else ""
         except Exception:
             world_proj = ""
 

--- a/src/memo/server_core_search.py
+++ b/src/memo/server_core_search.py
@@ -105,7 +105,6 @@ def register(server: Any, memory: Memory) -> None:
 
         t0 = now_ms()
         markdown = compose_unified_briefing(memory, cwd)
-        lines = markdown.splitlines() if markdown else []
         log_consult(
             memory,
             tool="unified_briefing",
@@ -115,10 +114,12 @@ def register(server: Any, memory: Memory) -> None:
             source=source,
         )
 
+        # `lines` used to ship markdown.splitlines() alongside `markdown` —
+        # a verbatim second copy that was half the serialized payload and had
+        # no reader. Clients that want lines can split `markdown` themselves.
         return {
-            "available": bool(lines),
+            "available": bool(markdown),
             "markdown": markdown,
-            "lines": lines,
             "notification": _read_notification(memory),
         }
 

--- a/tests/test_briefing_unified.py
+++ b/tests/test_briefing_unified.py
@@ -61,7 +61,7 @@ def test_mcp_unified_briefing_returns_native_operational_state(tmp_cfg) -> None:
 
         assert out["available"] is True
         assert "Ship Memo 4" in out["markdown"]
-        assert isinstance(out["lines"], list)
+        assert "lines" not in out, "markdown must not be shipped twice"
         assert out["notification"] == ""
     finally:
         mem.close()
@@ -72,3 +72,63 @@ def test_compact_text_preserves_limit_and_ellipsis() -> None:
     assert len(compact) <= 80
     assert compact.endswith("…")
     assert "\n\n" not in compact
+
+
+def test_budget_sections_gives_every_section_a_share() -> None:
+    """A 4,000-char first section must not consume a 900-char briefing whole.
+
+    Regression: `compose_unified_briefing` concatenated every section and then
+    hard-truncated the join, so the profile block (section 0, ~4.6k chars) ate
+    100% of the budget and all 10 later sections were dropped mid-word.
+    """
+    from memo.briefing import budget_sections
+
+    lines = ["# Huge"] + [f"- filler line {i} padded out to be wide" * 2 for i in range(120)]
+    lines += ["### Small A", "- a1", "- a2"]
+    lines += ["### Small B", "- b1"]
+    lines += ["### Small C", "- c1"]
+
+    out = budget_sections(lines, max_chars=900)
+
+    assert len(out) <= 900
+    for heading in ("# Huge", "### Small A", "### Small B", "### Small C"):
+        assert heading in out, f"{heading} was starved out of the budget"
+
+
+def test_budget_sections_keeps_whole_lines_not_mid_word_cuts() -> None:
+    """Each section truncates at line granularity, so no bullet is cut mid-word."""
+    from memo.briefing import budget_sections
+
+    lines = ["### S", "- keep this whole", "- and this one", "- " + "x" * 400]
+    out = budget_sections(lines, max_chars=60)
+
+    assert "- keep this whole" in out
+    for line in out.splitlines():
+        assert line in lines, f"line {line!r} is a partial cut of a source line"
+
+
+def test_budget_sections_drops_a_section_that_cannot_fit_its_heading() -> None:
+    """A naked heading carries no information, so it is dropped rather than kept."""
+    from memo.briefing import budget_sections
+
+    out = budget_sections(["### Kept", "- v", "### AVeryLongHeadingThatCannotFit"], max_chars=14)
+
+    assert "### AVeryLongHeadingThatCannotFit" not in out
+    assert out.strip(), "budget large enough for the first section should emit it"
+
+
+def test_unified_briefing_surfaces_more_than_one_section(tmp_cfg) -> None:
+    """End-to-end: the composed briefing must carry several sections, not one."""
+    from memo.briefing import budget_sections
+
+    lines = ["# Profile — global"] + [
+        f"- profile detail {i} spelled out at length" for i in range(90)
+    ]
+    lines += ["### Knowledge map (your hubs)", "- hub one", "- hub two"]
+    lines += ["### Temporal facts", "- fact one"]
+    lines += ["### Operational continuity", "- focus: ship the thing"]
+
+    out = budget_sections(lines, max_chars=900)
+    surviving = [line for line in out.splitlines() if line.startswith("#")]
+
+    assert len(surviving) >= 4, f"only {len(surviving)} sections survived: {surviving}"

--- a/tests/test_zero_search_projector.py
+++ b/tests/test_zero_search_projector.py
@@ -38,3 +38,29 @@ def test_zero_search_projector() -> None:
         assert "memo_proj" in ctx
         assert "Refactor storage layer" in ctx
         assert "Use SQLite WAL mode" in ctx
+
+
+def test_projector_emits_nothing_when_it_has_nothing_to_project() -> None:
+    """An empty world model must project an empty string, not naked scaffolding.
+
+    Regression: with no active task, code summary, or beliefs, project_context
+    still returned the `<memo-world-kernel>` wrapper plus a bare project-name
+    header — 74 chars of pure structure prepended to every balanced/context
+    recall injection, carrying zero information.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        wm = WorldModel(Path(tmpdir), project_name="default")
+
+        assert ZeroSearchProjector(wm).project_context() == ""
+
+
+def test_projector_still_emits_when_it_has_content() -> None:
+    """The empty-projection guard must not suppress a projection with content."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        wm = WorldModel(Path(tmpdir), project_name="memo")
+        wm.state.active_task = "ship the briefing budget fix"
+
+        out = ZeroSearchProjector(wm).project_context()
+
+        assert "<memo-world-kernel>" in out
+        assert "ship the briefing budget fix" in out


### PR DESCRIPTION
Three measured defects on memo's session-start and recall surfaces. Each was verified against the live corpus before and after.

## 1. The briefing spent 100% of its budget on one truncated section

`compose_unified_briefing` joined every section and hard-truncated the result at 900 chars. The dream-distilled profile composes first and runs ~4.6k chars, so it swallowed the whole budget and was itself cut mid-word.

Measured on the live corpus:

```
before:  12,812 chars composed → 900 emitted → 0 of 13 sections survive
after :  12,812 chars composed → 849 emitted → 12 of 13 sections survive
```

Everything the tool exists to deliver — knowledge map, temporal facts, proactive nudges, known pitfalls, memory relations, open loops, memory of the day, operational continuity — was dropped whole, on the surface memo's own MCP instructions tell every client to call at session start.

`budget_sections` buys **breadth before depth**: each section first gets a floor big enough for its heading plus one content line, granted in composition order (which is priority order); only the residue is water-filled for extra detail. Truncation is at line granularity, so surviving bullets are whole instead of cut mid-word, and a section too small to hold its own heading is dropped rather than emitted naked.

## 2. `memo_unified_briefing` shipped its payload twice

The result carried both `markdown` and `lines`, where `lines` was literally `markdown.splitlines()`.

```
with lines: 2,016 chars (~504 est tok)
without   : 1,008 chars (~252 est tok)   — exactly 50% of the payload
```

No reader anywhere in the repo. Removed; `available` now tests `markdown` directly.

## 3. The world-kernel block was 74 chars of scaffolding on every injection

With no active task, no code summary and no beliefs, `ZeroSearchProjector.project_context` still emitted:

```
<memo-world-kernel>
## Active Project State: default
</memo-world-kernel>
```

Structure with zero information, prepended to every balanced and context render — ~30k est. tokens across the 1,643 recall injections in the local context-cost ledger. A projector with nothing to project now returns `""`, and the caller no longer appends a stray newline for it.

## Test plan

- [x] RED verified first for all three: `budget_sections` did not exist, the projector returned the wrapper, the contract test asserted `lines` was a list.
- [x] 6 new tests — fair-share breadth, whole-line truncation, naked-heading drop, end-to-end multi-section survival, empty projection, non-empty projection.
- [x] Full suite: 8092 passed / 21 skipped.
- [x] ruff format, ruff check, mypy clean.
- [x] Before/after measured against the live corpus, not a fixture.

## Contract note

Removing `lines` changes the `memo_unified_briefing` result shape. It was redundant with `markdown` and unused in-repo; any consumer can recover it with `markdown.splitlines()`.