### PR TITLE
chore: sync homebrew formula to 4.14.5

### DIFF
--- a/docs/homebrew/mlx-memo.rb
+++ b/docs/homebrew/mlx-memo.rb
@@ -21,8 +21,8 @@ class MlxMemo < Formula
 
   desc "Local MCP memory for AI agents — MLX-native, sqlite-vec, markdown vault"
   homepage "https://github.com/jagoff/memo"
-  url "https://files.pythonhosted.org/packages/6e/c6/07b0f7c05531c4a53549e546a870cfd32969d3b5c83bb7065f4121d3c243/mlx_memo-4.14.4.tar.gz"
-  sha256 "6fd3793c433753e0cf1756396312170e3596dadd90baf334fd66ea9eeb863202"
+  url "https://files.pythonhosted.org/packages/8c/08/a5f043f20e2229846cf4cc2774d21a3134d7df1a791c4a6bb99aca65baee/mlx_memo-4.14.5.tar.gz"
+  sha256 "68075a2753058c057e384258504f8097b61fa6c9993d946417d5d2ef5eb3b0d7"
   license "MIT"
 
   depends_on arch: :arm64


### PR DESCRIPTION
Post-publish sync of the Homebrew formula to the released 4.14.5 sdist.

`memo release check` warns until the formula points at the real PyPI
artifact, which only exists after the tag publishes. Values taken from
`https://pypi.org/pypi/mlx-memo/4.14.5/json`.

- url  -> mlx_memo-4.14.5.tar.gz
- sha256 -> 68075a2753058c057e384258504f8097b61fa6c9993d946417d5d2ef5eb3b0d7

`memo release check` now passes with no warnings.

## Test plan
- [x] `memo release check` clean (was 2 warnings, now 0)
- [x] sha256 matches the PyPI JSON API digest for the 4.14.5 sdist
- [ ] CI green