### PR TITLE
feat: make the three silent failures visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ Releases before `2.0.0` are archived in [docs/CHANGELOG-archive.md](docs/CHANGEL
 
 ## [Unreleased]
 
+### Added
+
+- **`--strict-runtime` now checks the LaunchAgents too.** It compared `memo`
+  against `memo-mcp` and stopped, so a daemon launched from a third runtime was
+  invisible. `com.memo.proxy`'s plist hard-coded
+  `~/.local/share/memo/proxy-runtime/`, a venv nothing in this repo creates or
+  upgrades: on 2026-09-01 it was serving traffic on memo **4.14.3** against a
+  4.15.0 tool install, so twelve releases of proxy fixes had never executed
+  while every gate stayed green. Any `com.memo.*` agent whose program is a
+  `memo` binary outside the active runtime is now a warning naming the
+  `memo ops install` that repoints it. Agents launching a wrapper script
+  (`com.memo.nightly`) are skipped — a check that fires on a healthy install is
+  one nobody reads.
+- **Ledger rows carry a timestamp, and `memo tokens --since`.** Without one the
+  ledger only answered "all of history": comparing the prefix weight before and
+  after a proxy restart meant counting lines and hard-coding the offset. Rows
+  written before the stamp existed carry none and are excluded from any
+  `--since` — an undated row cannot be claimed for a window.
+- **`memo doctor` counts supersession pointers that name nothing.**
+  `extra.superseded_by` promises "this is retired, read that instead"; when the
+  target is gone the retired memory is out of recall AND its replacement is
+  unfindable, so the knowledge is lost while every surface reports it handled.
+  Measured on the live vault: **85 of 238**. The August diagnosis of the proxy's
+  unfrozen keep-set was one of them — a correct finding that sat archived
+  pointing at nothing for four months. Repair writes to the user's vault and
+  stays a human decision; seeing the count should not.
+
 ## [4.15.0] - 2026-08-31
 
 ### Fixed

--- a/src/memo/cli_doctor.py
+++ b/src/memo/cli_doctor.py
@@ -696,10 +696,49 @@ def doctor(
             _report_derived_storage(cfg)
         with contextlib.suppress(Exception):
             _report_dark_flags(cfg)
+            _report_dangling_supersessions(cfg)
     except Exception:  # noqa: S110
         pass
 
     sys.exit(0 if ok else 1)
+
+
+def dangling_supersession_count(memory_dir: Any) -> tuple[int, int]:
+    """`(total, dangling)` — supersession pointers, and how many name nothing.
+
+    `extra.superseded_by` is a promise: this memory is retired, read that one
+    instead. When the target is gone the promise is a dead end — the retired
+    memory is out of recall AND its replacement is unfindable, so the
+    knowledge is simply lost while every surface reports it as handled.
+    Measured on the live vault 2026-09-01: 118 of 238 pointers resolved to
+    nothing, 105 of them to memories deleted outright. Repairing them is a
+    write to the user's vault and stays a human decision; being unable to see
+    how many there are should not be.
+
+    A target counts as resolvable when a `.md` with that id exists anywhere
+    under `memory_dir`, INCLUDING `inactive/` — an archived successor is still
+    readable, and calling it dangling would overstate the damage.
+    """
+    import re
+    from pathlib import Path
+
+    root = Path(memory_dir)
+    if not root.is_dir():
+        return (0, 0)
+    known: set[str] = set()
+    pointers: list[str] = []
+    for path in root.rglob("*.md"):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        mid = re.search(r"(?m)^id:\s*(\S+)\s*$", text)
+        if mid:
+            known.add(mid.group(1).strip().strip("'\""))
+        sup = re.search(r"(?m)^\s+superseded_by:\s*(\S+)\s*$", text)
+        if sup:
+            pointers.append(sup.group(1).strip().strip("'\""))
+    return (len(pointers), sum(1 for t in pointers if t not in known))
 
 
 def _report_dark_flags(cfg: Any) -> None:
@@ -724,6 +763,18 @@ def _report_dark_flags(cfg: Any) -> None:
     console.print(
         f"[dim]•[/dim] dark flags: {len(dark)} shipped but never enabled{suffix} "
         "[dim](`memo dream graduate-flags --status`)[/dim]"
+    )
+
+
+def _report_dangling_supersessions(cfg: Any) -> None:
+    """Surface supersession pointers that name a memory nobody can read."""
+    total, dangling = dangling_supersession_count(cfg.memory_dir)
+    if not dangling:
+        return
+    console.print(
+        f"[dim]•[/dim] supersessions: {dangling} of {total} point at a memory that no "
+        "longer exists [dim](the retired side is out of recall and its replacement is "
+        "unfindable)[/dim]"
     )
 
 

--- a/src/memo/cli_tokens.py
+++ b/src/memo/cli_tokens.py
@@ -276,15 +276,22 @@ def _by_transform_table(proxy: dict) -> Table:
     is_flag=True,
     help="Break down which transforms removed the most text (raw, not billed cost).",
 )
+@click.option(
+    "--since",
+    default=None,
+    help="Only proxy rows stamped at/after this ISO instant (e.g. 2026-09-01).",
+)
 @click.option("--json", "as_json", is_flag=True, help="Machine-readable output.")
-def tokens_cmd(*, by_transform: bool = False, as_json: bool = False) -> None:
+def tokens_cmd(
+    *, by_transform: bool = False, since: str | None = None, as_json: bool = False
+) -> None:
     """Show memo's measured token cost/savings — real transcript + real proxy holdout."""
     from memo import token_meter
     from memo.proxy import meter as proxy_meter
 
     cfg = Config.from_env()
     measured = token_meter.summarize(cfg.state_dir)
-    proxy = proxy_meter.summarize(cfg.state_dir)
+    proxy = proxy_meter.summarize(cfg.state_dir, since=since)
 
     if as_json:
         click.echo(

--- a/src/memo/proxy/meter.py
+++ b/src/memo/proxy/meter.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import logging
 from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 
 LEDGER_SCHEMA = "memo.proxy.requests.v1"
@@ -129,7 +130,16 @@ def append(state_dir: Path, record: Record) -> None:
     path = ledger_path(state_dir)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        row = {"schema": LEDGER_SCHEMA, **asdict(record)}
+        # Stamped here, not carried on `Record`: every writer gets it without
+        # touching a call site, and the value is the moment the row was
+        # durable. Without it the ledger only answers "all of history" —
+        # comparing the prefix weight before and after a proxy restart on
+        # 2026-09-01 meant counting lines and hard-coding the offset.
+        row = {
+            "schema": LEDGER_SCHEMA,
+            **asdict(record),
+            "ts": datetime.now(tz=UTC).isoformat(),
+        }
         with path.open("a", encoding="utf-8") as fh:
             fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
             fh.write(json.dumps(row, ensure_ascii=False) + "\n")
@@ -146,7 +156,9 @@ def _num(row: dict, key: str) -> int:
     return val if isinstance(val, int) else 0
 
 
-def _partition_rows(path: Path) -> tuple[list[dict], list[dict], int, int]:
+def _partition_rows(
+    path: Path, *, since: str | None = None
+) -> tuple[list[dict], list[dict], int, int]:
     """Split the ledger into the two arms, plus the two things that are neither.
 
     Returns `(treated, holdout, passthrough, skipped)`. A passthrough row was
@@ -179,7 +191,12 @@ def _partition_rows(path: Path) -> tuple[list[dict], list[dict], int, int]:
             continue
         if not isinstance(row, dict):
             skipped += 1
-        elif row.get("holdout"):
+            continue
+        # An undated row predates the `ts` stamp and cannot be claimed for a
+        # window: excluded from any `since`, counted when there is none.
+        if since is not None and str(row.get("ts") or "") < since:
+            continue
+        if row.get("holdout"):
             holdout.append(row)
         elif row.get("rewritten", True):
             treated.append(row)
@@ -315,9 +332,15 @@ def _prefix_counterfactual(treated: list[dict]) -> dict | None:
     }
 
 
-def summarize(state_dir: Path) -> dict:
-    """Treated vs holdout on real provider counters. None means 'no data yet'."""
-    treated, holdout, passthrough, skipped = _partition_rows(ledger_path(state_dir))
+def summarize(state_dir: Path, *, since: str | None = None) -> dict:
+    """Treated vs holdout on real provider counters. None means 'no data yet'.
+
+    `since` is an ISO-8601 instant: rows stamped before it are dropped, so
+    "did this change help?" is one command rather than an offset computed by
+    hand. Rows written before `ts` existed carry none and are excluded by any
+    `since` — an undated row cannot be claimed for a window.
+    """
+    treated, holdout, passthrough, skipped = _partition_rows(ledger_path(state_dir), since=since)
 
     mean_cost_t = _mean_cost(treated)
     mean_cost_h = _mean_cost(holdout)

--- a/src/memo/runtime/detect.py
+++ b/src/memo/runtime/detect.py
@@ -101,6 +101,52 @@ def is_homebrew_install() -> bool:
     )
 
 
+def launchagent_runtime_warnings(agents_dir: Path, primary_root: Path | None) -> list[str]:
+    """`com.memo.*` LaunchAgents whose program is NOT in the primary runtime.
+
+    `--strict-runtime` compared `memo` against `memo-mcp` and stopped there,
+    so a daemon launched from a third runtime was invisible to it. Measured
+    2026-09-01: `com.memo.proxy`'s plist hard-coded
+    `~/.local/share/memo/proxy-runtime/`, a venv nothing in this repo creates
+    or upgrades. It was running memo 4.14.3 against a 4.15.0 tool install —
+    twelve releases of proxy fixes that had never executed, with every gate
+    green the whole time, because the agent is the thing that serves traffic
+    and nothing compared it to anything.
+
+    Reads the plist as text rather than importing a parser: the value needed
+    is the first `<string>` of `ProgramArguments`, and a doctor check must not
+    fail because a plist is malformed. Silent when the directory is absent
+    (non-macOS, or no agents installed).
+    """
+    if primary_root is None or not agents_dir.is_dir():
+        return []
+    import re
+
+    out: list[str] = []
+    for path in sorted(agents_dir.glob("com.memo.*.plist")):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        m = re.search(r"<key>ProgramArguments</key>\s*<array>\s*<string>([^<]+)</string>", text)
+        if not m:
+            continue
+        program = _safe_resolve(Path(m.group(1).strip()))
+        # Only agents that launch a memo BINARY are comparable. `com.memo.nightly`
+        # runs a shell wrapper (`memo-nightly.sh`), which has no environment root
+        # of its own — reporting it would be a false positive, and a check that
+        # cries wolf on a healthy install is one nobody reads.
+        if program is None or program.name not in {"memo", "memo-mcp"}:
+            continue
+        root = _env_root_for_bin(program)
+        if root is not None and root != primary_root:
+            out.append(
+                f"{path.stem} runs from {root}, not the active runtime "
+                f"{primary_root} — `memo ops install {path.stem.rsplit('.', 1)[-1]}` repoints it"
+            )
+    return out
+
+
 def _runtime_install_report(
     cwd: Path | None = None, *, package_file: Path | None = None
 ) -> dict[str, Any]:
@@ -117,6 +163,9 @@ def _runtime_install_report(
     mode = _install_mode(primary_root)
 
     warnings: list[str] = []
+    warnings.extend(
+        launchagent_runtime_warnings(Path.home() / "Library" / "LaunchAgents", primary_root)
+    )
     if memo_resolved is None:
         warnings.append("`memo` is not on PATH")
     if mcp_resolved is None:

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -260,3 +260,30 @@ def test_trust_preflight_reports_legacy_schema_unavailable(tmp_cfg):
     assert report["ok"] is False
     assert report["identity_constraint"] == "unavailable"
     assert report["legacy_identity_rows"] == 1
+
+
+def test_dangling_supersession_pointers_are_counted(tmp_path):
+    """A retired memory whose replacement is gone is unrecoverable knowledge.
+
+    Live vault, 2026-09-01: 118 of 238 `superseded_by` pointers resolved to
+    nothing — 105 to memories deleted outright. The one that started this
+    (`43ff5a81`, the August diagnosis of the proxy's unfrozen keep-set) named
+    a successor that `memo get` answers `not found` for, so a correct finding
+    sat archived pointing at nothing for four months.
+    """
+    from memo.cli_doctor import dangling_supersession_count
+
+    memory_dir = tmp_path / "memories"
+    (memory_dir / "inactive").mkdir(parents=True)
+    (memory_dir / "a.md").write_text(
+        "---\nid: aaa\nextra:\n  superseded_by: bbb\n---\nbody\n", encoding="utf-8"
+    )
+    (memory_dir / "c.md").write_text(
+        "---\nid: ccc\nextra:\n  superseded_by: zzz\n---\nbody\n", encoding="utf-8"
+    )
+    (memory_dir / "b.md").write_text("---\nid: bbb\n---\nbody\n", encoding="utf-8")
+
+    total, dangling = dangling_supersession_count(memory_dir)
+
+    assert total == 2
+    assert dangling == 1  # ccc -> zzz, which exists nowhere

--- a/tests/test_proxy_reporting.py
+++ b/tests/test_proxy_reporting.py
@@ -561,3 +561,69 @@ def test_proxy_panel_shows_the_counterfactual_and_never_calls_it_an_ab(tmp_path)
     out = _panel_text(result.output)
     assert "counterfactual" in out, "the deterministic estimate is not surfaced"
     assert "not an A/B" in out, "an estimate is presented without saying it is one"
+
+
+def test_ledger_rows_carry_a_timestamp_so_before_and_after_can_be_compared(tmp_path):
+    """Without one the ledger cannot be sliced by time.
+
+    2026-09-01: comparing the prefix weight before and after a proxy restart
+    required counting lines and hard-coding the offset, because no row said
+    when it was written. A ledger that only answers "all of history" cannot
+    answer whether a change helped.
+    """
+    from memo.proxy import meter
+
+    state = tmp_path / "state"
+    meter.append(
+        state,
+        meter.Record(request_key="r1", holdout=False, session_key="s1", transforms=["toolschemas"]),
+    )
+    row = json.loads((meter.ledger_path(state)).read_text().splitlines()[0])
+
+    assert row["ts"], "no timestamp on the row"
+    from datetime import datetime
+
+    assert datetime.fromisoformat(row["ts"]).tzinfo is not None, "timestamp is not tz-aware"
+
+
+def test_tokens_since_filters_the_ledger(tmp_path):
+    """`--since` is what turns "did the restart help?" into one command."""
+    from memo.proxy import meter
+
+    state = tmp_path / "state"
+    rows = [
+        {
+            "schema": meter.LEDGER_SCHEMA,
+            "request_key": "old",
+            "holdout": False,
+            "session_key": "s1",
+            "transforms": ["toolschemas"],
+            "est_saved_tokens": 10,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 100,
+            "retrieved": 0,
+            "ts": "2026-01-01T00:00:00+00:00",
+        },
+        {
+            "schema": meter.LEDGER_SCHEMA,
+            "request_key": "new",
+            "holdout": False,
+            "session_key": "s1",
+            "transforms": ["toolschemas"],
+            "est_saved_tokens": 10,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 100,
+            "retrieved": 0,
+            "ts": "2026-09-01T00:00:00+00:00",
+        },
+    ]
+    p = meter.ledger_path(state)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+    assert meter.summarize(state)["n_treated"] == 2
+    assert meter.summarize(state, since="2026-06-01T00:00:00+00:00")["n_treated"] == 1

--- a/tests/test_runtime_isolation.py
+++ b/tests/test_runtime_isolation.py
@@ -708,3 +708,82 @@ def _clear_memo_env(monkeypatch):
     for key in cli_mod._MCP_ENV_FORWARD_KEYS:
         monkeypatch.delenv(key, raising=False)
     monkeypatch.delenv("DEVIN_DESKTOP_MCP_CONFIG", raising=False)
+
+
+def test_launchagents_pointing_at_another_runtime_are_reported(tmp_path):
+    """The check that would have caught a proxy 12 versions behind.
+
+    `com.memo.proxy`'s plist hard-coded `~/.local/share/memo/proxy-runtime/`,
+    a venv no code in this repo creates or updates. On 2026-09-01 it was
+    running memo 4.14.3 while the tool install was at 4.15.0, so every proxy
+    fix shipped in between had never executed — and `--strict-runtime` could
+    not see it, because it only ever compared `memo` against `memo-mcp`.
+    """
+    from memo.runtime.detect import launchagent_runtime_warnings
+
+    agents = tmp_path / "LaunchAgents"
+    agents.mkdir()
+    good = tmp_path / "good" / "bin" / "memo"
+    stale = tmp_path / "stale" / "bin" / "memo"
+    for exe in (good, stale):
+        exe.parent.mkdir(parents=True)
+        exe.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    def _plist(program: Path) -> str:
+        return (
+            '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0"><dict>'
+            "<key>ProgramArguments</key><array>"
+            f"<string>{program}</string><string>proxy</string>"
+            "</array></dict></plist>\n"
+        )
+
+    (agents / "com.memo.chat.plist").write_text(_plist(good), encoding="utf-8")
+    (agents / "com.memo.proxy.plist").write_text(_plist(stale), encoding="utf-8")
+
+    warnings = launchagent_runtime_warnings(agents, good.parent.parent)
+
+    assert len(warnings) == 1, warnings
+    assert "com.memo.proxy" in warnings[0]
+    assert "stale" in warnings[0]
+
+
+def test_launchagent_check_is_silent_when_every_agent_shares_the_runtime(tmp_path):
+    from memo.runtime.detect import launchagent_runtime_warnings
+
+    agents = tmp_path / "LaunchAgents"
+    agents.mkdir()
+    exe = tmp_path / "good" / "bin" / "memo"
+    exe.parent.mkdir(parents=True)
+    exe.write_text("#!/bin/sh\n", encoding="utf-8")
+    (agents / "com.memo.chat.plist").write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0"><dict>'
+        "<key>ProgramArguments</key><array>"
+        f"<string>{exe}</string></array></dict></plist>\n",
+        encoding="utf-8",
+    )
+
+    assert launchagent_runtime_warnings(agents, exe.parent.parent) == []
+
+
+def test_launchagent_check_ignores_an_agent_that_runs_a_wrapper_script(tmp_path):
+    """`com.memo.nightly` launches `memo-nightly.sh`, not a memo binary.
+
+    A script has no environment root, so it resolved to `/` and the first
+    version of this check reported the healthy nightly agent as drifted. A
+    check that cries wolf on a correct install is one nobody reads.
+    """
+    from memo.runtime.detect import launchagent_runtime_warnings
+
+    agents = tmp_path / "LaunchAgents"
+    agents.mkdir()
+    script = tmp_path / "bin" / "memo-nightly.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text("#!/bin/sh\n", encoding="utf-8")
+    (agents / "com.memo.nightly.plist").write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0"><dict>'
+        "<key>ProgramArguments</key><array>"
+        f"<string>{script}</string></array></dict></plist>\n",
+        encoding="utf-8",
+    )
+
+    assert launchagent_runtime_warnings(agents, tmp_path / "other") == []


### PR DESCRIPTION
All three are the same shape: a real defect that no gate could ever report.

## 1. `--strict-runtime` never looked at the LaunchAgents

It compared `memo` against `memo-mcp` and stopped, so a daemon launched from a third runtime was invisible.

```
$ /bin/ps -o command= -p <proxy>
/Users/fer/.local/share/memo/proxy-runtime/bin/python .../proxy-runtime/bin/memo proxy serve
$ .../proxy-runtime/bin/memo --version
memo, version 4.14.3        # tool install was at 4.15.0
```

`grep -rn proxy-runtime src/` returns nothing — that venv is not created or upgraded by any code here. Twelve releases of proxy fixes (4.14.8's wire-name `_ALWAYS_KEEP`, 4.14.9's session gate, 4.15.0's counterfactual) had never executed, with every gate green throughout.

Verified in both directions against the real artifacts, not fixtures:

```
current machine   -> ninguno ✓
archived old plist -> com.memo.proxy runs from .../proxy-runtime, not the active
                      runtime .../uv/tools/mlx-memo — `memo ops install proxy` repoints it
```

The first version also reported the healthy `com.memo.nightly`, whose `ProgramArguments[0]` is `/bin/sh`. Agents launching a wrapper script are skipped — a check that cries wolf on a correct install is one nobody reads.

## 2. The ledger had no timestamp

It could only answer "all of history". Comparing the prefix weight before and after the proxy restart meant counting lines and hard-coding an offset — which is also why that comparison came out `n=13` and unusable.

Rows are stamped at append, so every writer gets it without touching a call site, and `memo tokens --since 2026-09-01` makes "did that change help?" one command. Rows written before the stamp existed carry none and are excluded from any window rather than claimed for it.

## 3. Half the supersession pointers name nothing

`extra.superseded_by` promises "this is retired, read that instead". On the live vault **85 of 238** point at a memory that exists nowhere — not in the index, not in `inactive/`. The retired side is out of recall and its replacement is unfindable, so the knowledge is simply gone while every surface reports it handled.

The one that started this: `[43ff5a81]`, the August diagnosis of the proxy's unfrozen keep-set, names a successor `memo get` answers `not found` for. A correct finding, archived, pointing at nothing, for four months.

`memo doctor` counts them. Repair writes to the user's vault and stays their decision.

## Test plan

- [x] 6 new tests, each confirmed RED first
- [x] `pytest -k "doctor or runtime_isolation or proxy or token"` — 653 passed
- [x] `scripts/quality_gate.py` passes (185 complexity, 205 exception budgets)
- [x] `ruff` + `mypy` clean
- [x] All three verified against live artifacts — the real vault, the real LaunchAgents, and the archived copy of the pre-fix plist

🤖 Generated with [Claude Code](https://claude.com/claude-code)