### PR TITLE
fix: promote accumulated Unreleased entries instead of stubbing over them

### DIFF
--- a/src/memo/cli_release.py
+++ b/src/memo/cli_release.py
@@ -710,17 +710,35 @@ def plan_release_edits(repo: Path, old: str, new: str, date: str) -> dict[Path, 
         edits[path] = _replace_target_version(path.read_text(encoding="utf-8"), target, new)
 
     changelog = repo / "CHANGELOG.md"
-    section = f"## [{new}] - {date}\n\n### Fixed\n\n- TODO: describe changes\n\n"
-    cl_text = changelog.read_text(encoding="utf-8")
-    cl_new, cl_n = re.subn(
-        r"## \[Unreleased\]\n\n",
-        lambda _m: f"## [Unreleased]\n\n{section}",
-        cl_text,
-    )
-    if cl_n != 1:
-        raise ValueError(f"expected 1 Unreleased section, got {cl_n}")
-    edits[changelog] = cl_new
+    edits[changelog] = _open_changelog_section(changelog.read_text(encoding="utf-8"), new, date)
     return edits
+
+
+def _open_changelog_section(text: str, new: str, date: str) -> str:
+    """Open a `## [new] - date` section, carrying accumulated entries into it.
+
+    Keep a Changelog accumulates under `[Unreleased]` and renames that section
+    on release, so anything already written there *is* the release notes: it
+    moves under the new heading and `[Unreleased]` is left empty for the next
+    cycle. Stubbing `- TODO: describe changes` above those entries instead
+    produced two `### Fixed` blocks under one version plus a TODO that
+    `release check` rejects, so every release had to hand-delete it.
+
+    The stub is still correct when nothing was accumulated — there it is the
+    prompt to write notes before committing.
+    """
+    marker = "## [Unreleased]\n\n"
+    count = text.count(marker)
+    if count != 1:
+        raise ValueError(f"expected 1 Unreleased section, got {count}")
+
+    start = text.index(marker) + len(marker)
+    following = re.search(r"^## \[", text[start:], re.M)
+    end = start + following.start() if following else len(text)
+
+    accumulated = text[start:end].strip()
+    body = accumulated if accumulated else "### Fixed\n\n- TODO: describe changes"
+    return f"{text[:start]}## [{new}] - {date}\n\n{body}\n\n{text[end:]}"
 
 
 def plan_release_sync_edits(repo: Path, version: str) -> dict[Path, str]:

--- a/tests/test_cli_release.py
+++ b/tests/test_cli_release.py
@@ -643,3 +643,42 @@ def test_release_check_reports_blocking_homebrew_mcp_test(tmp_path: Path) -> Non
     assert any("blocks waiting for input" in warning for warning in report.warnings)
     assert strict.ok is False
     assert any("blocks waiting for input" in issue for issue in strict.issues)
+
+
+def test_plan_release_edits_promotes_accumulated_unreleased_entries(tmp_path: Path) -> None:
+    """Entries already written under `[Unreleased]` are the release notes.
+
+    Keep a Changelog accumulates under `[Unreleased]` and renames that section
+    on release. Inserting a `- TODO: describe changes` stub above real entries
+    produces two `### Fixed` blocks under one version and a TODO that
+    `release check` then rejects — every release has to hand-delete it.
+    """
+    repo = _fake_repo(tmp_path, "1.2.3")
+    (repo / "CHANGELOG.md").write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "### Fixed\n\n"
+        "- a real thing that got fixed\n\n"
+        "## [1.2.3] - 2026-01-01\n\n- prior\n",
+        encoding="utf-8",
+    )
+
+    cl = plan_release_edits(repo, "1.2.3", "1.2.4", "2026-06-25")[repo / "CHANGELOG.md"]
+
+    assert "TODO: describe changes" not in cl
+    assert cl.count("### Fixed") == 1
+    body = cl[cl.index("## [1.2.4]") : cl.index("## [1.2.3]")]
+    assert "- a real thing that got fixed" in body
+    # `[Unreleased]` survives, emptied, ready for the next cycle.
+    assert cl.index("## [Unreleased]") < cl.index("## [1.2.4]")
+    assert "- a real thing" not in cl[cl.index("## [Unreleased]") : cl.index("## [1.2.4]")]
+
+
+def test_plan_release_edits_still_stubs_an_empty_unreleased(tmp_path: Path) -> None:
+    """With nothing accumulated there is nothing to promote, so the TODO stub
+    stays — it is the prompt to write the notes before committing."""
+    repo = _fake_repo(tmp_path, "1.2.3")
+
+    cl = plan_release_edits(repo, "1.2.3", "1.2.4", "2026-06-25")[repo / "CHANGELOG.md"]
+
+    assert "- TODO: describe changes" in cl


### PR DESCRIPTION
## The papercut

`memo release bump` always inserted this under the new version heading:

```markdown
## [4.14.6] - 2026-08-28

### Fixed

- TODO: describe changes

### Fixed

- **The déjà-vu nudge cited memories that answer nothing.** …
```

Two `### Fixed` blocks under one version, plus a `TODO` that `release check`
then rejects — so every release had to hand-delete four lines before
committing. That happened twice in today's cycle (4.14.5 and 4.14.6), both
times patched with a throwaway `sed -i '' '14,17d'`.

## The fix

Keep a Changelog accumulates under `[Unreleased]` and renames that section on
release, so whatever is already written there **is** the release notes. It now
moves under the new heading and `[Unreleased]` is left empty for the next cycle.

The stub is still correct — and still emitted — when nothing was accumulated.
There it is the prompt to write notes before committing, which is why
`release check` rejects it.

## Why the tests didn't catch it

`_fake_repo` writes `## [Unreleased]\n\n` with nothing under it, so every
existing `plan_release_edits` test exercised only the empty path. The populated
path — the one that runs on a real release — had no coverage at all. Both are
covered now.

## Test plan
- [x] New test asserts accumulated entries are promoted: no TODO, one `### Fixed`, body under the version heading, `[Unreleased]` emptied (RED before the fix)
- [x] New test pins the empty-`[Unreleased]` path so the stub behaviour cannot silently regress (GREEN before and after)
- [x] Verified against the real `CHANGELOG.md` on both paths
- [x] Release test suite: 133 passed
- [x] mypy clean, ruff (pinned 0.16.4) clean
- [ ] CI green