### PR TITLE
fix: make memo's own generators meet memo's own tag convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
   derived from the `synthesis_kind` it already records: no embedder call, no
   LLM, sorted and de-duplicated so re-saving never churns a record, and an
   unregistered kind still clears three tags rather than silently reopening
-  this.
+  this. The ⛔ AVOID producers had the same defect one level down —
+  `DEFAULT_SUPERSEDE_TAGS`, `DEFAULT_AVOID_VERDICT_TAGS` and the git miner
+  each built exactly two tags — and now carry a third, `failure-pattern`,
+  which also makes every anti-memory retrievable as one class.
 
 - **The `🔗 Also connected` tail could not be measured, only paid for.** It
   costs ~48 est. tokens on every injected prompt (193 chars, 19.9% of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ### Fixed
 
+- **`few_tags` was not a backlog to sweep — it was a nightly producer writing
+  below memo's own convention.** `memo lint` flags any memory with under three
+  tags, citing the CLAUDE.md "project + domain + topic" rule, and reported
+  3,941 of them. Broken down by type over the eight days to 2026-08-28 the
+  cause is not diffuse: `synthesis` violated the rule **107 times out of 109**
+  (98%) and `failure_pattern` 43 of 52, while `reference` — the bulk of the
+  corpus at 4,119 rows — sat at 4%. All five synthesis producers (distill,
+  consolidate, communities, bridges, folder abstracts) called `mem.save(...)`
+  with no `tags=` whatsoever, so each record kept only what `save` could derive
+  alone, usually one. Retro-tagging the corpus would have left the producer
+  refilling it every night. Each producer now passes `synthesis_tags(kind)`,
+  derived from the `synthesis_kind` it already records: no embedder call, no
+  LLM, sorted and de-duplicated so re-saving never churns a record, and an
+  unregistered kind still clears three tags rather than silently reopening
+  this.
+
 - **The `🔗 Also connected` tail could not be measured, only paid for.** It
   costs ~48 est. tokens on every injected prompt (193 chars, 19.9% of the
   block, ~80,400 est. tokens across the 1,665 logged injections), is on by

--- a/src/memo/dream_bridges.py
+++ b/src/memo/dream_bridges.py
@@ -19,6 +19,7 @@ from collections.abc import Callable
 from typing import Any
 
 from memo.dream_communities import provenance_hash
+from memo.dream_synthesis_tags import synthesis_tags
 
 _DATE_RE = re.compile(r"^\d{4}([-/]\d{1,2}){0,2}$")
 # Generic co-mention tokens that are not meaningful link anchors.
@@ -196,6 +197,7 @@ def run_synthesize_bridges(
                     mem.save(
                         content=f"{d['body']}\n\n[bridge {d['provenance_hash']}]",
                         type_="synthesis",
+                        tags=synthesis_tags("bridge"),
                         title=d["title"],
                         extra={
                             "synthesis_kind": "bridge",

--- a/src/memo/dream_communities.py
+++ b/src/memo/dream_communities.py
@@ -16,6 +16,8 @@ import hashlib
 from collections.abc import Callable
 from typing import Any
 
+from memo.dream_synthesis_tags import synthesis_tags
+
 _SYS = (
     "You abstract a cluster of a user's memories into one durable insight. "
     'Reply ONLY with JSON {"title": str, "insight": str}. The insight names '
@@ -194,6 +196,7 @@ def run_synthesize_communities(
                     mem.save(
                         content=f"{d['body']}\n\n[community {d['provenance_hash']}]",
                         type_="synthesis",
+                        tags=synthesis_tags("community"),
                         title=d["title"],
                         extra={
                             "synthesis_kind": "community",

--- a/src/memo/dream_consolidate.py
+++ b/src/memo/dream_consolidate.py
@@ -21,6 +21,8 @@ import os
 from collections.abc import Callable
 from typing import Any
 
+from memo.dream_synthesis_tags import synthesis_tags
+
 # --- pure core (testable) ----------------------------------------------------
 
 
@@ -179,6 +181,7 @@ def run_consolidate_episodes(
                     mem.save(
                         content=f"{d['body']}\n\n[cross-session {d['provenance_hash']}]",
                         type_="synthesis",
+                        tags=synthesis_tags("cross_session"),
                         title=d["title"],
                         extra={
                             "synthesis_kind": "cross_session",

--- a/src/memo/dream_distill.py
+++ b/src/memo/dream_distill.py
@@ -24,6 +24,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from memo.dream_synthesis_tags import synthesis_tags
+
 # --- pure core (testable) ----------------------------------------------------
 
 
@@ -298,6 +300,7 @@ def run_distill(
                     mem.save(
                         content=f"{d['body']}\n\n[distill {d['provenance_hash']}]",
                         type_="synthesis",
+                        tags=synthesis_tags("distillation"),
                         title=d["title"],
                         extra={
                             "synthesis_kind": "distillation",

--- a/src/memo/dream_folder_abstracts.py
+++ b/src/memo/dream_folder_abstracts.py
@@ -18,6 +18,8 @@ import logging
 from pathlib import PurePosixPath
 from typing import Any
 
+from memo.dream_synthesis_tags import synthesis_tags
+
 _log = logging.getLogger(__name__)
 
 _SYS = (
@@ -162,6 +164,7 @@ def run_folder_abstracts(
                     mem.save(
                         content=synth["body"],
                         type_="synthesis",
+                        tags=synthesis_tags("folder_abstract"),
                         title=synth["title"],
                         extra=extra,
                     )

--- a/src/memo/dream_synthesis_tags.py
+++ b/src/memo/dream_synthesis_tags.py
@@ -1,0 +1,42 @@
+"""Tags for dream-generated `synthesis` memories.
+
+Every synthesis producer used to call ``mem.save(...)`` with no ``tags=``, so
+the record kept only whatever ``save`` could derive on its own — usually one
+tag. ``memo lint`` flags anything under three as ``few_tags``, citing the
+CLAUDE.md convention, and on the live index `synthesis` violated it 107 times
+out of 109 over eight days. That is a nightly producer writing below the
+standard its own linter checks, not a legacy backlog.
+
+Tags are derived, never generated: no embedder call, no LLM, and the same kind
+always yields the same sorted set, so re-saving a memory never churns it.
+"""
+
+from __future__ import annotations
+
+SYNTHESIS_TAG = "synthesis"
+
+# What each producer is *about*, so a synthesis is findable by the question it
+# answers and not only by the machinery that wrote it.
+_KIND_TOPICS: dict[str, tuple[str, ...]] = {
+    "distillation": ("distillation", "summary"),
+    "cross_session": ("cross-session", "continuity"),
+    "community": ("community", "clustering"),
+    "bridge": ("bridge", "connection"),
+    "folder_abstract": ("folder-abstract", "structure"),
+}
+
+# Applied to any kind, known or not, so a producer added later still clears the
+# convention instead of silently reopening this defect.
+_FALLBACK_TOPICS: tuple[str, ...] = ("dream", "generated")
+
+
+def synthesis_tags(kind: str) -> list[str]:
+    """The tag set for a synthesis memory of ``kind``.
+
+    Always at least three tags, always containing ``synthesis`` so the whole
+    class stays retrievable, and always containing ``kind`` so provenance
+    survives into the record. Sorted and de-duplicated.
+    """
+    slug = (kind or "").strip() or "unknown"
+    tags = {SYNTHESIS_TAG, slug, *_KIND_TOPICS.get(slug, _FALLBACK_TOPICS)}
+    return sorted(tags)

--- a/src/memo/git_miner.py
+++ b/src/memo/git_miner.py
@@ -22,6 +22,19 @@ from typing import Any
 
 _log = logging.getLogger("memo.git_miner")
 
+
+def _mined_tags(slug: str) -> list[str]:
+    """Tags for a git-mined anti-memory.
+
+    ``failure-pattern`` names the class so mined entries are retrievable
+    alongside the ones Negative Recall writes, and it takes the list to three,
+    which is memo's own documented convention and what ``memo lint`` checks.
+    """
+    from memo.negative_recall import FAILURE_PATTERN_TAG
+
+    return ["git-mined", f"project:{slug}", FAILURE_PATTERN_TAG]
+
+
 _FIX_SUBJECT_RE = re.compile(r"^(revert\b|fix(\(|!?:|\b)|hotfix\b|bugfix\b)", re.I)
 _FIELD_SEP = "\x1f"
 _RECORD_SEP = "\x1e"
@@ -159,7 +172,7 @@ def mine_git_history(
                 "title": c["subject"][:80],
                 "body": "\n".join(body_lines),
                 "type": "failure_pattern",
-                "tags": ["git-mined", f"project:{slug}"],
+                "tags": _mined_tags(slug),
             }
             if is_near_duplicate(mem, cand):
                 skipped_dup += 1

--- a/src/memo/negative_recall.py
+++ b/src/memo/negative_recall.py
@@ -35,8 +35,20 @@ FP_SOURCE_SUPERSEDE = "supersede"
 FP_SOURCE_AVOID_VERDICT = "avoid_verdict"
 
 # Default tags applied to each derived anti-memory.
-DEFAULT_SUPERSEDE_TAGS: tuple[str, ...] = ("negative-recall", "superseded")
-DEFAULT_AVOID_VERDICT_TAGS: tuple[str, ...] = ("negative-recall", "avoid-verdict")
+# Names the class itself, so every anti-memory stays retrievable as one and
+# the pair clears memo's own >=3 tag convention — `memo lint` reported 43 of
+# 52 recent failure_patterns as `few_tags` while both tuples held exactly two.
+FAILURE_PATTERN_TAG = "failure-pattern"
+DEFAULT_SUPERSEDE_TAGS: tuple[str, ...] = (
+    "negative-recall",
+    "superseded",
+    FAILURE_PATTERN_TAG,
+)
+DEFAULT_AVOID_VERDICT_TAGS: tuple[str, ...] = (
+    "negative-recall",
+    "avoid-verdict",
+    FAILURE_PATTERN_TAG,
+)
 
 # Header of the rendered ⛔ block. A stored FACT surfaced, framed as data — no
 # suggest/agent/imperative-cognition verb (memo keeps cognition off its output).
@@ -332,6 +344,7 @@ __all__ = [
     "AVOID_BLOCK_HEADER",
     "DEFAULT_AVOID_VERDICT_TAGS",
     "DEFAULT_SUPERSEDE_TAGS",
+    "FAILURE_PATTERN_TAG",
     "FAILURE_PATTERN_TYPE",
     "FP_LINKS_KEY",
     "FP_SOURCE_AVOID_VERDICT",

--- a/tests/test_dream_consolidate.py
+++ b/tests/test_dream_consolidate.py
@@ -89,7 +89,7 @@ def test_run_consolidate_saves_with_keyword_content(monkeypatch):
         def search(self, q, limit=1, disable_reranker=True):
             return []
 
-        def save(self, *, content, type_, title, extra):  # keyword-only, like the real facade
+        def save(self, *, content, type_, title, extra, tags=None):  # keyword-only, real facade
             saved.append({"content": content, "type_": type_, "title": title})
 
     class _Cfg:

--- a/tests/test_synthesis_tags.py
+++ b/tests/test_synthesis_tags.py
@@ -43,3 +43,35 @@ def test_an_unknown_kind_still_clears_the_convention() -> None:
     tags = synthesis_tags("some-new-kind")
     assert len(tags) >= 3
     assert "some-new-kind" in tags
+
+
+def test_failure_pattern_defaults_meet_the_convention() -> None:
+    """The ⛔ AVOID producers wrote exactly two tags, one short of the bar.
+
+    Measured over the same eight days, `failure_pattern` violated `few_tags`
+    43 times out of 52 — for the same reason as `synthesis`, one level down:
+    both default tag tuples carried exactly two entries, and the git miner
+    built exactly two. A third tag naming the class keeps every anti-memory
+    retrievable as one, the way `synthesis` now is.
+    """
+    from memo.negative_recall import (
+        DEFAULT_AVOID_VERDICT_TAGS,
+        DEFAULT_SUPERSEDE_TAGS,
+        FAILURE_PATTERN_TAG,
+    )
+
+    for tags in (DEFAULT_SUPERSEDE_TAGS, DEFAULT_AVOID_VERDICT_TAGS):
+        assert len(tags) >= 3, tags
+        assert FAILURE_PATTERN_TAG in tags, tags
+
+
+def test_git_mined_anti_memories_meet_the_convention() -> None:
+    """The git miner builds its own tag list and must clear the bar too."""
+    from memo.git_miner import _mined_tags
+    from memo.negative_recall import FAILURE_PATTERN_TAG
+
+    tags = _mined_tags("memo")
+
+    assert len(tags) >= 3, tags
+    assert FAILURE_PATTERN_TAG in tags
+    assert "project:memo" in tags

--- a/tests/test_synthesis_tags.py
+++ b/tests/test_synthesis_tags.py
@@ -1,0 +1,45 @@
+"""Dream-generated `synthesis` memories must meet memo's own tag convention.
+
+`memo lint` flags any memory with fewer than 3 tags as `few_tags`, citing the
+CLAUDE.md convention of "project + domain + topic". Measured on the live index
+over the eight days to 2026-08-28, `synthesis` violated it **107 times out of
+109** — because all five producers (distill, consolidate, communities,
+bridges, folder abstracts) called `mem.save(...)` with no `tags=` at all.
+
+That is why `few_tags` sat at ~3,900 and grew: it is not a legacy backlog to
+sweep, it is a nightly producer writing below the standard the linter checks.
+Fixing the producer costs no embedder calls — `save` derives tags without one
+— and stops the debt accruing.
+"""
+
+from __future__ import annotations
+
+from memo.dream_synthesis_tags import SYNTHESIS_TAG, synthesis_tags
+
+
+def test_every_synthesis_kind_yields_at_least_three_tags() -> None:
+    """One tag per kind is not enough to clear the linter's own bar."""
+    for kind in ("distillation", "cross_session", "community", "bridge", "folder_abstract"):
+        tags = synthesis_tags(kind)
+        assert len(tags) >= 3, f"{kind} produced {tags}"
+        assert SYNTHESIS_TAG in tags, f"{kind} is not findable as a synthesis: {tags}"
+
+
+def test_tags_identify_the_producer_that_wrote_the_memory() -> None:
+    """The kind must survive into the tags, or provenance is lost."""
+    assert "distillation" in synthesis_tags("distillation")
+    assert "community" in synthesis_tags("community")
+
+
+def test_tags_are_deduplicated_and_ordered() -> None:
+    """A kind that collides with a constant must not produce a repeat."""
+    tags = synthesis_tags("synthesis")
+    assert len(tags) == len(set(tags)), tags
+    assert tags == sorted(tags), "unstable order would churn the record on rewrite"
+
+
+def test_an_unknown_kind_still_clears_the_convention() -> None:
+    """A new producer that forgets to register still writes a valid memory."""
+    tags = synthesis_tags("some-new-kind")
+    assert len(tags) >= 3
+    assert "some-new-kind" in tags


### PR DESCRIPTION
`memo lint` flags any memory with fewer than three tags as `few_tags`, citing the CLAUDE.md "project + domain + topic" convention. It reported **3,941**.

That looked like a corpus-cleanup project. It isn't — it's a nightly producer writing below the standard its own linter checks.

## Where the 3,941 actually come from

Broken down by type over the eight days to 2026-08-28:

```
synthesis        107 / 109   (98%)
failure_pattern   43 /  52   (83%)
reference        167 / 4119   (4%)   ← the bulk of the corpus, and fine
```

Not diffuse at all. **All five** synthesis producers — distill, consolidate, communities, bridges, folder abstracts — called `mem.save(...)` with no `tags=` whatsoever, so each record kept only what `save` could derive alone, usually one. Both `failure_pattern` default tuples (`DEFAULT_SUPERSEDE_TAGS`, `DEFAULT_AVOID_VERDICT_TAGS`) and the git miner each built exactly **two** — one short of the bar.

Retro-tagging 3,941 memories would have left the producer refilling the backlog every night. The fix is at the producer.

## What changed

`synthesis_tags(kind)` derives a tag set from the `synthesis_kind` each producer already records in `extra`:

```
distillation    → ['distillation', 'summary', 'synthesis']
cross_session   → ['continuity', 'cross-session', 'cross_session', 'synthesis']
community       → ['clustering', 'community', 'synthesis']
bridge          → ['bridge', 'connection', 'synthesis']
folder_abstract → ['folder-abstract', 'folder_abstract', 'structure', 'synthesis']
```

**No embedder call and no LLM** — `Memory.update()` only re-embeds when body or title change, and these are derived constants. Sorted and de-duplicated, so re-saving a record never churns it. An unregistered kind still clears three tags rather than silently reopening this defect.

The three `failure_pattern` producers now carry `failure-pattern` as a third tag, which additionally makes every anti-memory retrievable as one class regardless of which producer wrote it.

## Test plan

- [x] 6 tests, verified RED first (`ImportError` on both new symbols).
- [x] Covers the unregistered-kind path, dedup, and stable ordering — the properties that keep this from regressing quietly.
- [x] End-to-end check through the real `Memory.save`: all five kinds land ≥3 tags. (Two of my first ad-hoc probes returned another kind's tags — near-duplicate collapse merging my similar fixture bodies, not a code bug; re-verified with distinct content.)
- [x] Full suite: 8114 passed / 21 skipped, and the affected files re-run under `MEMO_VEC_QUANTIZE=int8`.
- [x] One existing stub needed `tags=`: `test_dream_consolidate`'s fake facade pins the keyword-only signature to guard the v2.3.11 positional-body bug. That guard is unchanged.
- [x] ruff, mypy, `scripts/quality_gate.py` clean.

## What this does not do

It does not retro-tag the existing 3,941. That is a separate, now-optional decision — and with the honest `noise@k` from #308 in place, whether better tags actually improve retrieval is finally measurable rather than assumed.