### PR TITLE
fix: two proactive nudges asserting more than the data supports

### DIFF
--- a/src/memo/cli_dream_passes.py
+++ b/src/memo/cli_dream_passes.py
@@ -34,7 +34,7 @@ from memo.outcome import (
     reconcile_roi,
     reconcile_source_feedback,
 )
-from memo.tiers import EVICTION_PROTECTED_TYPES
+from memo.tiers import EVICTION_PROTECTED_TYPES, STALE_AFTER_DAYS
 from memo.transcript_miner import mine_transcripts
 
 if TYPE_CHECKING:
@@ -792,7 +792,9 @@ def _run_stale(mem: Memory, dry_run: bool = False) -> dict[str, Any]:
     """
     result: dict[str, Any] = {"archived": []}
     try:
-        stale = mem.temporal.detect_stale_memories(days_threshold=365, min_access_count=0)
+        stale = mem.temporal.detect_stale_memories(
+            days_threshold=STALE_AFTER_DAYS, min_access_count=0
+        )
         for item in stale:
             mid = item.get("id")
             if not mid:

--- a/src/memo/cli_maintain.py
+++ b/src/memo/cli_maintain.py
@@ -53,6 +53,7 @@ from memo.maintain_compact import (
     _undo_targets,
     _write_synthesis_last_run,
 )
+from memo.tiers import STALE_AFTER_DAYS
 
 _log = logging.getLogger(__name__)
 _RUN_STAMP_RE = re.compile(r"\d{1,20}(?:-\d{1,20}-\d{1,30})?\Z")
@@ -218,8 +219,8 @@ def _fail_on_pass_errors(receipt: dict[str, Any], *, dry_run: bool) -> None:
 @click.option(
     "--stale-days",
     type=int,
-    default=365,
-    help="Archive never-accessed memories older than this (default 365).",
+    default=STALE_AFTER_DAYS,
+    help=f"Archive never-accessed memories older than this (default {STALE_AFTER_DAYS}).",
 )
 @click.option(
     "--dup-threshold",

--- a/src/memo/memory/facade.py
+++ b/src/memo/memory/facade.py
@@ -47,6 +47,7 @@ from memo.memory.search_scoring_ops import _SearchScoringMixin
 from memo.memory.secret_ops import _SecretOpsMixin
 from memo.memory.update_ops import _UpdateOpsMixin
 from memo.memory.write_ops import _WriteOpsMixin
+from memo.retrieval_boost import shares_content_term
 from memo.store import VecStore
 from memo.store.fact_edge_store import FactEdgeStore
 from memo.temporal import TemporalAnalyzer
@@ -626,9 +627,15 @@ class Memory(
         (`dashboard_logs.read_recall_log`) — true déjà-vu would compare
         against the CURRENT recall's live hits, but that context isn't
         available outside a recall call, so this re-runs `search()` (the
-        same retrieval machinery any query uses) to find a real citable
-        hit. A pattern with no matching memory is dropped; this never
-        fabricates a citation.
+        same retrieval machinery any query uses) to find a citable hit.
+
+        `search()` returns its best row for any input, so a hit alone is not
+        evidence: a pattern is kept only when its top hit shares a content
+        term with the prompt (`_cites_shared_topic`). That floor sits at
+        "zero shared terms" on purpose — scores are not comparable across
+        queries, so any higher cut drops real prompts too. A citation
+        matching on one incidental word can still get through: this bounds
+        the fabrication, it does not eliminate it.
         """
         from collections import Counter
 
@@ -656,9 +663,14 @@ class Memory(
             if count < min_count:
                 break
             hits = self.search(query, limit=1, disable_reranker=True)
-            if hits and hits[0].id not in seen:
-                seen.add(hits[0].id)
-                out.append((hits[0].id, query))
+            if not hits or hits[0].id in seen:
+                continue
+            title = getattr(hits[0], "title", "") or ""
+            snippet = getattr(hits[0], "snippet", "") or ""
+            if not shares_content_term(query, f"{title} {snippet}"):
+                continue
+            seen.add(hits[0].id)
+            out.append((hits[0].id, query))
         return out
 
     def capability(self, name: str) -> Any:

--- a/src/memo/memory/facade.py
+++ b/src/memo/memory/facade.py
@@ -64,16 +64,23 @@ _LOW_CONFIDENCE_FROM = (
 
 
 def _dead_memory_from(durable_types: frozenset[str]) -> str:
-    """FROM/WHERE tail for never-accessed durable memories.
+    """FROM/WHERE tail for never-accessed durable memories old enough to prune.
 
     Built rather than a constant because the `IN (...)` list needs one `?` per
-    durable type; the caller binds `durable_types` in the same order.
+    durable type; the caller binds `durable_types` in the same order, then the
+    `date('now', ?)` offset.
+
+    Never-accessed alone is not prunable: a memory saved this week has not had
+    a chance to be surfaced yet. The window matches `memo maintain
+    --stale-days`, the command that actually archives these, so the count and
+    its remediation agree.
     """
     placeholders = ",".join("?" for _ in durable_types)
     return (
         "FROM meta m LEFT JOIN access a ON a.id = m.id "
         "WHERE COALESCE(a.access_count, 0) = 0 "
         f"AND m.type IN ({placeholders}) "
+        "AND m.created < date('now', ?) "
         "AND (m.deleted_at IS NULL OR m.deleted_at = '')"
     )
 
@@ -595,11 +602,11 @@ class Memory(
         Capped by `limit`: pair with `dead_memory_count` when you need to
         report how many there really are.
         """
-        from memo.tiers import DURABLE_TYPES
+        from memo.tiers import DURABLE_TYPES, STALE_AFTER_DAYS
 
         rows = self.store._conn.execute(
             f"SELECT m.id {_dead_memory_from(DURABLE_TYPES)} ORDER BY m.created ASC LIMIT ?",
-            (*DURABLE_TYPES, limit),
+            (*DURABLE_TYPES, f"-{STALE_AFTER_DAYS} day", limit),
         ).fetchall()
         return [str(r["id"]) for r in rows]
 
@@ -609,11 +616,11 @@ class Memory(
         `dead_memory_ids` truncates to `limit`, so on a corpus with thousands
         of never-accessed memories its length reports the cap, not the backlog.
         """
-        from memo.tiers import DURABLE_TYPES
+        from memo.tiers import DURABLE_TYPES, STALE_AFTER_DAYS
 
         row = self.store._conn.execute(
             f"SELECT count(*) AS n {_dead_memory_from(DURABLE_TYPES)}",
-            tuple(DURABLE_TYPES),
+            (*DURABLE_TYPES, f"-{STALE_AFTER_DAYS} day"),
         ).fetchone()
         return int(row["n"]) if row else 0
 

--- a/src/memo/retrieval_boost.py
+++ b/src/memo/retrieval_boost.py
@@ -123,6 +123,26 @@ def query_terms(query: str) -> list[str]:
     ]
 
 
+def shares_content_term(query: str, text: str) -> bool:
+    """Whether ``text`` shares at least one significant term with ``query``.
+
+    A relevance floor for callers that must justify citing a specific memory
+    against a specific prompt. Retrieval always returns its best row for any
+    input, so "we got a hit" is not evidence. A score floor cannot supply that
+    evidence either — hybrid scores are not comparable across queries — but
+    "shares no content word at all" disqualifies without needing a calibrated
+    cut. Built on `query_terms`, so it agrees with every other retrieval path
+    on what counts as significant.
+
+    A query whose terms are all stopwords has nothing to match on and is
+    treated as unsubstantiated.
+    """
+    terms = set(query_terms(query))
+    if not terms:
+        return False
+    return bool(terms & set(query_terms(text)))
+
+
 def boost_for(
     *,
     query: str,

--- a/src/memo/tiers.py
+++ b/src/memo/tiers.py
@@ -71,6 +71,13 @@ DURABLE_TYPES: frozenset[str] = frozenset(
     }
 )
 
+# How long a never-accessed memory must sit before it counts as prunable.
+# `memo maintain --stale-days` archives never-accessed memories older than
+# this, so anything reporting "candidates to prune" has to use the same window
+# — otherwise the nudge recommends deleting work the remediation would refuse
+# to touch.
+STALE_AFTER_DAYS = 365
+
 # A chunk marker like "§54/130" in a title — the signature of a bulk vault
 # ingest (one source doc split across many memories).
 _CHUNK_TITLE_RE = re.compile(r"§\s*\d+\s*/\s*\d+")
@@ -113,6 +120,7 @@ __all__ = [
     "REFERENCE_TYPES",
     "SECRET_KINDS",
     "SENSITIVE_TYPES",
+    "STALE_AFTER_DAYS",
     "VerificationState",
     "is_reference_candidate",
 ]

--- a/tests/test_proactive_dejavu.py
+++ b/tests/test_proactive_dejavu.py
@@ -84,3 +84,34 @@ def test_real_facade_recurring_pattern_pairs_bounds_search_calls(mock_memory):
 
     assert pairs == []
     assert call_count <= 20
+
+
+def test_real_facade_recurring_pattern_pairs_drops_prompt_sharing_no_term(mock_memory, monkeypatch):
+    """On a populated corpus the `if hits` guard is dead code.
+
+    `search()` always ranks *something* once the corpus is large enough for a
+    hit to clear the similarity floor, so "a pattern with no matching memory is
+    dropped" never fires in production — every repeated prompt, gibberish
+    included, gets cited against whatever came back. The older empty-corpus
+    test passes only because an empty corpus makes the guard trivially true.
+
+    Force the production condition and require the pattern to be dropped on the
+    strength of the citation instead.
+    """
+    from memo.dashboard_logs import append_recall_log
+
+    mock_memory.save(
+        content="always restart the recall daemon after a config change",
+        type_="note",
+    )
+    prompt = "asdfgh qwerty zzz"
+    append_recall_log(mock_memory.cfg.state_dir, prompt=prompt, hits=[])
+    append_recall_log(mock_memory.cfg.state_dir, prompt=prompt, hits=[])
+
+    # The fixture corpus is too small for gibberish to clear the floor on its
+    # own, so pin `search` to the hit a real corpus would have returned.
+    hits = mock_memory.search("restart recall daemon", limit=1, disable_reranker=True)
+    assert hits, "fixture sanity: a matching query must return the seeded memory"
+    monkeypatch.setattr(mock_memory, "search", lambda *a, **k: hits)
+
+    assert mock_memory.recurring_pattern_pairs() == []

--- a/tests/test_proactive_roi.py
+++ b/tests/test_proactive_roi.py
@@ -33,12 +33,37 @@ def test_roi_guarded_returns_empty_on_error():
     assert detect_roi(Boom(), now="2026-07-21T00:00:00Z") == []
 
 
+def _age(mem, memo_id: str, *, days: int) -> None:
+    """Backdate `created` so the memory clears the staleness window."""
+    mem.store._conn.execute(
+        "UPDATE meta SET created = date('now', ?) WHERE id = ?",
+        (f"-{days} day", memo_id),
+    )
+    mem.store._conn.commit()
+
+
 def test_real_facade_dead_memory_ids_finds_never_accessed_durable_memory(mock_memory):
     rec = mock_memory.save(content="a fact nobody ever looked up again", type_="fact")
+    _age(mock_memory, rec.id, days=400)
 
     ids = mock_memory.dead_memory_ids()
 
     assert rec.id in ids
+
+
+def test_real_facade_dead_memory_ids_ignores_a_memory_too_young_to_prune(mock_memory):
+    """Never-accessed is not the same as prunable.
+
+    The nudge these ids feed says "candidates to prune", but the remediation
+    it points at (`memo maintain`) only archives never-accessed memories older
+    than `--stale-days`. Counting fresh ones tells the operator to delete work
+    they saved this week: on the live corpus that was 1505 memories against
+    which `memo maintain` would have archived zero.
+    """
+    rec = mock_memory.save(content="a fact saved moments ago", type_="fact")
+
+    assert rec.id not in mock_memory.dead_memory_ids()
+    assert mock_memory.dead_memory_count() == 0
 
 
 def test_roi_title_reports_the_true_total_not_the_evidence_cap():
@@ -75,6 +100,7 @@ def test_roi_falls_back_to_evidence_length_when_count_is_unavailable():
 
 def test_real_facade_dead_memory_count_matches_unlimited_ids(mock_memory):
     for i in range(3):
-        mock_memory.save(content=f"fact {i} nobody ever looked up", type_="fact")
+        rec = mock_memory.save(content=f"fact {i} nobody ever looked up", type_="fact")
+        _age(mock_memory, rec.id, days=400)
 
     assert mock_memory.dead_memory_count() == len(mock_memory.dead_memory_ids(limit=999))

--- a/tests/test_retrieval_boost.py
+++ b/tests/test_retrieval_boost.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from memo.retrieval_boost import boost_for, query_terms
+from memo.retrieval_boost import boost_for, query_terms, shares_content_term
 
 # ---------- query_terms ----------
 
@@ -112,3 +112,21 @@ def test_filename_partial_match_boost_1_3x() -> None:
     # 1/3 of terms in filename → <0.5 but >0 → x1.3
     b = boost_for(query="aws legacy login", filename="aws-only.md")
     assert 1.2 < b < 1.4
+
+
+def test_shares_content_term_matches_on_a_significant_term():
+    assert shares_content_term("recall hook budget", "Runtime manages the recall budget")
+
+
+def test_shares_content_term_rejects_when_nothing_overlaps():
+    assert not shares_content_term("asdfgh qwerty zzz", "MBR 2026 05 accounting export")
+
+
+def test_shares_content_term_rejects_a_query_of_only_stopwords():
+    """No significant term means nothing to substantiate a citation with."""
+    assert not shares_content_term("how do i", "how do i restart the daemon")
+
+
+def test_shares_content_term_is_diacritic_insensitive():
+    """Folding matches `query_terms`, so an accented prompt still matches."""
+    assert shares_content_term("configuración del daemon", "configuracion pendiente")


### PR DESCRIPTION
Two `memo digest` nudges make claims their evidence cannot carry. Both were
found by constructing the red case rather than trusting the green test — and in
both cases the existing test passed for the wrong reason.

---

## 1. Déjà-vu cited memories that answer nothing

`memo digest` was telling the user, live:

```
🔁 Déjà-vu (5)
   Recurring: asdfgh qwerty zzz — you already have this
```

`recurring_pattern_pairs` documented a guarantee it cannot keep:

> A pattern with no matching memory is dropped; this never fabricates a citation.

`search()` ranks the whole corpus and returns its best row for *any* input, so
on a populated corpus `if hits:` is dead code. Every repeated recall-log prompt
— keyboard mash included — became a `"you already have this"` assertion citing
an unrelated memory. The covering test ran against an **empty corpus**, where the
guard is trivially true. It measured nothing.

### Why the floor is at zero shared terms

Four candidate fixes were measured against the live 10,540-memory index; all but
one failed:

| Candidate | Why it fails |
|---|---|
| Score threshold | Scores aren't comparable across queries: real `recall hook budget` top-scored **0.038**, gibberish `my cat keeps knocking things off the table` scored **0.93** |
| Top-hit stability | Every repeated prompt showed `uniq=1` — retrieval is deterministic, so stability carries no signal |
| Trust the recall log's own `hits` | `min_sim 0.4` sits below the embedder's 0.6–0.8 noise floor, so gibberish logs hits like anything else — 0 empty across all repeated prompts |
| Join `grounding.log`'s `used_score` | Only **7** `(session_id, turn)` keys overlap between the two logs |

What survives is a threshold-free disqualifier: **a memory that shares no content
word with the prompt cannot be said to answer it.** On live data that is the only
safe cut — a real query (`recall hook budget` → `budget`) matches on a single
term just like an incidental one (`best pasta recipe for tonight` → `tonight`),
so any higher cut drops real prompts too.

**Honest limit:** this bounds the fabrication, it does not eliminate it. Pure
noise strings are dropped; single-incidental-word matches still get through. The
docstring now says exactly that instead of claiming a guarantee.

`shares_content_term` sits next to `query_terms` in `retrieval_boost.py` so the
floor agrees with every other retrieval path on what counts as significant, and
so `facade.py` stays under the 800-line limit (805 → 790).

---

## 2. ROI called this week's memories prunable

`dead_memory_ids`/`dead_memory_count` counted every never-accessed durable
memory and rendered it as `"N memories never surfaced — candidates to prune"`.

On the live corpus that claimed **1505 candidates**. `memo maintain` — the command
that actually archives these — would have archived **0**: it only takes
never-accessed memories older than `--stale-days` (365), and the corpus only goes
back to 2026-05-27. 95% of the count was from the last two months. The nudge was
recommending a destructive action on the operator's newest work.

Fix: apply the same window the remediation uses, so the count and the command
that acts on it agree. `STALE_AFTER_DAYS` now lives in `tiers.py` and replaces the
two hardcoded `365`s in `cli_maintain` and `cli_dream_passes`.

Here too the existing test encoded the bug — it saved a memory and immediately
asserted it was dead. It now backdates the row past the window.

---

## Also measured, no change made

`reference` is 39.4% of the live corpus, which the 2026-08-04 audit filed as a P0
("dilución de reference"). Against live recall data that finding does not hold:
reference is **1.6% of returned hits, a 0.04x lift**, while curated types run well
above their corpus share (`fact` 2.45x, `decision` 1.94x). `tiers.py` already
excludes the reference tier from auto-recall by design. Its cost is storage, not
recall quality — nothing to fix here.

## Test plan
- [x] Déjà-vu: new test reproduces the fabrication (RED: `[('08f1d96215…', 'asdfgh qwerty zzz')]`), forces the production condition explicitly, and sanity-checks the fixture so it cannot pass for the empty-corpus reason
- [x] 4 unit tests for `shares_content_term` (match, no-overlap, all-stopword query, diacritics)
- [x] ROI: new test asserts a fresh memory is not a prune candidate (RED before the fix); the two pre-existing facade tests now backdate their rows
- [x] `pytest -k "proactive or roi or tiers or maintain or dream or retrieval or recall or facade or boost"` → 1522 passed, 1 skipped
- [x] mypy clean, ruff (pinned 0.16.4) clean
- [x] pre-push recall gate PASS — prec@k 0.540 ≥ 0.530, noise@k 0.012 ≤ 0.041
- [x] Live corpus: `asdfgh qwerty zzz` no longer produces a pair; `dead_memory_count()` 1505 → 0
- [ ] CI green