### PR TITLE
fix: report what is measured, not what was once stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+### Fixed
+
+- **`memo token-savings` published a percentage its own gate rejected.** It
+  printed `crusher_L1 +44.4% (measured, gate-passed)` while
+  `memo eval tokens --gate` exited 1 on that lever with `Δquality -0.48` — the
+  stored `passed: true` is a claim about the run that wrote it, not about
+  today, and nothing re-checked it. The saving fraction was also recorded
+  without the sample it was folded from, so the command could not tell a lever
+  measured over 49 live prompts from one measured over the 2 synthetic cases in
+  `eval/token_corpus.json` (whose own `_doc` predicts the quality guard should
+  fail). `LeverRow` now carries `n_samples`, `gate_metrics` records it, and a
+  lever folded from fewer than ten cases — or from a baseline written before
+  the count existed — is named rather than published. An empty gate now also
+  points at the context proxy, which is measured separately, so "no lever
+  passed" cannot read as "memo saves nothing". The pre-existing fixture omitted
+  `n_samples` entirely, which is why no test caught this.
+- **`memo config flags` reported the environment, not the configuration.** Its
+  `active` column was `active_flags()` — env vars only — so every flag pinned
+  through `memo config set` rendered blank, and a blank cell beside a default of
+  `False` reads as OFF. On this machine that hid 60 flags: the graph subsystem
+  showed as entirely disabled while `graph-config.md` had it on. Markdown config
+  is the channel that reaches daemons, hooks, and the MCP server, so the layer
+  the column omitted is the one that decides behaviour. The table now shows the
+  resolved `effective` value and the `source` layer that decided it
+  (`env` > `config` > `overlay` > `default`), `--active` means explicitly
+  configured anywhere rather than exported in this shell, and the raw env value
+  stays available as `active` in `--json`.
+- **Dead statement in `aggregate_capture`.** `len(samples) or 1` was evaluated
+  and discarded; the count it was computing is now the recorded `n_samples`.
+
 ## [4.14.8] - 2026-08-30
 
 ### Fixed

--- a/src/memo/cli_config.py
+++ b/src/memo/cli_config.py
@@ -44,21 +44,60 @@ def config_group(ctx: click.Context) -> None:
     raise click.exceptions.Exit(run_config_tui())
 
 
+def _overlay_values() -> dict[str, str]:
+    """Registered flags pinned by the auto-tuner's overlay, if any."""
+    import os
+
+    from memo.tuned_overlay import overlay_values
+
+    return {n: v for n, v in overlay_values(os.environ).items() if n in flags.REGISTRY}
+
+
+def _flag_source(
+    name: str,
+    env_vals: dict[str, str],
+    config_vals: dict[str, str],
+    overlay_vals: dict[str, str],
+) -> str:
+    """Which layer decides this flag, in `flags.flag()`'s resolution order.
+
+    `env var > Markdown config > tuned overlay > built-in default`. Reporting
+    only the first layer — which is what an env-only `active` column does —
+    renders every `memo config set` value blank, and a blank cell beside a
+    default of `0` reads as "off". Markdown config is the channel that reaches
+    daemons, hooks, and the MCP server; the env layer is per-terminal.
+    """
+    if name in env_vals:
+        return "env"
+    if name in config_vals:
+        return "config"
+    if name in overlay_vals:
+        return "overlay"
+    return "default"
+
+
 @config_group.command(name="flags")
 @click.option("--group", "group_filter", default=None, help="Filter by subsystem group.")
-@click.option("--active", is_flag=True, help="Only flags currently set in the environment.")
+@click.option(
+    "--active",
+    is_flag=True,
+    help="Only flags explicitly configured (env, Markdown config, or tuned overlay).",
+)
 @click.option("--json", "as_json", is_flag=True, help="Output raw JSON.")
 def config_flags(group_filter: str | None, active: bool, as_json: bool) -> None:
-    """List documented MEMO_* flags (type, default, group, active value).
+    """List documented MEMO_* flags (type, default, group, effective value).
 
     Example: memo config flags --group recall
     """
-    active_vals = flags.active_flags()
+    env_vals = flags.active_flags()
+    config_vals = flags.active_config_values()
+    overlay_vals = _overlay_values()
     rows = []
     for name, spec in flags.REGISTRY.items():
         if group_filter and spec.group != group_filter:
             continue
-        if active and name not in active_vals:
+        source = _flag_source(name, env_vals, config_vals, overlay_vals)
+        if active and source == "default":
             continue
         rows.append(
             {
@@ -66,7 +105,11 @@ def config_flags(group_filter: str | None, active: bool, as_json: bool) -> None:
                 "group": spec.group,
                 "kind": spec.kind,
                 "default": spec.default,
-                "active": active_vals.get(name),
+                # `active` stays env-only for anyone reading the raw shell
+                # state; `effective`/`source` are what the flag actually does.
+                "active": env_vals.get(name),
+                "effective": flags.flag(name),
+                "source": source,
                 "help": spec.help,
             }
         )
@@ -80,17 +123,22 @@ def config_flags(group_filter: str | None, active: bool, as_json: bool) -> None:
     table.add_column("group", style="magenta")
     table.add_column("kind")
     table.add_column("default", style="dim")
-    table.add_column("active", style="green")
+    table.add_column("effective", style="green")
+    table.add_column("source", style="yellow")
     for r in rows:
         table.add_row(
             r["flag"],
             r["group"],
             r["kind"],
             "" if r["default"] is None else str(r["default"]),
-            "" if r["active"] is None else str(r["active"]),
+            "" if r["effective"] is None else str(r["effective"]),
+            "" if r["source"] == "default" else r["source"],
         )
     console.print(table)
-    console.print(f"[dim]{len(rows)} flag(s); {len(active_vals)} active in env[/dim]")
+    console.print(
+        f"[dim]{len(rows)} flag(s); {len(env_vals)} from env, "
+        f"{len(config_vals)} from Markdown config, {len(overlay_vals)} from tuned overlay[/dim]"
+    )
 
 
 @config_group.command(name="flags-audit")

--- a/src/memo/cli_token_savings.py
+++ b/src/memo/cli_token_savings.py
@@ -4,6 +4,14 @@ Reads `state_dir/eval/token_baseline.json` (written by
 `memo eval tokens --update-baseline`) and reports the measured, gate-passed
 savings per lever. A lever that never passed the gate reports nothing —
 honest zero, not an estimate.
+
+A stored `passed: true` is a claim about the run that wrote it, not about
+today, and the fraction beside it means nothing without the sample it was
+folded from. Live example (2026-08-30): this command printed
+`crusher_L1 +44.4% (measured, gate-passed)` from the 3 synthetic cases in
+`eval/token_corpus.json` — while `memo eval tokens --gate` exited 1 on that
+very lever with `Δquality -0.48`. So the sample travels with the number and
+anything below `_MIN_LEVER_SAMPLES` is named rather than published.
 """
 
 from __future__ import annotations
@@ -12,10 +20,21 @@ import click
 
 from .config import Config
 
+# Independent cases a lever must be folded from before its saving fraction
+# reads as evidence. Chosen to separate the two planes this gate measures: the
+# recall plane runs the full curated label set (49 prompts as of 2026-08),
+# while the capture plane's committed corpus is 3 hand-written cases whose own
+# `_doc` says they exist to make the quality guard fail. A corpus that small
+# cannot distinguish a real effect from the shape of the corpus.
+_MIN_LEVER_SAMPLES = 10
 
-def _measured_savings(cfg: Config) -> list[tuple[str, float]]:
-    """PASSED levers and their measured token-saving fraction, from the last
-    `memo eval tokens --update-baseline`. Empty when never measured."""
+
+def _measured_savings(cfg: Config) -> list[tuple[str, float, int]]:
+    """PASSED levers, their measured saving fraction, and the sample size.
+
+    `n_samples` is 0 for a baseline written before it was recorded — unknown
+    basis, which is not the same as a large one, so it is treated as thin.
+    """
     import json
 
     path = cfg.state_dir / "eval" / "token_baseline.json"
@@ -25,10 +44,10 @@ def _measured_savings(cfg: Config) -> list[tuple[str, float]]:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return []
-    out: list[tuple[str, float]] = []
+    out: list[tuple[str, float, int]] = []
     for lever, m in data.items():
         if isinstance(m, dict) and m.get("passed"):
-            out.append((str(lever), float(m.get("saved_frac", 0.0))))
+            out.append((str(lever), float(m.get("saved_frac", 0.0)), int(m.get("n_samples", 0))))
     return sorted(out, key=lambda t: t[1], reverse=True)
 
 
@@ -37,15 +56,29 @@ def token_savings_cmd() -> None:
     """Show measured per-lever token savings (from `memo eval tokens`)."""
     cfg = Config.from_env()
     savings = _measured_savings(cfg)
+    publishable = [(lever, frac, n) for lever, frac, n in savings if n >= _MIN_LEVER_SAMPLES]
+    thin = [(lever, n) for lever, _frac, n in savings if n < _MIN_LEVER_SAMPLES]
 
     click.echo("memo token savings (measured)")
     click.echo("")
-    if not savings:
+    for lever, frac, n in publishable:
+        click.echo(f"  {lever:<28} {frac * 100:+.1f}%  (measured, gate-passed, {n} samples)")
+    for lever, n in thin:
+        basis = f"{n} samples" if n else "an unrecorded sample"
+        click.echo(f"  {lever:<28} measured on {basis} — too thin to publish")
+    if not publishable:
+        click.echo("")
         click.echo("  No measured savings yet.")
         click.echo("  Seed the gate:  memo eval tokens --update-baseline")
         click.echo("  Then re-run:    memo token-savings")
+        # This command only knows the lever gate. The proxy is a separate,
+        # independently measured surface and it is where memo's savings
+        # actually come from (ToolSchemas alone accounts for the large
+        # majority of text the proxy removes), so an empty gate must not read
+        # as "memo saves nothing".
+        click.echo("")
+        click.echo("  Levers are not the only surface — the context proxy is measured")
+        click.echo("  separately:     memo tokens --by-transform")
         return
-    for lever, frac in savings:
-        click.echo(f"  {lever:<28} {frac * 100:+.1f}%  (measured, gate-passed)")
     click.echo("")
     click.echo("  Re-measure after any change:  memo eval tokens --gate")

--- a/src/memo/eval_tokens.py
+++ b/src/memo/eval_tokens.py
@@ -57,6 +57,11 @@ class LeverRow:
     tokens_on: int
     quality_off: float
     quality_on: float
+    # Independent cases the fractions above were folded from. Recorded because
+    # the baseline file is the ONLY thing `memo token-savings` sees: a
+    # `saved_frac` whose sample size was dropped here is unrecoverable
+    # downstream, and reads there exactly like one measured over a real corpus.
+    n_samples: int = 0
 
     @property
     def saved_frac(self) -> float:
@@ -105,6 +110,7 @@ def aggregate_recall(lever: str, samples: list[P1Sample]) -> LeverRow:
         tokens_on=sum(s.tokens_on for s in samples),
         quality_off=sum(s.prec_off for s in samples) / n,
         quality_on=sum(s.prec_on for s in samples) / n,
+        n_samples=len(samples),
     )
 
 
@@ -229,7 +235,6 @@ def _row_survived(row: Any, crushed_content: str) -> bool:
 
 def aggregate_capture(lever: str, samples: list[P2Sample]) -> LeverRow:
     """Fold per-case P2 samples into one LeverRow. Quality = mean row survival fraction."""
-    len(samples) or 1
     total_rows = sum(s.rows_total for s in samples) or 1
     survived_rows = sum(s.rows_survived for s in samples)
     return LeverRow(
@@ -239,6 +244,7 @@ def aggregate_capture(lever: str, samples: list[P2Sample]) -> LeverRow:
         tokens_on=sum(s.tokens_on for s in samples),
         quality_off=1.0,
         quality_on=survived_rows / total_rows,
+        n_samples=len(samples),
     )
 
 
@@ -249,6 +255,7 @@ def gate_metrics(rows: list[LeverRow]) -> dict[str, dict[str, float | bool]]:
             "saved_frac": round(r.saved_frac, 4),
             "quality_delta": round(r.quality_delta, 4),
             "passed": r.passed,
+            "n_samples": r.n_samples,
         }
         for r in rows
     }

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -191,3 +191,69 @@ def test_noninteractive_blocks_tui_even_with_tty(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert "show" in result.output
     run.assert_not_called()
+
+
+def test_config_flags_reports_the_effective_value_and_its_source(tmp_path, monkeypatch):
+    """`config flags` must answer "what is in effect", not "what is in the env".
+
+    The `active` column was `active_flags()` — env vars only — so every flag a
+    user had pinned through `memo config set` (the *recommended* channel, the
+    only one that reaches daemons and hooks) rendered blank, which reads as OFF.
+    That is the exact misreading the Markdown config exists to prevent.
+    """
+    from click.testing import CliRunner
+
+    from memo.cli_config import config_group
+
+    cfg_dir = tmp_path / "memo-home"
+    (cfg_dir / "config").mkdir(parents=True)
+    (cfg_dir / "config" / "graph-config.md").write_text(
+        '# Graph config\n\n```toml\n[graph]\nreason_enabled = "on"\n```\n',
+        encoding="utf-8",
+    )
+
+    env = {
+        "MEMO_NONINTERACTIVE": "1",
+        "MEMO_CONFIG_DIR": str(cfg_dir),
+        "MEMO_DATA_DIR": str(tmp_path / "data"),
+        "MEMO_STATE_DIR": str(tmp_path / "state"),
+    }
+    for key in ("MEMO_GRAPH_REASON_ENABLED",):
+        monkeypatch.delenv(key, raising=False)
+
+    result = CliRunner().invoke(config_group, ["flags", "--group", "graph", "--json"], env=env)
+    assert result.exit_code == 0, result.output
+    rows = {r["flag"]: r for r in json.loads(result.output)}
+
+    row = rows["MEMO_GRAPH_REASON_ENABLED"]
+    assert row["effective"] is True, "a flag pinned in Markdown config reads as OFF"
+    assert row["source"] == "config"
+
+
+def test_config_flags_active_filter_includes_markdown_config(tmp_path, monkeypatch):
+    """`--active` means "explicitly configured", not "exported in this shell"."""
+    from click.testing import CliRunner
+
+    from memo.cli_config import config_group
+
+    cfg_dir = tmp_path / "memo-home"
+    (cfg_dir / "config").mkdir(parents=True)
+    (cfg_dir / "config" / "graph-config.md").write_text(
+        '# Graph config\n\n```toml\n[graph]\nreason_enabled = "on"\n```\n',
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("MEMO_GRAPH_REASON_ENABLED", raising=False)
+
+    result = CliRunner().invoke(
+        config_group,
+        ["flags", "--group", "graph", "--active", "--json"],
+        env={
+            "MEMO_NONINTERACTIVE": "1",
+            "MEMO_CONFIG_DIR": str(cfg_dir),
+            "MEMO_DATA_DIR": str(tmp_path / "data"),
+            "MEMO_STATE_DIR": str(tmp_path / "state"),
+        },
+    )
+    assert result.exit_code == 0, result.output
+    names = {r["flag"] for r in json.loads(result.output)}
+    assert "MEMO_GRAPH_REASON_ENABLED" in names

--- a/tests/test_cli_token_savings.py
+++ b/tests/test_cli_token_savings.py
@@ -24,8 +24,18 @@ def test_reports_measured_savings_from_baseline(tmp_path):
     (eval_dir / "token_baseline.json").write_text(
         json.dumps(
             {
-                "recall_format_compact": {"saved_frac": 0.31, "quality_delta": 0.0, "passed": True},
-                "verbosity_steer_L2": {"saved_frac": -0.12, "quality_delta": 0.0, "passed": False},
+                "recall_format_compact": {
+                    "saved_frac": 0.31,
+                    "quality_delta": 0.0,
+                    "passed": True,
+                    "n_samples": 49,
+                },
+                "verbosity_steer_L2": {
+                    "saved_frac": -0.12,
+                    "quality_delta": 0.0,
+                    "passed": False,
+                    "n_samples": 49,
+                },
             }
         )
     )
@@ -41,3 +51,68 @@ def test_reports_unmeasured_when_no_baseline(tmp_path):
     assert r.exit_code == 0, r.output
     assert "memo eval tokens --update-baseline" in r.output
     assert "65%" not in r.output  # the fabricated estimate is gone
+
+
+# Every fixture above writes a baseline entry with no sample size, because
+# `gate_metrics` never recorded one — so the command could not tell a lever
+# measured over 49 live prompts from one measured over 3 synthetic cases, and
+# printed both as "measured, gate-passed". Live example (2026-08-30):
+# `crusher_L1 +44.4% (measured, gate-passed)` rested on the 3 cases in
+# `eval/token_corpus.json`, whose own `_doc` predicts the quality guard should
+# fail — and `memo eval tokens --gate` did exit 1 on it while the headline
+# still read as a supported claim.
+
+
+def test_a_lever_measured_on_a_toy_sample_is_not_published_as_a_headline(tmp_path):
+    eval_dir = tmp_path / "state" / "eval"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "token_baseline.json").write_text(
+        json.dumps(
+            {
+                "crusher_L1": {
+                    "saved_frac": 0.4443,
+                    "quality_delta": 0.0,
+                    "passed": True,
+                    "n_samples": 3,
+                }
+            }
+        )
+    )
+    r = CliRunner().invoke(cli, ["token-savings"], env=_env(tmp_path))
+    assert r.exit_code == 0, r.output
+    assert "+44.4%" not in r.output, "a 3-sample result is printed as a supported claim"
+    assert "3 sample" in r.output, "the sample it rests on is not disclosed"
+
+
+def test_a_published_lever_states_the_sample_it_rests_on(tmp_path):
+    eval_dir = tmp_path / "state" / "eval"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "token_baseline.json").write_text(
+        json.dumps(
+            {
+                "recall_format_compact": {
+                    "saved_frac": 0.31,
+                    "quality_delta": 0.0,
+                    "passed": True,
+                    "n_samples": 49,
+                }
+            }
+        )
+    )
+    r = CliRunner().invoke(cli, ["token-savings"], env=_env(tmp_path))
+    assert r.exit_code == 0, r.output
+    assert "+31.0%" in r.output
+    assert "49 sample" in r.output
+
+
+def test_a_baseline_predating_sample_recording_is_not_published(tmp_path):
+    """No `n_samples` means the number's basis is unknown, not large."""
+    eval_dir = tmp_path / "state" / "eval"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "token_baseline.json").write_text(
+        json.dumps({"crusher_L1": {"saved_frac": 0.4443, "quality_delta": 0.0, "passed": True}})
+    )
+    r = CliRunner().invoke(cli, ["token-savings"], env=_env(tmp_path))
+    assert r.exit_code == 0, r.output
+    assert "+44.4%" not in r.output
+    assert "memo eval tokens --update-baseline" in r.output

--- a/tests/test_eval_tokens.py
+++ b/tests/test_eval_tokens.py
@@ -230,3 +230,29 @@ def test_crushed_rows_survived_counts_only_rows_still_present():
     assert _count_rows_survived(rows, "not json at all") == 0
     assert _count_rows_survived(rows, json.dumps({"not": "a list"})) == 0
     assert _count_rows_survived(rows, None) == 0
+
+
+def test_gate_metrics_records_the_sample_each_lever_was_measured_on():
+    """`saved_frac` without its sample size cannot be read as evidence.
+
+    The baseline is the only thing `memo token-savings` sees, so a number
+    whose basis is dropped here is unrecoverable downstream.
+    """
+    from memo import eval_tokens
+
+    rows = [
+        eval_tokens.aggregate_capture(
+            "crusher_L1",
+            [
+                eval_tokens.P2Sample(
+                    tokens_off=100,
+                    tokens_on=50,
+                    survived=True,
+                    rows_survived=10,
+                    rows_total=10,
+                )
+            ],
+        )
+    ]
+    metrics = eval_tokens.gate_metrics(rows)
+    assert metrics["crusher_L1"]["n_samples"] == 1


### PR DESCRIPTION
Two commands presented a stored or partial value as if it were the current, complete one. Both had tests; neither fixture could produce the state the guard was meant to describe.

## `memo token-savings` published a percentage its own gate rejected

```
$ memo token-savings
  crusher_L1                   +44.4%  (measured, gate-passed)

$ memo eval tokens --gate ; echo $?
✗ token gate: FAIL — crusher_L1: was passing, now FAIL
1
```

The live run reports `crusher_L1 saved +44.4% Δquality -0.48`. The published claim came from a stored `passed: true`, which is a statement about the run that wrote it, not about today.

The fraction was also recorded with its sample discarded. The baseline file is the only thing `token-savings` reads, so a `saved_frac` folded from 49 live prompts and one folded from the 2 synthetic cases in `eval/token_corpus.json` were indistinguishable downstream — and that corpus's own `_doc` says it exists to make the quality guard fail.

`LeverRow` now carries `n_samples`, `gate_metrics` records it, and a lever below ten cases (or from a baseline predating the count — unknown basis is not a large one) is named rather than published. An empty gate now points at the context proxy, measured separately, so "no lever passed" cannot read as "memo saves nothing".

## `memo config flags` reported the environment, not the configuration

`active` was `active_flags()` — environment variables only. Every flag pinned through `memo config set` rendered blank, and blank beside a default of `False` reads as OFF. On this machine that hid **60 flags**, including a graph subsystem `graph-config.md` had fully enabled:

```
MEMO_GRAPH_PROJECTION_ENABLED   default=False  effective=True   source=config
MEMO_GRAPH_SEMANTIC_RELATIONS   default=False  effective=True   source=config
MEMO_GRAPH_CODE_TRACE_ENABLED   default=False  effective=True   source=config
```

Markdown config is the layer that reaches daemons, hooks and the MCP server, so the omitted layer is the deciding one. The table now shows the resolved `effective` value and the `source` that decided it (`env` > `config` > `overlay` > `default`); `--active` means explicitly configured anywhere; the raw env value stays as `active` in `--json`.

Also removes a dead `len(samples) or 1` statement in `aggregate_capture` — the count it computed is now the recorded `n_samples`.

## Test plan

- [x] 5 new tests, each confirmed RED against the unmodified source (the config pair re-run under `git stash` with the corrected fixture, not just the broken one)
- [x] `pytest tests/test_cli_config.py tests/test_cli_token_savings.py tests/test_eval_tokens.py tests/test_cli_eval_tokens.py tests/test_token_gate.py tests/test_token_economy_wave1.py tests/test_config_tui_*.py tests/test_config_md.py tests/test_journey_check.py` — 173 passed
- [x] `ruff check` + `ruff format --check` + `mypy` clean on the touched files
- [x] Verified against the live install: `config flags --group graph --active` now shows 7 config-sourced flags where it previously showed none; `token-savings` reports no publishable lever after re-seeding the baseline

The pre-existing `test_reports_measured_savings_from_baseline` fixture omitted `n_samples`, so it asserted the unqualified percentage. Its fixture is updated to state the sample; its intent (a passing lever surfaces, a failing one does not) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)