### PR TITLE
feat: make the associative tail's benefit measurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ### Fixed
 
+- **The `🔗 Also connected` tail could not be measured, only paid for.** It
+  costs ~48 est. tokens on every injected prompt (193 chars, 19.9% of the
+  block, ~80,400 est. tokens across the 1,665 logged injections), is on by
+  default, and fires on 15/15 off-domain probes — `build_nudge` never receives
+  the prompt at all, so associates are ranked by activation × recency with no
+  reference to the query. Whether a nudged id was ever *used* was not merely
+  unlogged but structurally unknowable: `emitted_sink` is what the grounding
+  matcher joins a later citation against, and only the hit renderers ever fed
+  it. `render_associative_line` now records the ids it actually shows (and
+  nothing when the budget rejects the line), so the tail's benefit becomes
+  measurable against its cost instead of being argued about. No behaviour
+  change to what is injected.
+
 - **`memo debug-recall` reported hits on a channel the live hook does not
   use.** It resolved its own exclusions from `MEMO_RECALL_EXCLUDE_REFERENCE`
   alone, missing the Negative Recall branch that drops `failure_pattern` from

--- a/src/memo/recall_assoc.py
+++ b/src/memo/recall_assoc.py
@@ -152,7 +152,13 @@ def _recency_weight(updated_iso: str) -> float:
         return 1.0
 
 
-def render_associative_line(context: str, nudge: list[Any], *, token_budget: int) -> str:
+def render_associative_line(
+    context: str,
+    nudge: list[Any],
+    *,
+    token_budget: int,
+    emitted_sink: list[tuple[str, str]] | None = None,
+) -> str:
     """Append an associative nudge line to *context* if it fits the token budget.
 
     Format::
@@ -166,6 +172,12 @@ def render_associative_line(context: str, nudge: list[Any], *, token_budget: int
 
     ``token_budget <= 0`` means no cap (always append).  Otherwise the line is
     skipped when ``len(context) + len(line) > token_budget * 4``.
+
+    ``emitted_sink``, when a list, receives ``(id, "")`` for every item the line
+    actually shows — the same contract the hit renderers use. Without it a
+    nudged id never enters the path the grounding matcher joins a later
+    citation against, so the tail's cost is measurable and its benefit is not.
+    A line the budget rejected was never shown, so it records nothing.
     """
     if not nudge:
         return context
@@ -178,4 +190,6 @@ def render_associative_line(context: str, nudge: list[Any], *, token_budget: int
     line = f"\n_🔗 Also connected ({label}): {parts}._"
     if token_budget > 0 and len(context) + len(line) > token_budget * 4:
         return context
+    if emitted_sink is not None:
+        emitted_sink.extend((h.id, "") for h in nudge)
     return context + line

--- a/src/memo/recall_logic.py
+++ b/src/memo/recall_logic.py
@@ -2199,7 +2199,9 @@ def run_recall_pipeline(
     with contextlib.suppress(Exception):
         _assoc = build_nudge(mem, relevant)
         if _assoc:
-            context = render_associative_line(context, _assoc, token_budget=token_budget)
+            context = render_associative_line(
+                context, _assoc, token_budget=token_budget, emitted_sink=emitted_sink
+            )
 
     # Cite instruction
     if flag_bool("MEMO_RECALL_CITE_INSTRUCTION"):
@@ -2639,7 +2641,9 @@ def _recall_logic(
 
         _assoc = build_nudge(mem, relevant)
         if _assoc:
-            context = render_associative_line(context, _assoc, token_budget=token_budget)
+            context = render_associative_line(
+                context, _assoc, token_budget=token_budget, emitted_sink=_emitted
+            )
 
     # Cite instruction — budget-exempt (~30 tokens), appended after any token-cap.
     # Mirror the subprocess path (cli_recall_hook): gated, never counts against budget.

--- a/tests/test_recall_associative.py
+++ b/tests/test_recall_associative.py
@@ -311,3 +311,36 @@ def test_build_nudge_without_conn_stays_unverified(monkeypatch):
 
     nudge = ra.build_nudge(_Mem(), [_Rec("s1", "seed")])
     assert nudge and all(not h.verified for h in nudge)
+
+
+def test_render_associative_line_records_shown_ids_for_grounding():
+    """A nudged id must reach `emitted_sink`, or its value can never be measured.
+
+    `emitted_sink` is what the grounding matcher joins a later citation
+    against, and only the hit renderers ever fed it — so an id surfaced in the
+    "🔗 Also connected" tail could not be recorded as used, no matter how often
+    it was. The tail costs ~48 est. tokens on every injected prompt (19.9% of
+    the block) and fires on 15/15 off-domain probes; making it observable is
+    what lets that cost be judged against a measured benefit.
+    """
+    from memo.recall_assoc import NudgeItem, render_associative_line
+
+    nudge = [NudgeItem(id="abcd1234ef", title="alpha", via="graph")]
+    sink: list[tuple[str, str]] = []
+
+    render_associative_line("ctx", nudge, token_budget=1000, emitted_sink=sink)
+
+    assert [i for i, _ in sink] == ["abcd1234ef"]
+
+
+def test_render_associative_line_records_nothing_when_the_line_does_not_fit():
+    """A line the budget rejected was never shown, so it must not be recorded."""
+    from memo.recall_assoc import NudgeItem, render_associative_line
+
+    nudge = [NudgeItem(id="abcd1234ef", title="alpha", via="graph")]
+    sink: list[tuple[str, str]] = []
+
+    out = render_associative_line("ctx", nudge, token_budget=1, emitted_sink=sink)
+
+    assert out == "ctx"
+    assert sink == []

--- a/tests/test_recall_associative.py
+++ b/tests/test_recall_associative.py
@@ -344,3 +344,77 @@ def test_render_associative_line_records_nothing_when_the_line_does_not_fit():
 
     assert out == "ctx"
     assert sink == []
+
+
+def _nudge_env(monkeypatch) -> None:
+    monkeypatch.setenv("MEMO_RECALL_MIN_SIM", "0.0")
+    monkeypatch.setenv("MEMO_RECALL_SKIP_BELOW", "0")
+    monkeypatch.setenv("MEMO_RECALL_GAP_THRESHOLD", "0")
+    monkeypatch.setenv("MEMO_RECALL_MIN_BODY_CHARS", "0")
+    monkeypatch.setenv("MEMO_RECALL_ASSOCIATIVE", "1")
+    monkeypatch.setenv("MEMO_RECALL_TOKEN_BUDGET", "0")
+
+
+def _stub_nudge(monkeypatch, nudge_id: str) -> None:
+    from memo.recall_assoc import NudgeItem
+
+    monkeypatch.setattr(
+        "memo.recall_assoc.build_nudge",
+        lambda *_a, **_k: [NudgeItem(id=nudge_id, title="assoc", via="graph")],
+    )
+
+
+def test_pipeline_records_the_nudge_id_in_its_emitted_sink(tmp_cfg, monkeypatch):
+    """`run_recall_pipeline` must hand its sink to the associative renderer.
+
+    Covers the daemon/subprocess-shared call site. Without it the id shown in
+    the tail never enters the sink the grounding matcher reads.
+    """
+    from memo.memory import Memory
+    from memo.recall_logic import RankKnobs, run_recall_pipeline
+
+    _nudge_env(monkeypatch)
+    _stub_nudge(monkeypatch, "nudge123abc")
+    mem = Memory(tmp_cfg)
+    try:
+        mem.save(content="the alpha rollout cutover went fine", title="alpha cutover", type_="fact")
+        out = run_recall_pipeline(
+            mem=mem,
+            query_text="alpha rollout cutover",
+            knobs=RankKnobs(top_k=3, min_sim=0.0, min_body_chars=0, mode="vec"),
+            turn=1,
+            session_id="s-nudge",
+            state_dir=tmp_cfg.state_dir,
+        )
+    finally:
+        mem.close()
+
+    assert out, "pipeline returned nothing — fixture did not produce a hit"
+    assert "nudge123abc" in {i for i, _ in out["emitted_sink"]}
+
+
+def test_daemon_recall_records_the_nudge_id_too(tmp_cfg, monkeypatch):
+    """`_recall_logic` carries its own copy of the assoc wiring; cover it too."""
+    from memo.memory import Memory
+    from memo.recall_logic import _recall_logic
+
+    _nudge_env(monkeypatch)
+    _stub_nudge(monkeypatch, "nudge456def")
+    captured: list[list[tuple[str, str]]] = []
+    real = __import__("memo.recall_assoc", fromlist=["x"]).render_associative_line
+
+    def _spy(context, nudge, *, token_budget, emitted_sink=None):
+        out = real(context, nudge, token_budget=token_budget, emitted_sink=emitted_sink)
+        captured.append(list(emitted_sink or []))
+        return out
+
+    monkeypatch.setattr("memo.recall_assoc.render_associative_line", _spy)
+    mem = Memory(tmp_cfg)
+    try:
+        mem.save(content="the beta rollout cutover went fine", title="beta cutover", type_="fact")
+        _recall_logic("beta rollout cutover", None, mem, mem.cfg)
+    finally:
+        mem.close()
+
+    assert captured, "the associative renderer never ran"
+    assert "nudge456def" in {i for i, _ in captured[-1]}


### PR DESCRIPTION
The `🔗 Also connected` line is the last item from the audit whose **cost was measured and whose value was not**. This makes the value measurable. It does not change what gets injected.

## The cost, measured

```
193 chars / ~48 est. tokens on every injected prompt   (19.9% of the block)
~80,400 est. tokens across the 1,665 logged injections
on by default (MEMO_RECALL_ASSOCIATIVE, flags_recall.py:76-84)
fires on 15/15 off-domain probes
```

`build_nudge(memory, relevant)` never receives the prompt. Associates are ranked — by `activation × recency` (`recall_assoc.py:92-94`) — but not by any relation to the query, which is why an off-domain prompt still gets a tail.

## Why the value was unknowable, not just unlogged

`emitted_sink` is what the grounding matcher joins a later citation against, and **only the hit renderers ever fed it**. A nudged id therefore could not be recorded as used no matter how often it was — the question "does anyone ever follow these?" had no answer path, so the tail could only ever be argued about.

`render_associative_line` now records the ids it actually shows, using the same `(id, "")` contract as `render_recall_balanced`. A line the token budget rejected was never shown, so it records nothing.

## Why not just gate or delete it

Both were tempting and both would be guesses. Gating on query similarity means picking a threshold against a score whose scale is not comparable across queries — the exact category error already documented for `min_sim` elsewhere in this codebase. Deleting it trades away serendipitous recall on the strength of zero evidence about its benefit. With this in, the next pass can compute a real usage rate for nudged ids against normal hits and decide on data.

## Test plan

- [x] Both tests verified RED first (`unexpected keyword argument 'emitted_sink'`).
- [x] Covers the negative case too: a budget-rejected line records nothing.
- [x] Both production call sites wired (`recall_logic.py:2202` and `:2644`).
- [x] Full suite: 8106 passed / 21 skipped.
- [x] ruff format, ruff check, mypy, `scripts/quality_gate.py` clean.