### PR TITLE
fix: drop a reliability nudge whose successor is also gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+### Fixed
+
+- **A reliability nudge whose successor was also retired still pointed at it.**
+  4.14.9 moved the nudge's action from the archived stale id to the superseding
+  one, which is an improvement only while the successor exists —
+  `superseded_pairs` reads the archive off disk and never checks. Measured
+  against the live store right after that change: of the first three actions
+  the refreshed digest offered, only one resolved. The detector now drops a
+  pair whose successor no longer resolves, so every nudge it emits is
+  actionable by construction. The check sits inside the detector's existing
+  guard, because the module contract is that it never sinks a proactive
+  surface.
+
 ## [4.14.9] - 2026-08-30
 
 ### Fixed

--- a/src/memo/proactive/detectors/reliability.py
+++ b/src/memo/proactive/detectors/reliability.py
@@ -16,12 +16,21 @@ _log = logging.getLogger(__name__)
 
 
 def detect_reliability(mem: Any, *, now: str, limit: int = 20) -> list[Nudge]:
+    out: list[Nudge] = []
     try:
         pairs = mem.superseded_pairs()[:limit]
+        # A nudge whose action cannot resolve is worse than no nudge. Pointing
+        # at the successor is only an improvement while the successor exists,
+        # and `superseded_pairs` reads the archive from disk without checking:
+        # measured 2026-08-30, only one of the first three successors the
+        # refreshed digest offered still resolved — the other two had been
+        # retired since they won. The lookup sits inside the guard because the
+        # module contract is that this detector never sinks a surface, and a
+        # `mem` that cannot answer `get` would otherwise raise past it.
+        pairs = [p for p in pairs if mem.get(p[1]) is not None]
     except Exception as exc:  # guarded — never sink a surface
         _log.debug("proactive.reliability failed: %s", exc)
         return []
-    out: list[Nudge] = []
     for stale_id, superseding_id, title in pairs:
         out.append(
             Nudge.make(

--- a/tests/test_proactive_dream.py
+++ b/tests/test_proactive_dream.py
@@ -21,6 +21,12 @@ class _FakeMem:
     def superseded_pairs(self):
         return [("old1", "new1", "use X")]
 
+    def get(self, mid):
+        # Stands in for `Memory.get`: the reliability detector drops a pair
+        # whose successor no longer resolves, so the fake must answer for
+        # `new1` or this stops standing in for a store that has it.
+        return object() if mid == "new1" else None
+
     def open_loops(self, limit):
         return [("m9", "finish study")]
 

--- a/tests/test_proactive_engine.py
+++ b/tests/test_proactive_engine.py
@@ -9,6 +9,10 @@ pytestmark = pytest.mark.resource_hygiene
 
 
 class _FullFakeMem:
+    def get(self, mid):
+        # Stands in for `Memory.get`: every successor these fakes name is live.
+        return object()
+
     """Fake mem exposing all five v1+v2 proactive accessors."""
 
     def superseded_pairs(self):
@@ -71,6 +75,7 @@ def test_refresh_candidates_dedups_colliding_nudge_ids(tmp_path: Path):
     """
 
     class _CollidingMem(_FullFakeMem):
+        # `get` is inherited from _FullFakeMem.
         def recurring_pattern_pairs(self, *, limit):
             return [("m1", "same memory, first phrasing"), ("m1", "same memory, again")]
 

--- a/tests/test_proactive_reliability.py
+++ b/tests/test_proactive_reliability.py
@@ -3,9 +3,15 @@ from memo.proactive.nudge import KIND_RELIABILITY
 
 
 class _FakeMem:
+    def __init__(self, live=("new1",)):
+        self._live = set(live)
+
     def superseded_pairs(self):
         # (stale_id, superseding_id, title)
         return [("old1", "new1", "use X not Y")]
+
+    def get(self, mid):
+        return object() if mid in self._live else None
 
 
 def test_reliability_nudges_cite_superseding_id():
@@ -28,3 +34,16 @@ def test_reliability_guarded_returns_empty_on_error():
             raise RuntimeError("boom")
 
     assert detect_reliability(Boom(), now="2026-07-21T00:00:00Z") == []
+
+
+def test_reliability_skips_a_pair_whose_successor_is_also_gone():
+    """A nudge whose action cannot resolve is worse than no nudge.
+
+    Pointing at the successor (rather than the archived stale side) is only an
+    improvement while the successor exists. Live check on 2026-08-30, after
+    that change: of the first three actions the refreshed digest offered, only
+    one resolved — the other two successors had themselves been retired since.
+    """
+    nudges = detect_reliability(_FakeMem(live=()), now="2026-07-21T00:00:00Z")
+
+    assert nudges == []


### PR DESCRIPTION
Found by verifying #330 end-to-end against the live store instead of trusting its unit test.

#330 moved the nudge's action from the archived stale id to the superseding one, because `memo get` does not read `inactive/`. That is an improvement only while the successor itself exists — and `superseded_pairs` reads the archive off disk without checking.

Right after deploying 4.14.9 and refreshing the candidates:

```
888fad25a6954fc39c5d1f3aca720ef5 -> not found
287a9564f13c4e20b37b515b8790a46e -> Handling default-off flags and unre…
d530574a458343feb8dbd4131d19eb5a -> not found
```

Two of three successors had been retired since they won, so the nudge still sent the reader to `not found` — the same dead end, one hop further along.

## Fix

The detector drops a pair whose successor does not resolve, so every nudge it emits is actionable by construction. The lookup sits inside the existing `try/except`: the module contract is that this detector never sinks a proactive surface, and a `mem` that cannot answer `get` would otherwise raise past it.

Placed in the detector rather than in `superseded_pairs` on purpose — the facade's job is reading the archive, the detector's is emitting something worth interrupting for.

Three fakes stood in for `Memory` without a `get`; they answer now, and the one in `test_proactive_dream.py` answers only for the id it actually names, so it cannot mask the filter.

## Test plan

- [x] New test confirmed RED (the nudge was emitted for a successor that does not resolve)
- [x] `pytest -k "proactive or superseded or briefing or digest"` — 174 passed
- [x] `ruff check` + `ruff format --check` + `mypy` clean on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)