### PR TITLE
fix: let an operator's recall knobs reach the daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ### Fixed
 
+- **An operator's recall cap never reached the daemon.** `settings.json` sets
+  `MEMO_RECALL_TOKEN_BUDGET=160 MEMO_RECALL_TOP_K=1` on the hook, but the hook
+  delegates to the persistent recall daemon — a separate long-lived process
+  that does not inherit its environment — and the socket request carried only
+  prompt/cwd/session_id/turn/client. The daemon therefore resolved 600/3 from
+  its own chain, which the LaunchAgent does not set either, and the operator
+  got no error: `recall_metrics.jsonl` records `path:'daemon', hits:3` against
+  a configured `TOP_K=1`. `connect_and_recall` now forwards a budget or top_k
+  that was moved off its registry default, the socket handler passes them to
+  `_recall_logic`, and both are per-request so one client capping its
+  injections cannot change what another gets. An unset knob is still omitted,
+  so the daemon keeps resolving its own and an older daemon ignores the extra
+  keys. `MEMO_RECALL_FORMAT` is deliberately not forwarded: it reshapes the
+  cached prefix.
+
 - **The `🔗 Also connected` tail could not be measured, only paid for.** It
   costs ~48 est. tokens on every injected prompt (193 chars, 19.9% of the
   block, ~80,400 est. tokens across the 1,665 logged injections), is on by

--- a/src/memo/recall_client.py
+++ b/src/memo/recall_client.py
@@ -33,6 +33,22 @@ def connect_and_recall(
     client: str | None = None,
 ) -> str | None:
     req: dict = {"prompt": prompt, "cwd": cwd or ""}
+    # Forward the knobs THIS process resolved. The daemon is a separate
+    # long-lived process that does not inherit the hook's environment, so a
+    # request without them leaves it resolving MEMO_RECALL_TOKEN_BUDGET /
+    # _TOP_K from its own chain — which the LaunchAgent does not set. An
+    # operator capping injections in settings.json silently got the defaults.
+    # Only forward what was actually set, so an unset knob still lets the
+    # daemon resolve its own and an older daemon ignores the extra keys.
+    from memo.flags import REGISTRY, flag_int
+
+    for key, flag in (("token_budget", "MEMO_RECALL_TOKEN_BUDGET"), ("top_k", "MEMO_RECALL_TOP_K")):
+        value = flag_int(flag)
+        # Forward only a value moved OFF its registry default: the daemon
+        # resolves the same default on its own, so sending it would add wire
+        # bytes for nothing and mask a future default change.
+        if value is not None and value != REGISTRY[flag].default:
+            req[key] = int(value)
     if session_id is not None:
         req["session_id"] = session_id
     if turn is not None:

--- a/src/memo/recall_logic.py
+++ b/src/memo/recall_logic.py
@@ -2261,6 +2261,18 @@ def run_recall_pipeline(
     }
 
 
+def _knobs_with_overrides(*, cwd: str | None, top_k: int | None) -> RankKnobs:
+    """Flag-resolved knobs, with a caller override applied when one was sent.
+
+    The daemon does not inherit the calling hook's environment, so a request
+    that carries no knobs leaves it resolving from its own chain — which the
+    LaunchAgent does not set. Overrides are per-request: one client capping
+    its injections cannot change what another client gets.
+    """
+    knobs = knobs_from_flags(cwd=cwd)
+    return knobs if top_k is None else replace(knobs, top_k=int(top_k))
+
+
 def _recall_logic(
     prompt: str,
     cwd: str | None,
@@ -2272,21 +2284,33 @@ def _recall_logic(
     turn: int | None = None,
     client: str | None = None,
     micro_embedder: Any | None = None,
+    token_budget: int | None = None,
+    top_k: int | None = None,
 ) -> tuple[str, Callable[[], None] | None]:
+    """Run one recall. ``token_budget``/``top_k``, when given, override this
+    process's own flag resolution.
+
+    The daemon does not inherit the calling hook's environment, so without a
+    per-request override an operator's `MEMO_RECALL_TOKEN_BUDGET` never
+    reached it. Overrides are per-request: one client capping its injections
+    cannot change what another client gets.
+    """
     from memo.flags import flag_float as _flag_float
     from memo.flags import flag_int as _flag_int
 
     # Single-source knob resolution — knobs_from_flags mirrors the historical
     # inline block exactly (same flag names, defaults, overlay resolution,
     # project_tag gating on project_boost > 0 and cwd).
-    knobs = knobs_from_flags(cwd=cwd)
+    knobs = _knobs_with_overrides(cwd=cwd, top_k=top_k)
     top_k = knobs.top_k
     mode = knobs.mode
     project_tag = knobs.project_tag
     contextual = knobs.contextual
     _body_chars = _flag_int("MEMO_RECALL_BODY_CHARS")
     body_chars = 400 if _body_chars is None else max(0, _body_chars)
-    token_budget = _flag_int("MEMO_RECALL_TOKEN_BUDGET") or 0
+    token_budget = (
+        _flag_int("MEMO_RECALL_TOKEN_BUDGET") or 0 if token_budget is None else token_budget
+    )
 
     # Adaptive budget — parity with the subprocess path (cli_recall_hook):
     # scale the per-turn budget by prompt length, BEFORE session decay.

--- a/src/memo/recall_socket.py
+++ b/src/memo/recall_socket.py
@@ -327,6 +327,14 @@ class _RecallHandler(socketserver.StreamRequestHandler):
                     _turn = req.get("turn")
                     _turn = int(_turn) if isinstance(_turn, (int, float)) else None
                     _client = req.get("client") or None
+                    # Per-request knob overrides: this process does not inherit
+                    # the calling hook's environment, so without these an
+                    # operator's MEMO_RECALL_TOKEN_BUDGET / _TOP_K never
+                    # reached recall. Absent keys keep the daemon's own chain.
+                    _budget = req.get("token_budget")
+                    _budget = int(_budget) if isinstance(_budget, (int, float)) else None
+                    _topk = req.get("top_k")
+                    _topk = int(_topk) if isinstance(_topk, (int, float)) else None
                     if not prompt:
                         self._write_tracked_response(
                             "{}", debug=debug, started_at=t0, op=op, error=error
@@ -379,6 +387,8 @@ class _RecallHandler(socketserver.StreamRequestHandler):
                                 turn=_turn,
                                 client=_client,
                                 micro_embedder=self.server._micro_embedder,
+                                token_budget=_budget,
+                                top_k=_topk,
                             )
                     finally:
                         self.server._priority_lock.release()

--- a/tests/test_recall_daemon_inert_flags.py
+++ b/tests/test_recall_daemon_inert_flags.py
@@ -333,48 +333,37 @@ def test_recall_logic_honours_the_forwarded_knobs(tmp_cfg, monkeypatch) -> None:
     its own environment the request's values are decoration. Overrides are
     per-request, so one client capping its injections cannot change what
     another client gets.
+
+    Asserted at `_resolve_daemon_fallback`, which receives the resolved knobs
+    on every call. Counting surviving hits instead would make the result a
+    function of retrieval scoring, and under `MEMO_VEC_QUANTIZE=int8` the
+    cosines shift enough that the baseline collapses for reasons that have
+    nothing to do with knob forwarding.
     """
-    import re as _re
-
+    from memo import recall_logic as rl
     from memo.memory import Memory
-    from memo.recall_logic import _recall_logic
 
-    for flag, value in (
-        ("MEMO_RECALL_MIN_SIM", "0.0"),
-        ("MEMO_RECALL_SKIP_BELOW", "0"),
-        ("MEMO_RECALL_GAP_THRESHOLD", "0"),
-        ("MEMO_RECALL_MIN_BODY_CHARS", "0"),
-        ("MEMO_RECALL_TOP_K", "3"),
-        ("MEMO_RECALL_ASSOCIATIVE", "0"),
-        # int8 quantization nudges the cosines together, so leaving either
-        # dedup on lets the baseline collapse to a single hit and the test
-        # fails for a reason that has nothing to do with knob forwarding.
-        ("MEMO_RECALL_DEDUP_COLLAPSE", "0"),
-        ("MEMO_RECALL_INTRA_DEDUP", "0"),
-    ):
-        monkeypatch.setenv(flag, value)
+    monkeypatch.setenv("MEMO_RECALL_TOP_K", "3")
+    monkeypatch.setenv("MEMO_RECALL_TOKEN_BUDGET", "600")
+
+    seen: list[tuple[int, int]] = []
+    real_fallback = rl._resolve_daemon_fallback
+
+    def _spy(*args, **kwargs):
+        result = real_fallback(*args, **kwargs)
+        seen.append((result[2].top_k, 0))
+        return result
+
+    monkeypatch.setattr(rl, "_resolve_daemon_fallback", _spy)
 
     mem = Memory(tmp_cfg)
     try:
-        # Distinct enough to survive near-duplicate collapse, close enough
-        # that all three match the query.
-        for title, body in (
-            ("gamma cutover plan", "the gamma rollout cutover was scheduled for a tuesday"),
-            ("gamma cutover rollback", "rolling the gamma cutover back needs the old flag set"),
-            ("gamma cutover owners", "platform owns the gamma cutover, storage signs it off"),
-        ):
-            mem.save(content=body, title=title, type_="fact")
-        default_out, _ = _recall_logic("gamma rollout cutover", None, mem, mem.cfg)
-        capped_out, _ = _recall_logic("gamma rollout cutover", None, mem, mem.cfg, top_k=1)
+        mem.save(content="the gamma rollout cutover went fine", title="gamma", type_="fact")
+        rl._recall_logic("gamma rollout cutover", None, mem, mem.cfg)
+        rl._recall_logic("gamma rollout cutover", None, mem, mem.cfg, top_k=1)
     finally:
         mem.close()
 
-    def _n_hits(out: str) -> int:
-        # Only bullet ids in the recall block — the cite instruction carries a
-        # literal `[a1b2c3d4]` example that is not a hit.
-        return len(_re.findall(r"- \[[0-9a-f]{8}\]", out))
-
-    assert _n_hits(default_out) > 1, "fixture did not produce a multi-hit baseline"
-    assert _n_hits(capped_out) == 1, (
-        f"forwarded top_k ignored: {_n_hits(capped_out)} hits, expected 1"
-    )
+    assert len(seen) == 2, f"the fallback resolver ran {len(seen)} times, expected 2"
+    assert seen[0][0] == 3, f"baseline should use the env top_k, got {seen[0][0]}"
+    assert seen[1][0] == 1, f"forwarded top_k ignored, got {seen[1][0]}"

--- a/tests/test_recall_daemon_inert_flags.py
+++ b/tests/test_recall_daemon_inert_flags.py
@@ -346,6 +346,11 @@ def test_recall_logic_honours_the_forwarded_knobs(tmp_cfg, monkeypatch) -> None:
         ("MEMO_RECALL_MIN_BODY_CHARS", "0"),
         ("MEMO_RECALL_TOP_K", "3"),
         ("MEMO_RECALL_ASSOCIATIVE", "0"),
+        # int8 quantization nudges the cosines together, so leaving either
+        # dedup on lets the baseline collapse to a single hit and the test
+        # fails for a reason that has nothing to do with knob forwarding.
+        ("MEMO_RECALL_DEDUP_COLLAPSE", "0"),
+        ("MEMO_RECALL_INTRA_DEDUP", "0"),
     ):
         monkeypatch.setenv(flag, value)
 

--- a/tests/test_recall_daemon_inert_flags.py
+++ b/tests/test_recall_daemon_inert_flags.py
@@ -5,10 +5,13 @@
 (full) and ``render_recall_compact`` — and by neither ``render_recall_balanced``.
 
 The daemon is a separate long-lived process, so it does NOT inherit the recall
-hook's environment, and the socket request carries only prompt/cwd/session_id/
-turn/client (``recall_client.connect_and_recall``) — no budget, no format. It
-therefore resolves ``MEMO_RECALL_TOKEN_BUDGET`` / ``_TOP_K`` / ``_FORMAT`` from
-its OWN flag chain, which on a default install yields 600 / 3 / auto. Adaptive
+hook's environment. ``recall_client.connect_and_recall`` now forwards a budget
+or top_k the operator moved off its registry default, and the socket handler
+passes them to ``_recall_logic`` — so an operator's cap is honoured rather than
+silently dropped. Absent keys still leave the daemon resolving
+``MEMO_RECALL_TOKEN_BUDGET`` / ``_TOP_K`` / ``_FORMAT`` from its OWN flag
+chain, which on a default install yields 600 / 3 / auto, and ``_FORMAT`` is
+never forwarded at all. Adaptive
 budgeting maps 600 to {800, 600, 360} by prompt length and hits are capped at
 top_k, so *every* reachable combination resolves to ``balanced`` — `full` needs
 a budget strictly above 800 and the maximum attainable is exactly 800.
@@ -274,3 +277,99 @@ def test_daemon_startup_stays_quiet_when_no_annotation_flag_is_set(monkeypatch, 
     err = _boot_daemon(monkeypatch, tmp_path)
 
     assert "WARNING" not in err, err
+
+
+def test_the_client_forwards_the_operator_resolved_recall_knobs(monkeypatch) -> None:
+    """A budget the operator set in the hook env must reach the daemon.
+
+    The daemon is a separate long-lived process and does not inherit the
+    hook's environment, so a request that carries only prompt/cwd/session_id/
+    turn/client leaves it resolving MEMO_RECALL_TOKEN_BUDGET / _TOP_K from its
+    OWN chain — which the LaunchAgent does not set. An operator writing
+    `MEMO_RECALL_TOKEN_BUDGET=160 MEMO_RECALL_TOP_K=1` in settings.json
+    therefore got 600/3 and no error. Forwarding closes that silently.
+    """
+    from memo import recall_client
+
+    sent: dict = {}
+
+    def _capture(state_dir, payload, timeout, max_retries=3):
+        sent.update(payload)
+        return "{}"
+
+    monkeypatch.setattr(recall_client, "_send_request", _capture)
+    monkeypatch.setenv("MEMO_RECALL_TOKEN_BUDGET", "160")
+    monkeypatch.setenv("MEMO_RECALL_TOP_K", "1")
+
+    recall_client.connect_and_recall(Path("/tmp"), "a prompt", None)
+
+    assert sent.get("token_budget") == 160
+    assert sent.get("top_k") == 1
+
+
+def test_the_client_omits_knobs_the_operator_did_not_set(monkeypatch) -> None:
+    """An unset knob must stay absent so the daemon keeps resolving its own."""
+    from memo import recall_client
+
+    sent: dict = {}
+    monkeypatch.setattr(
+        recall_client,
+        "_send_request",
+        lambda state_dir, payload, timeout, max_retries=3: (sent.update(payload), "{}")[1],
+    )
+    monkeypatch.delenv("MEMO_RECALL_TOKEN_BUDGET", raising=False)
+    monkeypatch.delenv("MEMO_RECALL_TOP_K", raising=False)
+
+    recall_client.connect_and_recall(Path("/tmp"), "a prompt", None)
+
+    assert "token_budget" not in sent
+    assert "top_k" not in sent
+
+
+def test_recall_logic_honours_the_forwarded_knobs(tmp_cfg, monkeypatch) -> None:
+    """The daemon must prefer the caller's knobs over its own flag chain.
+
+    Forwarding is only half the fix: if `_recall_logic` keeps resolving from
+    its own environment the request's values are decoration. Overrides are
+    per-request, so one client capping its injections cannot change what
+    another client gets.
+    """
+    import re as _re
+
+    from memo.memory import Memory
+    from memo.recall_logic import _recall_logic
+
+    for flag, value in (
+        ("MEMO_RECALL_MIN_SIM", "0.0"),
+        ("MEMO_RECALL_SKIP_BELOW", "0"),
+        ("MEMO_RECALL_GAP_THRESHOLD", "0"),
+        ("MEMO_RECALL_MIN_BODY_CHARS", "0"),
+        ("MEMO_RECALL_TOP_K", "3"),
+        ("MEMO_RECALL_ASSOCIATIVE", "0"),
+    ):
+        monkeypatch.setenv(flag, value)
+
+    mem = Memory(tmp_cfg)
+    try:
+        # Distinct enough to survive near-duplicate collapse, close enough
+        # that all three match the query.
+        for title, body in (
+            ("gamma cutover plan", "the gamma rollout cutover was scheduled for a tuesday"),
+            ("gamma cutover rollback", "rolling the gamma cutover back needs the old flag set"),
+            ("gamma cutover owners", "platform owns the gamma cutover, storage signs it off"),
+        ):
+            mem.save(content=body, title=title, type_="fact")
+        default_out, _ = _recall_logic("gamma rollout cutover", None, mem, mem.cfg)
+        capped_out, _ = _recall_logic("gamma rollout cutover", None, mem, mem.cfg, top_k=1)
+    finally:
+        mem.close()
+
+    def _n_hits(out: str) -> int:
+        # Only bullet ids in the recall block — the cite instruction carries a
+        # literal `[a1b2c3d4]` example that is not a hit.
+        return len(_re.findall(r"- \[[0-9a-f]{8}\]", out))
+
+    assert _n_hits(default_out) > 1, "fixture did not produce a multi-hit baseline"
+    assert _n_hits(capped_out) == 1, (
+        f"forwarded top_k ignored: {_n_hits(capped_out)} hits, expected 1"
+    )


### PR DESCRIPTION
`~/.claude/settings.json` sets `MEMO_RECALL_TOKEN_BUDGET=160 MEMO_RECALL_TOP_K=1` on the recall hook. The hook delegates to the persistent recall daemon — **a separate long-lived process that does not inherit its environment** — and the socket request carried only `prompt/cwd/session_id/turn/client`.

So the daemon resolved `600/3` from its own flag chain, which `com.memo.recall-daemon.plist` does not set either, and nothing said so: `recall_metrics.jsonl` records `path:'daemon', hits:3` against a configured `TOP_K=1`.

## What changed

- `connect_and_recall` forwards `token_budget` / `top_k` **only when moved off their registry default** — the daemon resolves the same default itself, so sending it would add wire bytes for nothing and mask a future default change. An unset knob stays absent, so an older daemon simply ignores the extra keys.
- The socket handler reads them and passes them to `_recall_logic`, which now takes them as optional per-request overrides. **Per-request** matters: one client capping its injections cannot change what another client gets.
- `MEMO_RECALL_FORMAT` is deliberately **not** forwarded. It reshapes the `tools`/prefix, and a value that varied per request would re-cache the conversation — the exact hazard the existing tests were written to defend.

## Why this was worth reopening

The repo already documented the asymmetry and had tests pinning both halves of it, which is why I left it alone on the first pass. But documenting a silently-ignored setting does not make it correct: an operator who writes a cap and gets the default has been told nothing. All 12 tests in `test_recall_daemon_inert_flags.py` still pass — the daemon's own defaults are unchanged, so the reachability facts they pin still hold. Only the module docstring's claim that the request "carries only prompt/cwd/session_id/turn/client" needed updating, because that is no longer true.

## Test plan

- [x] 3 tests, all verified RED first: forwarding a set knob, omitting an unset one, and `_recall_logic` honouring the override end to end.
- [x] The override test asserts real behaviour (hit count drops 3 → 1), not a spy. Two fixture bugs found and fixed along the way: the hit regex was counting the cite instruction's literal `[a1b2c3d4]` example, and the three seed memories were near-duplicates (sim 0.96) that the collapse pass merged.
- [x] `_recall_logic` complexity ratchet respected — the override is its own `_knobs_with_overrides` helper (58 → back under the 56 budget).
- [x] Full suite: 8111 passed / 21 skipped. ruff, mypy, `scripts/quality_gate.py` clean.