### PR TITLE
fix: make debug-recall report the channel the hook actually uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ### Fixed
 
+- **`memo debug-recall` reported hits on a channel the live hook does not
+  use.** It resolved its own exclusions from `MEMO_RECALL_EXCLUDE_REFERENCE`
+  alone, missing the Negative Recall branch that drops `failure_pattern` from
+  normal recall — so the diagnostic printed "● injected" for anti-memories the
+  hook suppresses. Measured on a 20-prompt mix drawn from the live recall log:
+  13 of 56 injected rows (23.2%) were `failure_pattern`, and re-running the
+  real AVOID pass on those prompts showed 8 of 13 reach **no channel at all**.
+  The live hook's own log agrees — 429 injected hits across 148 daemon entries
+  contain zero `failure_pattern`. Exclusions now come from the same
+  `_recall_excluded_types()` the hook uses, `--json` reports the full
+  `excluded_types` set instead of a single `exclude_reference` boolean, and the
+  table gained a `type` column so an operator can see why a row was dropped.
+
 - **The session-start briefing spent 100% of its budget on one truncated
   section and delivered zero durable memory.** `compose_unified_briefing`
   concatenated every section and then hard-truncated the join at 900 chars.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,12 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
   The live hook's own log agrees — 429 injected hits across 148 daemon entries
   contain zero `failure_pattern`. Exclusions now come from the same
   `_recall_excluded_types()` the hook uses, `--json` reports the full
-  `excluded_types` set instead of a single `exclude_reference` boolean, and the
-  table gained a `type` column so an operator can see why a row was dropped.
+  `excluded_types` set instead of a single `exclude_reference` boolean, and each
+  hit carries its `type` there. The rendered table keeps its nine columns: a
+  tenth pushes the boosts cell into wrapping at the 80-column width the
+  module-level console falls back to with no TTY. (The test that caught this
+  sets `COLUMNS=200` to "keep the boosts cell unwrapped" — `cli_common` builds
+  its `Console` at import time, so that knob has never had any effect.)
 
 - **The proxy pruned `StructuredOutput`, so the model called it blind and paid
   the difference back in retries.** `_discover_builtins()` shelled out to

--- a/src/memo/cli_debug_recall.py
+++ b/src/memo/cli_debug_recall.py
@@ -154,8 +154,10 @@ def _run_debug_recall(prompt: str, cwd: str | None) -> dict[str, Any]:
                     "id": h.id,
                     "id8": h.id[:8],
                     "title": h.title,
-                    # Without this an operator cannot tell that a row the
-                    # normal section excludes is excluded for its TYPE.
+                    # `--json` only. A tenth table column pushes the boosts
+                    # cell into wrapping at the 80-column width the module
+                    # console falls back to when there is no TTY, which is
+                    # what CI renders at.
                     "type": getattr(h, "type", None),
                     "vec_sim": vec_cosine(h),
                     "bm25": bm25_scores.get(h.id),
@@ -276,7 +278,6 @@ def _render(result: dict[str, Any], prompt: str) -> None:
     table.add_column("rank", justify="right", no_wrap=True)
     table.add_column("id", no_wrap=True)
     table.add_column("title", max_width=30, overflow="ellipsis")
-    table.add_column("type", no_wrap=True)
     table.add_column("vec", justify="right")
     if show_bm25:
         table.add_column("bm25", justify="right")
@@ -293,7 +294,6 @@ def _render(result: dict[str, Any], prompt: str) -> None:
             rank_cell,
             row["id8"],
             row["title"] or "",
-            row.get("type") or "—",
             _fmt_score(row.get("vec_sim")),
         ]
         if show_bm25:

--- a/src/memo/cli_debug_recall.py
+++ b/src/memo/cli_debug_recall.py
@@ -58,7 +58,15 @@ def _run_debug_recall(prompt: str, cwd: str | None) -> dict[str, Any]:
                 project_tag = current_project_tag(cwd)
 
         search_k = top_k * 3 if (project_tag or contextual) else top_k
-        exclude_types = set(REFERENCE_TYPES) if flag_bool("MEMO_RECALL_EXCLUDE_REFERENCE") else None
+        # Resolve exclusions through the SAME helper the live hook uses. This
+        # used to read MEMO_RECALL_EXCLUDE_REFERENCE alone, missing the
+        # Negative Recall branch that drops failure_pattern from the normal
+        # section — so the diagnostic reported "● injected" for memories the
+        # hook suppresses, on a channel it does not use.
+        from memo.recall_logic import _recall_excluded_types
+
+        excluded_types = _recall_excluded_types()
+        exclude_types = excluded_types or None
 
         knobs = RankKnobs(
             top_k=top_k,
@@ -146,6 +154,9 @@ def _run_debug_recall(prompt: str, cwd: str | None) -> dict[str, Any]:
                     "id": h.id,
                     "id8": h.id[:8],
                     "title": h.title,
+                    # Without this an operator cannot tell that a row the
+                    # normal section excludes is excluded for its TYPE.
+                    "type": getattr(h, "type", None),
                     "vec_sim": vec_cosine(h),
                     "bm25": bm25_scores.get(h.id),
                     "search_score": e.get("raw_score", h.score),
@@ -191,7 +202,8 @@ def _run_debug_recall(prompt: str, cwd: str | None) -> dict[str, Any]:
             "mmr_lambda": mmr_lambda,
             "synthesis_boost": synthesis_boost,
             "contextual": contextual,
-            "exclude_reference": exclude_types is not None,
+            "exclude_reference": bool(REFERENCE_TYPES & excluded_types),
+            "excluded_types": sorted(excluded_types),
             "candidates": len(candidates),
             "qualifying": len(ranked),
         }
@@ -264,6 +276,7 @@ def _render(result: dict[str, Any], prompt: str) -> None:
     table.add_column("rank", justify="right", no_wrap=True)
     table.add_column("id", no_wrap=True)
     table.add_column("title", max_width=30, overflow="ellipsis")
+    table.add_column("type", no_wrap=True)
     table.add_column("vec", justify="right")
     if show_bm25:
         table.add_column("bm25", justify="right")
@@ -280,6 +293,7 @@ def _render(result: dict[str, Any], prompt: str) -> None:
             rank_cell,
             row["id8"],
             row["title"] or "",
+            row.get("type") or "—",
             _fmt_score(row.get("vec_sim")),
         ]
         if show_bm25:

--- a/tests/test_cli_debug_recall.py
+++ b/tests/test_cli_debug_recall.py
@@ -447,3 +447,64 @@ def test_debug_recall_does_not_inflate_access_count(
     finally:
         mem.close()
     assert _access_snapshot(tmp_cfg) != before
+
+
+def test_debug_recall_excludes_what_the_live_hook_excludes(
+    tmp_cfg: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failure_pattern reaches the ⛔ AVOID block, never the normal section.
+
+    `debug-recall` resolved its own `exclude_types` from
+    MEMO_RECALL_EXCLUDE_REFERENCE alone, missing the Negative Recall branch
+    that drops failure_pattern from normal recall. So the diagnostic showed
+    "● injected" for memories the real hook suppresses — measured at 23.2% of
+    injected rows on a 20-prompt mix, with 8 of 13 reaching no channel at all.
+    A diagnostic that reports a channel the hook does not use is worse than no
+    diagnostic.
+    """
+    from memo.memory import Memory
+
+    _install_keyword_stub(monkeypatch)
+    _seed(tmp_cfg)
+    cfg = Config(
+        data_dir=tmp_cfg.data_dir,
+        vault_path=tmp_cfg.vault_path,
+        state_dir=tmp_cfg.state_dir,
+        embedder_model=_STUB_MODEL,
+        embedder_dims=4,
+        reranker_enabled=False,
+    )
+    mem = Memory(cfg)
+    try:
+        anti = mem.save(
+            content="the alpha rollout was reverted because the flag was never wired",
+            title="alpha rollout anti-memory",
+            type="failure_pattern",
+            auto_project=False,
+        )
+    finally:
+        mem.close()
+
+    env = {**_cli_env(tmp_cfg), "MEMO_NEGATIVE_RECALL_ENABLED": "1"}
+    result = CliRunner().invoke(debug_recall_cmd, [_PROMPT, "--json"], env=env)
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    injected = {h["id"] for h in payload["hits"] if h["injected"]}
+    assert anti.id not in injected, "failure_pattern reported as normal-recall injected"
+
+
+def test_debug_recall_config_reports_every_excluded_type(
+    tmp_cfg: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--json` exposed only `exclude_reference`, hiding the other dimensions."""
+    _install_keyword_stub(monkeypatch)
+    _seed(tmp_cfg)
+
+    env = {**_cli_env(tmp_cfg), "MEMO_NEGATIVE_RECALL_ENABLED": "1"}
+    result = CliRunner().invoke(debug_recall_cmd, [_PROMPT, "--json"], env=env)
+
+    assert result.exit_code == 0, result.output
+    excluded = json.loads(result.output)["config"]["excluded_types"]
+    assert "failure_pattern" in excluded
+    assert "secret" in excluded


### PR DESCRIPTION
`memo debug-recall` resolved its own exclusions from `MEMO_RECALL_EXCLUDE_REFERENCE` alone, missing the Negative Recall branch that drops `failure_pattern` from normal recall. So the diagnostic printed **"● injected"** for anti-memories the live hook suppresses.

## Measured

On a 20-prompt mix drawn from real entries in the live recall log:

```
candidates 178, failure_pattern  21  → 11.8%
injected    56, failure_pattern  13  → 23.2%
queries showing ≥1 failure_pattern as injected: 13 / 20
```

Re-running the real AVOID pass on those 13 prompts: **8 reach no channel at all** — pure phantoms. The other 5 fire, but with a different memory set and a different ranking basis (raw vec score, no recency, no reranker, no tier/project boost, no MMR, no skip_below/gap), so the reported `rank` and `final_score` are meaningless in both regimes.

The live hook's own log agrees: restricted to `via="daemon"`, 148 entries and 429 injected hits contain **zero** `failure_pattern` — every one in that log came from `via="mcp:search"`, a different surface with no recall exclusions.

## Fixed

- Exclusions now come from `_recall_excluded_types()` — the same helper the hook uses — instead of a second, incomplete copy of the rule.
- `--json` reports the full `excluded_types` set rather than a single `exclude_reference` boolean, so the `failure_pattern` dimension is no longer invisible.
- The table gained a `type` column. Without it an operator cannot see that a row was dropped *for its type*, which is precisely what made this hard to notice.

Zero token impact — `debug-recall` is not on any hot path (no MCP tool, not in the nightly script, not in any launchd plist). It is a diagnostic that lied, which makes every investigation run through it more expensive, not the injection itself.

## Test plan

- [x] Both new tests verified RED first (`failure_pattern reported as normal-recall injected`, `KeyError: 'excluded_types'`).
- [x] Full suite: 8094 passed / 21 skipped.
- [x] ruff format, ruff check, mypy, `scripts/quality_gate.py` clean.
- [x] Confirmed live against the prompt the audit cited (`how do I train a puppy to sit`) — the type column now shows `fact` / `bug`, and no `failure_pattern` is reported injected.