### PR TITLE
fix: a one-request session is not an independent draw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
   is the memory worth reading. Neither fixture stamped `superseded_at`, and the
   ordering fixture used ids whose filename order already matched the expected
   order, so the sort could not be observed as wrong.
+- **The proxy A/B session floor counted stray rows as independent draws.** The
+  distinct-session count treated any non-empty `session_key` as a session, so
+  the live holdout arm read as two sessions when it held 37 real requests from
+  ONE session plus a single stray row. One more such row would have cleared the
+  three-session floor added in 4.14.8 and published a ratio that is still one
+  session of evidence — the floor would have withheld the small version of the
+  bad number and shipped the large one, which is the exact failure it was added
+  to prevent. A session must now carry at least two requests to count: a
+  singleton cannot exhibit any within-session variation, which is precisely
+  what the session count exists to detect.
 
 ## [4.14.8] - 2026-08-30
 

--- a/src/memo/proxy/meter.py
+++ b/src/memo/proxy/meter.py
@@ -247,6 +247,16 @@ def _by_transform(treated: list[dict]) -> dict[str, dict]:
     return by_transform
 
 
+# Requests a session must carry before it counts as an independent draw. A
+# session with exactly one request cannot exhibit any within-session variation,
+# which is precisely what the session count exists to detect — so it inflates
+# the count without adding evidence. Live ledger, 2026-08-30: the holdout arm
+# read as 2 sessions on 37 real requests from ONE session plus a single stray
+# row; one more stray would have cleared the three-session floor and published
+# a ratio that is still one session of evidence.
+_MIN_SESSION_REQUESTS = 2
+
+
 def _distinct_sessions(rows: list[dict]) -> int:
     """How many DISTINCT sessions an arm represents. Since holdout assignment
     is per-session (`server.py` calls `meter.is_holdout(session_key, ...)`),
@@ -254,8 +264,14 @@ def _distinct_sessions(rows: list[dict]) -> int:
     (a request count) overstates the effective, independent sample size. Rows
     with no `session_key` (hand-built test Records, or a row written before
     this field existed) are excluded rather than folded into a fake shared
-    session."""
-    return len({r.get("session_key") for r in rows if r.get("session_key")})
+    session, and a session under `_MIN_SESSION_REQUESTS` is not counted at
+    all — see that constant for why a singleton is an artifact, not a draw."""
+    counts: dict[str, int] = {}
+    for r in rows:
+        key = r.get("session_key")
+        if key:
+            counts[str(key)] = counts.get(str(key), 0) + 1
+    return sum(1 for n in counts.values() if n >= _MIN_SESSION_REQUESTS)
 
 
 def summarize(state_dir: Path) -> dict:

--- a/tests/test_proxy_reporting.py
+++ b/tests/test_proxy_reporting.py
@@ -51,6 +51,17 @@ def _record(key: str, *, holdout: bool, input_tokens: int, **kw) -> meter.Record
     )
 
 
+def _panel_text(output: str) -> str:
+    """Panel body as one line: ANSI stripped, box borders dropped, runs of
+    whitespace collapsed. Rich wraps the body mid-sentence, so a plain
+    substring match against `result.output` fails on wrapped counts."""
+    import re
+
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", output)
+    plain = re.sub(r"[\u2500-\u257f]", " ", plain)
+    return " ".join(plain.split())
+
+
 def test_no_data_says_so_instead_of_printing_a_zero(tmp_path):
     result = CliRunner().invoke(tokens_cmd, [], env=_env(tmp_path))
     assert result.exit_code == 0
@@ -381,3 +392,34 @@ def test_proxy_panel_withholds_a_ratio_drawn_from_one_holdout_session(tmp_path):
     assert "not enough data" in result.output.lower()
     assert "% saved" not in result.output
     assert "% cost" not in result.output
+
+
+def test_a_one_request_session_does_not_count_toward_the_session_floor(tmp_path):
+    """The floor asks how many independent draws an arm holds.
+
+    Live ledger, 2026-08-30: the holdout arm read as 2 sessions on 37 real
+    requests from ONE session plus a single stray row keyed `live-sess-1`.
+    One more such row would have cleared the three-session floor and published
+    a ratio that is still one session of evidence. A session contributing a
+    single request cannot exhibit any within-session variation, which is
+    exactly what the session count exists to detect, so it is not a draw.
+    """
+    rows = [
+        _record(f"t{i}", holdout=False, input_tokens=100, session_key=f"t-sess-{i % 4}")
+        for i in range(40)
+    ]
+    rows += [
+        _record(f"h{i}", holdout=True, input_tokens=200, session_key="h-real") for i in range(38)
+    ]
+    rows += [
+        _record("stray-a", holdout=True, input_tokens=10, session_key="stray-a"),
+        _record("stray-b", holdout=True, input_tokens=10, session_key="stray-b"),
+    ]
+    _seed(tmp_path / "state", rows)
+
+    result = CliRunner().invoke(tokens_cmd, [], env=_env(tmp_path))
+
+    assert result.exit_code == 0, result.output
+    out = _panel_text(result.output)
+    assert "not enough data to compare arms yet" in out
+    assert "4/1 sessions" in out, "the stray one-request rows still count as draws"


### PR DESCRIPTION
Follow-up to #326. That PR added a three-distinct-session floor to the proxy A/B, because a request floor alone cannot tell one large session from a real sample. The session count it gates on treats any non-empty `session_key` as a session.

## The floor is one stray row from failing the way it was meant to prevent

Live ledger, 2026-08-30:

```
holdout   n=39   sessions=3
            600bc6e9-cf77-4956-9a86-bbac   37     ← one real session
            None                            1     ← already excluded
            live-sess-1                     1     ← a stray, counted as a draw
```

`memo tokens` reports `39 holdout requests, 7/2 sessions`. One more stray row with a distinct key and it reads three sessions, clears the floor, and publishes a percentage that is still **one session of evidence**. That is exactly the shape #326 existed to catch: withhold the small version of the bad number, ship the large one.

Seeded reproduction, before this change:

```
40 treated (4 sessions) + 38 holdout (1 session) + 2 one-request strays
→  47.5% saved on prompt cost
```

## Fix

A session counts only when it carries at least two requests. A singleton cannot exhibit any within-session variation, which is precisely what the session count exists to detect — so it inflates the count without adding evidence.

After: `not enough data to compare arms yet (40 treated / 40 holdout requests, 4/1 sessions — need 30 requests and 3 sessions per arm)`.

This does not claim two requests is a statistically sufficient session; it removes the class of row that is an artifact rather than usage.

## Why no test caught it

`_record` spreads rows deterministically across four sessions per arm, so every fixture produced multi-request sessions. No fixture could contain a singleton, so the difference between "distinct keys" and "independent draws" was unobservable.

## Test plan

- [x] New test confirmed RED (printed `47.5% saved` before the fix)
- [x] `pytest -k proxy` — 398 passed
- [x] `ruff check` + `ruff format --check` + `mypy` clean on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)