### PR TITLE
fix: order reliability nudges by recency, and point them somewhere readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,21 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
   stays available as `active` in `--json`.
 - **Dead statement in `aggregate_capture`.** `len(samples) or 1` was evaluated
   and discarded; the count it was computing is now the recorded `n_samples`.
+- **The reliability nudge showed the same seven memories forever, and its
+  action did not work.** `superseded_pairs()` ordered `inactive/*.md` with
+  `sorted(glob(...))` — by FILENAME, which for these files is the hex memory
+  id, so a store with 767 archived memories surfaced the alphabetically-first
+  seven at every session start indefinitely, all resolved weeks earlier. The
+  scan now orders most-recently-superseded first and drops supersessions older
+  than 30 days, because the caller is an interrupt surface and a supersession
+  is only worth interrupting for while it is news. Entries with no
+  `superseded_at` sort last but are kept, so archives written before the stamp
+  existed are not hidden. The nudge's action pointed at the stale id, which
+  lives in `inactive/` and which `memo get` does not read — every one of those
+  seven answered `not found`; it now points at the successor, which exists and
+  is the memory worth reading. Neither fixture stamped `superseded_at`, and the
+  ordering fixture used ids whose filename order already matched the expected
+  order, so the sort could not be observed as wrong.
 
 ## [4.14.8] - 2026-08-30
 

--- a/src/memo/memory/facade.py
+++ b/src/memo/memory/facade.py
@@ -85,6 +85,12 @@ def _dead_memory_from(durable_types: frozenset[str]) -> str:
     )
 
 
+# How long a supersession stays worth interrupting a session about. The
+# reliability nudge is a session-start surface, and `inactive/` only grows —
+# without a window the oldest entries would nudge forever.
+_SUPERSEDED_NEWS_DAYS = 30
+
+
 class Memory(
     _WriteOpsMixin,
     _UpdateOpsMixin,
@@ -525,23 +531,35 @@ class Memory(
         return [(r.get("id") or "", r.get("title") or "—") for r in rows]
 
     def superseded_pairs(self, *, limit: int = 50) -> list[tuple[str, str, str]]:
-        """Archived memories with a live successor, as `(stale_id, superseding_id, title)`.
+        """Recently superseded memories, as `(stale_id, superseding_id, title)`.
 
         Scans `cfg.memory_dir / "inactive" / *.md` for files stamped by
         `lifecycle.py`'s `archive_memory(superseded_by=...)` — the WINNING
         memory id lives in frontmatter `extra.superseded_by`. Dream-only (a
         disk scan is fine there; never called from the recall path). Guarded
         per-file: a malformed archive entry is skipped, not fatal.
+
+        Ordered most-recently-superseded first and capped at
+        `_SUPERSEDED_NEWS_DAYS`, because the caller is a nudge surface and a
+        supersession is only worth interrupting for while it is news. The
+        previous `sorted(glob("*.md"))` ordered by FILENAME, which for these
+        files is the hex memory id — neither recency nor relevance. On a store
+        with 767 archived memories that pinned the same seven nudges to every
+        session indefinitely, all of them resolved weeks earlier. An entry with
+        no `superseded_at` sorts last but is kept: an unstamped archive is old,
+        not necessarily stale news, and dropping it would hide real pairs
+        written before the stamp existed.
         """
+        from datetime import UTC, datetime, timedelta
+
         inactive_dir = self.cfg.memory_dir / "inactive"
         if not inactive_dir.is_dir():
             return []
         import frontmatter
 
-        out: list[tuple[str, str, str]] = []
-        for path in sorted(inactive_dir.glob("*.md")):
-            if len(out) >= limit:
-                break
+        cutoff = datetime.now(tz=UTC) - timedelta(days=_SUPERSEDED_NEWS_DAYS)
+        scored: list[tuple[str, tuple[str, str, str]]] = []
+        for path in inactive_dir.glob("*.md"):
             try:
                 post = frontmatter.loads(path.read_text(encoding="utf-8"))
                 extra = post.get("extra")
@@ -551,14 +569,28 @@ class Memory(
                 stale_id = str(post.get("id") or "")
                 if not stale_id:
                     continue
+                at_raw = str(extra.get("superseded_at") or "") if isinstance(extra, dict) else ""
+                at = None
+                with contextlib.suppress(ValueError):
+                    at = datetime.fromisoformat(at_raw) if at_raw else None
+                if at is not None:
+                    # A naive stamp is read as UTC — the writer
+                    # (`lifecycle.archive_memory`) is UTC-aware, so this only
+                    # affects hand-edited archives.
+                    if at.tzinfo is None:
+                        at = at.replace(tzinfo=UTC)
+                    if at < cutoff:
+                        continue
                 title = str(post.get("title") or "—")
-                out.append((stale_id, str(superseded_by), title))
+                scored.append((at_raw, (stale_id, str(superseded_by), title)))
             except Exception:  # noqa: S112 — a malformed archive entry (bad YAML
                 # frontmatter, unreadable file, etc.) must not sink reliability
                 # nudges for every OTHER valid pair (I3 review fix: frontmatter.loads
                 # can raise yaml.YAMLError, which (OSError, ValueError) missed).
                 continue
-        return out
+        # Empty stamps sort last: "" is below every ISO timestamp descending.
+        scored.sort(key=lambda kv: kv[0], reverse=True)
+        return [pair for _at, pair in scored[:limit]]
 
     def low_confidence_ids(self, *, threshold: float = 0.4, limit: int = 50) -> list[str]:
         """Memory ids whose `memory_health.confidence` is below `threshold`.

--- a/src/memo/proactive/detectors/reliability.py
+++ b/src/memo/proactive/detectors/reliability.py
@@ -31,7 +31,11 @@ def detect_reliability(mem: Any, *, now: str, limit: int = 20) -> list[Nudge]:
                 value=0.8,
                 title=f"You may be relying on a superseded fact: {title}",
                 evidence=(superseding_id, stale_id),
-                action=f"memo get {stale_id}",
+                # The SUCCESSOR, not the stale side: `superseded_pairs` sources
+                # the stale id from `memory_dir/inactive/`, which `memo get`
+                # does not read — every action this emitted answered "not
+                # found". The replacement is the memory worth reading anyway.
+                action=f"memo get {superseding_id}",
                 created_at=now,
             )
         )

--- a/tests/test_proactive_reliability.py
+++ b/tests/test_proactive_reliability.py
@@ -14,7 +14,12 @@ def test_reliability_nudges_cite_superseding_id():
     n = ns[0]
     assert n.kind == KIND_RELIABILITY
     assert "new1" in n.evidence and n.urgency >= 0.7
-    assert n.action == "memo get old1"
+    # The SUCCESSOR, not the stale side. `superseded_pairs` sources the stale
+    # id from `memory_dir/inactive/`, and `memo get` does not read the archive:
+    # on 2026-08-30 all seven ids the live digest offered as `memo get <id>`
+    # answered "not found". This assertion used to pin `old1`, so the suite
+    # certified the dead-end.
+    assert n.action == "memo get new1"
 
 
 def test_reliability_guarded_returns_empty_on_error():

--- a/tests/test_superseded_pairs.py
+++ b/tests/test_superseded_pairs.py
@@ -7,6 +7,8 @@ with `extra.superseded_by` (see `lifecycle.py:archive_memory`) and returns
 
 from __future__ import annotations
 
+from datetime import UTC
+
 import frontmatter
 
 
@@ -91,5 +93,65 @@ def test_superseded_pairs_skips_entries_missing_own_id(mock_memory, tmp_cfg):
         extra={"superseded_by": "new1"},
     )
     (inactive / "idless.md").write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    assert mock_memory.superseded_pairs() == []
+
+
+# Every fixture above writes files whose filename order already matches the
+# order under test, and none stamps `superseded_at` — so `sorted(glob("*.md"))`
+# looked correct. On the live store that sort is by hex memory id, which is
+# neither recency nor relevance: 767 archived memories produced the same seven
+# nudges every session (ids 03ef…, 1f28…, 2b77…, 4ae2…, 4dd7…, 550e…, 68e0…),
+# forever, for supersessions resolved weeks earlier.
+
+
+def _archived(inactive, *, mid, superseded_by, title, superseded_at=None):
+    extra = {"superseded_by": superseded_by}
+    if superseded_at is not None:
+        extra["superseded_at"] = superseded_at
+    post = frontmatter.Post("body", id=mid, title=title, type="fact", extra=extra)
+    (inactive / f"{mid}.md").write_text(frontmatter.dumps(post), encoding="utf-8")
+
+
+def test_superseded_pairs_are_ordered_by_recency_not_by_filename(mock_memory, tmp_cfg):
+    from datetime import datetime, timedelta
+
+    inactive = tmp_cfg.memory_dir / "inactive"
+    inactive.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    # `aaa` sorts first by filename but was superseded longest ago.
+    _archived(
+        inactive,
+        mid="aaa",
+        superseded_by="n1",
+        title="old news",
+        superseded_at=(now - timedelta(days=20)).isoformat(),
+    )
+    _archived(
+        inactive,
+        mid="zzz",
+        superseded_by="n2",
+        title="just superseded",
+        superseded_at=(now - timedelta(hours=1)).isoformat(),
+    )
+
+    pairs = mock_memory.superseded_pairs()
+
+    assert [p[0] for p in pairs] == ["zzz", "aaa"]
+
+
+def test_superseded_pairs_drops_supersessions_too_old_to_be_news(mock_memory, tmp_cfg):
+    from datetime import datetime, timedelta
+
+    inactive = tmp_cfg.memory_dir / "inactive"
+    inactive.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    _archived(
+        inactive,
+        mid="ancient",
+        superseded_by="n1",
+        title="resolved months ago",
+        superseded_at=(now - timedelta(days=400)).isoformat(),
+    )
 
     assert mock_memory.superseded_pairs() == []


### PR DESCRIPTION
Every session opened with the same seven warnings, each offering a command that fails.

```
⚠️ Reliability (7)
   You may be relying on a superseded fact: 809 tests passed · memo get 1f285d55c00a4ae1bf435801c8a551e0
   ...

$ memo get 1f285d55c00a4ae1bf435801c8a551e0
not found: 1f285d55c00a4ae1bf435801c8a551e0
```

## Two defects

**The ordering was by filename.** `superseded_pairs()` used `sorted(inactive_dir.glob("*.md"))`, and for these files the filename is the hex memory id. With 767 archived memories the surface was the alphabetically-first seven — `03ef…`, `1f28…`, `2b77…`, `4ae2…`, `4dd7…`, `550e…`, `68e0…` — pinned there permanently. `inactive/` only grows, so nothing would ever have rotated them out. The one shown above was superseded on 2026-08-13 and had already been invalid since 2026-08-10.

Now ordered most-recently-superseded first, and capped at 30 days: the caller is a session-start interrupt surface, and a supersession is worth interrupting for only while it is news. Entries with no `superseded_at` sort last but are kept — an unstamped archive is old, not necessarily stale news, and dropping it would hide pairs written before the stamp existed.

**The action pointed into the archive.** `memo get <stale_id>` cannot work by construction: `superseded_pairs` sources the stale id from `memory_dir/inactive/`, which `memo get` does not read. All seven live actions answered `not found`. It now points at the successor, which exists and is the memory actually worth reading.

## Why no test caught it

Neither fixture could produce the failing condition:

- no fixture stamped `superseded_at`, so the recency window and its ordering were unobservable;
- the ordering fixture wrote `old0`/`old1`/`old2`, whose filename order already matches the expected order, so a filename sort and a recency sort are indistinguishable in it;
- `test_reliability_nudges_cite_superseding_id` asserted `n.action == "memo get old1"` — it pinned the dead end.

The new ordering test writes `aaa` (superseded 20 days ago) and `zzz` (superseded an hour ago), so filename order and recency order disagree.

## Test plan

- [x] 2 new tests plus one corrected assertion, all confirmed RED before the fix
- [x] `pytest tests/test_superseded_pairs.py tests/test_proactive_reliability.py tests/test_proactive_{engine,surfaces,integration,nudge,arbiter}.py tests/test_lifecycle.py tests/test_cli_proactive.py tests/test_briefing_unified.py tests/test_cli_briefing.py` — 84 passed
- [x] `ruff check` + `ruff format --check` + `mypy` clean on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)