### PR TITLE
fix: measure the saving, and stop paying for the same lines every session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
   (non-bullet lines are never deduped). Measured across the seven live profile
   documents: -9.2% overall, -23.2% on the global one, ~238 tokens per session
   for a briefing loading global plus project.
+- **The profile's `identity` section never said what the project was.** The
+  distill prompt lists `identity` as a heading without defining it, so the
+  model filled it with whatever the recent sessions were about — a session
+  still had to be told what the project is, which is the thing the profile
+  exists to carry. Verified against the live store: a `decision` memory
+  titled "Qué es memo (identidad del proyecto)" sat at row 1 of the 40-row
+  source window and the rewrite still opened with last week's token work.
+  `identity` now leads with what the project or system IS whenever a memory
+  states it. After the change the memo profile opens with "a local-first
+  semantic memory for AI agents. Stack: embeddings MLX + hybrid sqlite-vec…",
+  and the SessionStart briefing carries it.
 - **`### Memory relations` named nothing.** It rendered `- \`492e8d82\` related
   \`715ed835\`` — two hex prefixes and a verb, the only graph output in the
   briefing a human could not read. Titles now come from one `get_batch`, and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+### Fixed
+
+- **The transcript panel published a net drawn from a 9-turn control.** It
+  printed `1,905 tok/turn cost` in bold against an "ungrounded" cohort of 3
+  sessions totalling 9 turns (1, 2 and 6), versus 100 grounded sessions with a
+  median of 15. The cohorts are observational and confounded by session
+  length — a session that never grounds is usually one that barely started, and
+  the 9 sessions in NEITHER cohort, equally short, spent MORE per turn than the
+  grounded ones. The sign was not evidence in either direction. `_proxy_panel`
+  already withholds below its floor in this same module, calling a too-thin
+  sample "not a measurement with a caveat — not a measurement"; that standard
+  now applies to both panels instead of one getting the word "provisional".
+- **Duplicate title and repeated bullets in the dream profile.** The distill
+  prompt says "no top-level title" and asks for a distillation, but nothing
+  checked either. Live `_profile/profile.md`: `# Profile — global` on lines 8
+  AND 10, and 13 of 62 bullets literal duplicates — one line repeated 12
+  times — in a document the briefing injects verbatim on every session, where
+  it was 43% of the whole payload. `render_profile` now drops an echoed
+  heading and collapses repeated bullets, order-preserving and deterministic
+  (non-bullet lines are never deduped). Measured across the seven live profile
+  documents: -9.2% overall, -23.2% on the global one, ~238 tokens per session
+  for a briefing loading global plus project.
+- **`### Memory relations` named nothing.** It rendered `- \`492e8d82\` related
+  \`715ed835\`` — two hex prefixes and a verb, the only graph output in the
+  briefing a human could not read. Titles now come from one `get_batch`, and a
+  row whose memories no longer resolve is dropped rather than shown as bare
+  ids.
+
+### Added
+
+- **`memo tokens` reports a prefix counterfactual.** The holdout A/B is the
+  better instrument but its control arm fills per session at
+  `MEMO_PROXY_HOLDOUT_FRAC`, so "not enough data to compare arms" was reading
+  as "memo saves nothing" — a different and false claim. The transforms are
+  pure functions of the payload: the volume removed is recorded per request,
+  and the surviving prefix's own counters say what tier that volume would have
+  billed at. Weighting the removed volume at that same observed weight needs no
+  control arm. Measured on 10,398 live requests: **54.1%**, 1.62B tokens of
+  prefix removed at the 0.131x weight the surviving prefix actually billed at.
+  Labelled "not an A/B" wherever it appears, and never substituted for one.
+
 ## [4.14.10] - 2026-08-30
 
 ### Fixed

--- a/src/memo/briefing.py
+++ b/src/memo/briefing.py
@@ -579,22 +579,19 @@ def relation_lines(store: Any, *, limit: int = 3) -> list[str]:
     memories no longer resolve is dropped rather than rendered as bare ids —
     the same rule the reliability nudge follows.
     """
-    try:
-        judged = [
-            row
-            for row in store.list_relations(status="judged", limit=12)
-            if row.get("relation") not in {None, "not_conflict"}
-        ][:limit]
-    except Exception:
-        # A graph read must never sink the briefing.
-        return []
+    # No local guard: the only caller wraps this in `contextlib.suppress`, the
+    # convention for every graph read in `unified_briefing`. A second handler
+    # here would just re-state it, and the repo's quality gate ratchets broad
+    # excepts per file.
+    judged = [
+        row
+        for row in store.list_relations(status="judged", limit=12)
+        if row.get("relation") not in {None, "not_conflict"}
+    ][:limit]
     if not judged:
         return []
     ids = {str(r["source_id"]) for r in judged} | {str(r["target_id"]) for r in judged}
-    try:
-        titles = {str(r.get("id")): str(r.get("title") or "") for r in store.get_batch(sorted(ids))}
-    except Exception:
-        titles = {}
+    titles = {str(r.get("id")): str(r.get("title") or "") for r in store.get_batch(sorted(ids))}
     lines: list[str] = []
     for row in judged:
         src, tgt = str(row["source_id"]), str(row["target_id"])

--- a/src/memo/briefing.py
+++ b/src/memo/briefing.py
@@ -568,6 +568,46 @@ def profile_lines(cfg: Any, *, cwd: str | None = None) -> list[str]:
     return lines
 
 
+def relation_lines(store: Any, *, limit: int = 3) -> list[str]:
+    """``### Memory relations`` — judged relations, named.
+
+    The rows carry ids only, and the section used to render them raw:
+    ``- `492e8d82` related `715ed835``. Two hex prefixes and a verb name
+    nothing a reader can act on, and it was the one piece of graph output in
+    the briefing a human could not read. Titles come from a single
+    `get_batch`, so naming them costs one query, not one per row. A row whose
+    memories no longer resolve is dropped rather than rendered as bare ids —
+    the same rule the reliability nudge follows.
+    """
+    try:
+        judged = [
+            row
+            for row in store.list_relations(status="judged", limit=12)
+            if row.get("relation") not in {None, "not_conflict"}
+        ][:limit]
+    except Exception:
+        # A graph read must never sink the briefing.
+        return []
+    if not judged:
+        return []
+    ids = {str(r["source_id"]) for r in judged} | {str(r["target_id"]) for r in judged}
+    try:
+        titles = {str(r.get("id")): str(r.get("title") or "") for r in store.get_batch(sorted(ids))}
+    except Exception:
+        titles = {}
+    lines: list[str] = []
+    for row in judged:
+        src, tgt = str(row["source_id"]), str(row["target_id"])
+        s_title, t_title = titles.get(src), titles.get(tgt)
+        if not s_title or not t_title:
+            continue
+        lines.append(
+            f"- `{src[:8]}` {_clip(s_title, limit=48)} "
+            f"**{row['relation']}** `{tgt[:8]}` {_clip(t_title, limit=48)}"
+        )
+    return ["### Memory relations", "", *lines, ""] if lines else []
+
+
 def code_impact_lines(mem: Any, cwd: str) -> list[str]:
     """Render linked memories affected by working-tree changes."""
     from memo.flags import flag_int
@@ -669,19 +709,7 @@ def memo_native_briefing_lines(
 
     # Judged relation truth only; pending candidates belong to review surfaces.
     with contextlib.suppress(Exception):
-        judged = [
-            row
-            for row in mem.store.list_relations(status="judged", limit=12)
-            if row.get("relation") not in {None, "not_conflict"}
-        ][:3]
-        if judged:
-            lines.extend(["### Memory relations", ""])
-            for row in judged:
-                lines.append(
-                    f"- `{str(row['source_id'])[:8]}` {row['relation']} "
-                    f"`{str(row['target_id'])[:8]}`"
-                )
-            lines.append("")
+        lines.extend(relation_lines(mem.store))
 
     # ── Open loops: recently updated memories ────────────────────────────
     try:
@@ -793,5 +821,6 @@ __all__ = [
     "operational_briefing_lines",
     "proactive_lines",
     "profile_lines",
+    "relation_lines",
     "temporal_fact_lines",
 ]

--- a/src/memo/cli_tokens.py
+++ b/src/memo/cli_tokens.py
@@ -118,19 +118,35 @@ def _transcript_panel(measured: dict) -> Panel:
     # memo save tokens" — tool-spend delta alone ignores the context memo
     # injects to earn it. Negative means memo cost more than it saved; that
     # is a real result and it is reported as one.
+    # Both cohorts are observational, not assigned, and they are confounded by
+    # session length: a session that never grounds is usually a session that
+    # barely started. Measured 2026-08-31 on the live ledger — 100 grounded
+    # sessions (median 15 turns) against an "ungrounded" control of 3 sessions
+    # totalling 9 turns, while the 9 sessions in NEITHER cohort, equally short,
+    # spent MORE per turn than the grounded ones. So the sign was not evidence
+    # in either direction, and the panel printed it in bold anyway.
+    #
+    # `_proxy_panel` withholds below its floor for exactly this reason, three
+    # screens-worth of code below, with the note that a sample too thin to
+    # compare is not a measurement with a caveat — it is not a measurement.
+    # Applying that standard to one panel and a "provisional" adjective to the
+    # other, on the same screen, is the inconsistency this removes.
+    thin = min(p["grounded_turns"], p["ungrounded_turns"]) < _MIN_COHORT_TURNS
     if net is None:
         net_line = "[dim]net: needs grounded and ungrounded sessions to compare[/dim]"
+    elif thin:
+        net_line = (
+            "[dim]net: not enough data to compare cohorts yet "
+            f"({p['grounded_turns']} grounded / {p['ungrounded_turns']} ungrounded turns "
+            f"— need {_MIN_COHORT_TURNS} per cohort)[/dim]"
+        )
     else:
         colour = "green" if net > 0 else "red"
         verb = "saved" if net > 0 else "cost"
-        # Both cohorts are observational, not assigned: a thin one means the
-        # sign is not yet evidence. Say so rather than let the number stand
-        # unqualified.
-        thin = min(p["grounded_turns"], p["ungrounded_turns"]) < _MIN_COHORT_TURNS
         net_line = (
             f"[bold {colour}]{abs(net):,.0f} tok/turn {verb}[/bold {colour}] net of injection "
             f"[dim](n={p['grounded_turns']} grounded / {p['ungrounded_turns']} ungrounded "
-            f"turns{' · provisional, thin cohort' if thin else ''})[/dim]"
+            f"turns)[/dim]"
         )
     return Panel(
         Text.from_markup(
@@ -204,6 +220,19 @@ def _proxy_panel(proxy: dict) -> Panel:
             f"(treated {cost_t:.0f} vs holdout {cost_h:.0f} tok-equiv/request; "
             f"raw input_tokens {mean_in_t:.0f} vs {mean_in_h:.0f}) "
             f"[dim](n={n_t} treated / {n_h} holdout requests{sessions_note})[/dim]"
+        )
+    # An A/B that is still filling its control arm must not read as a measured
+    # zero. The counterfactual needs no control arm (see
+    # `meter._prefix_counterfactual`) and is labelled so it can never be
+    # mistaken for the arm comparison above it.
+    cf = proxy.get("prefix_counterfactual")
+    if cf and cf.get("saving_frac") is not None:
+        body += (
+            f"\n[dim]prefix counterfactual (not an A/B): "
+            f"[/dim][bold]{cf['saving_frac'] * 100:.1f}%[/bold][dim] — "
+            f"{_fmt_tokens(cf['removed_tok'])} tok of prefix removed over {cf['n']} requests, "
+            f"priced at the {cf['effective_prefix_weight']:.3f}x weight the surviving "
+            f"prefix actually billed at[/dim]"
         )
     if proxy.get("retrieved"):
         body += f"\n[dim]{proxy['retrieved']} recovered originals (cost their tokens twice)[/dim]"

--- a/src/memo/dream_profile.py
+++ b/src/memo/dream_profile.py
@@ -97,6 +97,38 @@ def project_buckets(rows: list[dict[str, Any]]) -> list[str]:
     return seen
 
 
+def _clean_narrative(narrative: str, *, scope: str) -> str:
+    """Strip what the model was told not to emit, and what it repeated.
+
+    `_SYS` asks for "no top-level title" and for a distillation, but an
+    instruction to a model is not a guarantee and nothing checked. Measured on
+    the live `_profile/profile.md`, 2026-08-31: `# Profile — global` appeared
+    on lines 8 AND 10 (the document's own heading plus the echoed one), and 13
+    of its 62 bullets were literal duplicates — one line repeated 12 times — in
+    a document that was 43% of the whole SessionStart briefing. The briefing
+    injects this file verbatim on every session, so each repeat is billed
+    again, forever.
+
+    Deterministic and order-preserving: the first occurrence of a bullet stays
+    where the model put it, later identical ones are dropped. Comparison is on
+    the stripped text so indentation does not defeat it; non-bullet lines
+    (headings, blanks, prose) are never deduped — repetition there can be
+    meaningful.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for line in (narrative or "").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# ") and stripped.lstrip("# ").strip() == f"Profile — {scope}":
+            continue
+        if stripped.startswith(("- ", "* ")):
+            if stripped in seen:
+                continue
+            seen.add(stripped)
+        out.append(line)
+    return "\n".join(out).strip()
+
+
 def render_profile(
     *,
     scope: str,
@@ -129,7 +161,7 @@ def render_profile(
         rule_lines += [f"- {text} `[{rid[:8]}]`" for rid, text in rules]
     budget = max(0, char_budget)
     remaining = budget - len("\n".join(rule_lines))
-    body = (narrative or "").strip()
+    body = _clean_narrative(narrative, scope=scope)
     if len(body) > remaining:
         body = body[: max(0, remaining - 1)].rstrip() + ("…" if remaining > 0 else "")
     parts = list(head)

--- a/src/memo/dream_profile.py
+++ b/src/memo/dream_profile.py
@@ -249,6 +249,14 @@ _SYS = (
     "fold in the new memories, drop anything superseded. State ONLY what the "
     "memories state — never invent. Plain markdown bullet points under short "
     "headings (identity, preferences, conventions, key decisions). "
+    # Without this the model fills `identity` with whatever the recent
+    # sessions happened to be about. Verified 2026-08-31: a memory titled
+    # "Qué es memo (identidad del proyecto)" sat at row 1 of the 40-row source
+    # window and the rewrite still opened with last week's token work, so a
+    # session still had to be told what the project was.
+    "Under `identity`, lead with WHAT THE PROJECT OR SYSTEM IS whenever a "
+    "memory states it — purpose, stack and scope — before anything about "
+    "recent work; that line is why a new session does not have to ask. "
     "No frontmatter, no top-level title. Stay under {budget} characters."
 )
 

--- a/src/memo/proxy/meter.py
+++ b/src/memo/proxy/meter.py
@@ -274,6 +274,47 @@ def _distinct_sessions(rows: list[dict]) -> int:
     return sum(1 for n in counts.values() if n >= _MIN_SESSION_REQUESTS)
 
 
+def _prefix_counterfactual(treated: list[dict]) -> dict | None:
+    """What the treated arm would have billed had the prefix transforms not run.
+
+    The holdout A/B answers the same question experimentally and is the better
+    instrument, but its control arm fills at `MEMO_PROXY_HOLDOUT_FRAC` per
+    SESSION — months of real traffic before three independent draws exist. In
+    the meantime "not enough data to compare arms" reads as "memo saves
+    nothing", which is a different and false claim.
+
+    This needs no control arm because the transform is a pure function of the
+    payload: `est_saved_tokens` is the volume it removed, and the surviving
+    prefix's own counters say what tier that volume would have billed at. The
+    removed tokens are prefix content — schemas sit at the head of the prompt,
+    ahead of the conversation — so they are weighted at the SAME effective
+    weight the rest of the prefix actually achieved, rather than at a guessed
+    one. Measured on this machine 2026-08-31: 98.9% of prefix volume billed as
+    cache-read, an effective weight of 0.114x.
+
+    It is a counterfactual under a stated assumption, NOT a measured A/B, and
+    callers must label it as such. Returns None when nothing was rewritten.
+    """
+    removed = sum(_num(r, "est_saved_tokens") for r in treated)
+    if removed <= 0:
+        return None
+    prefix_volume = sum(
+        _num(r, "cache_read_tokens") + _num(r, "cache_creation_tokens") for r in treated
+    )
+    if prefix_volume <= 0:
+        return None
+    prefix_cost = sum(_prompt_cost(r) - _num(r, "input_tokens") for r in treated)
+    weight = prefix_cost / prefix_volume
+    actual = sum(_prompt_cost(r) for r in treated)
+    extra = removed * weight
+    return {
+        "removed_tok": int(removed),
+        "effective_prefix_weight": round(weight, 4),
+        "saving_frac": round(extra / (actual + extra), 6) if (actual + extra) else None,
+        "n": len(treated),
+    }
+
+
 def summarize(state_dir: Path) -> dict:
     """Treated vs holdout on real provider counters. None means 'no data yet'."""
     treated, holdout, passthrough, skipped = _partition_rows(ledger_path(state_dir))
@@ -308,6 +349,10 @@ def summarize(state_dir: Path) -> dict:
         "mean_prompt_cost_treated": mean_cost_t,
         "mean_prompt_cost_holdout": mean_cost_h,
         "measured_saving_frac": saving,
+        # A counterfactual, not an arm comparison — see `_prefix_counterfactual`.
+        # Reported alongside the A/B so a control arm that is still filling
+        # does not read as a measured zero.
+        "prefix_counterfactual": _prefix_counterfactual(treated),
         "by_transform": _by_transform(treated),
         "retrieved": sum(_num(r, "retrieved") for r in treated),
         "skipped": skipped,

--- a/tests/test_briefing_graph.py
+++ b/tests/test_briefing_graph.py
@@ -59,3 +59,30 @@ def test_entity_graph_lines_empty_graph_returns_nothing():
         graph = _EmptyGraph()
 
     assert entity_graph_lines(_EmptyMem()) == []
+
+
+def test_memory_relations_name_the_memories_they_relate():
+    """Two hex prefixes and a verb are not a relation a reader can act on.
+
+    Live briefing, 2026-08-31: `- `492e8d82` related `715ed835``, three of
+    them, 31 tokens per session, naming nothing. The row already carries the
+    ids; the titles are one batch lookup away, and without them the section is
+    the only graph output in the briefing that a human cannot read.
+    """
+    from memo import briefing
+
+    class _Store:
+        def list_relations(self, *, status, limit):
+            return [{"source_id": "492e8d82aa", "target_id": "715ed835bb", "relation": "related"}]
+
+        def get_batch(self, ids):
+            return [
+                {"id": "492e8d82aa", "title": "MLX embedder choice"},
+                {"id": "715ed835bb", "title": "sqlite-vec dims guard"},
+            ]
+
+    lines = briefing.relation_lines(_Store())
+    body = "\n".join(lines)
+
+    assert "MLX embedder choice" in body
+    assert "sqlite-vec dims guard" in body

--- a/tests/test_dream_profile.py
+++ b/tests/test_dream_profile.py
@@ -325,3 +325,46 @@ def test_run_profile_pass_never_raises(tmp_path):
     res = dp.run_profile_pass(_mk_cfg(tmp_path), _Boom())
     assert res["status"] == "error"
     assert "store exploded" in res["error"]
+
+
+def test_render_profile_drops_a_title_the_narrative_repeats():
+    """`_SYS` tells the model "no top-level title"; nothing checked.
+
+    Live `_profile/profile.md` on 2026-08-31 carried `# Profile — global` on
+    lines 8 AND 10 — `render_profile` adds the heading and the narrative had
+    echoed it. An instruction to a model is not a guarantee.
+    """
+    from memo.dream_profile import render_profile
+
+    out = render_profile(
+        scope="global",
+        narrative="# Profile — global\n\n- **identity**\n  - Ships memo.",
+        rules=[],
+        source_ids=["abc12345"],
+        updated="2026-08-31T00:00:00+00:00",
+        char_budget=4000,
+    )
+
+    assert out.count("# Profile — global") == 1
+
+
+def test_render_profile_collapses_repeated_bullets():
+    """The briefing injects this document verbatim, every session.
+
+    Live `profile.md` on 2026-08-31: 62 bullets, 49 distinct — one line
+    ("Ensure the `decision to not touch the clustering` is respected.")
+    repeated 12 times, in a document that was 43% of the whole briefing.
+    """
+    from memo.dream_profile import render_profile
+
+    dup = "  - Ensure the decision is respected."
+    out = render_profile(
+        scope="global",
+        narrative="- **key decisions**\n" + "\n".join([dup] * 12),
+        rules=[],
+        source_ids=["abc12345"],
+        updated="2026-08-31T00:00:00+00:00",
+        char_budget=4000,
+    )
+
+    assert out.count("Ensure the decision is respected.") == 1

--- a/tests/test_dream_profile.py
+++ b/tests/test_dream_profile.py
@@ -368,3 +368,15 @@ def test_render_profile_collapses_repeated_bullets():
     )
 
     assert out.count("Ensure the decision is respected.") == 1
+
+
+def test_distill_prompt_defines_what_identity_means():
+    """Without this, `identity` gets filled with whatever the recent sessions
+    were about. Verified 2026-08-31: a `decision` memory titled "Qué es memo
+    (identidad del proyecto)" sat at row 1 of the 40-row source window and the
+    rewrite still described last week's token work, so a session still had to
+    be told what the project is.
+    """
+    from memo.dream_profile import _SYS
+
+    assert "WHAT THE PROJECT OR SYSTEM IS" in _SYS

--- a/tests/test_proxy_reporting.py
+++ b/tests/test_proxy_reporting.py
@@ -423,3 +423,141 @@ def test_a_one_request_session_does_not_count_toward_the_session_floor(tmp_path)
     out = _panel_text(result.output)
     assert "not enough data to compare arms yet" in out
     assert "4/1 sessions" in out, "the stray one-request rows still count as draws"
+
+
+def _render(panel) -> str:
+    """Panel as one plain line — same normalisation as `_panel_text`."""
+    import io
+    import re
+
+    from rich.console import Console
+
+    buf = io.StringIO()
+    Console(file=buf, width=200, no_color=True).print(panel)
+    plain = re.sub(r"[─-╿]", " ", buf.getvalue())
+    return " ".join(plain.split())
+
+
+def _measured(*, grounded_turns: int, ungrounded_turns: int) -> dict:
+    return {
+        "sessions": 100,
+        "answer_tok": 1_000_000,
+        "tool_tok": 17_000_000,
+        "injected_tokens": 280_000,
+        "input_tok": 0,
+        "cache_read_tok": 0,
+        "cache_creation_tok": 0,
+        "models": {},
+        "proxy": {
+            "grounded_tool_tok_per_turn": 6958.46,
+            "ungrounded_tool_tok_per_turn": 5166.89,
+            "delta": -1791.57,
+            "injected_tok_per_turn": 113.72,
+            "net_tok_per_turn": -1905.29,
+            "grounded_turns": grounded_turns,
+            "ungrounded_turns": ungrounded_turns,
+        },
+    }
+
+
+def test_transcript_net_is_withheld_when_the_control_cohort_is_thin():
+    """Same standard the proxy panel already applies on this screen.
+
+    Live ledger, 2026-08-31: the "ungrounded" control was 3 sessions / 9 turns
+    (1, 2 and 6 turns each) against 100 grounded sessions with a median of 15
+    turns, and the panel printed `1,905 tok/turn cost` in bold red. The cohorts
+    are observational and confounded by session length — the 9 sessions in
+    neither cohort, equally short, spend MORE per turn than the grounded ones —
+    so the sign is not evidence in either direction. `_proxy_panel` withholds
+    below its floor for exactly this reason, in this same module.
+    """
+    from memo.cli_tokens import _transcript_panel
+
+    out = _render(_transcript_panel(_measured(grounded_turns=2469, ungrounded_turns=9)))
+
+    assert "1,905" not in out, "a net drawn from a 9-turn control is printed as a result"
+    assert "9 ungrounded" in out, "the sample that withheld it is not disclosed"
+
+
+def test_transcript_net_is_published_once_both_cohorts_are_thick():
+    from memo.cli_tokens import _transcript_panel
+
+    out = _render(_transcript_panel(_measured(grounded_turns=2469, ungrounded_turns=120)))
+
+    assert "1,905 tok/turn cost" in out
+
+
+def test_summarize_reports_the_prefix_counterfactual_without_a_control_arm():
+    """ "Nothing to report" and "no saving" are different claims.
+
+    The holdout A/B answers whether the whole prompt got cheaper, and it needs
+    a control arm that fills at MEMO_PROXY_HOLDOUT_FRAC — months, on real
+    traffic. But the transform is a pure function of the payload: the tokens it
+    removed are recorded per request, and so is the cache tier the rest of the
+    prefix actually billed at. Weighting the removed volume at the SAME
+    observed prefix weight gives a counterfactual that needs no control arm.
+    It is not an A/B and must never be printed as one.
+    """
+    from memo.proxy import meter
+
+    rows = [
+        # 1000 removed, and the surviving prefix billed entirely as cache-read
+        # (0.1x), so the counterfactual adds 100 tok-equiv to a 100 tok-equiv
+        # actual — a 50% saving.
+        meter.Record(
+            request_key=f"t{i}",
+            holdout=False,
+            session_key="s1",
+            transforms=["toolschemas"],
+            est_saved_tokens=1000,
+            input_tokens=0,
+            output_tokens=10,
+            cache_creation_tokens=0,
+            cache_read_tokens=1000,
+            retrieved=0,
+        )
+        for i in range(5)
+    ]
+    import tempfile
+    from pathlib import Path
+
+    state = Path(tempfile.mkdtemp()) / "state"
+    for r in rows:
+        meter.append(state, r)
+
+    cf = meter.summarize(state)["prefix_counterfactual"]
+
+    assert cf["removed_tok"] == 5000
+    assert cf["effective_prefix_weight"] == 0.1
+    assert cf["saving_frac"] == 0.5
+    assert cf["n"] == 5
+
+
+def test_proxy_panel_shows_the_counterfactual_and_never_calls_it_an_ab(tmp_path):
+    """A withheld A/B must not read as "memo saves nothing"."""
+    # Built directly: `_record` pins both cache counters to 0, so a prefix
+    # weight cannot be derived from it — the counterfactual would be None and
+    # this test would pass for the wrong reason.
+    rows = [
+        meter.Record(
+            request_key=f"t{i}",
+            holdout=False,
+            session_key="s1",
+            transforms=["toolschemas"],
+            est_saved_tokens=1000,
+            input_tokens=0,
+            output_tokens=10,
+            cache_creation_tokens=0,
+            cache_read_tokens=1000,
+            retrieved=0,
+        )
+        for i in range(5)
+    ]
+    _seed(tmp_path / "state", rows)
+
+    result = CliRunner().invoke(tokens_cmd, [], env=_env(tmp_path))
+
+    assert result.exit_code == 0, result.output
+    out = _panel_text(result.output)
+    assert "counterfactual" in out, "the deterministic estimate is not surfaced"
+    assert "not an A/B" in out, "an estimate is presented without saying it is one"


### PR DESCRIPTION
Goal was to confirm memo's token saving is real, and to stop the per-session payload repeating itself. Both turned out to be reporting problems first.

## Two panels, two standards, one screen

`_proxy_panel` withholds a ratio below its sample floor — *"a sample too thin to compare is not a measurement with a caveat — it is not a measurement"*. `_transcript_panel`, in the same module, printed this:

```
1,905 tok/turn cost net of injection (n=2469 grounded / 9 ungrounded turns · provisional, thin cohort)
```

The control is **3 sessions, 9 turns total** (1, 2 and 6 turns each) against 100 grounded sessions with a median of 15 and a max of 228. And the cohorts are confounded by session length — a session that never grounds is usually one that barely started:

| cohort | sessions | turns | median turns | tool_tok/turn |
|---|---|---|---|---|
| grounded | 100 | 2469 | 15 | 6958 |
| ungrounded (control) | 3 | 9 | 2 | 5167 |
| **neither** | 9 | 18 | 2 | **8908** |

Equally short sessions in neither cohort spend *more* per turn than the grounded ones, so the sign is not evidence in either direction. Both panels now hold the same line.

## "Nothing to report" is not "no saving"

That left both surfaces silent. The holdout A/B needs a control arm that fills per session at `MEMO_PROXY_HOLDOUT_FRAC` — months of real traffic — and until then the panel read as a measured zero.

The transforms are pure functions of the payload, so a counterfactual needs no control arm: the volume removed is recorded per request, and the surviving prefix's own counters say what tier that volume would have billed at. Weighting the removed volume at that same observed weight gives:

```
prefix counterfactual (not an A/B): 54.1% — 1617.66M tok of prefix removed over 10398 requests,
priced at the 0.131x weight the surviving prefix actually billed at
```

Cross-checked two independent ways: the ledger's own removed-volume figure (156k tok/request, 77.5% of the payload) matches a direct computation over `tool_schema_cache.json` (79–84% pruned on this machine's real tool surface). It is labelled "not an A/B" everywhere it appears and never substituted for one.

## The session payload was paying for the same lines

The dream profile's distill prompt says *"no top-level title"* and asks for a distillation. Nothing checked either — an instruction to a model is not a guarantee. Live `_profile/profile.md`:

- `# Profile — global` on **lines 8 and 10** (`render_profile` adds the heading; the narrative echoed it)
- **62 bullets, 49 distinct** — `- Ensure the \`decision to not touch the clustering\` is respected.` repeated **12 times**
- 43% of the entire SessionStart briefing, injected verbatim every session

`render_profile` now drops an echoed heading and collapses repeated bullets, deterministically and order-preserving; non-bullet lines are never deduped. Measured across all seven live profile documents — the defect is systemic, not one bad file:

```
profile.md                    4,022 -> 3,090  (-23.2%)
project-relojitos-sf.md       3,524 -> 3,118  (-11.5%)
...
ALL                          16,356 -> 14,857  (-9.2%)   ~238 tok/session for global + project
```

## `### Memory relations` named nothing

```
- `492e8d82` related `715ed835`
```

Two hex prefixes and a verb — the only graph output in the briefing a human could not read, 31 tokens per session. Titles now come from a single `get_batch`, and a row whose memories no longer resolve is dropped rather than rendered as bare ids (same rule the reliability nudge follows).

## Test plan

- [x] 6 new tests, each confirmed RED first (the profile ones failed `assert 2 == 1` and `assert 12 == 1`)
- [x] `pytest -k "briefing or profile or proxy or token or dream"` — 1407 passed
- [x] `ruff check` + `ruff format --check` + `mypy` clean on all touched files
- [x] Verified against the live install and the live profile documents, not only fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)