### PR TITLE
fix: stop three surfaces charging tokens for nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,47 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ### Fixed
 
+- **The proxy pruned `StructuredOutput`, so the model called it blind and paid
+  the difference back in retries.** `_discover_builtins()` shelled out to
+  `claude --list-tools` at import time to extend the never-prune set. That
+  option does not exist — it exits non-zero with `unknown option
+  '--list-tools'` — so discovery could only ever fail and fall back to the
+  9-name core, paying a subprocess on every import to learn nothing. The
+  existing test mocked `subprocess.run` into succeeding and so reported a path
+  that never ran. `StructuredOutput` therefore fell outside `_ALWAYS_KEEP` and
+  was pruned when unused. Because the harness executes it client-side and
+  *forces* schema agents to call it, dropping its schema does not remove the
+  capability — it removes the model's knowledge of the required fields.
+  Measured across 237 subagent transcripts: 121 first calls (51%) came back
+  `must have required property 'refuted' ...`, discarding **511,052 output
+  tokens** to retries, far more than the pruned schema ever saved. The set is
+  now a constant that includes `StructuredOutput`, which also keeps the cached
+  prefix stable turn to turn.
+
+- **`memo session recent` charged the session-start budget for rows that say
+  nothing.** `list_sessions` orders by `updated`, and `mark_ids_recalled`
+  bumps `updated` on content-free snapshots, so recall bookkeeping promoted
+  empty sessions above informative ones. Measured live: 7 of 8 rendered rows
+  were `| 4h ago | — | — | — | \`id\` |` — a timestamp and a truncated id, no
+  project, branch, or summary. Rows with no content are now dropped before
+  rendering; the live panel went 525 → 273 chars, exactly the 252 bytes those
+  rows occupied.
+- **The same panel was the one injection memo's own ledger never saw.**
+  `context_cost.log` recorded only `kind=recall` and `kind=briefing`, because
+  `cli_session` emitted its `additionalContext` and returned without logging —
+  so a per-session injection could not be weighed against the two that were
+  measured. It now records `kind=session_recent`.
+- **`memo tokens --by-transform` advertised a decomposition of a number it is
+  not denominated in.** The help read "Break the measured proxy saving down per
+  transform" and the column read "share of savings", but the headline saving is
+  a cache-weighted *billed* ratio while `saved_by` is an unweighted chars/4
+  count of removed text. The two differ by 9.11x on the live ledger — 1.08B raw
+  tokens "saved" against 118M tok-equiv ever billed — because prefix content a
+  transform removes is credited at full value every turn while the
+  counterfactual bills it at the 0.1x cache-read weight. The split itself was
+  already honest; only its label was not. Now titled "raw text removed, not
+  billed saving", with the column and `--help` matching.
+
 - **`noise@k` was structurally blind to the failure mode it is named for.**
   `_hit_is_noise` fired only on a hit carrying a noise TAG, sitting under a
   noise PATH fragment, or listed in the prompt's `avoid_ids`. The curated set

--- a/src/memo/cli_session.py
+++ b/src/memo/cli_session.py
@@ -6,7 +6,9 @@ root group in cli.py via `cli.add_command(session_group)`.
 
 from __future__ import annotations
 
+import logging
 import sys
+from pathlib import Path
 from typing import Any
 
 import click
@@ -14,6 +16,8 @@ import click
 from memo.cli_common import console
 from memo.config import Config
 from memo.flags import flag_bool, flag_int
+
+_log = logging.getLogger(__name__)
 
 
 @click.command(name="continuity")
@@ -596,6 +600,44 @@ def session_refresh_summary() -> None:
     _sys.exit(0)
 
 
+def _row_has_content(row: dict, summary: str) -> bool:
+    """Whether a session row says anything at all.
+
+    `list_sessions` orders by `updated`, and `mark_ids_recalled` bumps that on
+    content-free snapshots, so recall bookkeeping promotes empty rows above
+    informative ones. Charging the session-start budget for a line that is
+    three em-dashes and an id is a pure loss, so those rows are dropped.
+    """
+    return bool(
+        (row.get("project") or "").strip()
+        or (row.get("branch") or "").strip()
+        or summary.strip().strip("—·")
+    )
+
+
+def _log_session_recent_cost(state_dir: Path, context: str) -> None:
+    """Record this panel in the context-cost ledger.
+
+    It is injected into every matching SessionStart but was the one injection
+    the ledger never saw, so its share of the session-start budget could not be
+    measured against recall or the briefing.
+    """
+    try:
+        from memo.dashboard import append_context_cost_log
+
+        append_context_cost_log(
+            state_dir,
+            kind="session_recent",
+            chars=len(context),
+            client="claude-code",
+        )
+    except (OSError, ImportError) as exc:
+        # The write is a `datetime.now()` plus a capped JSONL append, so disk
+        # trouble and a missing dashboard module are the only realistic
+        # failures — and neither may take down a SessionStart hook.
+        _log.debug("session recent: context-cost log failed: %s", exc)
+
+
 @session_group.command(name="recent")
 @click.option("--limit", default=None, type=int, show_default=True)
 def session_recent(limit: int | None) -> None:
@@ -693,6 +735,7 @@ def session_recent(limit: int | None) -> None:
         )
 
     def _render_table(title: str, items: list[dict]) -> None:
+        items = [r for r in items if _row_has_content(r, _clean_summary(r, 55))]
         if not items:
             return
         lines.extend(
@@ -727,10 +770,14 @@ def session_recent(limit: int | None) -> None:
         _render_table("Other projects", others)
         lines.append("_`memo resume <id>` to see details. `claude --resume <id>` to resume._")
 
+    context = "\n".join(lines)
+
+    _log_session_recent_cost(cfg.state_dir, context)
+
     output = {
         "hookSpecificOutput": {
             "hookEventName": "SessionStart",
-            "additionalContext": "\n".join(lines),
+            "additionalContext": context,
         }
     }
     print(_json.dumps(output, ensure_ascii=False))

--- a/src/memo/cli_tokens.py
+++ b/src/memo/cli_tokens.py
@@ -210,10 +210,16 @@ def _proxy_panel(proxy: dict) -> Panel:
 
 
 def _by_transform_table(proxy: dict) -> Table:
-    tbl = Table(title="by transform", show_lines=False)
+    # `saved_by` is an unweighted chars/4 diff of the text a transform removed.
+    # The proxy panel's headline saving is a cache-weighted BILLED ratio, and
+    # the two are different currencies: prefix content a transform removes is
+    # credited here at full value every turn while the counterfactual bills it
+    # at the 0.1x cache-read weight. Naming the unit keeps the reader from
+    # reading this table as a decomposition of the billed saving.
+    tbl = Table(title="by transform — raw text removed, not billed saving", show_lines=False)
     tbl.add_column("transform")
     tbl.add_column("requests", justify="right")
-    tbl.add_column("share of savings", justify="right")
+    tbl.add_column("share of text removed", justify="right")
     for name, stats in sorted(
         proxy["by_transform"].items(), key=lambda kv: kv[1]["n"], reverse=True
     ):
@@ -228,7 +234,7 @@ def _by_transform_table(proxy: dict) -> Table:
     "--by-transform",
     "by_transform",
     is_flag=True,
-    help="Break the measured proxy saving down per transform.",
+    help="Break down which transforms removed the most text (raw, not billed cost).",
 )
 @click.option("--json", "as_json", is_flag=True, help="Machine-readable output.")
 def tokens_cmd(*, by_transform: bool = False, as_json: bool = False) -> None:

--- a/src/memo/proxy/transforms/toolschemas.py
+++ b/src/memo/proxy/transforms/toolschemas.py
@@ -92,32 +92,35 @@ _OWNED_PREFIX = "memo_"
 # included for the same reason `memo_tool_docs` is: it is Claude Code's OWN
 # discovery-then-hydrate primitive for every other deferred/pruned tool, so
 # losing it breaks the recovery path for everything else, not just memo's.
-# Core built-ins that must never be pruned. These are the minimum set;
-# discover_builtins() extends this with any additional tools discovered at runtime.
-_BUILTIN_CORE = frozenset(
-    {"Read", "Write", "Edit", "Bash", "Glob", "Grep", "Task", "Agent", "ToolSearch"}
+# Core built-ins that must never be pruned.
+#
+# This used to be a floor that `_discover_builtins()` extended by running
+# `claude --list-tools` at import time. That option does not exist — it exits
+# non-zero with `unknown option '--list-tools'` — so discovery could only ever
+# fail and fall back here, paying a subprocess on every import to learn
+# nothing. The set is a constant, and is written as one.
+#
+# StructuredOutput belongs here for a reason the file-access tools do not: the
+# harness executes it client-side and *forces* schema agents to call it, so
+# pruning its schema does not remove the capability, it removes the model's
+# knowledge of the required fields. The model then calls it blind and the call
+# is rejected. Measured across 237 subagent transcripts: 121 first calls (51%)
+# failed with `must have required property ...`, discarding 511k output tokens
+# to retries — far more than the schema ever saved.
+_BUILTIN_NEVER_PRUNE = frozenset(
+    {
+        "Read",
+        "Write",
+        "Edit",
+        "Bash",
+        "Glob",
+        "Grep",
+        "Task",
+        "Agent",
+        "ToolSearch",
+        "StructuredOutput",
+    }
 )
-
-
-def _discover_builtins() -> frozenset[str]:
-    """Try to discover built-in tools from the Claude Code installation.
-    Falls back to _BUILTIN_CORE if discovery fails."""
-    import contextlib
-
-    with contextlib.suppress(Exception):
-        import subprocess
-
-        result = subprocess.run(
-            ["claude", "--list-tools"], capture_output=True, text=True, timeout=5
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            names = {line.strip().split()[0] for line in result.stdout.splitlines() if line.strip()}
-            if names:
-                return _BUILTIN_CORE | names
-    return _BUILTIN_CORE
-
-
-_BUILTIN_NEVER_PRUNE = _discover_builtins()
 # Kept regardless of usage or scope: without these the model cannot reach
 # memo, or the agent's own built-in tools, at all.
 _ALWAYS_KEEP = frozenset({DOCS_TOOL_NAME, "memo_search", "memo_save"}) | _BUILTIN_NEVER_PRUNE

--- a/tests/test_proxy_reporting.py
+++ b/tests/test_proxy_reporting.py
@@ -289,3 +289,44 @@ def test_suppressed_headline_still_reports_the_session_counts(tmp_path):
     result = CliRunner().invoke(tokens_cmd, [], env=_env(tmp_path))
     assert result.exit_code == 0, result.output
     assert "session" in result.output.lower()
+
+
+def test_by_transform_does_not_claim_to_decompose_the_billed_saving(tmp_path):
+    """The per-transform split is raw removed text, not the cache-weighted cost.
+
+    `measured_saving_frac` is a billed-cost ratio built with the 1.25x / 2.0x /
+    0.1x cache weights; `saved_by` is an unweighted chars/4 diff that cannot
+    carry a weight and cannot go negative. On the live ledger the two differ by
+    9.11x, because cached prefix content is credited at full value every turn
+    while the counterfactual bills it at 0.1x. The panel must not present one
+    as a breakdown of the other.
+    """
+    state_dir = tmp_path / "state"
+    for i in range(10):
+        _seed(
+            state_dir,
+            [
+                _record(
+                    f"a{i}",
+                    holdout=False,
+                    input_tokens=500,
+                    transforms=["toolschemas"],
+                    est_saved_tokens=100,
+                    saved_by={"toolschemas": 100},
+                )
+            ],
+        )
+
+    result = CliRunner().invoke(tokens_cmd, ["--by-transform"], env=_env(tmp_path))
+
+    assert result.exit_code == 0, result.output
+    assert "share of savings" not in result.output, "implies the billed saving"
+    assert "text removed" in result.output, "must name the unit it actually reports"
+
+
+def test_by_transform_help_names_the_unit_it_reports(tmp_path):
+    """`--by-transform` help must not advertise the measured proxy saving."""
+    result = CliRunner().invoke(tokens_cmd, ["--help"], env=_env(tmp_path))
+
+    assert result.exit_code == 0, result.output
+    assert "measured proxy saving" not in result.output

--- a/tests/test_proxy_toolschemas.py
+++ b/tests/test_proxy_toolschemas.py
@@ -1,5 +1,4 @@
 import json
-from types import SimpleNamespace
 
 from memo.proxy.plan import Context
 from memo.proxy.transforms.toolschemas import DOCS_TOOL_NAME, ToolSchemas, recent_tool_names
@@ -486,38 +485,58 @@ def test_the_keep_set_never_grows_mid_session(tmp_path, monkeypatch):
     assert {t["name"] for t in zones2.tools} == first
 
 
-def test_builtin_discovery_shells_out_and_degrades_to_the_core_set(monkeypatch):
-    """`_discover_builtins` asks the real CLI, and must never depend on it.
+def test_the_builtin_set_is_a_constant_not_a_subprocess() -> None:
+    """The never-prune set must be stable across turns, so it is a constant.
 
-    Whatever this returns lands in the `tools` array, which sits at the front
-    of the cached prefix — so a discovery that answers on one turn and fails
-    on the next would reshape the prefix and re-cache the conversation. Every
-    failure mode therefore collapses to the same `_BUILTIN_CORE`: a non-zero
-    exit, empty stdout, a timeout, a missing binary.
+    Whatever it holds lands in the `tools` array at the front of the cached
+    prefix, so a set that answered on one turn and failed on the next would
+    reshape the prefix and re-cache the whole conversation. This used to be
+    computed by shelling out to `claude --list-tools` — an option that does
+    not exist, so the call could only ever fail and fall back. The previous
+    test for it mocked `subprocess.run` into succeeding, and so reported a
+    discovery path that never ran in production.
     """
-    import subprocess
-
     import memo.proxy.transforms.toolschemas as ts
 
-    core = ts._BUILTIN_CORE
+    assert isinstance(ts._BUILTIN_NEVER_PRUNE, frozenset)
+    assert {"Read", "Write", "Edit", "Bash", "Glob", "Grep"} <= ts._BUILTIN_NEVER_PRUNE
+    assert ts._BUILTIN_NEVER_PRUNE == ts._BUILTIN_NEVER_PRUNE, "must not be recomputed"
 
-    def _ok(*_a, **_k):
-        return SimpleNamespace(returncode=0, stdout="Bash  run a command\nGlob  find files\n")
 
-    monkeypatch.setattr(subprocess, "run", _ok)
-    ts._discover_builtins.cache_clear() if hasattr(ts._discover_builtins, "cache_clear") else None
-    found = ts._discover_builtins()
-    assert core <= found
-    assert {"Bash", "Glob"} <= found
+def test_structuredoutput_is_never_pruned(tmp_path, monkeypatch):
+    """Pruning StructuredOutput makes the model call it blind, and it must.
 
-    for failure in (
-        lambda *_a, **_k: SimpleNamespace(returncode=1, stdout=""),
-        lambda *_a, **_k: SimpleNamespace(returncode=0, stdout="   \n"),
-        lambda *_a, **_k: (_ for _ in ()).throw(subprocess.TimeoutExpired("claude", 5)),
-        lambda *_a, **_k: (_ for _ in ()).throw(FileNotFoundError("claude")),
-    ):
-        monkeypatch.setattr(subprocess, "run", failure)
-        ts._discover_builtins.cache_clear() if hasattr(
-            ts._discover_builtins, "cache_clear"
-        ) else None
-        assert ts._discover_builtins() == core
+    The harness executes StructuredOutput client-side and *forces* schema
+    agents to call it, so stripping its schema from the request does not
+    remove the capability — it removes the model's knowledge of the required
+    fields. Measured across 237 subagent transcripts: 121 first calls (51%)
+    came back `must have required property ...`, discarding 511k output
+    tokens to retries. A tool the model is compelled to call is the one tool
+    whose schema is never safe to drop.
+    """
+    monkeypatch.delenv("MEMO_PROXY_TOOL_SCHEMAS_SCOPE", raising=False)
+    monkeypatch.setattr(
+        "memo.proxy.transforms.toolschemas.recent_tool_names",
+        lambda state_dir, window: set(),
+    )
+    zones = make_zones(["StructuredOutput", "memo_rename"])
+
+    ToolSchemas().apply(zones, _ctx(tmp_path))
+
+    names = {t["name"] for t in zones.tools}
+    assert "StructuredOutput" in names
+    assert "memo_rename" not in names, "unrelated pruning must still happen"
+
+
+def test_builtin_discovery_does_not_shell_out() -> None:
+    """The built-in set is a constant, not the result of a subprocess.
+
+    `_discover_builtins` ran `claude --list-tools` at import time. That option
+    does not exist — it exits non-zero with `unknown option '--list-tools'` —
+    so the call could only ever fail, then fall back. It paid a subprocess on
+    every import to learn nothing.
+    """
+    import memo.proxy.transforms.toolschemas as ts
+
+    assert not hasattr(ts, "_discover_builtins")
+    assert "StructuredOutput" in ts._BUILTIN_NEVER_PRUNE

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2123,3 +2123,42 @@ def test_refresh_summary_llm_failure_has_stable_diagnostic(
 
     assert not refresh_summary(tmp_path, "sid-llm-failure", min_new_turns=3)
     assert "session: reflect summary LLM call failed: model unavailable" in caplog.messages
+
+
+def test_session_recent_drops_content_free_rows(tmp_cfg, monkeypatch, tmp_path):
+    """A row with no project, branch, or summary costs bytes and says nothing.
+
+    `list_sessions` sorts by `updated` desc and `mark_ids_recalled` bumps
+    `updated` on content-free snapshots, so recall bookkeeping promoted empty
+    rows above informative ones. Measured live: 7 of 8 rendered rows were
+    `| 4h ago | - | - | - | id |`.
+    """
+    from memo import session as session_mod
+
+    hollow = [
+        {"session_id": f"empty-{i}", "project": "", "branch": "", "summary": "", "cwd": ""}
+        for i in range(4)
+    ]
+    real = {
+        "session_id": "real-one",
+        "project": "memo",
+        "branch": "master",
+        "summary": "ship the briefing budget fix",
+        "cwd": str(tmp_path),
+    }
+    monkeypatch.setattr(session_mod, "list_sessions", lambda *a, **k: [real, *hollow])
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(
+        session_group,
+        ["recent"],
+        env={
+            "MEMO_STATE_DIR": str(tmp_cfg.state_dir),
+            "MEMO_DATA_DIR": str(tmp_cfg.data_dir),
+            "MEMO_NONINTERACTIVE": "1",
+        },
+    )
+
+    assert result.exit_code == 0, result.output
+    for i in range(4):
+        assert f"empty-{i}" not in result.output, "content-free row was rendered"


### PR DESCRIPTION
Four measured defects, each verified on live data rather than a fixture.

## 1. `memo session recent` rendered rows that say nothing

`list_sessions` orders by `updated`, and `mark_ids_recalled` bumps `updated` on content-free snapshots — so recall bookkeeping promoted empty sessions above informative ones. Measured on the live store, 7 of 8 rendered rows were:

```
| 4h ago | — | — | — | `adv-wait` |
```

A timestamp and a truncated id. Rows with no project, branch, or summary are now dropped before rendering.

```
live panel: 525 → 273 chars   (exactly the 252 bytes those rows occupied)
```

## 2. That panel was the one injection memo's own ledger never saw

`context_cost.log` held only `kind=recall` (1,665) and `kind=briefing` (318). `cli_session` emitted its `additionalContext` and returned without logging, so a per-session cost could not be weighed against the two that *were* measured. Now recorded as `kind=session_recent`.

## 3. `--by-transform` advertised a decomposition of a different currency

The help read *"Break the measured proxy saving down per transform"* and the column read *"share of savings"*. But the headline saving is a **cache-weighted billed ratio**, while `saved_by` is an **unweighted chars/4 count of removed text**. On the live ledger:

```
by_transform raw est_saved_tokens : 1,076,360,614
total billed prompt cost          :   118,110,443 tok-equiv
ratio                             : 9.11x
```

More "saved" than was ever billed — because prefix content a transform removes is credited at full value every turn while the counterfactual bills it at the 0.1x cache-read weight. The split itself was already honest; only its label was not. Now titled *"raw text removed, not billed saving"*, with the column and `--help` matching.

## 4. The proxy pruned `StructuredOutput`, and the model paid it back in retries

`_discover_builtins()` shelled out to `claude --list-tools` at import time to extend the never-prune set. That option does not exist:

```
$ claude --list-tools
error: unknown option '--list-tools'
```

So discovery could only ever fail and fall back to the 9-name core, paying a subprocess on every import to learn nothing. **The existing test mocked `subprocess.run` into succeeding**, and so reported a path that never ran in production.

`StructuredOutput` therefore fell outside `_ALWAYS_KEEP`. Because the harness executes it client-side and *forces* schema agents to call it, dropping its schema does not remove the capability — it removes the model's knowledge of the required fields. Measured across 237 subagent transcripts:

```
first StructuredOutput call FAILED: 121 / 237  (51%)
discarded output tokens          : 511,052
error text                       : "must have required property 'refuted', 'reasoning', 'evidence'"
```

Far more than the pruned schema ever saved. The built-in set is now a constant that includes `StructuredOutput` — which also keeps the cached prefix stable turn to turn, the property the old test was really defending.

## Test plan

- [x] RED verified first for every fix; the session-recent test re-checked by reverting the filter and confirming it fails.
- [x] 5 new tests; 1 replaced (the mocked-subprocess discovery test).
- [x] Full suite: 8089 passed / 21 skipped. The two failures this first surfaced were mine — `os.environ` bypassing the flag registry — and are fixed; `test_operational_surfaces_are_memo_owned` fails identically on a stashed tree (pre-existing isolation artifact).
- [x] ruff format, ruff check, mypy, and `scripts/quality_gate.py` (185 complexity / 205 exception budgets) all clean.