### PR TITLE
fix: repair the blanked homebrew formula and let release check see it

### DIFF
--- a/docs/homebrew/mlx-memo.rb
+++ b/docs/homebrew/mlx-memo.rb
@@ -21,8 +21,8 @@ class MlxMemo < Formula
 
   desc "Local MCP memory for AI agents — MLX-native, sqlite-vec, markdown vault"
   homepage "https://github.com/jagoff/memo"
-  url ""
-  sha256 ""
+  url "https://files.pythonhosted.org/packages/1a/8e/a78f98a2a11e19132be5cdf837d9aff4250024650e2d74b3ff82d3965d4d/mlx_memo-4.14.7.tar.gz"
+  sha256 "66a8f83a53d7b207c539b5e106c9b060e9054d68582f74c8deea9ceb79586c55"
   license "MIT"
 
   depends_on arch: :arm64

--- a/src/memo/cli_release.py
+++ b/src/memo/cli_release.py
@@ -549,10 +549,17 @@ def _check_formula(
     if match and match.group(1) != version:
         _add_doc_drift(destination, path=formula, expected=version, found=match.group(1))
 
-    url_match = re.search(r'^\s*url\s+"(?P<url>[^"]+)"', text, flags=re.MULTILINE)
+    # `[^"]*`, not `[^"]+`: an emptied attribute has nothing between the quotes,
+    # so the old pattern failed to match and skipped every URL check in silence.
+    # A blank `url` is not a docs nit — `brew info` refuses the formula with
+    # `invalid attribute for formula: url ("")` — so it lands in `issues`
+    # regardless of `strict_docs`.
+    url_match = re.search(r'^\s*url\s+"(?P<url>[^"]*)"', text, flags=re.MULTILINE)
     if url_match:
         url = url_match.group("url")
-        if not re.fullmatch(
+        if not url.strip():
+            issues.append(f"{formula.relative_to(repo)} has an empty url")
+        elif not re.fullmatch(
             rf"https://files\.pythonhosted\.org/packages/(?!source/)[^\s]+/"
             rf"mlx_memo-{re.escape(version)}\.tar\.gz",
             url,
@@ -560,6 +567,10 @@ def _check_formula(
             destination.append(
                 f"{formula.relative_to(repo)} should use the exact PyPI source distribution URL"
             )
+
+    sha_match = re.search(r'^\s*sha256\s+"(?P<sha>[^"]*)"', text, flags=re.MULTILINE)
+    if sha_match and not re.fullmatch(r"[0-9a-f]{64}", sha_match.group("sha")):
+        issues.append(f"{formula.relative_to(repo)} sha256 is not a 64-character hex digest")
 
     arch_dependency = text.find("depends_on arch:")
     macos_dependency = text.find("depends_on :macos")

--- a/tests/test_cli_release.py
+++ b/tests/test_cli_release.py
@@ -682,3 +682,40 @@ def test_plan_release_edits_still_stubs_an_empty_unreleased(tmp_path: Path) -> N
     cl = plan_release_edits(repo, "1.2.3", "1.2.4", "2026-06-25")[repo / "CHANGELOG.md"]
 
     assert "- TODO: describe changes" in cl
+
+
+def test_release_check_reports_emptied_homebrew_url_and_sha(tmp_path: Path) -> None:
+    """An emptied `url`/`sha256` is the one breakage the check could not see.
+
+    The URL guard matched `"[^"]+"` — one or more characters — so `url ""`
+    simply failed to match and the whole validation was skipped in silence. A
+    formula with both attributes blanked passed `release check` clean while
+    `brew info` rejected it outright: `invalid attribute for formula: url ("")`.
+    """
+    repo = _fake_repo(tmp_path, "1.2.3")
+    formula = repo / "docs" / "homebrew" / "mlx-memo.rb"
+    formula.parent.mkdir(parents=True)
+    formula.write_text('  url ""\n  sha256 ""\n', encoding="utf-8")
+
+    report = release_check_report(repo)
+
+    assert report.ok is False
+    assert any("url" in issue and "mlx-memo.rb" in issue for issue in report.issues)
+    assert any("sha256" in issue and "mlx-memo.rb" in issue for issue in report.issues)
+
+
+def test_release_check_accepts_a_populated_homebrew_formula(tmp_path: Path) -> None:
+    """The new emptiness guard must not fire on a well-formed formula."""
+    repo = _fake_repo(tmp_path, "1.2.3")
+    formula = repo / "docs" / "homebrew" / "mlx-memo.rb"
+    formula.parent.mkdir(parents=True)
+    formula.write_text(
+        '  url "https://files.pythonhosted.org/packages/ab/cd/ef/mlx_memo-1.2.3.tar.gz"\n'
+        f'  sha256 "{"a" * 64}"\n',
+        encoding="utf-8",
+    )
+
+    report = release_check_report(repo)
+
+    assert not any("url" in issue for issue in report.issues)
+    assert not any("sha256" in issue for issue in report.issues)


### PR DESCRIPTION
## What broke

The 4.14.7 formula sync (#322) wrote `url ""` and `sha256 ""` into **both** the
repo formula and the tap:

```
$ brew info --formula jagoff/memo/mlx-memo
Error: invalid attribute for formula 'jagoff/memo/mlx-memo': url ("")
```

`brew install jagoff/memo/mlx-memo` was broken from the moment #322 merged until
this fix. Values restored from `https://pypi.org/pypi/mlx-memo/4.14.7/json`; the
tap is already repaired at `jagoff/homebrew-memo@4a39686` and `brew info` now
resolves `stable 4.14.7`.

Cause was a shell quoting bug in the sync step, not in this repo: `set -- $META`
under zsh, which does **not** word-split unquoted parameters, so the URL and sha
variables were empty strings. The sync is now done entirely in Python.

## Why release check said it was fine

`memo release check` passed on the blanked formula. Its guard was:

```python
url_match = re.search(r'^\s*url\s+"(?P<url>[^"]+)"', text, flags=re.MULTILINE)
if url_match:
    ...
```

`[^"]+` requires at least one character, so `url ""` failed to match and the
entire URL validation was skipped — silently. The single state that makes brew
reject the formula was the single state the check could not observe. Same shape
as the other blind instruments this repo has been working through: the guard
only fires when there is already something to check.

The pattern is now `[^"]*`, and an empty `url` or a `sha256` that is not 64 hex
characters is an **issue**, not a `strict_docs` warning — neither is a
documentation nit, they make the formula unusable.

## Test plan
- [x] New test blanks both attributes and asserts `report.ok is False` with an issue naming each (RED before the fix: `issues=[]`, `ok=True`)
- [x] New test pins a well-formed formula so the emptiness guard cannot start false-positiving
- [x] Verified against the real formula: repaired → `release check` clean; re-blanked → `has an empty url` + `sha256 is not a 64-character hex digest`; restored
- [x] `brew info --formula jagoff/memo/mlx-memo` resolves `stable 4.14.7`
- [x] `tests/test_cli_release.py` 41 passed; mypy clean, ruff (pinned 0.16.4) clean
- [ ] CI green