### PR TITLE
fix: two guards that never matched the form production actually produces

### DIFF
--- a/src/memo/code_traceability.py
+++ b/src/memo/code_traceability.py
@@ -235,7 +235,14 @@ class CodeReferenceResolver:
         if db_path is None or repo_root is None:
             from memo import codegraph_loader
 
-            db_path = db_path or codegraph_loader.CODEGRAPH_DB
+            # `_resolve_db`, not the bare `CODEGRAPH_DB` constant: the constant
+            # is derived from `__file__`, so under an isolated `uv tool` install
+            # it points inside site-packages, where no index ever lives. Going
+            # through the resolver picks up cwd discovery and the
+            # `MEMO_CODEGRAPH_DB` override, same as every other caller
+            # (`code_intel`, `recall_logic`, `cli_code_facts`, `cli_doctor`,
+            # `cli_dream_passes`).
+            db_path = db_path or codegraph_loader._resolve_db()
             repo_root = repo_root or db_path.parent.parent
         assert db_path is not None
         assert repo_root is not None

--- a/src/memo/proxy/transforms/toolschemas.py
+++ b/src/memo/proxy/transforms/toolschemas.py
@@ -127,6 +127,30 @@ _ALWAYS_KEEP = frozenset({DOCS_TOOL_NAME, "memo_search", "memo_save"}) | _BUILTI
 _DEFAULT_WINDOW = 20
 _DEFAULT_SCOPE = "all"
 
+# An MCP client namespaces every tool it proxies, so memo's tools reach the
+# wire as `mcp__memo__memo_search`, never as the bare `memo_search` the two
+# guards above are written in. Both comparisons therefore normalize first:
+# without this, `_ALWAYS_KEEP` matches nothing (memo's write path gets pruned
+# off the model's surface on a session that has not called it yet) and the
+# `scope="memo"` rollback recognizes no tool as owned, so it keeps every
+# schema and saves zero — a fallback that silently disables itself.
+_MCP_SERVER_SEGMENT = "__memo__"
+
+
+def _bare_name(tool_name: str) -> str:
+    """The tool's own name, with any `mcp__<server>__` namespace removed."""
+    _, sep, bare = tool_name.rpartition("__")
+    return bare if sep else tool_name
+
+
+def _is_owned(tool_name: str) -> bool:
+    """Whether memo owns this tool, in wire or bare form.
+
+    The server segment is checked as well as the name prefix because memo also
+    exposes `mem_*` tools, which the prefix alone would disown.
+    """
+    return _MCP_SERVER_SEGMENT in tool_name or _bare_name(tool_name).startswith(_OWNED_PREFIX)
+
 
 def _scope() -> str:
     """`MEMO_PROXY_TOOL_SCHEMAS_SCOPE`, defaulting (and falling back on any
@@ -281,7 +305,7 @@ def _frozen_keep_set(ctx: Context, window: int, scope: str) -> tuple[str, frozen
     else:
         names = recent_tool_names(ctx.state_dir, window)
         if scope == "memo":
-            names = {n for n in names if n.startswith(_OWNED_PREFIX)}
+            names = {n for n in names if _is_owned(n)}
         result = (scope, frozenset(names) | _ALWAYS_KEEP)
         _persist(ctx.state_dir, ctx.session_key, result)
 
@@ -369,11 +393,11 @@ class ToolSchemas:
                 tool_name = tool.get("name")
                 if not isinstance(tool_name, str) or not tool_name:
                     return True
-                if frozen_scope == "memo" and not tool_name.startswith(_OWNED_PREFIX):
+                if frozen_scope == "memo" and not _is_owned(tool_name):
                     # Conservative scope: memo never touches a schema it
                     # doesn't own.
                     return True
-                return tool_name in keep
+                return tool_name in keep or _bare_name(tool_name) in keep
 
             # List-comprehension over the ORIGINAL order — never a set, never
             # sorted by anything derived from `keep` — so the surviving tools

--- a/src/memo/server_graph_tool.py
+++ b/src/memo/server_graph_tool.py
@@ -40,9 +40,14 @@ def _with_code_evidence(
     from memo.code_evidence import codegraph_evidence
     from memo.code_traceability import codegraph_repo_id
 
-    repo_root = codegraph_loader.CODEGRAPH_DB.parent.parent
+    # `_resolve_db`, not the bare constant — the constant is derived from
+    # `__file__` and points inside site-packages under an isolated `uv tool`
+    # install, so the tool reports "missing" on a machine whose index is
+    # configured and readable. See the same fix in `code_traceability`.
+    db_path = codegraph_loader._resolve_db()
+    repo_root = db_path.parent.parent
     payload["code_evidence"] = codegraph_evidence(
-        db_path=codegraph_loader.CODEGRAPH_DB,
+        db_path=db_path,
         repo_root=repo_root,
         repo_id=codegraph_repo_id(repo_root),
     ).to_dict()

--- a/tests/test_code_traceability.py
+++ b/tests/test_code_traceability.py
@@ -100,3 +100,33 @@ def test_default_resolver_uses_shared_codegraph_from_git_worktree(
     assert [(ref.stable_symbol_id, ref.relation) for ref in refs] == [
         ("file:src/memo/graph.py", "modified")
     ]
+
+
+def test_default_resolver_honours_the_configured_codegraph_db(tmp_path: Path, monkeypatch) -> None:
+    """The resolver must go through `codegraph_loader._resolve_db()`, like
+    `code_intel`, `recall_logic`, `cli_code_facts`, `cli_doctor` and
+    `cli_dream_passes` already do.
+
+    Reading the `CODEGRAPH_DB` constant instead skips both cwd discovery and
+    the `MEMO_CODEGRAPH_DB` override. That constant is derived from
+    `__file__`, so under an isolated `uv tool` install it points inside
+    site-packages — a path that never holds an index. Every memory then
+    resolves to zero code references while the index sits configured and
+    readable, which is what puts `0 code nodes` in `memo graph stats`.
+    """
+    configured = tmp_path / "real" / ".codegraph" / "codegraph.db"
+    _seed_codegraph(configured)
+    # Pin the two cheaper resolution steps off so only the override can win:
+    # discovery would otherwise walk up from the test runner's own cwd.
+    monkeypatch.setenv("MEMO_CODEGRAPH_DISCOVERY", "0")
+    monkeypatch.setenv("MEMO_CODEGRAPH_DB", str(configured))
+    monkeypatch.setattr(
+        codegraph_loader, "CODEGRAPH_DB", tmp_path / "nowhere" / ".codegraph" / "codegraph.db"
+    )
+    monkeypatch.setattr(code_traceability, "_git_common_repo_root", lambda _root: None)
+
+    refs = resolve_code_references({"files_modified": ["src/memo/graph.py"]})
+
+    assert [(ref.stable_symbol_id, ref.relation) for ref in refs] == [
+        ("file:src/memo/graph.py", "modified")
+    ]

--- a/tests/test_proxy_toolschemas.py
+++ b/tests/test_proxy_toolschemas.py
@@ -540,3 +540,48 @@ def test_builtin_discovery_does_not_shell_out() -> None:
 
     assert not hasattr(ts, "_discover_builtins")
     assert "StructuredOutput" in ts._BUILTIN_NEVER_PRUNE
+
+
+# ── Wire names are MCP-prefixed; bare names never reach the proxy ────────────
+# Every test above names its tools `memo_search` / `memo_rename`. A real
+# payload never does: Claude Code puts memo's tools on the wire as
+# `mcp__memo__memo_search`. So the fixtures could not produce the production
+# condition, and the two guards that key off a bare name — `_ALWAYS_KEEP` and
+# the `scope="memo"` ownership test — passed here while matching nothing live.
+
+
+def test_always_keep_survives_under_the_real_mcp_wire_name(tmp_path, monkeypatch):
+    """`memo_save` is in `_ALWAYS_KEEP` ("kept regardless of usage or scope"),
+    but the wire spells it `mcp__memo__memo_save`. With no recorded usage the
+    exact-match lookup misses and the write path is pruned off the model's
+    surface — the same defect class as pruning a forced-call schema."""
+    monkeypatch.delenv("MEMO_PROXY_TOOL_SCHEMAS_SCOPE", raising=False)
+    monkeypatch.setattr(
+        "memo.proxy.transforms.toolschemas.recent_tool_names",
+        lambda state_dir, window: set(),
+    )
+    zones = make_zones(["mcp__memo__memo_save", "mcp__memo__memo_search", "mcp__memo__memo_rename"])
+    ToolSchemas().apply(zones, _ctx(tmp_path))
+    names = {t["name"] for t in zones.tools}
+    assert "mcp__memo__memo_save" in names
+    assert "mcp__memo__memo_search" in names
+    # Not in _ALWAYS_KEEP and unused: pruning it is the whole point.
+    assert "mcp__memo__memo_rename" not in names
+
+
+def test_scope_memo_prunes_an_unused_memo_tool_under_its_wire_name(tmp_path, monkeypatch):
+    """The conservative rollback scope must still prune memo's OWN unused
+    tools. Keyed on `startswith("memo_")`, no wire name is ever recognized as
+    owned, so every tool takes the passthrough branch and the transform saves
+    nothing at all — a rollback that silently disables itself."""
+    monkeypatch.setenv("MEMO_PROXY_TOOL_SCHEMAS_SCOPE", "memo")
+    monkeypatch.setattr(
+        "memo.proxy.transforms.toolschemas.recent_tool_names",
+        lambda state_dir, window: set(),
+    )
+    zones = make_zones(["Read", "mcp__octocode__localSearchCode", "mcp__memo__memo_rename"])
+    saved = ToolSchemas().apply(zones, _ctx(tmp_path))
+    names = {t["name"] for t in zones.tools}
+    assert {"Read", "mcp__octocode__localSearchCode"} <= names
+    assert "mcp__memo__memo_rename" not in names
+    assert saved > 0

--- a/tests/test_server_graph_tool.py
+++ b/tests/test_server_graph_tool.py
@@ -14,6 +14,12 @@ def _isolate_codegraph(monkeypatch, tmp_path):
     """Keep the merged graph hermetic — never read the machine's real codegraph."""
     from memo import codegraph_loader
 
+    # Pinning the constant is no longer enough: resolution honours cwd
+    # discovery and MEMO_CODEGRAPH_DB first, and the test runner's cwd is a
+    # repo that HAS an index. Both are turned off here so a hermetic test can
+    # never reach the machine's real codegraph.
+    monkeypatch.setenv("MEMO_CODEGRAPH_DISCOVERY", "0")
+    monkeypatch.setenv("MEMO_CODEGRAPH_DB", str(tmp_path / "no-codegraph.db"))
     monkeypatch.setattr(codegraph_loader, "CODEGRAPH_DB", tmp_path / "no-codegraph.db")
     codegraph_loader.reset()
     yield
@@ -284,3 +290,45 @@ def test_communities_verb_bounds_both_dimensions() -> None:
     assert first["entities_truncated"] is True
     assert len(first["entities"]) == first["entities_shown"] <= 25
     assert first["size"] == 60  # the TRUE size, not the shown count
+
+
+def test_memo_graph_code_evidence_honours_the_configured_codegraph_db(
+    mock_memory, tmp_path, monkeypatch
+):
+    """`memo_graph` must resolve its index the same way every other caller
+    does — through `codegraph_loader._resolve_db()`.
+
+    Reading the `CODEGRAPH_DB` constant skips cwd discovery and the
+    `MEMO_CODEGRAPH_DB` override, and the constant is derived from `__file__`,
+    so under an isolated `uv tool` install it points inside site-packages. The
+    tool then reports `recording_status="missing"` on a machine whose index is
+    configured, present and readable.
+    """
+    import sqlite3
+
+    configured = tmp_path / "configured" / ".codegraph" / "codegraph.db"
+    configured.parent.mkdir(parents=True)
+    conn = sqlite3.connect(configured)
+    conn.executescript(
+        """
+        CREATE TABLE nodes (
+            id TEXT PRIMARY KEY, kind TEXT NOT NULL, name TEXT NOT NULL,
+            qualified_name TEXT NOT NULL, file_path TEXT NOT NULL,
+            language TEXT NOT NULL, start_line INTEGER NOT NULL,
+            end_line INTEGER NOT NULL
+        );
+        INSERT INTO nodes VALUES
+          ('file:src/memo/graph.py', 'file', 'graph.py', 'src/memo/graph.py',
+           'src/memo/graph.py', 'python', 1, 900);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("MEMO_CODEGRAPH_DISCOVERY", "0")
+    monkeypatch.setenv("MEMO_CODEGRAPH_DB", str(configured))
+
+    _seed_chain(mock_memory)
+    out = _call(mock_memory, verb="path", a="alpha", b="gamma", include_code=True)
+
+    assert out["code_evidence"]["recording_status"] != "missing"


### PR DESCRIPTION
## Problem

`ToolSchemas` is the proxy's dominant lever — it accounts for **96.4%** of all `est_saved_tokens` in this machine's ledger (1.15B of 1.19B), pruning 537 tool schemas down to 15 (188,321 → 10,896 est tok per request).

Two of its guards are written in terms of a **bare** tool name (`memo_search`), but an MCP client namespaces every tool it proxies. Memo's tools reach the wire as `mcp__memo__memo_search`. Neither guard ever matched a real payload.

### 1. `_ALWAYS_KEEP` matched nothing

It is documented *"Kept regardless of usage or scope: without these the model cannot reach memo … at all."* On a session with no recorded usage, the exact-match lookup missed and **the entire memo surface was pruned, `memo_save` included**.

Verified live rather than argued: the tool surface of the session that found this carries `mcp__memo__memo_search`, `memo_tool_docs`, `memo_crush_retrieve` — all retained via the *usage* path — but **no `mcp__memo__memo_save`**. A tool declared unprunable was pruned, and memo's write contract ("persist durable outcomes so the next session inherits them") was silently off the wire.

Same defect class as the earlier `StructuredOutput` pruning incident: you cannot prune the schema of a tool the model is required to reach.

### 2. `scope="memo"` was an inverted no-op

`MEMO_PROXY_TOOL_SCHEMAS_SCOPE=memo` is the documented *"one-flag-away rollback"* to the conservative pre-widening behaviour. Keyed on `startswith("memo_")`, **no wire name is ever recognised as owned**, so every tool takes the `return True` passthrough branch, `len(kept) == len(tools)`, and the transform saves zero. The rollback quietly disabled itself.

## Fix

Both comparisons normalize through `_bare_name()`, which strips the `mcp__<server>__` namespace. Ownership additionally accepts the `__memo__` server segment, because memo also exposes `mem_*` tools that the name prefix alone would disown.

## Why the tests were green

Every existing fixture names its tools bare (`memo_search`, `memo_rename`) — a shape that never occurs on a real wire. **The fixtures could not produce the production condition**, so the suite certified both guards while they matched nothing.

The two new tests use real wire names. Both fail before this change:

```
E  AssertionError: assert 'mcp__memo__memo_save' in set()
E  AssertionError: assert 'mcp__memo__memo_rename' not in {'Read', 'mcp__memo__memo_rename', ...}
```

The first is the sharper one — the surviving set is *empty*.

## Token cost, stated plainly

This fix **costs** tokens, and that is the correct trade. Restoring `memo_save` + `memo_search` + `memo_tool_docs` to the wire adds ~1,566 est tok to the tools block. That block lives in the cached prefix, so the billed cost is ~157 tok-eq/request at the `cache_read` 0.1x multiplier — against the ~10,896 est tok the pruner already keeps. The alternative is a memory system that cannot write.

## Test plan

- [x] `pytest tests/test_proxy_toolschemas.py` — 27 passed (25 pre-existing + 2 new)
- [x] `pytest tests/ -k proxy` — 396 passed
- [x] `ruff check` + `ruff format --check` on both files
- [x] `mypy src/memo/proxy/transforms/toolschemas.py` — clean
- [x] Both new tests confirmed RED before the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)