### PR TITLE
fix: gate the proxy A/B on distinct sessions, not request counts

### DIFF
--- a/src/memo/cli_tokens.py
+++ b/src/memo/cli_tokens.py
@@ -43,6 +43,11 @@ _MIN_COHORT_TURNS = 30
 # swing a ratio wildly (n=1 vs n=1 can print a two-digit swing in bold colour
 # with nothing marking it as unproven).
 _MIN_PROXY_SAMPLE = 30
+# Distinct sessions required per arm. Arms are assigned per session, so this is
+# the count of independent draws; the request floor above only bounds how much
+# evidence each draw carries. Three is the smallest number that cannot be one
+# atypical session plus noise.
+_MIN_PROXY_SESSIONS = 3
 
 
 def _fmt_tokens(tokens: float) -> str:
@@ -161,13 +166,19 @@ def _proxy_panel(proxy: dict) -> Panel:
     # traffic once put 2 holdout requests worth 5 tok-equiv against 4984
     # treated worth 19320 and rendered "386295.8% cost" in bold. Withhold the
     # ratio below the floor instead of shipping it with a "provisional" word.
-    thin = min(n_t, n_h) < _MIN_PROXY_SAMPLE
+    # …and the request floor alone cannot catch that shape: one holdout session
+    # of 400 requests clears `n_h >= 30` while still being a single draw. The
+    # session counts computed just above are what the arms are actually drawn
+    # in, so they gate too — otherwise the floor withholds the small version of
+    # the bad number and ships the large one.
+    thin = min(n_t, n_h) < _MIN_PROXY_SAMPLE or min(n_ts, n_hs) < _MIN_PROXY_SESSIONS
     if frac is None or thin:
         if n_t or n_h:
             body = (
                 f"[dim]not enough data to compare arms yet[/dim] "
                 f"([dim]{n_t} treated / {n_h} holdout requests{sessions_note}"
-                f" — need {_MIN_PROXY_SAMPLE} per arm[/dim])"
+                f" — need {_MIN_PROXY_SAMPLE} requests and"
+                f" {_MIN_PROXY_SESSIONS} sessions per arm[/dim])"
             )
         else:
             body = "[dim]no measured data yet — the proxy has not logged any requests[/dim]"

--- a/tests/test_proxy_reporting.py
+++ b/tests/test_proxy_reporting.py
@@ -28,9 +28,18 @@ def _seed(state_dir: Path, records: list[meter.Record]) -> None:
 
 
 def _record(key: str, *, holdout: bool, input_tokens: int, **kw) -> meter.Record:
+    # Arms are drawn per session, and the panel gates on the distinct-session
+    # count, so a row with no session identity is a row the reporter cannot
+    # count toward a healthy sample. Spread rows deterministically across four
+    # sessions per arm by default; a test that cares about session shape (see
+    # test_proxy_panel_withholds_a_ratio_drawn_from_one_holdout_session) passes
+    # `session_key` explicitly.
+    arm = "h" if holdout else "t"
+    default_session = f"{arm}-sess-{sum(map(ord, key)) % 4}"
     return meter.Record(
         request_key=key,
         holdout=holdout,
+        session_key=kw.pop("session_key", default_session),
         transforms=kw.pop("transforms", []),
         est_saved_tokens=kw.pop("est_saved_tokens", 0),
         input_tokens=input_tokens,
@@ -330,3 +339,45 @@ def test_by_transform_help_names_the_unit_it_reports(tmp_path):
 
     assert result.exit_code == 0, result.output
     assert "measured proxy saving" not in result.output
+
+
+def test_proxy_panel_withholds_a_ratio_drawn_from_one_holdout_session(tmp_path):
+    """The request-count floor cannot see the failure it was added for.
+
+    Arms are assigned per SESSION, so every request inside one holdout session
+    is the same draw repeated. A single large session clears `n_h >= 30`
+    trivially — 400 requests here — and the panel would then print a bold
+    percentage comparing one cluster against many. That is the exact shape of
+    the "386295.8% cost" render the floor exists to prevent, at a scale the
+    floor cannot catch.
+    """
+    state_dir = tmp_path / "state"
+    for i in range(400):
+        _seed(
+            state_dir,
+            [
+                _record(
+                    f"t{i}",
+                    holdout=False,
+                    input_tokens=500,
+                    session_key=f"treated-{i % 8}",
+                )
+            ],
+        )
+    for i in range(400):
+        _seed(
+            state_dir,
+            [
+                _record(
+                    f"h{i}",
+                    holdout=True,
+                    input_tokens=1000,
+                    session_key="the-one-holdout-session",
+                )
+            ],
+        )
+    result = CliRunner().invoke(tokens_cmd, [], env=_env(tmp_path))
+    assert result.exit_code == 0, result.output
+    assert "not enough data" in result.output.lower()
+    assert "% saved" not in result.output
+    assert "% cost" not in result.output


### PR DESCRIPTION
## The gate cannot see the failure it was added for

`_proxy_panel` withholds the treated-vs-holdout ratio below a floor of 30 requests per arm. Its own comment, three lines above the gate, already explains why that unit is wrong:

> Defect 2: holdout is assigned per SESSION, not per request, so n_t/n_h (request counts) **overstate the effective sample size** — every request in one holdout session is correlated, not an independent draw.

The gate then uses exactly those request counts:

```python
thin = min(n_t, n_h) < _MIN_PROXY_SAMPLE
```

The floor exists because live traffic once rendered **"386295.8% cost"** in bold from 2 holdout requests. It withholds that *small* version of the bad number and ships the *large* one: one holdout session of 400 requests clears `n_h >= 30` trivially while still being a single draw, and the panel prints a confident percentage comparing one cluster against many.

`n_treated_sessions` / `n_holdout_sessions` were already computed in `meter.summarize` and already printed beside the request counts. They just never gated. Now they do, with a floor of 3 — the smallest number that cannot be one atypical session plus noise.

## Why the tests were green

`_record` never set `session_key`, so every seeded row was session-less and **both arms had zero distinct sessions**. Three existing tests were asserting that a percentage renders from a sample with no identified sessions at all — the fixture could not express the dimension the gate is about.

`_record` now spreads rows deterministically across four sessions per arm, which is what those tests meant by "a healthy sample". The new test pins all 400 holdout rows to one session:

```
E  AssertionError: assert 'not enough data' in '...│  50.0% saved on prompt cost (trea...'
```

That is the defect, printed.

## Effect on this machine

The live ledger holds 7,665 treated requests across 7 sessions and 2 holdout requests across 1 session. It was already withheld by the request floor, and stays withheld — correctly, and now for the right reason. Both holdout rows have `cache_creation=0` *and* `cache_read=0`, which no real Claude Code turn produces, so the true control arm is empty rather than thin.

## Test plan

- [x] `pytest tests/test_proxy_reporting.py` — 17 passed
- [x] `pytest tests/ -k "proxy or tokens"` — 441 passed
- [x] `ruff check` + `ruff format` + `mypy` clean
- [x] New test confirmed RED before the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)