### PR TITLE
chore: sync homebrew formula to 4.14.8

### DIFF
--- a/docs/homebrew/mlx-memo.rb
+++ b/docs/homebrew/mlx-memo.rb
@@ -21,8 +21,8 @@ class MlxMemo < Formula
 
   desc "Local MCP memory for AI agents — MLX-native, sqlite-vec, markdown vault"
   homepage "https://github.com/jagoff/memo"
-  url "https://files.pythonhosted.org/packages/1a/8e/a78f98a2a11e19132be5cdf837d9aff4250024650e2d74b3ff82d3965d4d/mlx_memo-4.14.7.tar.gz"
-  sha256 "66a8f83a53d7b207c539b5e106c9b060e9054d68582f74c8deea9ceb79586c55"
+  url "https://files.pythonhosted.org/packages/fe/8b/e92b54c61ec81364f6a5f74b2e7eb1cf9c3eb2ada7f462400845a1cba5ce/mlx_memo-4.14.8.tar.gz"
+  sha256 "a99231e7122c461f0d40eea01851be750f36382ed811d64ac2dcc180fcc06bf8"
   license "MIT"
 
   depends_on arch: :arm64


### PR DESCRIPTION
Post-publish formula sync. `url` and `sha256` are taken from the PyPI JSON API for 4.14.8, not hand-typed.

Verified before pushing:
- byte-identical to the tap at `jagoff/homebrew-memo@57e92cc`
- `brew info --formula jagoff/memo/mlx-memo` → `stable 4.14.8`
- neither attribute is empty (the guard `release check` gained in #323)

🤖 Generated with [Claude Code](https://claude.com/claude-code)